### PR TITLE
Addressed the issue where `dsolve` does not output constant solutions

### DIFF
--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -863,9 +863,9 @@ def _get_constant_solutions(eq, func, ics):
             else:
                 raise NotImplementedError("Unrecognized initial condition")
 
-    d = Dummy("d")
     eq = eq.lhs - eq.rhs if isinstance(eq, Equality) else eq
-    eq = eq.subs(func, d).doit()
+    eq = eq.replace(lambda e: isinstance(e, Derivative) and e.expr == func,
+                    lambda e: S.Zero)
     if eq is S.Zero:
         # e.g., y' = 0
         if const_val is None:
@@ -874,7 +874,7 @@ def _get_constant_solutions(eq, func, ics):
         else:
             return [Eq(func, const_val)]
     result = []
-    for sol in solve(eq, d):
+    for sol in solve(eq, func):
         if not sol.has(x) and (const_val is None or sol == const_val):
             result.append(Eq(func, sol))
     return result

--- a/sympy/solvers/ode/ode.py
+++ b/sympy/solvers/ode/ode.py
@@ -698,20 +698,24 @@ def _helper_simplify(eq, hint, match, simplify=True, ics=None, **kwargs):
         if len(rv) == 1:
             rv = rv[0]
     if ics and 'power_series' not in hint:
-        if isinstance(rv, (Expr, Eq)):
-            solved_constants = solve_ics([rv], [r['func']], cons(rv), ics)
-            rv = rv.subs(solved_constants)
-        else:
-            rv1 = []
-            for s in rv:
-                try:
-                    solved_constants = solve_ics([s], [r['func']], cons(s), ics)
-                except ValueError:
-                    continue
-                rv1.append(s.subs(solved_constants))
-            if len(rv1) == 1:
-                return rv1[0]
-            rv = rv1
+        rv1 = []
+        if not isinstance(rv, list):
+            rv = [rv]
+        for s in rv:
+            try:
+                solved_constants = solve_ics([s], [func], cons(s), ics)
+            except ValueError:
+                continue
+            rv1.append(s.subs(solved_constants))
+
+        if rv_c := _get_constant_solutions(eq, func, ics):
+            rv1 = [s for s in rv1 if s != False]
+            for s in rv_c:
+                if s not in rv1:
+                    rv1.append(s)
+        if len(rv1) == 1:
+            return rv1[0]
+        rv = rv1
     return rv
 
 
@@ -816,6 +820,65 @@ def solve_ics(sols, funcs, constants, ics):
         raise NotImplementedError("Initial conditions produced too many solutions for constants")
 
     return solved_constants[0]
