### PR TITLE
typ(core): fix type inference for Expr + Expr

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -940,7 +940,7 @@ class Quaternion(Expr):
         q = self
         if not q.norm():
             raise ValueError("Cannot compute inverse for a quaternion with zero norm")
-        return conjugate(q) * (1/q.norm()**2)
+        return q._eval_conjugate() * (1/q.norm()**2)
 
     def pow(self, p: int) -> Quaternion:
         """Finds the pth power of the quaternion.

--- a/sympy/core/decorators.py
+++ b/sympy/core/decorators.py
@@ -193,7 +193,8 @@ def sympify_method_args(cls: type[T1]) -> type[T1]:
     return cls
 
 
-def sympify_return(*args):
+def sympify_return(*args
+    ) -> Callable[[Callable[[T1, T2], T3]], Callable[[T1, T2], T3]]:
     '''Function/method decorator to sympify arguments automatically
 
     See the docstring of sympify_method_args for explanation.

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from typing import Any, Hashable
     from typing_extensions import Self
     from .numbers import Number
+    from sympy.logic.boolalg import Boolean
 
 from collections import defaultdict
 
@@ -247,7 +248,7 @@ class Expr(Basic, EvalfMixin):
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__radd__')
-    def __add__(self, other: complex) -> Expr:
+    def __add__(self, other: Expr | complex) -> Expr:
         return Add(self, other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
@@ -257,7 +258,7 @@ class Expr(Basic, EvalfMixin):
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rsub__')
-    def __sub__(self, other: complex) -> Expr:
+    def __sub__(self, other: Expr | complex) -> Expr:
         return Add(self, -other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
@@ -267,7 +268,7 @@ class Expr(Basic, EvalfMixin):
 
     @sympify_return([('other', 'Expr')], NotImplemented)
     @call_highest_priority('__rmul__')
-    def __mul__(self, other: complex) -> Expr:
+    def __mul__(self, other: Expr | complex) -> Expr:
         return Mul(self, other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
@@ -396,22 +397,22 @@ class Expr(Basic, EvalfMixin):
         return complex(float(re), float(im))
 
     @sympify_return([('other', 'Expr')], NotImplemented)
-    def __ge__(self, other):
+    def __ge__(self, other) -> Boolean:
         from .relational import GreaterThan
         return GreaterThan(self, other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
-    def __le__(self, other):
+    def __le__(self, other) -> Boolean:
         from .relational import LessThan
         return LessThan(self, other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
-    def __gt__(self, other):
+    def __gt__(self, other) -> Boolean:
         from .relational import StrictGreaterThan
         return StrictGreaterThan(self, other)
 
     @sympify_return([('other', 'Expr')], NotImplemented)
-    def __lt__(self, other):
+    def __lt__(self, other) -> Boolean:
         from .relational import StrictLessThan
         return StrictLessThan(self, other)
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -481,7 +481,7 @@ class Number(AtomicExpr):
     @overload
     def __add__(self, other: Number | int | float) -> Number: ...
     @overload
-    def __add__(self, other: Expr) -> Expr: ...
+    def __add__(self, other: Expr | complex) -> Expr: ...
 
     @_sympifyit('other', NotImplemented)
     def __add__(self, other) -> Expr:
@@ -544,36 +544,6 @@ class Number(AtomicExpr):
     def __ne__(self, other):
         raise NotImplementedError('%s needs .__ne__() method' %
             (self.__class__.__name__))
-
-    def __lt__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
-            raise TypeError("Invalid comparison %s < %s" % (self, other))
-        raise NotImplementedError('%s needs .__lt__() method' %
-            (self.__class__.__name__))
-
-    def __le__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
-            raise TypeError("Invalid comparison %s <= %s" % (self, other))
-        raise NotImplementedError('%s needs .__le__() method' %
-            (self.__class__.__name__))
-
-    def __gt__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
-            raise TypeError("Invalid comparison %s > %s" % (self, other))
-        return _sympify(other).__lt__(self)
-
-    def __ge__(self, other):
-        try:
-            other = _sympify(other)
-        except SympifyError:
-            raise TypeError("Invalid comparison %s >= %s" % (self, other))
-        return _sympify(other).__le__(self)
 
     def __hash__(self):
         return super().__hash__()
@@ -1130,7 +1100,7 @@ class Float(Number):
                 re, im = _mpc_pow((mpfself, fzero), (expt, fzero), prec, rnd)
                 return Float._new(re, prec) + Float._new(im, prec)*S.ImaginaryUnit
 
-    def __abs__(self):
+    def __abs__(self) -> Float:
         return Float._new(_mpf_abs(self._mpf_), self._prec)
 
     def __int__(self):
@@ -1621,7 +1591,7 @@ class Rational(Number):
     def _mpmath_(self, prec, rnd):
         return _make_mpf(_from_rational(self.p, self.q, prec, rnd))
 
-    def __abs__(self):
+    def __abs__(self) -> Rational:
         return Rational(abs(self.p), self.q)
 
     def __int__(self):
@@ -1909,7 +1879,7 @@ class Integer(Rational):
     def __neg__(self):
         return Integer(-self.p)
 
-    def __abs__(self):
+    def __abs__(self) -> Integer:
         if self.p >= 0:
             return self
         else:
@@ -2864,7 +2834,7 @@ class Zero(IntegerConstant, metaclass=Singleton):
         return ()
 
     @staticmethod
-    def __abs__():
+    def __abs__() -> Zero:
         return S.Zero
 
     @staticmethod
@@ -2927,7 +2897,7 @@ class One(IntegerConstant, metaclass=Singleton):
         return ()
 
     @staticmethod
-    def __abs__():
+    def __abs__() -> One:
         return S.One
 
     @staticmethod
@@ -2983,7 +2953,7 @@ class NegativeOne(IntegerConstant, metaclass=Singleton):
         return ()
 
     @staticmethod
-    def __abs__():
+    def __abs__() -> One:
         return S.One
 
     @staticmethod
@@ -3041,7 +3011,7 @@ class Half(RationalConstant, metaclass=Singleton):
         return ()
 
     @staticmethod
-    def __abs__():
+    def __abs__() -> Half:
         return S.Half
 
 
@@ -3157,7 +3127,7 @@ class Infinity(Number, metaclass=Singleton):
             return S.NegativeInfinity
         return Number.__truediv__(self, other)
 
-    def __abs__(self):
+    def __abs__(self) -> Infinity:
         return S.Infinity
 
     def __neg__(self):
@@ -3212,11 +3182,6 @@ class Infinity(Number, metaclass=Singleton):
 
     def __ne__(self, other):
         return other is not S.Infinity and other != float('inf')
-
-    __gt__ = Expr.__gt__
-    __ge__ = Expr.__ge__
-    __lt__ = Expr.__lt__
-    __le__ = Expr.__le__
 
     @_sympifyit('other', NotImplemented)
     def __mod__(self, other):
@@ -3318,7 +3283,7 @@ class NegativeInfinity(Number, metaclass=Singleton):
             return S.Infinity
         return Number.__truediv__(self, other)
 
-    def __abs__(self):
+    def __abs__(self) -> Infinity:
         return S.Infinity
 
     def __neg__(self):
@@ -3378,11 +3343,6 @@ class NegativeInfinity(Number, metaclass=Singleton):
 
     def __ne__(self, other):
         return other is not S.NegativeInfinity and other != float('-inf')
-
-    __gt__ = Expr.__gt__
-    __ge__ = Expr.__ge__
-    __lt__ = Expr.__lt__
-    __le__ = Expr.__le__
 
     @_sympifyit('other', NotImplemented)
     def __mod__(self, other):
@@ -3511,12 +3471,6 @@ class NaN(Number, metaclass=Singleton):
     def __ne__(self, other):
         return other is not S.NaN
 
-    # Expr will _sympify and raise TypeError
-    __gt__ = Expr.__gt__
-    __ge__ = Expr.__ge__
-    __lt__ = Expr.__lt__
-    __le__ = Expr.__le__
-
 nan = S.NaN
 
 @dispatch(NaN, Expr) # type:ignore
@@ -3574,7 +3528,7 @@ class ComplexInfinity(AtomicExpr, metaclass=Singleton):
         return r"\tilde{\infty}"
 
     @staticmethod
-    def __abs__():
+    def __abs__() -> Infinity:
         return S.Infinity
 
     def floor(self):
@@ -3703,7 +3657,7 @@ class Exp1(NumberSymbol, metaclass=Singleton):
         return r"e"
 
     @staticmethod
-    def __abs__():
+    def __abs__() -> Exp1:
         return S.Exp1
 
     def __int__(self):
@@ -3866,7 +3820,7 @@ class Pi(NumberSymbol, metaclass=Singleton):
         return r"\pi"
 
     @staticmethod
-    def __abs__():
+    def __abs__() -> Pi:
         return S.Pi
 
     def __int__(self):
@@ -4180,7 +4134,7 @@ class ImaginaryUnit(AtomicExpr, metaclass=Singleton):
         return printer._settings['imaginary_unit_latex']
 
     @staticmethod
-    def __abs__():
+    def __abs__() -> One:
         return S.One
 
     def _eval_evalf(self, prec):

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from types import FunctionType
 

--- a/sympy/matrices/determinant.py
+++ b/sympy/matrices/determinant.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from types import FunctionType
 
@@ -57,7 +57,7 @@ def _find_reasonable_pivot(
     if all(isinstance(x, (Float, Integer)) for x in col) and any(
             isinstance(x, Float) for x in col):
         col_abs = [abs(x) for x in col]
-        max_value = max(col_abs)
+        max_value = max(col_abs) # type: ignore[type-var]
         if iszerofunc(max_value):
             # just because iszerofunc returned True, doesn't
             # mean the value is numerically zero.  Make sure

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -3041,10 +3041,10 @@ class MatrixBase(Printable):
     @overload
     def __mul__(self, other: MatrixBase) -> MatrixBase: ... # type: ignore
     @overload
-    def __mul__(self, other: Expr) -> MatrixBase: ...
+    def __mul__(self, other: SExpr) -> Self: ...
 
     @call_highest_priority('__rmul__')
-    def __mul__(self, other: MatrixBase | Expr) -> MatrixBase | Expr:
+    def __mul__(self, other: MatrixBase | SExpr) -> MatrixBase | Self:
         """Return self*other where other is either a scalar or a matrix
         of compatible dimensions.
 
