### PR TITLE
CI: Fix test fails from timeout on master

### DIFF
--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -11,7 +11,7 @@ from sympy.functions.special.zeta_functions import (dirichlet_eta, lerchphi, pol
 from sympy.series.order import O
 from sympy.core.function import ArgumentIndexError
 from sympy.functions.combinatorial.numbers import bernoulli, factorial, genocchi, harmonic
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, slow
 from sympy.core.random import (test_derivative_numerically as td,
                       random_complex_number as randcplx, verify_numerically)
 
@@ -182,6 +182,7 @@ def test_polylog_series():
         - sqrt(3)*z**3/9 + z**4/8 + O(z**5)
 
 
+@slow
 def test_issue_8404():
     i = Symbol('i', integer=True)
     assert Abs(Sum(1/(3*i + 1)**2, (i, 0, S.Infinity)).doit().n(4)

--- a/sympy/utilities/_compilation/tests/test_compilation.py
+++ b/sympy/utilities/_compilation/tests/test_compilation.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import tempfile
 from sympy.external import import_module
-from sympy.testing.pytest import skip, skip_under_pyodide
+from sympy.testing.pytest import skip, skip_under_pyodide, slow
 
 from sympy.utilities._compilation.compilation import compile_link_import_py_ext, compile_link_import_strings, compile_sources, get_abspath
 
@@ -66,6 +66,7 @@ def test_compile_link_import_strings():
             shutil.rmtree(info['build_dir'])
 
 
+@slow
 @skip_under_pyodide("Emscripten does not support subprocesses")
 def test_compile_sources():
     tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes: #29853
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Added a slow decorator to the failing test (`test_issue_8404`) to fix the CI pipeline.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
