### PR TITLE
[GSoC 2026] Implements conjugate, real and imag for domains

### DIFF
--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -26,6 +26,7 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
 
     has_assoc_Ring = False
     has_assoc_Field = True
+    has_conjugate = True
 
     _default_precision = 53
 
@@ -194,5 +195,15 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
         slightly inaccurate due to floating point rounding error.
         """
         return a ** 0.5
+
+    def conjugate(self, a):
+        return self.dtype(a.real, -a.imag)
+
+    def real(self, a):
+        return self.dtype(a.real, 0)
+
+    def imag(self, a):
+        return self.dtype(a.imag, 0)
+
 
 CC = ComplexField()

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -520,6 +520,9 @@ class Domain(Generic[Er]):
     has_CharacteristicZero: bool = False
     """Boolean flag indicating if the domain has characteristic zero."""
 
+    has_conjugate: bool = False
+    """Boolean flag indicating if the domain supports complex conjugation."""
+
     rep: str
     alias: str | None = None
 
@@ -1556,11 +1559,28 @@ class Domain(Generic[Er]):
 
     n = evalf
 
-    def real(self, a) -> Er:
-        return a
+    def conjugate(self, a: Er) -> Er:
+        """Returns the complex conjugate of ``a``.
 
-    def imag(self, a) -> Er:
-        return self.zero
+        Explanation
+        ===========
+        For domains that are closed under complex conjugation (e.g., ZZ, QQ, RR,
+        CC), this returns the complex conjugate of ``a``. For domains where complex
+        conjugation is not defined, this raises NotImplementedError.
+
+        See also
+        ========
+        real, imag
+        """
+        raise NotImplementedError(f"conjugate not defined for domain {self}")
+
+    def real(self, a: Er) -> Er:
+        """Returns the real part of ``a``. """
+        raise NotImplementedError(f"real not defined for domain {self}")
+
+    def imag(self, a: Er) -> Er:
+        """Returns the imaginary part of ``a``. """
+        raise NotImplementedError(f"imag not defined for domain {self}")
 
     def almosteq(self, a: Er, b: Er, tolerance: float | None = None):
         """Check if ``a`` and ``b`` are almost equal. """

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -19,6 +19,8 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
 
     is_SymbolicDomain = is_EX = True
 
+    has_conjugate = True
+
     class Expression(DomainElement, PicklableWithSlots):
         """An arbitrary expression. """
 
@@ -277,6 +279,17 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
 
     def lcm(self, a, b):
         return a.lcm(b)
+
+    def conjugate(self, a):
+        return self.dtype(a.ex.conjugate())
+
+    def real(self, a):
+        from sympy.functions.elementary.complexes import re
+        return self.dtype(re(a.ex))
+
+    def imag(self, a):
+        from sympy.functions.elementary.complexes import im
+        return self.dtype(im(a.ex))
 
 
 EX = ExpressionDomain()

--- a/sympy/polys/domains/expressionrawdomain.py
+++ b/sympy/polys/domains/expressionrawdomain.py
@@ -25,6 +25,7 @@ class ExpressionRawDomain(Field, CharacteristicZero, SimpleDomain):
 
     has_assoc_Ring = False
     has_assoc_Field = True
+    has_conjugate = True
 
     def __init__(self):
         pass
@@ -53,6 +54,17 @@ class ExpressionRawDomain(Field, CharacteristicZero, SimpleDomain):
 
     def sum(self, items):
         return Add(*items)
+
+    def conjugate(self, a):
+        return a.conjugate()
+
+    def real(self, a):
+        from sympy.functions.elementary.complexes import re
+        return re(a)
+
+    def imag(self, a):
+        from sympy.functions.elementary.complexes import im
+        return im(a)
 
 
 EXRAW = ExpressionRawDomain()

--- a/sympy/polys/domains/gaussiandomains.py
+++ b/sympy/polys/domains/gaussiandomains.py
@@ -285,6 +285,7 @@ class GaussianDomain(RingExtension[Telem, Tdom]):
 
     has_assoc_Ring = True
     has_assoc_Field = True
+    has_conjugate = True
 
     def to_dict(self, element: Telem) -> dict[tuple[int, ...], Tdom]:
         return {(0,): element.x, (1,): element.y}
@@ -360,6 +361,18 @@ class GaussianDomain(RingExtension[Telem, Tdom]):
         if K0.ext.args[0] == I:
             return K1.from_sympy(K0.to_sympy(a))
         return None
+
+    def conjugate(self, a: Telem) -> Telem:
+        """Returns the complex conjugate of ``a``."""
+        return self.dtype(a.x, -a.y)
+
+    def real(self, a: Telem) -> Telem:
+        """Returns the real part of ``a``."""
+        return self.dtype(a.x, 0)
+
+    def imag(self, a: Telem) -> Telem:
+        """Returns the imaginary part of ``a``."""
+        return self.dtype(a.y, 0)
 
 
 class GaussianIntegerRing(GaussianDomain[GaussianInteger, MPZ], Ring[MPZ]):

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -47,6 +47,7 @@ class IntegerRing(Ring[MPZ], CharacteristicZero, SimpleDomain):
 
     has_assoc_Ring = True
     has_assoc_Field = True
+    has_conjugate = True
 
     def __init__(self):
         """Allow instantiation of this domain. """
@@ -271,6 +272,18 @@ class IntegerRing(Ring[MPZ], CharacteristicZero, SimpleDomain):
     def factorial(self, a):
         """Compute factorial of ``a``. """
         return factorial(a)
+
+    def conjugate(self, a: MPZ) -> MPZ:
+        """Returns the complex conjugate of ``a``."""
+        return a
+
+    def real(self, a: MPZ) -> MPZ:
+        """Returns the real part of ``a``."""
+        return a
+
+    def imag(self, a: MPZ) -> MPZ:
+        """Returns the imaginary part of ``a``."""
+        return self.zero
 
 
 ZZ = IntegerRing()

--- a/sympy/polys/domains/rationalfield.py
+++ b/sympy/polys/domains/rationalfield.py
@@ -37,6 +37,7 @@ class RationalField(Field[MPQ], CharacteristicZero, SimpleDomain):
 
     has_assoc_Ring = True
     has_assoc_Field = True
+    has_conjugate = True
 
     dtype = MPQ
     zero = dtype(0)
@@ -197,5 +198,18 @@ class RationalField(Field[MPQ], CharacteristicZero, SimpleDomain):
         if q_rem != 0:
             return None
         return MPQ(p_sqrt, q_sqrt)
+
+    def conjugate(self, a: MPQ) -> MPQ:
+        """Returns the complex conjugate of ``a``."""
+        return a
+
+    def real(self, a: MPQ) -> MPQ:
+        """Returns the real part of ``a``."""
+        return a
+
+    def imag(self, a: MPQ) -> MPQ:
+        """Returns the imaginary part of ``a``."""
+        return self.zero
+
 
 QQ = RationalField()

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -64,6 +64,7 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
 
     has_assoc_Ring = False
     has_assoc_Field = True
+    has_conjugate = True
 
     _default_precision = 53
 
@@ -214,6 +215,18 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
         rounding error.
         """
         return a ** 0.5 if a >= 0 else None