@@ -3078,12 +3078,12 @@ class MatrixBase(Printable):
     @overload
     def multiply(self, other: MatrixBase, dotprodsimp: bool | None = None) -> MatrixBase: ... # type: ignore
     @overload
-    def multiply(self, other: Expr, dotprodsimp: bool | None = None) -> Expr: ...
+    def multiply(self, other: SExpr, dotprodsimp: bool | None = None) -> Self: ...
 
     def multiply(self,
-                 other: MatrixBase | Expr,
+                 other: MatrixBase | SExpr,
                  dotprodsimp: bool | None = None
-             ) -> MatrixBase | Expr:
+             ) -> MatrixBase | Self:
         """Same as __mul__() but with optional simplification.
 
         Parameters
@@ -3097,14 +3097,14 @@ class MatrixBase(Printable):
 
         isimpbool = _get_intermediate_simp_bool(False, dotprodsimp)
 
-        self, other, T = _unify_with_other(self, other)
+        self_mat, other, T = _unify_with_other(self, other)
 
         if isinstance(other, MatrixBase):
 
-            if self.shape[1] != other.shape[0]:
-                raise ShapeError(f"Matrix size mismatch: {self.shape} * {other.shape}.")
+            if self_mat.shape[1] != other.shape[0]:
+                raise ShapeError(f"Matrix size mismatch: {self_mat.shape} * {other.shape}.")
 
-            m = self._eval_matrix_mul(other)
+            m = self_mat._eval_matrix_mul(other)
 
             if isimpbool:
                 m = m._new(m.rows, m.cols, [_dotprodsimp(e) for e in m.flat()])
@@ -3264,11 +3264,21 @@ class MatrixBase(Printable):
 
         return self.__rmul__(other)
 
+    @overload
+    def __rmul__(self, other: MatrixBase) -> MatrixBase: ...
+    @overload
+    def __rmul__(self, other: SExpr) -> Self: ...
+
     @call_highest_priority('__mul__')
-    def __rmul__(self, other: MatrixBase | SExpr) -> MatrixBase:
+    def __rmul__(self, other: MatrixBase | SExpr) -> MatrixBase | Self:
         return self.rmultiply(other)
 
-    def rmultiply(self, other: MatrixBase | SExpr, dotprodsimp: bool | None = None) -> MatrixBase:
+    @overload
+    def rmultiply(self, other: MatrixBase, dotprodsimp: bool | None = None) -> MatrixBase: ...
+    @overload
+    def rmultiply(self, other: SExpr, dotprodsimp: bool | None = None) -> Self: ...
+
+    def rmultiply(self, other: MatrixBase | SExpr, dotprodsimp: bool | None = None) -> MatrixBase | Self:
         """Same as __rmul__() but with optional simplification.
 
         Parameters
