### PR TITLE
ENH: Add logic for piecewise summations that conditions depend on the sum variable.

### DIFF
--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1078,16 +1078,16 @@ def eval_sum(f, limits):
                         a_i, b_i = a, b
                     else:
                         cond_set = solveset(cond_i, i, S.Reals)
-                        a_i = a if cond_set.inf <= a else cond_set.inf
-                        b_i = b if cond_set.sup >= b else cond_set.sup
+                        a_i = max(a, cond_set.inf)
+                        b_i = min(b, cond_set.sup)
                     if b_i < a_i:
                         continue
                     val = eval_sum(expr_i, (i, a_i, b_i))
                     if val is None:
-                        raise NotImplementedError
+                        val = Sum(expr_i, (i, a_i, b_i))
                     total += val
                 return total
-            except Exception:
+            except (NotImplementedError, TypeError, ValueError):
                 pass
 
     if f.has(KroneckerDelta):

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -1064,6 +1064,31 @@ def eval_sum(f, limits):
                     return None
                 newargs.append((newexpr, arg.cond))
             return f.func(*newargs)
+        # Piecewise conditions depend on the dummy summation variable
+        # This logic is only possible if the summation is well defined for all values
+        # of the dummy variable
+        elif f.args[-1].cond is S.true:
+            try:
+                from sympy.solvers.solveset import solveset
+                total = S.Zero
+                for expr_i, cond_i in f.args:
+                    if expr_i.is_zero:
+                        continue
+                    if cond_i is S.true:
+                        a_i, b_i = a, b
+                    else:
+                        cond_set = solveset(cond_i, i, S.Reals)
+                        a_i = a if cond_set.inf <= a else cond_set.inf
+                        b_i = b if cond_set.sup >= b else cond_set.sup
+                    if b_i < a_i:
+                        continue
+                    val = eval_sum(expr_i, (i, a_i, b_i))
+                    if val is None:
+                        raise NotImplementedError
+                    total += val
+                return total
+            except Exception:
+                pass
 
     if f.has(KroneckerDelta):
         from .delta import deltasummation, _has_simple_delta

--- a/sympy/concrete/tests/test_sums_products.py
+++ b/sympy/concrete/tests/test_sums_products.py
@@ -655,8 +655,7 @@ def test_Sum_doit():
     # issue 2597
     nmax = symbols('N', integer=True, positive=True)
     pw = Piecewise((1, And(1 <= n, n <= nmax)), (0, True))
-    assert Sum(pw, (n, 1, nmax)).doit() == Sum(Piecewise((1, nmax >= n),
-                    (0, True)), (n, 1, nmax))
+    assert Sum(pw, (n, 1, nmax)).doit() == nmax
 
     q, s = symbols('q, s')
     assert summation(1/n**(2*s), (n, 1, oo)) == Piecewise((zeta(2*s), 2*re(s) > 1),

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -305,9 +305,6 @@ def test_conditional():
 def test_product_spaces():
     X1 = Geometric('X1', S.Half)
     X2 = Geometric('X2', Rational(1, 3))
-    assert str(P(X1 + X2 < 3).rewrite(Sum)) == (
-        "Sum(Piecewise((1/(4*2**n), n >= -1), (0, True)), (n, -oo, -1))/3")
-    assert str(P(X1 + X2 > 3).rewrite(Sum)) == (
-        'Sum(Piecewise((2**(X2 - n - 2)*(2/3)**(X2 - 1)/6, '
-        'X2 - n <= 2), (0, True)), (X2, 1, oo), (n, 1, oo))')
+    assert P(X1 + X2 < 3) == S(1/6)
+    assert P(X1 + X2 > 3) == S(23/26)
     assert P(Eq(X1 + X2, 3)) == Rational(1, 12)

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from sympy.concrete.summations import Sum
 from sympy.core.numbers import (I, Rational, oo, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol

--- a/sympy/stats/tests/test_discrete_rv.py
+++ b/sympy/stats/tests/test_discrete_rv.py
@@ -305,6 +305,6 @@ def test_conditional():
 def test_product_spaces():
     X1 = Geometric('X1', S.Half)
     X2 = Geometric('X2', Rational(1, 3))
-    assert P(X1 + X2 < 3) == S(1/6)
-    assert P(X1 + X2 > 3) == S(23/26)
+    assert P(X1 + X2 < 3) == Rational(1, 6)
+    assert P(X1 + X2 > 3) == Rational(23, 36)
     assert P(Eq(X1 + X2, 3)) == Rational(1, 12)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Partially fixes #29647.
Improves a summation that were shown in #2597

#### Brief description of what is fixed or changed
This PR adds a code block for piecewise summations when the conditions depend on the summation variable itself. Such examples can be found at the issues #2597 and #29647

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

The `solveset` line was proposed by Claude as I couldn't find another way to handle that case. I am not sure if there's a better alternative here. The error handling was also introduced by Claude. Other stuff is mine
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