+
+
+def _get_constant_solutions(eq, func, ics):
+    """
+    Return constant solutions
+
+    If any solver misses them, this function catches them.
+
+    Example
+    =======
+
+    >>> from sympy import symbols, Function, Eq, Derivative, log
+    >>> from sympy.solvers.ode.ode import _get_constant_solutions
+    >>> x = symbols("x")
+    >>> y = Function("y")
+    >>> ode = Eq(Derivative(y(x), x), log(y(x)))
+    >>> _get_constant_solutions(ode, func=y(x), ics={y(1): 1})
+    [Eq(y(x), 1)]
+
+    """
+    x = func.args[0]
+    const_val = None
+    if ics:
+        for funcarg, value in ics.items():
+            if isinstance(funcarg, Subs):
+                funcarg = funcarg.doit()
+                if isinstance(funcarg, Subs):
+                    funcarg = funcarg.args[0]
+            if isinstance(funcarg, AppliedUndef):
+                if func.func != funcarg.func:
+                    continue
+                if const_val is None:
+                    const_val = value
+                elif const_val != value:
+                    return []
+            elif isinstance(funcarg, Derivative):
+                if func.func != funcarg.args[0].func:
+                    continue
+                if value != S.Zero:
+                    return []
+            else:
+                raise NotImplementedError("Unrecognized initial condition")
+
+    d = Dummy("d")
+    eq = eq.lhs - eq.rhs if isinstance(eq, Equality) else eq
+    eq = eq.subs(func, d).doit()
+    if eq is S.Zero:
+        # e.g., y' = 0
+        if const_val is None:
+            C1 = get_numbered_constants(eq, num=1)
+            return [Eq(func, C1)]
+        else:
+            return [Eq(func, const_val)]
+    result = []
+    for sol in solve(eq, d):
+        if not sol.has(x) and (const_val is None or sol == const_val):
+            result.append(Eq(func, sol))
+    return result
+
 
 def classify_ode(eq, func=None, dict=False, ics=None, *, prep=True, xi=None, eta=None, n=None, **kwargs):
     r"""

--- a/sympy/solvers/ode/tests/test_ode.py
+++ b/sympy/solvers/ode/tests/test_ode.py
@@ -20,7 +20,8 @@ from sympy.solvers.ode import (classify_ode,
 
 from sympy.solvers.ode.subscheck import checkodesol
 from sympy.solvers.ode.ode import (classify_sysode,
-    constant_renumber, constantsimp, get_numbered_constants, solve_ics)
+    constant_renumber, constantsimp, get_numbered_constants, solve_ics,
+    _get_constant_solutions)
 
 from sympy.solvers.ode.nonhomogeneous import _undetermined_coefficients_match
 from sympy.solvers.ode.single import LinearCoefficients
@@ -572,6 +573,18 @@ def test_solve_ics():
     ics = {f(x).diff(x).subs(x, 0): f(x).diff(x).subs(x, 0), f(0): f(0)}
     assert dsolve(f(x).diff(x, x) + f(x), f(x), ics=ics) == \
         Eq(f(x), f(0)*cos(x) + f(x).diff(x).subs(x, 0)*sin(x))
+
+
+def test_get_constant_solutions():
+    eq = Derivative(f(x), (x, 2)) - f(x)*(f(x) - 1)
+    assert _get_constant_solutions(eq, f(x),
+        {f(0): 1, Derivative(f(x), x).subs(x, 0): 0}) == [Eq(f(x), 1)]
+    assert _get_constant_solutions(eq, f(x),
+        {f(0): 0, Derivative(f(x), x).subs(x, 0): 0}) == [Eq(f(x), 0)]
+    assert _get_constant_solutions(eq, f(x),
+        {f(0): 1, Derivative(f(x), x).subs(x, 0): 1}) == []
+    assert _get_constant_solutions(eq, f(x), {f(0): 2}) == []
+
 
 def test_ode_order():
     f = Function('f')
@@ -1149,3 +1162,15 @@ def test_issue_28438():
     expected3 = Eq(y(x), sqrt(x)*(C1*besselj(S(1)/4, x**2/2) +
                                    C2*bessely(S(1)/4, x**2/2)))
     assert sol3 == expected3
+
+
+def test_issue_29827():
+    ode = Eq(Derivative(f(x), x), log(f(x)))
+    result = dsolve(ode, func=f(x), ics={f(1): 1})
+    # `result` should basically match `Eq(f(x), 1)`.
+    # However, with the current implementation, when `x` is real,
+    # the solution includes `Eq(li(f(x)), -oo)`.
+    assert result == Eq(f(x), 1) or Eq(f(x), 1) in result
+
+    ode = Eq(Derivative(f(x), x), f(x)*(1 - f(x)))
+    assert dsolve(ode, f(x), ics={f(0): 0}) == Eq(f(x), 0)


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
#29827
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
In some cases, `dsolve` would miss constant solutions. To address this, I added a new `_get_constant_solutions` function so that such solutions can at least be detected there. This does not prevent individual solvers from outputting constant solutions themselves; in fact, duplicates are removed from the final output.

#### Other comments


#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Addressed the issue where `dsolve` misses constant solutions.
<!-- END RELEASE NOTES -->