@@ -3280,14 +3290,14 @@ class MatrixBase(Printable):
             speed up calculation. Default is off.
         """
         isimpbool = _get_intermediate_simp_bool(False, dotprodsimp)
-        self, other_mat, T = _unify_with_other(self, other)
+        self_mat, other_mat, T = _unify_with_other(self, other)
 
         if isinstance(other_mat, MatrixBase):
 
-            if self.shape[0] != other_mat.shape[1]:
+            if self_mat.shape[0] != other_mat.shape[1]:
                 raise ShapeError("Matrix size mismatch.")
 
-            m = self._eval_matrix_rmul(other_mat)
+            m = self_mat._eval_matrix_rmul(other_mat)
 
             if isimpbool:
                 return m._new(m.rows, m.cols, [_dotprodsimp(e) for e in m.flat()])

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -14,6 +14,7 @@ from .dimensions import Dimension
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from sympy.core.expr import Expr
     from sympy.physics.units.quantities import Quantity
 
 
@@ -29,7 +30,7 @@ class UnitSystem(_QuantityMapper):
 
     _unit_systems: dict[str, UnitSystem] = {}
 
-    def __init__(self, base_units, units=(), name="", descr="", dimension_system=None, derived_units: dict[Dimension, Quantity]={}):
+    def __init__(self, base_units, units=(), name="", descr="", dimension_system=None, derived_units: dict[Dimension, Expr]={}):
 
         UnitSystem._unit_systems[name] = self
 
@@ -61,7 +62,7 @@ class UnitSystem(_QuantityMapper):
     def __repr__(self):
         return '<UnitSystem: %s>' % repr(self._base_units)
 
-    def extend(self, base, units=(), name="", description="", dimension_system=None, derived_units: dict[Dimension, Quantity]={}):
+    def extend(self, base, units=(), name="", description="", dimension_system=None, derived_units: dict[Dimension, Expr]={}):
         """Extend the current system into a new one.
 
         Take the base and normal units of the current system to merge
