### PR TITLE
docs: update copyright year to 2026

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1909,3 +1909,5 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Kumari Pratibha <kp939331@gmail.com> <kp939331@gmail.com>
+Kumari Pratibha <kp939331@gmail.com> K-Pratzz <kp939331@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -974,6 +974,8 @@ Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com> Kuldeep <kuldeepborkar.jr@gmail
 Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com> Kuldeep Borkar Jr <74557588+KuldeepBorkar@users.noreply.github.com>
 Kuldeep Borkar Jr <kuldeepborkarjr765@gmail.com> Kuldeep-GitWorks <100110333+Kuldeep-GitWorks@users.noreply.github.com>
 Kumar Krishna Agrawal <kumar.1994.14@gmail.com>
+Kumari Pratibha <kp939331@gmail.com> <kp939331@gmail.com>
+Kumari Pratibha <kp939331@gmail.com> K-Pratzz <kp939331@gmail.com>
 Kunal Arora <kunalarora.135@gmail.com>
 Kunal Sheth <kunal@kunalsheth.info>
 Kunal Singh <ksingh19136@gmail.com> kunal singh <ksingh19136@gmail.com>
@@ -1909,5 +1911,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Kumari Pratibha <kp939331@gmail.com> <kp939331@gmail.com>
-Kumari Pratibha <kp939331@gmail.com> K-Pratzz <kp939331@gmail.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2023 SymPy Development Team
+Copyright (c) 2006-2026 SymPy Development Team
 
 All rights reserved.
 
@@ -33,7 +33,7 @@ Patches that were taken from the Diofant project (https://github.com/diofant/dio
 are licensed as:
 
 Copyright (c) 2006-2018 SymPy Development Team,
-              2013-2023 Sergey B Kirpichev
+              2013-2026 Sergey B Kirpichev
 
 All rights reserved.
 
@@ -101,7 +101,7 @@ DAMAGE.
 The files under the directory sympy/parsing/autolev/tests/pydy-example-repo
 are directly copied from PyDy project and are licensed as:
 
-Copyright (c) 2009-2023, PyDy Authors
+Copyright (c) 2009-2026, PyDy Authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
#### References to other Issues or PRs

#### Brief description of what is fixed or changed
Updated the copyright year range in the LICENSE file to include 2026.


#### Other comments
Routine repository maintenance to keep the license current.


#### AI Generation Disclosure

NO AI USE

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->