### PR TITLE
assumptions: add refine handler for GreaterThan

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -615,7 +615,6 @@ def refine_GreaterThan(expr, assumptions):
     True
 
     """
-    from sympy.core import Pow, Rational
     lhs, rhs = expr.args
     if rhs == S.Zero:
         if ask(Q.nonnegative(lhs), assumptions):

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -601,6 +601,32 @@ def refine_floor_ceiling(expr, assumptions):
         return Add(*gaussian_integer_terms) + expr.func(Add(*nongausian_intergers_terms))
     return expr
 
+def refine_GreaterThan(expr, assumptions):
+    """
+    Handler for GreaterThan (>=) relational expressions.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_GreaterThan
+    >>> from sympy import Q, sqrt
+    >>> from sympy.abc import x
+    >>> refine_GreaterThan(sqrt(x) >= 0, Q.real(sqrt(x)))
+    True
+
+    """
+    from sympy.core import Pow, Rational
+    lhs, rhs = expr.args
+    if rhs == S.Zero:
+        if ask(Q.nonnegative(lhs), assumptions):
+            return S.true
+        if isinstance(lhs, Pow) and lhs.exp == Rational(1, 2):
+            if ask(Q.real(lhs), assumptions):
+                return S.true
+        if ask(Q.negative(lhs), assumptions):
+            return S.false
+    return expr
+
 
 handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Abs': refine_abs,
@@ -617,4 +643,5 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
+    'GreaterThan': refine_GreaterThan,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -354,3 +354,9 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+def test_refine_GreaterThan():
+    assert refine(sqrt(x) >= 0, Q.real(sqrt(x))) == True
+    assert refine(x >= 0, Q.nonnegative(x)) == True
+    assert refine(x >= 0, Q.negative(x)) == False
+    assert refine(x >= 0, Q.complex(x)) == (x >= 0)


### PR DESCRIPTION
References to other Issues or PRs
Fixes #27750
See #27888

Brief description of what is fixed or changed
Added the refine_GreaterThan handler in sympy/assumptions/refine.py to correctly evaluate inequality comparisons involving >= 0. When the left-hand side of the relation is a square root (Pow with an exponent of 1/2) and is established as real under the provided assumptions, the handler evaluates and returns True, as the principal square root of a real number is non-negative.

Other comments
AI Generation Disclosure
I used Claude (AI assistant) to help navigate the SymPy codebase and debug the fix. The logic and implementation strategy were developed interactively.
Lines generated/assisted: The implementation of the refine_GreaterThan function and its corresponding registration entry within handlers_dict in refine.py.

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added a refine handler for `GreaterThan` so that expressions like `(sqrt(x) >= 0).refine(Q.real(sqrt(x)))` now correctly evaluate to `True`.
<!-- END RELEASE NOTES -->