### PR TITLE
stats: Add finite mixture distributions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1634,6 +1634,8 @@ Thomas Hunt <thomashunt13@gmail.com> <twhunt@users.noreply.github.com>
 Thomas Sidoti <TSidoti@gmail.com>
 Thomas Wiecki <thomas.wiecki@gmail.com> <thomas.wieki@gmail.com>
 Thomas Wiecki <thomas.wiecki@gmail.com> <whyking@Lateralus.(none)>
+Tiago Pinto <tiagobfpinto@tecnico.ulisboa.pt>
+Tiago Pinto <tiagobfpinto@tecnico.ulisboa.pt> Tiago Pinto <67421012+tiagobfpinto@users.noreply.github.com>
 Tien Nguyen <viettien23102006@gmail.com> <95487001+tiennguyen2310@users.noreply.github.com>
 Tiffany Zhu <bubble.wubble.303@gmail.com>
 Tilo Reneau-Cardoso <tiloreneau@gmail.com> Tilo Reneau-Cardoso <67246777+TiloRC@users.noreply.github.com>

--- a/doc/src/modules/stats.rst
+++ b/doc/src/modules/stats.rst
@@ -127,6 +127,11 @@ Compound Distribution
 .. autoclass:: sympy.stats.compound_rv.CompoundDistribution
    :members:
 
+Mixture Distribution
+--------------------
+.. autofunction:: Mixture
+.. autofunction:: GaussianMixture
+
 Interface
 ^^^^^^^^^
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1202,6 +1202,22 @@ def test_sympy__stats__compound_rv__CompoundPSpace():
     assert _test_args(CompoundPSpace('C', C))
 
 
