### PR TITLE
doc(printing): add class docstrings to llvmjitcode module

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1610,6 +1610,7 @@ Sunny Aggarwal <sunnyaggarwal1994@gmail.com>
 Supreet Agrawal <supreet11agrawal@gmail.com> stm <supreet11agrawal@gmail.com>
 Suraj Channappanavar <surajchannappanavar@gmail.com> Suraj Channappanavar <145254642+suraj5030@users.noreply.github.com>
 Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
+Suraj Singh Shekhawat <ss2580@srmist.edu.in> surajsinghshekhawat <ss2580@srmist.edu.in>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
 Susumu Ishizuka <susumu.ishizuka@kii.com>

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -35,7 +35,24 @@ __doctest_requires__ = {('llvm_callable'): ['llvmlite']}
 
 
 class LLVMJitPrinter(Printer):
-    '''Convert expressions to LLVM IR'''
+    """
+    Convert SymPy expressions to LLVM IR using an llvmlite IR builder.
+
+    This printer is used internally by :class:`LLVMJitCode` when compiling
+    expressions to native code. See :func:`llvm_callable` for the public API.
+
+    Parameters
+    ==========
+
+    module : llvmlite.ir.Module
+        LLVM module that will contain the generated function.
+    builder : llvmlite.ir.IRBuilder
+        Builder used to emit instructions in the current basic block.
+    fn : llvmlite.ir.Function
+        LLVM function being constructed.
+    func_arg_map : dict
+        Mapping from SymPy symbols (or indexed bases) to LLVM values.
+    """
     def __init__(self, module, builder, fn, *args, **kwargs):
         self.func_arg_map = kwargs.pop("func_arg_map", {})
         if not llvmlite:
@@ -122,6 +139,12 @@ class LLVMJitPrinter(Printer):
 # Used when parameters are passed by array.  Often used in callbacks to
 # handle a variable number of parameters.
 class LLVMJitCallbackPrinter(LLVMJitPrinter):
+    """
+    LLVM printer for callback signatures that pass vector arguments.
+
+    This subclass is used by :class:`LLVMJitCodeCallback` when compiling
+    functions for numerical libraries (for example ``scipy.integrate``).
+    """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -158,6 +181,12 @@ current_link_suffix = 0
 
 
 class LLVMJitCode:
+    """
+    Compile a SymPy expression to a native function via LLVM.
+
+    Instances are created internally during JIT compilation and are not part
+    of the public API. Use :func:`llvm_callable` instead.
+    """
     def __init__(self, signature):
         self.signature = signature
         self.fp_type = ll.DoubleType()
@@ -306,6 +335,12 @@ class LLVMJitCode:
 
 
 class LLVMJitCodeCallback(LLVMJitCode):
+    """
+    LLVM JIT compiler for callback-style function signatures.
+
+    This variant uses :class:`LLVMJitCallbackPrinter` so that integration
+    callbacks can receive array arguments.
+    """
     def __init__(self, signature):
         super().__init__(signature)
 
@@ -344,6 +379,22 @@ class LLVMJitCodeCallback(LLVMJitCode):
 
 
 class CodeSignature:
+    """
+    Ctypes signature description for a JIT-compiled function.
+
+    Attributes
+    ==========
+
+    ret_type : ctypes type
+        Return type of the compiled function.
+    arg_ctypes : list
+        Ctypes types of the formal arguments.
+    input_arg : int
+        Index of the array argument for callback signatures.
+    ret_arg : int or None
+        Index of the output array when the return value is written via a
+        parameter instead of the function return value.
+    """
     def __init__(self, ret_type):
         self.ret_type = ret_type
         self.arg_ctypes = []


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Partially fixes #28470

#### Brief description of what is fixed or changed

The Sphinx docs already include `sympy.printing.llvmjitcode` via `automodule` in `doc/src/modules/printing.rst`, but several classes had no class-level docstrings. I added docstrings for `LLVMJitPrinter`, `LLVMJitCallbackPrinter`, `LLVMJitCode`, `LLVMJitCodeCallback`, and `CodeSignature` so they show up under `:members:` in the generated docs. No runtime logic was changed.

#### Other comments

I read the existing `llvm_callable` docstring and the LLVM JIT tests to understand how these classes fit together. Happy to shorten or reword any docstring if it does not match SymPy style.

#### AI Generation Disclosure

I used Cursor (LLM assistant) to help draft the initial docstring text and set up the local dev environment. I reviewed and edited the docstrings before committing. The added text is only the new triple-quoted docstrings on the five classes listed above in `sympy/printing/llvmjitcode.py` (no other lines were generated).

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* printing
  * Added class docstrings to `sympy.printing.llvmjitcode` for Sphinx documentation.

<!-- END RELEASE NOTES -->