### PR TITLE
Use linear_eq_to_matrix when forming the Lagrange equations where appropriate

### DIFF
--- a/doc/src/explanation/modules/physics/mechanics/lagrange.rst
+++ b/doc/src/explanation/modules/physics/mechanics/lagrange.rst
@@ -71,7 +71,7 @@ The complete equations of motion take the final form:
 
 .. math::
 
-   \mathbf{M}(\mathbf{q}, t) x = \mathbf{F}(\dot{\mathbf{q}}, \mathbf{q}, t)`
+   \mathbf{M}(\mathbf{q}, t) x = \mathbf{F}(\dot{\mathbf{q}}, \mathbf{q}, t)
 
 where:
 
@@ -215,4 +215,4 @@ This is shown below by modifying the example above::
   [2*q2'' + 4]])
 
 Exploration of the provided :ref:`examples <mechanics_tutorial>` is encouraged
-in order to gain more understanding of the ``LagrangesMethod`` class.
+in order to gain more understanding of the :py:class:`~.LagrangesMethod` class.

--- a/doc/src/explanation/modules/physics/mechanics/lagrange.rst
+++ b/doc/src/explanation/modules/physics/mechanics/lagrange.rst
@@ -2,137 +2,217 @@
 Lagrange's Method in Physics/Mechanics
 ======================================
 
-:mod:`sympy.physics.mechanics` provides functionality for deriving equations of motion
-using `Lagrange's method <https://en.wikipedia.org/wiki/Lagrangian_mechanics>`_.
-This document will describe Lagrange's method as used in this module, but not
-how the equations are actually derived.
+:mod:`sympy.physics.mechanics` provides functionality for deriving equations of
+motion using `Lagrange's method
+<https://en.wikipedia.org/wiki/Lagrangian_mechanics>`_. This page describes
+Lagrange's method as used in this module, but not how Lagrange's equations are
+derived.
 
 Structure of Equations
 ======================
 
-In :mod:`sympy.physics.mechanics` we are assuming there are 3 basic sets of equations needed
-to describe a system; the constraint equations, the time differentiated
-constraint equations and the dynamic equations.
+In :mod:`sympy.physics.mechanics` there are three sets of equations needed to
+describe a system: the holonomic constraint equations, the nonholonomic
+constraint equations and the dynamical differential equations.
+
+The :math:`M` holonomic constraints are:
 
 .. math::
-  \mathbf{m_{c}}(q, t) \dot{q} + \mathbf{f_{c}}(q, t) &= 0\\
-  \mathbf{m_{dc}}(\dot{q}, q, t) \ddot{q} + \mathbf{f_{dc}}(\dot{q}, q, t) &= 0\\
-  \mathbf{m_d}(\dot{q}, q, t) \ddot{q} + \mathbf{\Lambda_c}(q, t)
-  \lambda + \mathbf{f_d}(\dot{q}, q, t) &= 0\\
 
-In this module, the expressions formed by using Lagrange's equations of the
-second kind are rearranged into the following form:
+   \mathbf{f}_h(\mathbf{q}, t) = \mathbf{0}
 
- :math:`\mathbf{M}(q, t) x = \mathbf{f}(q, \dot{q}, t)`
-
-where in the case of a system without constraints:
-
- :math:`x = \ddot{q}`
-
-For a constrained system with `n` generalized speeds and `m` constraints, we
-will get n - m equations. The mass-matrix/forcing equations are then augmented
-in the following fashion:
+The :math:`m` nonholonomic constraints are:
 
 .. math::
-  x = \begin{bmatrix} \ddot{q} \\ \lambda \end{bmatrix} \\
-  \mathbf{M}(q, t) &= \begin{bmatrix} \mathbf{m_d}(q, t) &
-  \mathbf{\Lambda_c}(q, t) \end{bmatrix}\\
-  \mathbf{F}(\dot{q}, q, t) &= \begin{bmatrix} \mathbf{f_d}(q, \dot{q}, t)
-  \end{bmatrix}\\
 