+
+    def conjugate(self, a):
+        """Returns the complex conjugate of ``a``."""
+        return a
+
+    def real(self, a):
+        """Returns the real part of ``a``."""
+        return a
+
+    def imag(self, a):
+        """Returns the imaginary part of ``a``."""
+        return self.zero
 
 
 RR = RealField()

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1163,6 +1163,9 @@ def test_gaussian_domains():
         assert 2*i + r == q
         i, r = divmod(2, q)
         assert q*i + r == G(2, 0)
+        assert G.conjugate(q) == G(3, -4)
+        assert G.real(q) == G(3)
+        assert G.imag(q) == G(4)
 
         a, b = G(2, 0), G(1, -1)
         c, d, g = G.gcdex(a, b)
@@ -1433,3 +1436,57 @@ def test_exsqrt():
     assert F7.exsqrt(F7(3)) is None
     assert F7.is_square(F7(0)) is True
     assert F7.exsqrt(F7(0)) == F7(0)
+
+
+def test_Domain_conjugate():
+    domains = [ZZ, QQ, RR, CC, ZZ_I, QQ_I, EX, EXRAW]
+    for domain in domains:
+        a = domain(7)
+        assert domain.has_conjugate
+        assert domain.conjugate(a) == a
+        assert domain.real(a) == a
+        assert domain.imag(a) == domain.zero
+
+        assert all(domain.of_type(elt) for elt in [
+            domain.conjugate(a), domain.real(a), domain.imag(a)
+        ])
+
+        if domain.is_Field:
+            b = domain(-5)
+            assert domain.conjugate(a / b) == domain(a / b)
+            assert domain.real(a / b) == domain(a / b)
+            assert domain.imag(a / b) == domain.zero
+
+    domains = [CC, ZZ_I, QQ_I, EX, EXRAW]
+    for domain in domains:
+        a = domain.from_sympy(7 + 3*I)
+        b = domain.from_sympy(7 - 3*I)
+        assert domain.conjugate(b) == a
+        assert domain.conjugate(a) == b
+        assert domain.real(a) == domain(7)
+        assert domain.imag(b) == domain(-3)
+
+        assert all(domain.of_type(elt) for elt in [
+            domain.conjugate(a), domain.real(a), domain.imag(b)
+        ])
+
+    domains = [
+        ZZ[x], QQ[x], QQ[x, y], RR[z], CC[z],
+        ZZ_I[x], QQ_I[x, y], QQ_I.frac_field(x, y), EXRAW[z],
+    ]
+    for domain in domains:
+        assert not domain.has_conjugate
+        a = domain(7) + domain.gens[0]
+        raises(NotImplementedError, lambda: domain.conjugate(a))
+        raises(NotImplementedError, lambda: domain.real(a))
+        raises(NotImplementedError, lambda: domain.imag(a))
+
+    K = FF(11)
+    raises(NotImplementedError, lambda: K.conjugate(K(7)))
+
+    r = Poly(x**3 - x + 1, x, domain=ZZ).all_roots()[-1]
+    ALG = QQ.algebraic_field(r)
+    raises(NotImplementedError, lambda: ALG.conjugate(r))
+    raises(NotImplementedError, lambda: ALG.real(r))
+    raises(NotImplementedError, lambda: ALG.imag(r))
+

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1489,4 +1489,3 @@ def test_Domain_conjugate():
     raises(NotImplementedError, lambda: ALG.conjugate(r))
     raises(NotImplementedError, lambda: ALG.real(r))
     raises(NotImplementedError, lambda: ALG.imag(r))
-


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

For the `Domain` class these APIs are added:
* `has_conjugate` (property) indicating whether the domainelements support complex conjugation
* `conjugate(self, a)` returns the complex conjugate of a domainelement
* `real(self, a)` returns the real part
* `imag(self, a)` returns the imaginary part

Also, these methods are implemented for specific domains: ZZ, QQ, RR, CC, GaussianDomains (ZZ_I and QQ_I), EX, EXRAW.

For other domains, `has_conjugate` defaults to False and the methods raises NotImplementedError.

Currently, the property `has_conjugate` has been set of False for AlgebraicFields, as discussed in [#27436](https://github.com/sympy/sympy/issues/27436).

#### Other comments

Previously there were `Domain.real(self, a)` and `Domain.imag(self, a)` methods, which returned `a` and `0` for all domains, respectively. This PR makes them return correct values for specific domains and raises an error for other domains where the methods are not well-defined.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Codex is used for API designs and some auto completions. I have modified the code manually to keep the code style consistent with the SymPy codebase.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Implements `conjugate`, `real` and `imag` for domains ZZ, QQ, RR, CC, GaussianDomains (ZZ_I and QQ_I), EX, EXRAW.
<!-- END RELEASE NOTES -->
