### PR TITLE
[GSOC 2026] Add Vandermonde systems solver

### DIFF
--- a/sympy/polys/modulargcd.py
+++ b/sympy/polys/modulargcd.py
@@ -5,10 +5,12 @@ from sympy.ntheory import nextprime
 from sympy.ntheory.modular import crt
 from sympy.polys.domains import PolynomialRing
 from sympy.polys.galoistools import (
-    gf_gcd, gf_from_dict, gf_gcdex, gf_div, gf_lcm)
+    gf_gcd, gf_from_dict, gf_gcdex, gf_div, gf_lcm, gf_eval, gf_mul)
 from sympy.polys.polyerrors import ModularGCDFailed
 
 import random
+
+from sympy.polys.domains.integerring import ZZ
 
 
 def _trivial_gcd(f, g):
@@ -629,6 +631,81 @@ def _chinese_remainder_reconstruction_multivariate(hp, hq, p, q):
         hpq[monom] = crt_(zero, hq[monom], p, q)
 
     return hpq
+
+def lag_basis(evalpoints, p):
+    """
+    Computes the Lagrange basis associated to the given
+    list of evaluation points over Z_p.
+
+    Example
+    =======
+
+    >>> from sympy.polys.modulargcd import lag_basis
+    >>> evalpoints = [1, 2, 5]
+    >>> p = 11
+    >>> lag_basis(evalpoints, p)
+    [[3, 1, 8], [7, 2, 2], [1, 8, 2]]
+
+    """
+    master_pol = [1]
+    for k in evalpoints:
+        master_pol = gf_mul(master_pol, [1, -k], p, ZZ)
+
+    v = [gf_div(master_pol, [1, -k], p, ZZ)[0] for k in evalpoints]
+    for i, poly in enumerate(v):
+        c = gf_eval(poly, evalpoints[i], p, ZZ)
+        c = pow(c, -1, p)
+        v[i] = [(c*el) % p for el in v[i]]
+    return v
+
+
+def vandermonde_interp(basis, values, p, trans=True):
+    """
+    Solves for x the linear system A^T * x = values in Z_p,
+    where A is the Vandermonde matrix such that a_{i,j} = k[i]^j.
+    If trans = False, it solves the linear system A*x = values.
+    Both systems are solved in O(n^2) time.
+
+    The parameter basis can be computed using lag_basis(k, p).
+
+    Note that solving a linear system with associated Vandermonde matrix is
+    equivalent to interpolating an univariate polynomial.
+    Note also that the interpolation of a multivariate polynomial in
+    Z_p[x1,...,xn], can be made equivalent to the resolution of a linear system
+    with the transposed of a Vandermonde matrix as the associated matrix.
+    It is sufficient to choose a random tuple (t1,...,tn),
+    and to use (t1^j,...,tn^j) for j in {0,1,...} as evaluation points.
+
+    Example
+    =======
+
+    >>> from sympy.polys.modulargcd import vandermonde_interp, lag_basis
+    >>> from sympy import Matrix
+
+    >>> k = [1, 2, 5]
+    >>> p = 9973
+    >>> values = [4, 9, 36]
+    >>> A = Matrix([[1, 1, 1], [1, 2, 4], [1, 5, 25]])
+
+    >>> bas = lag_basis(k, p)
+
+    >>> x = vandermonde_interp(bas, values, p, trans = False)
+
+    >>> A * Matrix(x) == Matrix(values)
+    True
+
+    """
+    deg = len(values)-1
+    if trans:
+        sol = []
+        for poly in basis:
+            sol.append(sum(val * poly[deg-i] for i, val in enumerate(values)) % p)
+    else:
+        sol = []
+        for i in range(len(values)):
+            sol.append(sum(values[j] * basis[j][deg-i] for j in range(len(values))) % p)
+
+    return sol
 
 
 def _interpolate_multivariate(evalpoints, hpeval, ring, i, p, ground=False):
@@ -1670,7 +1747,7 @@ def _func_field_modgcd_p(f, g, minpoly, p):
         n += 1
 
         # polynomial in Z_p[t_1, ..., t_k][x, z]
-        h = _interpolate_multivariate(evalpoints_a, heval_a, ring, k-1, p, ground=True)
+        h = _interpolate_multivariate(evalpoints_a, heval_a, ring, k-1, p, ground = True)
 
         # polynomial in Z_p(t_k)[t_1, ..., t_{k-1}][x, z]
         h = _rational_reconstruction_func_coeffs(h, p, m, qring, k-1)

--- a/sympy/polys/tests/test_modulargcd.py
+++ b/sympy/polys/tests/test_modulargcd.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from sympy.polys.rings import ring
 from sympy.polys.domains import ZZ, QQ, AlgebraicField
 from sympy.polys.modulargcd import (
+    lag_basis,
     modgcd_univariate,
     modgcd_bivariate,
     _chinese_remainder_reconstruction_multivariate,
@@ -9,8 +10,10 @@ from sympy.polys.modulargcd import (
     _to_ZZ_poly,
     _to_ANP_poly,
     func_field_modgcd,
-    _func_field_modgcd_m)
+    _func_field_modgcd_m,
+    vandermonde_interp)
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.matrices import Matrix
 
 
 def test_modgcd_univariate_integers():
@@ -324,3 +327,18 @@ def test_modgcd_func_field():
     f, g = x + 1, x - 1
 
     assert _func_field_modgcd_m(f, g, minpoly) == R.one
+
+
+def test_vandermonde_interpolate():
+    p = 100003
+    k = [3, 6, 12, 33]
+    A = Matrix([[el**j for j in range(len(k))] for el in k])
+    x = Matrix([12, 2, 1, 27])
+    v = A * x
+    v_t = A.T * x
+
+    bas = lag_basis(k, p)
+    sol_t = vandermonde_interp(bas, v_t, p)
+    sol = vandermonde_interp(bas, v, p, trans = False)
+
+    assert sol == sol_t == list(x)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Implementation of the functions lag_basis() and vandermonde_interp(), that are useful during the stage of sparse interpolation in Zippel's algorithm. 


#### Other comments
During the sparse interpolation stage of Zippel's algorithm, a multivariate polynomial has to be interpolated. 
This is done by evaluating the polynomial in random points, and setting up a system of linear equations.
If every evalution point is chosen randomly, then this has complexity of O(n^3) (the complexity of solving a generic linear system).
Instead a more efficient approach can be adopted:
the problem can be made equivalent to the resolution of a linear system with the transposed of a Vandermonde matrix as the associated matrix. It is sufficient to choose a random tuple (t1,...,tn), and to use (t1^j,...,tn^j) for j in {0,1,...} as evaluation points.
The two functions of this pr are implemented to solve this particular type of linear system over Z_p.
You can find a more detailed description of the math behind this approach in section 2.4 of the paper: 
[Computing the Greatest Common Divisor of Multivariate Polynomials over Finite Fields], by Suling Yang.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Code was written by myself, and I used the assistance of gemini for reviewing and ideas validation.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added two functions to solve systems with a Vandermonde matrix as the associated matrix, which is useful during the sparse interpolation stage in Zippel's algorithm
<!-- END RELEASE NOTES -->