@@ -126,7 +127,7 @@ class UnitSystem(_QuantityMapper):
         return self.get_dimension_system().is_consistent
 
     @property
-    def derived_units(self) -> dict[Dimension, Quantity]:
+    def derived_units(self) -> dict[Dimension, Expr]:
         return self._derived_units
 
     def get_dimensional_expr(self, expr):

--- a/sympy/polys/polyroots.py
+++ b/sympy/polys/polyroots.py
@@ -382,6 +382,7 @@ def roots_binomial(f: Poly) -> list[Expr]:
     sorted (but will be canonical).
     """
     n = f.degree()
+    assert isinstance(n, int)
 
     a, b = f.nth(n), f.nth(0)
     base = -cancel(b/a)


### PR DESCRIPTION
This commit makes it so that mypy can understand the type of e.g. x+1 where x is an Expr.

It also adds annotations for other Expr dunders and should broadly help basic type inference for user code.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

See gh-28806

#### Brief description of what is fixed or changed

Adds/improves annotations for Expr dunder methods like `__add__` and `__gt__` so that mypy is better at inferring the type of e.g. `x+1`.

These changes exposed problems in other places that needed to be fixed as well.

#### Other comments

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Improved type checker inference for arithmetic and relational operations with Expr and Number types.
<!-- END RELEASE NOTES -->