+   \mathbf{m}_n(\mathbf{q}, t) \dot{\mathbf{q}} + \mathbf{f}_n(\mathbf{q}, t) = \mathbf{0}
+
+These can be combined into :math:`M + m` velocity constraints (time
+differentiated holonomic constraints with the nonholonomic constraints):
+
+.. math::
+
+   \dot{\mathbf{f}}_h(\mathbf{q}, t) =
+   \mathbf{m}_{hd} \dot{\mathbf{q}} +
+   \mathbf{f}_{hd} = \mathbf{0}
+
+.. math::
+
+   \begin{bmatrix}
+     \mathbf{m}_{hd} \\
+     \mathbf{m}_n
+   \end{bmatrix}
+   \dot{\mathbf{q}} +
+   \begin{bmatrix}
+     \mathbf{f}_{hd} \\
+     \mathbf{f}_n
+   \end{bmatrix} =
+   \mathbf{m}_v(\mathbf{q}, t) \dot{\mathbf{q}} + \mathbf{f}_v(\mathbf{q}, t) = 0
+
+Time differentiating the velocity constraints then gives the acceleration level
+constraints:
+
+.. math::
+
+   \mathbf{m}_v(\mathbf{q}, t)\ddot{\mathbf{q}} + \mathbf{f}_a(\dot{\mathbf{q}}, \mathbf{q}, t) = 0
+
+:math:`\mathbf{m}_v` is called "the Jacobian of the constraints" and can be
+used to augment Lagrange's :math:`n` dynamical differential equations with
+constraint forces:
+
+.. math::
+
+  \mathbf{m}_d(\mathbf{q}, t) \ddot{\mathbf{q}} + \mathbf{\Lambda}(\mathbf{q}, t) \mathbf{\lambda} + \mathbf{f}_d(\dot{\mathbf{q}}, \mathbf{q}, t) = 0
+
+where :math:`\mathbf{\Lambda}(\mathbf{q}, t) = \mathbf{m}_v^T` and :math:`\mathbf{\lambda}` are
+the :math:`M + m` unknown Lagrange multipliers.
+
+The complete equations of motion take the final form:
+
+.. math::
+
+   \mathbf{M}(\mathbf{q}, t) x = \mathbf{F}(\dot{\mathbf{q}}, \mathbf{q}, t)`
+
+where:
+
+.. math::
+
+   \mathbf{x} =
+   \begin{bmatrix}
+     \ddot{\mathbf{q}} \\
+     \mathbf{\lambda}
+   \end{bmatrix}
+
+For a constrained system with `n` generalized coordinates and `m + M`
+constraints, there are :math:`n` equations of the form:
+
+.. math::
+
+   \mathbf{M}(\mathbf{q}, t)\mathbf{x} =
+   \begin{bmatrix}
+     \mathbf{m}_d(\mathbf{q}, t) & \mathbf{\Lambda}(\mathbf{q}, t)
+   \end{bmatrix}\mathbf{x} =
+   -\mathbf{f}_d(\dot{\mathbf{q}}, \mathbf{q}, t) =
+   \mathbf{F}(\dot{\mathbf{q}}, \mathbf{q}, t)
 
 Lagrange's Method in Physics/Mechanics
 ======================================
 
-The formulation of the equations of motion in :mod:`sympy.physics.mechanics` using
-Lagrange's Method starts with the creation of generalized coordinates and a
-Lagrangian. The Lagrangian can either be created with the ``Lagrangian``
-function or can be a user supplied function. In this case we will supply the
-Lagrangian. ::
+The formulation of the equations of motion in :mod:`sympy.physics.mechanics`
+using Lagrange's Method starts with the creation of generalized coordinates and
+a Lagrangian. The Lagrangian can either be created with the
+:py:func:`~.Lagrangian` function or can be a user supplied expression. In this
+case we will supply the Lagrangian.::
 
-  >>> from sympy.physics.mechanics import *
+  >>> from sympy.physics.mechanics import (dynamicsymbols, LagrangesMethod,
+  ...     mechanics_printing)
   >>> q1, q2 = dynamicsymbols('q1 q2')
   >>> q1d, q2d = dynamicsymbols('q1 q2', 1)
-  >>> L = q1d**2 + q2d**2
+  >>> lagrangian = q1d**2 + q2d**2 - 3*q1 - 4*q2
 
 To formulate the equations of motion we create a ``LagrangesMethod``
 object. The Lagrangian and generalized coordinates need to be supplied upon
 initialization. ::
 
-  >>> LM = LagrangesMethod(L, [q1, q2])
+  >>> lm = LagrangesMethod(lagrangian, (q1, q2))
 
-With that the equations of motion can be formed. ::
+With that, the equations of motion can be formed::
 
   >>> mechanics_printing(pretty_print=False)
-  >>> LM.form_lagranges_equations()
+  >>> lm.form_lagranges_equations()
   Matrix([
-  [2*q1''],
-  [2*q2'']])
+  [2*q1'' + 3],
+  [2*q2'' + 4]])
 
-It is possible to obtain the mass matrix and the forcing vector. ::
+The mass matrix :math:`\mathbf{M}` and the forcing vector :math:`\mathbf{F}`
+are now accessible::
 
-  >>> LM.mass_matrix
+  >>> lm.mass_matrix
   Matrix([
   [2, 0],
   [0, 2]])
-
-  >>> LM.forcing
+  >>> lm.forcing
   Matrix([
-  [0],
-  [0]])
+  [-3],
+  [-4]])
 
 If there are any holonomic or non-holonomic constraints, they must be supplied
 as keyword arguments (``hol_coneqs`` and ``nonhol_coneqs`` respectively) in a
 list of expressions which are equal to zero. Modifying the example above, the
-equations of motion can then be generated: ::
+equations of motion can then be generated::
 
-  >>> LM = LagrangesMethod(L, [q1, q2], hol_coneqs=[q1 - q2])
+  >>> lm = LagrangesMethod(lagrangian, (q1, q2), hol_coneqs=[q1 - q2])
 
 When the equations of motion are generated in this case, the Lagrange
-multipliers are introduced; they are represented by ``lam1`` in this case. In
-general, there will be as many multipliers as there are constraint equations. ::
+multipliers are introduced; they are represented by ``lam1`` here. In general,
+there will be as many multipliers as there are constraint equations.
 
-  >>> LM.form_lagranges_equations()
+::
+
+  >>> lm.form_lagranges_equations()
   Matrix([
-  [ lam1 + 2*q1''],
-  [-lam1 + 2*q2'']])
+  [ lam1 + 2*q1'' + 3],
+  [-lam1 + 2*q2'' + 4]])
 
-Also in the case of systems with constraints, the 'full' mass matrix is
-augmented by the :math:`k_{dc}(q, t)` matrix, and the forcing vector by the
-:math:`f_{dc}(q, \dot{q}, t)` vector. The 'full' mass matrix is of size
-(2n + o) x (2n + o), i.e. it's a square matrix. ::
+The Lagrange multipliers :math:`\mathbf{\lambda}` are accessed with::
 
-  >>> LM.mass_matrix_full
+  >>> lm.lam_vec
+  Matrix([[lam1]])
+
+The :math:`-\mathbf{\Lambda}` matrix is accessed with::
+
+  >>> lm.lam_coeffs
+  Matrix([[-1, 1]])
+
+The augmented mass matrix :math:`\left[ \mathbf{m}_d \quad
+-\mathbf{\Lambda}\right]` is then::
+
+  >>> lm.mass_matrix
+  Matrix([
+  [2, 0, -1],
+  [0, 2,  1]])
+  >>> lm.forcing
+  Matrix([
+  [-3],
+  [-4]])
+
+In the case of systems with constraints, the 'full' mass matrix includes the
+kinematical differential equations. The 'full' mass matrix is of size (2n + M +
+m) x (2n + M + m), i.e. it's a square matrix. ::
+
+  >>> lm.mass_matrix_full
   Matrix([
   [1, 0, 0,  0,  0],
   [0, 1, 0,  0,  0],
   [0, 0, 2,  0, -1],
   [0, 0, 0,  2,  1],
   [0, 0, 1, -1,  0]])
-  >>> LM.forcing_full
+  >>> lm.forcing_full
   Matrix([
   [q1'],
   [q2'],
-  [  0],
-  [  0],
+  [ -3],
+  [ -4],
   [  0]])
 
-If there are any non-conservative forces or moments acting on the system,
-they must also be supplied as keyword arguments in a list of 2-tuples of the
-form ``(Point, Vector)`` or ``(ReferenceFrame, Vector)`` where the ``Vector``
-represents the non-conservative forces and torques. Along with this 2-tuple,
-the inertial frame must also be specified as a keyword argument. This is shown
-below by modifying the example above: ::
+If there are any non-conservative forces or moments acting on the system, they
+must also be supplied as keyword arguments in a list of 2-tuples of the form
+(:py:obj:`~.vector.point.Point`, :py:obj:`~.physics.vector.vector.Vector`) or
+(:py:obj:`~.ReferenceFrame`, :py:obj:`~.physics.vector.vector.Vector`) where
+the ``Vector`` represents the non-conservative forces and torques. Along with
+this 2-tuple, the inertial frame must also be specified as a keyword argument.
+This is shown below by modifying the example above::
 
+  >>> from sympy.physics.mechanics import ReferenceFrame, Point
   >>> N = ReferenceFrame('N')
   >>> P = Point('P')
-  >>> P.set_vel(N, q1d * N.x)
-  >>> FL = [(P, 7 * N.x)]
-  >>> LM = LagrangesMethod(L, [q1, q2], forcelist=FL, frame=N)
-  >>> LM.form_lagranges_equations()
+  >>> P.set_vel(N, q1d*N.x)
+  >>> loads = [(P, 7*N.x)]
+  >>> lm = LagrangesMethod(lagrangian, (q1, q2), forcelist=loads, frame=N)
+  >>> lm.form_lagranges_equations()
   Matrix([
-  [2*q1'' - 7],
-  [    2*q2'']])
+  [2*q1'' - 4],
+  [2*q2'' + 4]])
 
-Exploration of the provided examples is encouraged in order to gain more
-understanding of the ``LagrangesMethod`` object.
+Exploration of the provided :ref:`examples <mechanics_tutorial>` is encouraged
+in order to gain more understanding of the ``LagrangesMethod`` class.

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -8,6 +8,7 @@ from sympy.physics.mechanics.functions import (
 from sympy.physics.mechanics.linearize import Linearizer
 from sympy.utilities.iterables import iterable
 from sympy.utilities.exceptions import sympy_deprecation_warning
+from sympy.solvers.solveset import linear_eq_to_matrix
 
 __all__ = ['LagrangesMethod']
 
@@ -65,7 +66,7 @@ class LagrangesMethod(MethodBase):
         Velocity constraints [time differentiated holonomic, nonholonomic].
     lam_vec : Matrix, shape(m + M, 1)
         Column matrix of functions of time representing the Lagrange
-        multipliers λ , one for each constraint in ``velocity_constraints``.
+        multipliers λ, one for each constraint in ``velocity_constraints``.
     lam_coeffs : Matrix, shape(m + M, n)
         Jacobian of the constraints, i.e. linear coefficients of the speeds in
         the velocity constraints.
@@ -229,12 +230,38 @@ class LagrangesMethod(MethodBase):
         self._nonhol_coneqs = nonhol_coneqs
 
     def form_lagranges_equations(self):
-        """Method to form Lagrange's equations of motion.
+        """Returns a column matrix containing Lagrange's equations of motion as
+        coupled second order ordinary differential equations. If there are
+        holonomic or nonholonomic constraints the generalized constraint forces
+        that are linear functions of the Lagrange multipliers are included.
 
-        Returns a vector of equations of motion using Lagrange's equations of
-        the second kind.
+        Explanation
+        ===========
+
+        Given the ``n`` generalized coordinates ``q``, specified functions of
+        time ``r``, and the ``m`` Lagrange multipliers ``λ`` the equations of
+        motion will be one of the following forms.
+
+        Without holonomic or nonholonomic constraints:
+
+        .. code:: text
+
+            fd(q'', q', q, r, t) = Md*q'' + gd(q', q, r, t) =  0
+
+        With holonomic or nonholonomic constraints:
+
+        .. code:: text
+
+            fd(q'', λ, q', q, r, t) = Md*q'' + CT*λ + gd(q', q, r, t) = 0
+
+        ``CT`` is the transpose of the Jacobian of the constraints from the
+        velocity constraints:
+
+        .. code:: text
+
+            fv(q', q, t) = C*q' + gv(q, t) = 0
+
         """
-
         qds = self._qdots
         qdd_zero = dict.fromkeys(self._qdoubledots, 0)
         n = len(self.q)
@@ -243,8 +270,7 @@ class LagrangesMethod(MethodBase):
         # EOM = term1 - term2 - term3 - term4 = 0
 
         # First term
-        self._term1 = self._L.jacobian(qds)
-        self._term1 = self._term1.diff(dynamicsymbols._t).T
+        self._term1 = self._L.jacobian(qds).diff(dynamicsymbols._t).T
 
         # Second term
         self._term2 = self._L.jacobian(self.q).T
@@ -255,16 +281,20 @@ class LagrangesMethod(MethodBase):
             m = len(coneqs)
             # Creating the multipliers
             self.lam_vec = Matrix(dynamicsymbols('lam1:' + str(m + 1)))
-            # TODO : Use linear_eq_to_matrix here, less costly. coneques are
-            # already at velocity level.
-            self.lam_coeffs = -coneqs.jacobian(qds)
+            # NOTE : It is odd that the negative of the Jacobian of the
+            # constraints is stored and then below - self._term3 is used. It
+            # would make more sense to store the positive value and add the
+            # term3.
+            self.lam_coeffs = linear_eq_to_matrix(-coneqs, qds[:])[0]
             self._term3 = self.lam_coeffs.T * self.lam_vec
-            # Extracting the coeffecients of the qdds from the diff coneqs
-            diffconeqs = coneqs.diff(dynamicsymbols._t)
-            # TODO : _m_cd should be equal to lam_coeffs, no need to take the
-            # Jacobian again.
-            self._m_cd = diffconeqs.jacobian(self._qdoubledots)
+            # Extracting the coeffecients of the qdds from the diff coneqs,
+            # which, due to the chain rule, is the same as the constraints
+            # Jacobian.
+            # Mcd*q'' = f_cd = -(-C.T)*q'' = C.T*q''
+            self._m_cd = -self.lam_coeffs
             # The remaining terms i.e. the 'forcing' terms in diff coneqs
+            diffconeqs = coneqs.diff(dynamicsymbols._t)
+            self._diffconeqs = diffconeqs
             self._f_cd = -diffconeqs.subs(qdd_zero)
         else:
             self._term3 = zeros(n, 1)
@@ -281,11 +311,12 @@ class LagrangesMethod(MethodBase):
 
         # Form the dynamic mass and forcing matrices
         without_lam = self._term1 - self._term2 - self._term4
-        # TODO : Use linear_eq_to_matrix here.
-        self._m_d = without_lam.jacobian(self._qdoubledots)
-        self._f_d = -without_lam.subs(qdd_zero)
+        # Md*q'' = Fd
+        self._m_d, self._f_d = linear_eq_to_matrix(without_lam,
+                                                   self._qdoubledots[:])
 
         # Form the EOM
+        # Md*q'' + gd(q', q, r, t) - (-C.T*λ)
         self.eom = without_lam - self._term3
         return self.eom
 
@@ -294,51 +325,97 @@ class LagrangesMethod(MethodBase):
 
     @property
     def mass_matrix(self):
-        """Returns the mass matrix, which is augmented by the Lagrange
-        multipliers, if necessary.
+        """Mass matrix of the second order equations of motion which is
+        augmented by the transpose of the Jacobian of the constraints if the
+        system has holonomic or nonholonomic constraints.
 
         Explanation
         ===========
 
-        If the system is described by 'n' generalized coordinates and there are
-        no constraint equations then an n X n matrix is returned.
+        Given the ``n`` second order equations of motion:
 
-        If there are 'n' generalized coordinates and 'm' constraint equations
-        have been supplied during initialization then an n X (n+m) matrix is
-        returned. The (n + m - 1)th and (n + m)th columns contain the
-        coefficients of the Lagrange multipliers.
+        .. code:: text
+
+            fd(q'', λ, q', q, r, t) = Md*q'' + CT*λ + gd(q', q, r, t) = 0
+
+        The n x n mass matrix ``Md`` is returned if there are no constraints
+        and the n x (n + m) augmented mass matrix ``[Md -CT]`` is returned if
+        there are constraints.
+
         """
-
         if self.eom is None:
             raise ValueError('Need to compute the equations of motion first')
         if self.coneqs:
+            # TODO : This seems possibly incorrect because lam_coeffs = -C.T.
+            # [Md -C.T]
             return (self._m_d).row_join(self.lam_coeffs.T)
         else:
             return self._m_d
 
     @property
     def mass_matrix_full(self):
-        """Augments the coefficients of qdots to the mass_matrix."""
+        """Mass matrix ``M`` of the first order form of the equations of
+        motion. Augmented with the time differentiated constraints and
+        constraint forces if the system has constraints.
 
+        Explanation
+        ===========
+
+        Without holonomic or nonholonomic constraints:
+
+        .. code:: text
+
+            M[q' ] = [I  0 ][q' ] = [q'] = F
+             [q'']   [0  Md][q'']   [Fd]
+
+        With holonomic or nonholonomic constraints:
+
+        .. code:: text
+
+            M[q' ] = [I  0   0 ][q' ] = [q'] = F
+             [q'']   [0  Md -CT][q'']   [Fd]
+             [λ  ]   [0  C   0 ][λ  ]   [Fc]
+
+        """
         if self.eom is None:
             raise ValueError('Need to compute the equations of motion first')
         n = len(self.q)
         m = len(self.coneqs)
         row1 = eye(n).row_join(zeros(n, n + m)) # [I 0] or [I 0 0]
-        row2 = zeros(n, n).row_join(self.mass_matrix) # [0 M] or [0 M C.T]
+        row2 = zeros(n, n).row_join(self.mass_matrix) # [0 M] or [0 M -C.T]
         if self.coneqs:
             # [0 C 0]
             row3 = zeros(m, n).row_join(self._m_cd).row_join(zeros(m, m))
-            # [I 0 0  ]
-            # [0 M C.T]
-            # [0 C 0]
+            # [I  0  0  ]
+            # [0  M -C.T]
+            # [0  C  0  ]
             return row1.col_join(row2).col_join(row3)
         else:
             return row1.col_join(row2)
 
     @property
     def forcing(self):
-        """Returns the forcing vector from 'lagranges_equations' method."""
+        """Forcing vector ``F`` of the second order equations of motion.
+
+        Explanation
+        ===========
+
+        Given the ``n`` second order equations of motion:
+
+        .. code:: text
+
+            f(q'', q', q, r, t) = Md*q'' + gd(q', q, r, t) = 0
+
+        rewritten as:
+
+        .. code:: text
+
+            Md*q'' = -gd(q', q, r, t) = F
+
+        ``F`` of ``shape(n, 1)`` is returned. This is the same regardless is
+        the system has constraints.
+
+        """
 
         if self.eom is None:
             raise ValueError('Need to compute the equations of motion first')
@@ -346,8 +423,29 @@ class LagrangesMethod(MethodBase):
 
     @property
     def forcing_full(self):
-        """Augments qdots to the forcing vector above."""
+        """Forcing vector ``F`` of the first order equations of motion.
+        Augmented with the time differentiated constraints if the system has
+        constraints.
 
+        Explanation
+        ===========
+
+        Without holonomic or nonholonomic constraints:
+
+        .. code:: text
+
+            M[q' ] = [I  0 ][q' ] = [q'] = F
+             [q'']   [0  Md][q'']   [Fd]
+
+        With holonomic or nonholonomic constraints:
+
+        .. code:: text
+
+            M[q' ] = [I  0   0 ][q' ] = [q'] = F
+             [q'']   [0  Md -CT][q'']   [Fd]
+             [λ  ]   [0  C   0 ][λ  ]   [Fc]
+
+        """
         if self.eom is None:
             raise ValueError('Need to compute the equations of motion first')
         if self.coneqs:
@@ -580,7 +678,10 @@ class LagrangesMethod(MethodBase):
     @property
     def acceleration_constraints(self):
         """Column matrix of acceleration constraint residuals."""
-        return self.velocity_constraints.diff(dynamicsymbols._t)
+        if hasattr(self, '_diffconeqs'):
+            return self._diffconeqs
+        else:
+            return self.velocity_constraints.diff(dynamicsymbols._t)
 
     def constraints_jacobian(self):
         """Jacobian of the constraints. A matrix of shape(M + m, n) which are

--- a/sympy/physics/mechanics/tests/test_lagrange.py
+++ b/sympy/physics/mechanics/tests/test_lagrange.py
@@ -6,9 +6,10 @@ from sympy.core.function import (Derivative, Function)
 from sympy.core.numbers import pi
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.trigonometric import (cos, sin, tan)
-from sympy.matrices.dense import Matrix
-from sympy.simplify.simplify import simplify
+from sympy.matrices.dense import Matrix, zeros
+from sympy.simplify.simplify import simplify, trigsimp
 from sympy.testing.pytest import raises, warns_deprecated_sympy
+from sympy.solvers.solveset import linear_eq_to_matrix
 
 
 def test_invalid_coordinates():
@@ -264,9 +265,16 @@ def test_rolling_disc():
     l = LagrangesMethod(Lag, q, nonhol_coneqs=nonholonomic)
     assert l.nonholonomic_constraints == Matrix(nonholonomic)
     assert l.velocity_constraints == Matrix(nonholonomic)
-    l.form_lagranges_equations()
+    eom = l.form_lagranges_equations()
+    x = Matrix(q).diff(t, 2).col_join(l.lam_vec)
     assert l.mass_matrix.shape == (3, 5)
-    assert l.mass_matrix == Matrix([
+    exp_mass_matrix, exp_forcing = linear_eq_to_matrix(eom, x[:])
+    # TODO : The following line fails because Lagrange's method uses the
+    # negative of the transpose of the Jacobian of the constraints.
+    # assert trigsimp(l.mass_matrix - exp_mass_matrix) == zeros(3, 5)
+    assert trigsimp(l.forcing - exp_forcing) == zeros(3, 1)
+    exp_mass_matrix = Matrix([
         [3*m*r**2*sin(q2(t))**2/2 + m*r**2*cos(q2(t))**2/4,          0, 3*m*r**2*sin(q2(t))/2, r*sin(q2(t)),             0],
         [                                                0, 5*m*r**2/4,                     0,            0, -r*cos(q2(t))],
         [                            3*m*r**2*sin(q2(t))/2,          0,            3*m*r**2/2,            r,             0]])
+    assert trigsimp(l.mass_matrix - exp_mass_matrix) == zeros(3, 5)

--- a/sympy/polys/matrices/linsolve.py
+++ b/sympy/polys/matrices/linsolve.py
@@ -224,7 +224,11 @@ def _lin_eq2dict(a, symset):
             return coeff, {}
         else:
             terms = {sym: coeff * c for sym, c in terms.items()}
-            return  coeff * terms_coeff, terms
+            if terms_coeff is S.Zero:
+                return S.Zero, terms
+            else:
+                coeff = Mul._from_args(coeff_list)
+                return  coeff * terms_coeff, terms
     elif not a.has_xfree(symset):
         return a, {}
     else:


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

#29815 should be merged before this PR

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

- Switched two instances of .jacobian to linear_eq_to_matrix in forming Lagranges equations.
- Removed one unnecessary call to .jacobian (due to product rule).
- Improved the docstrings of the equations of motion attributes by adding equation explanations and using common terminology.
- I also discovered a likely bug that gives negatives of the Lagrange multipliers. I'll leave this for now and address that in another PR.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.mechanics
  * Improved the computational efficiency of forming the equations of motion in `LagrangesMethod`.
* polys
  * Improve computational efficiency of zero terms in _lin_eq2dict and thus linear_eq_to_matrix.

<!-- END RELEASE NOTES -->