+def test_sympy__stats__mixture_rv__MixtureDistribution():
+    from sympy.stats.mixture_rv import MixtureDistribution
+    from sympy.stats.crv_types import NormalDistribution
+    M = MixtureDistribution([1, 1],
+                            [NormalDistribution(0, 1), NormalDistribution(5, 1)])
+    assert _test_args(M)
+
+
+def test_sympy__stats__mixture_rv__MixturePSpace():
+    from sympy.stats.mixture_rv import MixtureDistribution, MixturePSpace
+    from sympy.stats.crv_types import NormalDistribution
+    M = MixtureDistribution([1, 1],
+                            [NormalDistribution(0, 1), NormalDistribution(5, 1)])
+    assert _test_args(MixturePSpace('M', M))
+
+
 @SKIP("abstract class")
 def test_sympy__stats__drv__SingleDiscreteDistribution():
     pass

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -126,6 +126,8 @@ __all__ = [
     'FlorySchulz', 'Geometric','Hermite', 'Logarithmic', 'NegativeBinomial', 'Poisson', 'Skellam',
     'YuleSimon', 'Zeta', 'DiscreteRV', 'DiscreteDistributionHandmade',
 
+    'Mixture', 'MixtureDistribution', 'GaussianMixture',
+
     'JointRV', 'Dirichlet', 'GeneralizedMultivariateLogGamma',
     'GeneralizedMultivariateLogGammaOmega', 'Multinomial', 'MultivariateBeta',
     'MultivariateEwens', 'MultivariateT', 'NegativeMultinomial',
@@ -175,6 +177,8 @@ from .crv_types import (ContinuousRV, Arcsin, Benini, Beta, BetaNoncentral,
 
 from .drv_types import (FlorySchulz, Geometric, Hermite, Logarithmic, NegativeBinomial, Poisson,
         Skellam, YuleSimon, Zeta, DiscreteRV, DiscreteDistributionHandmade)
+
+from .mixture_rv import Mixture, MixtureDistribution, GaussianMixture
 
 from .joint_rv_types import (JointRV, Dirichlet,
         GeneralizedMultivariateLogGamma, GeneralizedMultivariateLogGammaOmega,

--- a/sympy/stats/mixture_rv.py
+++ b/sympy/stats/mixture_rv.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+from sympy.core.add import Add
+from sympy.core.basic import Basic
+from sympy.core.containers import Tuple
+from sympy.core.function import Lambda
+from sympy.core.singleton import S
+from sympy.core.sympify import sympify
+from sympy.sets.sets import Union
+from sympy.core.symbol import Dummy
+from sympy.stats.rv import (Distribution, NamedArgsMixin, RandomSymbol,
+                            _symbol_converter, _value_check, PSpace)
+from sympy.stats.crv import ContinuousDistribution, SingleContinuousPSpace
+from sympy.stats.drv import DiscreteDistribution, SingleDiscretePSpace
+from sympy.stats.frv import SingleFiniteDistribution, SingleFinitePSpace
+from sympy.stats.crv_types import (ContinuousDistributionHandmade,
+                                   NormalDistribution)
+from sympy.stats.drv_types import DiscreteDistributionHandmade
+from sympy.stats.frv_types import FiniteDistributionHandmade
+
+
+class MixturePSpace(PSpace):
+    """
+    A probability space for a Mixture Distribution. Builds a handmade
+    single-kind probability space from the weighted component densities and
+    delegates the actual computations to it.
+    """
+    def __new__(cls, s, distribution):
+        s = _symbol_converter(s)
+        if not isinstance(distribution, MixtureDistribution):
+            raise ValueError("%s should be an instance of MixtureDistribution" % distribution)
+        return Basic.__new__(cls,s,distribution)
+
+    @property
+    def value(self):
+        return RandomSymbol(self.symbol, self)
+
+    @property
+    def symbol(self):
+        return self.args[0]
+
+    @property
+    def is_Continuous(self):
+        return self.distribution.is_Continuous
+
+    @property
+    def is_Finite(self):
+        return self.distribution.is_Finite
+
+    @property
+    def is_Discrete(self):
+        return self.distribution.is_Discrete
+
+    @property
+    def distribution(self):
+        return self.args[1]
+
+    @property
+    def pdf(self):
+        return self.distribution.pdf(self.symbol)
+
+    @property
+    def set(self):
+        return self.distribution.set
+
+    @property
+    def domain(self):
+        return self._get_newpspace().domain
+
+    def _get_newpspace(self):
+        x = Dummy('x')
+        dist = self.distribution
+
+        if dist.is_Continuous:
+            pdf = Lambda(x, dist.pdf(x))
+            return SingleContinuousPSpace(self.symbol,
+                                          ContinuousDistributionHandmade(pdf, dist.set))
+
+        if dist.is_Discrete:
+            pdf = Lambda(x,dist.pdf(x))
+            return SingleDiscretePSpace(self.symbol,
+                                        DiscreteDistributionHandmade(pdf, dist.set))
+
+        if dist.is_Finite:
+            dens = {k: dist.pdf(k) for k in dist.set}
+            return SingleFinitePSpace(self.symbol,
+                                      FiniteDistributionHandmade(dens))
+
+        raise NotImplementedError("Mixture pspace is not implemented for "
+            "this distribution kind.")
+
+    def _component_pspaces(self):
+        pspaces = []
+        for comp in self.distribution.components:
+            if isinstance(comp, ContinuousDistribution):
+                ps = SingleContinuousPSpace(self.symbol, comp)
+            elif isinstance(comp, DiscreteDistribution):
+                ps = SingleDiscretePSpace(self.symbol, comp)
+            else:
+                ps = SingleFinitePSpace(self.symbol, comp)
+            pspaces.append(ps)
+        return pspaces
+
+    def compute_density(self, expr, **kwargs):
+        new_pspace = self._get_newpspace()
+        expr = expr.subs({self.value: new_pspace.value})
+        return new_pspace.compute_density(expr, **kwargs)
+
+    def compute_cdf(self, expr, **kwargs):
+        dist = self.distribution
+        # Continuous/discrete CDFs are the weighted sum of the component CDFs
+        # (linearity). Integrating the combined PDF instead can introduce a
+        # removable 0/0 singularity at a component's mean, so use the
+        # distribution's own cdf here. Finite mixtures have no component cdf,
+        # so they fall back to the handmade probability space.
+        if expr == self.value and not dist.is_Finite:
+            x = Dummy('x')
+            return Lambda(x, dist.cdf(x))
+        new_pspace = self._get_newpspace()
+        expr = expr.subs({self.value: new_pspace.value})
+        return new_pspace.compute_cdf(expr, **kwargs)
+
+    def compute_expectation(self, expr, rvs=None, evaluate=False, **kwargs):
+        # Linearity over components: E[g(M)] = sum_i w_i E[g(X_i)]. Integrating
+        # the combined PDF over a union support (disjoint components) fails, so
+        # delegate to each component's own probability space and weight.
+        total = S.Zero
+        for w, ps in zip(self.distribution.weights, self._component_pspaces()):
+            e = expr.subs({self.value: ps.value})
+            total += w*ps.compute_expectation(e, evaluate=evaluate, **kwargs)
+        return total
+
+    def probability(self, condition, **kwargs):
+        # Same linearity argument: P(g(M)) = sum_i w_i P(g(X_i)).
+        total = S.Zero
+        for w, ps in zip(self.distribution.weights, self._component_pspaces()):
+            cond = condition.subs({self.value: ps.value})
+            total += w*ps.probability(cond)
+        return total
+
+    def compute_characteristic_function(self, expr, **kwargs):
+        # Linearity: CF_M(t) = sum_i w_i * CF_{X_i}(t).  Each component pspace
+        # returns a Lambda; evaluate them at a shared dummy and wrap the
+        # weighted sum back into a Lambda so the result is callable.
+        t = Dummy('t', real=True)
+        total = S.Zero
+        for w, ps in zip(self.distribution.weights, self._component_pspaces()):
+            e = expr.subs({self.value: ps.value})
+            total += w*ps.compute_characteristic_function(e, **kwargs)(t)
+        return Lambda(t, total)
+
+    def compute_moment_generating_function(self, expr, **kwargs):
+        # Same linearity argument for the MGF.
+        t = Dummy('t', real=True)
+        total = S.Zero
+        for w, ps in zip(self.distribution.weights, self._component_pspaces()):
+            e = expr.subs({self.value: ps.value})
+            total += w*ps.compute_moment_generating_function(e, **kwargs)(t)
+        return Lambda(t, total)
+
+    def sample(self, size=(), library='scipy', seed=None):
+
+        import numpy
+        if any(w.free_symbols for w in self.distribution.weights):
+            raise ValueError("Cannot sample a mixture with symbolic weights.")
+        if seed is None or isinstance(seed, int):
+            rand_state = numpy.random.default_rng(seed=seed)
+        else:
+            rand_state = seed
+        weights = [float(w) for w in self.distribution.weights]
+        pspaces = self._component_pspaces()
+        idx = rand_state.choice(len(pspaces), size=size, p=weights)
+        # Draw every component at the requested size, threading the same
+        # generator, then select element-wise by the chosen component index.
+        draws = [list(ps.sample(size=size, library=library,
+                                seed=rand_state).values())[0]
+                 for ps in pspaces]
+        stacked = numpy.stack(draws)
+        result = numpy.take_along_axis(
+            stacked, numpy.asarray(idx)[numpy.newaxis], axis=0)[0]
+        return {self.value: result}
+
+    def conditional_space(self, condition, **kwargs):
+        new_pspace = self._get_newpspace()
+        condition = condition.subs({self.value: new_pspace.value})
+        return new_pspace.conditional_space(condition)
+
+
+class MixtureDistribution(Distribution, NamedArgsMixin):
+    """
+    Class for finite Mixture Distributions.
+
+    Parameters
+    ==========
+
+    weights : list of Expr
+        The mixing weights, one per component. Must be non-negative; they are
+        normalised to sum to one.
+    components : list of Distribution
+        The component distributions being mixed. They must all be of the same
+        kind (all continuous, all discrete, or all finite).
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Mixture_distribution
+
+
+    """
+
+    _argnames = ('weights', 'components')
+
+    def __new__(cls, weights, components):
+        weights = [sympify(w) for w in weights]
+        components = list(components)
+
+        # one weight per component, and at least one component
+        if len(weights) != len(components):
+            raise ValueError("Got %d weights but %d components; they must "
+                "match." % (len(weights), len(components)))
+        if len(components) == 0:
+            raise ValueError("A mixture needs at least one component.")
+
+        # only the three univariate distribution kinds are supported
+        for c in components:
+            if not isinstance(c, (ContinuousDistribution, DiscreteDistribution,
+                    SingleFiniteDistribution)):
+                raise ValueError("Mixture component %s is not a supported "
+                    "distribution." % c)
+
+        # components must be homogeneous (all the same kind); supports are
+        # combined as a union, so they need not coincide
+        kinds = (ContinuousDistribution, DiscreteDistribution,
+                 SingleFiniteDistribution)
+        if not any(all(isinstance(c, k) for c in components) for k in kinds):
+            raise ValueError("All mixture components must be of the same kind "
+                "(all continuous, all discrete, or all finite).")
+
+        # weights must be non-negative; then normalise them to sum to one
+        for w in weights:
+            _value_check(w >= 0, "Weights must be non-negative.")
+        total = Add(*weights)
+        if total == S.Zero:
+            raise ValueError("Weights must not all be zero.")
+        weights = Tuple(*[w/total for w in weights])
+        components = Tuple(*components)
+
+        return Basic.__new__(cls, weights, components)
+
+    @property
+    def is_Continuous(self):
+        return all(isinstance(c, ContinuousDistribution)
+                   for c in self.components)
+
+    @property
+    def is_Discrete(self):
+        return all(isinstance(c, DiscreteDistribution)
+                   for c in self.components)
+
+    @property
+    def is_Finite(self):
+        return all(isinstance(c, SingleFiniteDistribution)
+                   for c in self.components)
+
+    @property
+    def set(self):
+        return Union(*[c.set for c in self.components])
+
+    def pdf(self, x):
+        if self.is_Finite:
+            terms = [w*c.pmf(x) for w, c in zip(self.weights, self.components)]
+        else:
+            terms = [w*c.pdf(x) for w, c in zip(self.weights, self.components)]
+        return Add(*terms)
+
+    def cdf(self, x):
+        if self.is_Finite:
+            raise NotImplementedError("Finite mixture CDFs are computed via the "
+                "probability space, not the distribution.")
+        return Add(*[w*c.cdf(x) for w, c in zip(self.weights, self.components)])
+
+    def _characteristic_function(self, t):
+        # Linearity: CF_M(t) = sum_i w_i * CF_{X_i}(t).  Return None if any
+        # component lacks a closed-form CF so the generic dispatcher in
+        # ContinuousDistribution/DiscreteDistribution falls back to
+        # integrating the pdf.
+        parts = []
+        for c in self.components:
+            cf = getattr(c, '_characteristic_function', None)
+            if cf is None:
+                return None
+            value = cf(t)
+            if value is None:
+                return None
+            parts.append(value)
+        return Add(*[w*p for w, p in zip(self.weights, parts)])
+
+    def _moment_generating_function(self, t):
+        # Same linearity argument for the MGF.
+        parts = []
+        for c in self.components:
+            mgf = getattr(c, '_moment_generating_function', None)
+            if mgf is None:
+                return None
+            value = mgf(t)
+            if value is None:
+                return None
+            parts.append(value)
+        return Add(*[w*p for w, p in zip(self.weights, parts)])
+
+
+class _WeightedDistribution(Basic):
+    """
+    Internal helper used to support the ``w * Distribution + ...`` syntax for
+    building two-component mixtures.  Pairs a sympified non-negative weight
+    with a univariate component distribution.
+
+    Summing two ``_WeightedDistribution``s, or adding a plain ``Distribution``
+    to one, yields a :class:`MixtureDistribution`.  Three-or-more-component
+    chaining is not supported by the operator syntax: use
+    :func:`Mixture` directly for that.
+
+    Not part of the public API.
+    """
+
+    def __new__(cls, weight, distribution):
+        weight = sympify(weight)
+        return Basic.__new__(cls, weight, distribution)
+
+    @property
+    def weight(self):
+        return self.args[0]
+
+    @property
+    def distribution(self):
+        return self.args[1]
+
+    def __add__(self, other):
+        if isinstance(other, _WeightedDistribution):
+            return MixtureDistribution(
+                [self.weight, other.weight],
+                [self.distribution, other.distribution])
+        if isinstance(other, (ContinuousDistribution, DiscreteDistribution,
+                              SingleFiniteDistribution)):
+            return MixtureDistribution(
+                [self.weight, S.One],
+                [self.distribution, other])
+        return NotImplemented
+
+    def __radd__(self, other):
+        if isinstance(other, (ContinuousDistribution, DiscreteDistribution,
+                              SingleFiniteDistribution)):
+            return MixtureDistribution(
+                [S.One, self.weight],
+                [other, self.distribution])
+        return NotImplemented
+
+
+def Mixture(name, weights, components):
+    """
+    Create a random variable with a finite mixture distribution.
+
+    A finite mixture draws its value from one of several component
+    distributions, chosen according to fixed weights. Its density is the
+    weighted sum of the component densities. All components must be of the same
+    kind (all continuous, all discrete, or all finite). The weights need not
+    sum to one; they are normalised automatically.
+
+    Parameters
+    ==========
+
+    name : str
+        Name of the random variable.
+    weights : list of Expr
+        Non-negative mixing weights, one per component.
+    components : list of RandomSymbol or Distribution
+        The component distributions being mixed. Random variables are accepted
+        as a convenience; their distributions are used.
+
+    Returns
+    =======
+
+    RandomSymbol
+
+    Examples
+    ========
+
+    >>> from sympy.stats import Mixture, Die, E, P, density
+
+    >>> M = Mixture('M', [1, 1], [Die('D1', 2), Die('D2', 4)])
+    >>> E(M)
+    2
+    >>> P(M > 3)
+    1/8
+    >>> density(M).dict
+    {1: 3/8, 2: 3/8, 3: 1/8, 4: 1/8}
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Mixture_distribution
+
+    """
+    dists = []
+    for c in components:
+        if isinstance(c, RandomSymbol):
+            c = c.pspace.distribution
+        dists.append(c)
+    dist = MixtureDistribution(weights, dists)
+    return MixturePSpace(name, dist).value
+
+
+def GaussianMixture(name, weights, means, sigmas):
+    """
+    Create a random variable that is a mixture of univariate normals.
+
+    Convenience constructor mirroring Mathematica's ``GaussianMixture``.
+    Equivalent to ``Mixture(name, weights, [Normal(...), ...])`` but
+    expressed in terms of the Gaussian parameters directly.
+
+    Parameters
+    ==========
+
+    name : str
+        Name of the random variable.
+    weights : list of Expr
+        Non-negative mixing weights, one per component; normalised to sum
+        to one.
+    means : list of Expr
+        Means of the normal components.
+    sigmas : list of Expr
+        Standard deviations of the normal components (must be positive).
+
+    Returns
+    =======
+
+    RandomSymbol
+
+    Examples
+    ========
+
+    >>> from sympy.stats import GaussianMixture, E
+
+    >>> G = GaussianMixture('G', [1, 1], [0, 5], [1, 1])
+    >>> E(G)
+    5/2
+
+    References
+    ==========
+
+    .. [1] https://reference.wolfram.com/language/ref/method/GaussianMixture.html
+
+    """
+    if not (len(weights) == len(means) == len(sigmas)):
+        raise ValueError("weights, means and sigmas must have the same length.")
+    components = [NormalDistribution(m, s) for m, s in zip(means, sigmas)]
+    return Mixture(name, weights, components)

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -1596,6 +1596,47 @@ class NamedArgsMixin:
 
 class Distribution(Basic):
 
+    def __rmul__(self, other):
+        """``w * Distribution`` returns a weighted distribution that can be
+        summed with another (weighted) distribution to build a two-component
+        finite mixture (see :func:`sympy.stats.Mixture`).
+        """
+        from sympy.core.sympify import SympifyError
+        try:
+            weight = sympify(other)
+        except SympifyError:
+            return NotImplemented
+        if isinstance(weight, Distribution):
+            return NotImplemented
+        from sympy.stats.mixture_rv import _WeightedDistribution
+        return _WeightedDistribution(weight, self)
+
+    __mul__ = __rmul__
+
+    def __add__(self, other):
+        """``Distribution + Distribution`` builds an equal-weight mixture;
+        adding a weighted distribution uses the given weight on the right
+        and weight one on the left.  Falls back to ``Basic.__add__`` for
+        any other type.
+        """
+        from sympy.stats.mixture_rv import (_WeightedDistribution,
+                                            MixtureDistribution)
+        # Only the simple two-component case: refuse if either side is
+        # already a MixtureDistribution.  Users wanting 3+ components should
+        # call Mixture(name, weights, components) directly.
+        if isinstance(self, MixtureDistribution) or \
+                isinstance(other, MixtureDistribution):
+            return NotImplemented
+        if isinstance(other, _WeightedDistribution):
+            return MixtureDistribution(
+                [S.One, other.weight],
+                [self, other.distribution])
+        if isinstance(other, Distribution):
+            return MixtureDistribution(
+                [S.One, S.One],
+                [self, other])
+        return NotImplemented
+
     def sample(self, size=(), library='scipy', seed=None):
         """ A random realization from the distribution """
 

--- a/sympy/stats/tests/test_mixture_rv.py
+++ b/sympy/stats/tests/test_mixture_rv.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from sympy.core.containers import Tuple
+from sympy.core.function import expand_func
+from sympy.core.numbers import oo
+from sympy.core.singleton import S
+from sympy.core.symbol import Symbol
+from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.special.error_functions import erf
+from sympy.sets.sets import Interval, Union
+from sympy.simplify.simplify import simplify
+from sympy.stats import (E, P, cdf, density, given, variance, sample, Die,
+                         Mixture, GaussianMixture, Normal, Poisson,
+                         characteristic_function, moment_generating_function)
+from sympy.stats.crv_types import NormalDistribution, UniformDistribution
+from sympy.stats.drv_types import PoissonDistribution
+from sympy.stats.frv_types import BernoulliDistribution, DieDistribution
+from sympy.stats.mixture_rv import (MixtureDistribution, MixturePSpace,
+                                    _WeightedDistribution)
+from sympy.external import import_module
+from sympy.testing.pytest import raises, skip
+
+
+def test_mixture_distribution_constructor():
+    components = Tuple(NormalDistribution(0, 1), NormalDistribution(2, 3))
+    dist = MixtureDistribution([3, 7], components)
+
+    assert dist.args == (Tuple(S(3)/10, S(7)/10), components)
+    assert dist.weights == Tuple(S(3)/10, S(7)/10)
+    assert dist.components == components
+    assert dist.is_Continuous
+    assert not dist.is_Discrete
+    assert not dist.is_Finite
+    assert dist.set == Interval(-oo, oo)
+
+
+def test_mixture_distribution_discrete_and_finite_types():
+    discrete = MixtureDistribution([1, 1],
+                                   [PoissonDistribution(1), PoissonDistribution(2)])
+    finite = MixtureDistribution([1, 3],
+                                 [DieDistribution(4),
+                                  BernoulliDistribution(S.Half, 0, -1)])
+
+    assert discrete.weights == Tuple(S.Half, S.Half)
+    assert discrete.is_Discrete
+    assert not discrete.is_Continuous
+    assert not discrete.is_Finite
+    assert discrete.set == S.Naturals0
+
+    assert finite.weights == Tuple(S(1)/4, S(3)/4)
+    assert finite.is_Finite
+    assert not finite.is_Continuous
+    assert not finite.is_Discrete
+    assert finite.set == {-1, 0, 1, 2, 3, 4}
+
+
+def test_mixture_distribution_set_union():
+    dist = MixtureDistribution([1, 1],
+                               [UniformDistribution(0, 1),
+                                UniformDistribution(2, 3)])
+
+    assert dist.set == Union(Interval(0, 1), Interval(2, 3))
+
+
+def test_mixture_distribution_validation():
+    normal = NormalDistribution(0, 1)
+    other_normal = NormalDistribution(1, 2)
+
+    raises(ValueError, lambda: MixtureDistribution([], []))
+    raises(ValueError, lambda: MixtureDistribution([1], []))
+    raises(ValueError, lambda: MixtureDistribution([1, 1], [normal]))
+    raises(ValueError, lambda: MixtureDistribution([-1, 2],
+                                                  [normal, other_normal]))
+    raises(ValueError, lambda: MixtureDistribution([0, 0],
+                                                  [normal, other_normal]))
+    raises(ValueError, lambda: MixtureDistribution([1], [object()]))
+    raises(ValueError, lambda: MixtureDistribution([1, 1],
+                                                  [normal,
+                                                   PoissonDistribution(1)]))
+
+
+def test_mixture_pspace_continuous():
+    x = Symbol('x')
+    dist = MixtureDistribution([3, 7],
+                               [NormalDistribution(0, 1),
+                                NormalDistribution(5, 2)])
+    M = MixturePSpace('M', dist).value
+    N1, N2 = Normal('N1', 0, 1), Normal('N2', 5, 2)
+
+    assert simplify(density(M)(x) -
+                    (S(3)/10*density(N1)(x) + S(7)/10*density(N2)(x))) == 0
+    # CDF is the weighted sum of the component CDFs, and stays finite at a
+    # component mean (x = 5) where integrating the combined PDF would give 0/0.
+    assert simplify(cdf(M)(x) -
+                    (S(3)/10*cdf(N1)(x) + S(7)/10*cdf(N2)(x))) == 0
+    assert cdf(M)(x).subs(x, 5) == S(3)*erf(5*sqrt(2)/2)/20 + S.Half
+    assert simplify(E(M)) == S(7)/2
+    # Var = sum w_i (Var_i + E_i**2) - E**2 = 3/10*1 + 7/10*29 - (7/2)**2
+    assert simplify(expand_func(variance(M))) == S(167)/20
+
+
+def test_mixture_pspace_discrete():
+    x = Symbol('x')
+    dist = MixtureDistribution([1, 1],
+                               [PoissonDistribution(1), PoissonDistribution(2)])
+    M = MixturePSpace('M', dist).value
+    P1, P2 = Poisson('P1', 1), Poisson('P2', 2)
+
+    # E = 1/2*1 + 1/2*2
+    assert simplify(E(M)) == S(3)/2
+    assert simplify(cdf(M)(x) - (S.Half*cdf(P1)(x) + S.Half*cdf(P2)(x))) == 0
+
+
+def test_mixture_pspace_finite():
+    dist = MixtureDistribution([1, 3],
+                               [DieDistribution(4),
+                                BernoulliDistribution(S.Half, 0, -1)])
+    M = MixturePSpace('M', dist).value
+
+    # E = 1/4*E(Die(4)) + 3/4*E(Bernoulli) = 1/4*5/2 + 3/4*(-1/2)
+    assert simplify(E(M)) == S(1)/4
+    # P(M > 0) = 1/4*P(Die(4) > 0) + 3/4*P(Bernoulli > 0) = 1/4*1 + 3/4*0
+    assert simplify(P(M > 0)) == S(1)/4
+    assert dict(cdf(M)) == {-1: S(3)/8, 0: S(3)/4, 1: S(13)/16,
+                            2: S(7)/8, 3: S(15)/16, 4: S.One}
+
+
+def test_mixture_disjoint_supports():
+    # E and Var are computed by linearity over components, so each component
+    # integrates over its own interval. Integrating the combined PDF over the
+    # union support would raise NotImplementedError.
+    dist = MixtureDistribution([1, 1],
+                               [UniformDistribution(0, 1),
+                                UniformDistribution(2, 3)])
+    M = MixturePSpace('M', dist).value
+
+    assert E(M) == S(3)/2
+    assert simplify(variance(M)) == S(13)/12
+    assert simplify(P(M > S(5)/2)) == S(1)/4
+
+
+def test_mixture_conditional_space():
+    # Conditioning needs MixturePSpace.conditional_space; finite and discrete
+    # conditionals are exact (summation, not integration).
+    MF = Mixture('MF', [1, 1], [Die('DF1', 2), Die('DF2', 4)])
+    assert P(MF > 3, MF > 1) == S(1)/5
+    assert E(MF, MF > 2) == S(7)/2
+
+    MD = Mixture('MD', [1, 1], [Poisson('Q1', 1), Poisson('Q2', 2)])
+    assert simplify(P(MD > 2, MD > 0) - P(MD > 2)/P(MD > 0)) == 0
+
+    # Continuous conditioning is wired up (no AttributeError).
+    Mc = Mixture('Mc', [S.Half, S.Half],
+                 [Normal('Nc1', 0, 1), Normal('Nc2', 5, 2)])
+    assert given(Mc, Mc > 1) is not None
+
+
+def test_mixture_sample():
+    numpy = import_module('numpy')
+    scipy = import_module('scipy')
+    if numpy is None or scipy is None:
+        skip('numpy and scipy are required for sampling')
+    M = Mixture('Ms', [1, 1], [Die('Da', 2), Die('Db', 4)])
+    s = sample(M, size=(20,), seed=1)
+    assert s.shape == (20,)
+    # every draw lies in the union support {1, 2, 3, 4}
+    assert set(map(int, s)).issubset({1, 2, 3, 4})
+    # reproducible with the same seed
+    assert (sample(M, size=(20,), seed=1) == s).all()
+
+
+def test_mixture_characteristic_function():
+    t = Symbol('t', real=True)
+
+    # Continuous: CF of an equal-weight mixture of Normals matches the
+    # weighted sum of the component CFs.
+    M = Mixture('Mc', [1, 1], [Normal('a', 0, 1), Normal('b', 5, 1)])
+    N1 = Normal('N1', 0, 1)
+    N2 = Normal('N2', 5, 1)
+    assert simplify(characteristic_function(M)(t) -
+                    (S.Half*characteristic_function(N1)(t) +
+                     S.Half*characteristic_function(N2)(t))) == 0
+
+    # Discrete: same property for a Poisson mixture.
+    MD = Mixture('Md', [1, 3], [Poisson('P1', 1), Poisson('P2', 2)])
+    P1, P2 = Poisson('Q1', 1), Poisson('Q2', 2)
+    assert simplify(characteristic_function(MD)(t) -
+                    (S(1)/4*characteristic_function(P1)(t) +
+                     S(3)/4*characteristic_function(P2)(t))) == 0
+
+
+def test_mixture_moment_generating_function():
+    t = Symbol('t', real=True)
+    M = Mixture('Mg', [3, 7], [Normal('a', 0, 1), Normal('b', 2, 3)])
+    N1 = Normal('N1', 0, 1)
+    N2 = Normal('N2', 2, 3)
+    assert simplify(moment_generating_function(M)(t) -
+                    (S(3)/10*moment_generating_function(N1)(t) +
+                     S(7)/10*moment_generating_function(N2)(t))) == 0
+
+
+def test_gaussian_mixture():
+    # GaussianMixture is equivalent to building the mixture by hand.
+    G = GaussianMixture('G', [1, 1], [0, 5], [1, 1])
+    M = Mixture('M', [1, 1], [Normal('a', 0, 1), Normal('b', 5, 1)])
+    assert E(G) == E(M)
+    assert simplify(variance(G) - variance(M)) == 0
+
+    # Symbolic parameters are accepted (just like Normal).
+    mu = Symbol('mu', real=True)
+    GS = GaussianMixture('GS', [1, 1], [0, mu], [1, 1])
+    assert E(GS) == mu/2
+
+    # Length mismatch raises before any RV is built.
+    raises(ValueError, lambda: GaussianMixture('X', [1], [0, 5], [1]))
+    raises(ValueError, lambda: GaussianMixture('X', [1, 1], [0], [1, 1]))
+    raises(ValueError, lambda: GaussianMixture('X', [1, 1], [0, 5], [1]))
+
+
+def test_mixture_operator_overload():
+    N1 = NormalDistribution(0, 1)
+    N2 = NormalDistribution(5, 1)
+    N3 = NormalDistribution(10, 1)
+
+    # w * D returns a _WeightedDistribution.
+    wd = S(3)/10 * N1
+    assert isinstance(wd, _WeightedDistribution)
+    assert wd.weight == S(3)/10
+    assert wd.distribution == N1
+
+    # The target case from issue #18730: w*D + w*D produces a mixture.
+    m = S(3)/10*N1 + S(7)/10*N2
+    assert isinstance(m, MixtureDistribution)
+    assert m.weights == Tuple(S(3)/10, S(7)/10)
+    assert tuple(m.components) == (N1, N2)
+
+    # Plain D + D is an equal-weight two-component mixture.
+    m2 = N1 + N2
+    assert isinstance(m2, MixtureDistribution)
+    assert m2.weights == Tuple(S.Half, S.Half)
+
+    # Mixed forms: w*D + D and D + w*D treat the bare distribution as
+    # weight one.
+    m3 = S(1)/3*N1 + N2
+    assert m3.weights == Tuple(S(1)/4, S(3)/4)
+    m4 = N1 + S(2)/3*N2
+    assert m4.weights == Tuple(S(3)/5, S(2)/5)
+
+    # Three-or-more chaining is not supported by the operator syntax:
+    # users should call Mixture(name, weights, components) directly.
+    raises(TypeError, lambda: S(1)/3*N1 + S(1)/3*N2 + S(1)/3*N3)


### PR DESCRIPTION
Introduce finite mixture distributions in sympy.stats, requested in issue #18730, following Mathematica's MixtureDistribution. A mixture draws from one of several component distributions chosen by fixed, normalised weights; its density is the weighted sum of the component densities.


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #18730

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Added in sympy/stats/mixture_rv.py:

- **MixtureDistribution**: takes weights and component distributions then normalises the weights and unions the supports.  Exposes closed-form characteristic and moment-generating functions via linearity.
- **MixturePSpace**: similar to all other distribution PSpaces, computes density, cdf, expectation, probability, characteristic function, moment generating function, conditional spaces and sampling.  Expectation, probability and the analytical functions use linearity over components, handling disjoint supports.
- **Mixture**(name, weights, components): public constructor returning a random variable; accepts random variables or distributions.
- **GaussianMixture**(name, weights, means, sigmas): convenience constructor for the common all-Normal case, mirroring Mathematica.
- **Operator syntax for two-component mixtures**: w*D + w*D and D + D return a MixtureDistribution (a request from the issue).


#### Other comments
Operator support adds Distribution.__rmul__ and __add__ in sympy/stats/rv.py; they only intercept Distribution operands.

Exported from sympy.stats, documented in doc/src/modules/stats.rst, tested in sympy/stats/tests/test_mixture_rv.py with class-args entries added to sympy/core/tests/test_args.py.

#### AI Generation Disclosure
We did not use AI on this pull request.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.



DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
