### PR TITLE
render beta function's arguments as latex

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1822,6 +1822,7 @@ extraymond <extraymond@gmail.com>
 faizan2700 <syedfaizan824@gmail.com>
 fazledyn-or <ataf@openrefactory.com>
 foice <foice.news@gmail.com>
+gf <573848+generatingfunctions@users.noreply.github.com>
 goddus <39923708+goddus@users.noreply.github.com>
 gregmedlock <gmedlo@gmail.com>
 helo9 <helo9@users.noreply.github.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1258,7 +1258,7 @@ class LatexPrinter(Printer):
         x = expr.args[0]
         # Deal with unevaluated single argument beta
         y = expr.args[0] if len(expr.args) == 1 else expr.args[1]
-        tex = rf"\left({x}, {y}\right)"
+        tex = r"\left(%s, %s\right)" % (self._print(x), self._print(y))
 
         if exp is not None:
             return r"\operatorname{B}^{%s}%s" % (exp, tex)

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2324,6 +2324,10 @@ def test_latex_greek_functions():
     assert latex(c(x)) == r'\chi{\left(x \right)}'
     assert latex(c) == r'\chi'
 
+    # make sure arguments to beta function are rendered as latex
+    alpha_, beta_ = symbols("alpha beta")
+    assert r'\operatorname{B}\left(\alpha, \beta\right)' == latex(beta(alpha_, beta_))
+
 
 def test_translate():
     s = 'Alpha'


### PR DESCRIPTION
#### References to other Issues or PRs

Does not reference any known issue or PR

#### Brief description of what is fixed or changed

Fixes rendering of arguments of beta function when they are more than just simple (roman font) symbols. Also adds a unit test for the case.

reproducing example:
```
from sympy.abc import alpha, omega
from sympy import beta, latex
print(latex(beta(alpha, omega)))
```

expected:`\operatorname{B}\left(\alpha, \omega\right)`

actual: `\operatorname{B}\left(alpha, omega\right)`

screenshot from sympy live:

<img width="375" height="128" alt="sympy-beta" src="https://github.com/user-attachments/assets/238acf92-9357-4350-8d65-1ba80e4f4a7b" />


#### Other comments

The arguments to the beta function do not themselves render as latex as of [this commit](https://github.com/sympy/sympy/commit/fa545f6d8806959b286826adebda0c50c9514d01#diff-2a60b6b9791931a1418810380aae96f630bc05e34e3fb4b073f2a3a19f66dfa4)

I reviewed the rest of the file and didn't see any other obvious cases where this was happening.

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->