### PR TITLE
Uses equivalence for predicate encoding in Z3 backend

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1909,4 +1909,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Shubhankar Joshi <shubhankarjoshi2489@gmail.com>
+Shubhankar Joshi <shubhankarjoshi2489@gmail.com> Shubhankar-Joshi2489 <shubhankarjoshi2489@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1544,6 +1544,7 @@ Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>
 Shubham Maheshwari <rmaheshwari05@gmail.com>
 Shubham Thorat <37049710+sbt4104@users.noreply.github.com>
 Shubham Tibra <shubh.tibra@gmail.com>
+Shubhankar Joshi <shubhankarjoshi2489@gmail.com>
 Siddhanathan Shanmugam <siddhanathan@gmail.com>
 Siddhanathan Shanmugam <siddhanathan@gmail.com> <siddhu@siddhu-laptop.(none)>
 Siddhant Jain <getsiddhant@gmail.com>
@@ -1909,4 +1910,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Shubhankar Joshi <shubhankarjoshi2489@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1909,3 +1909,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Shubhankar Joshi <shubhankarjoshi2489@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1909,4 +1909,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Shubhankar Joshi <shubhankarjoshi2489@gmail.com> Shubhankar-Joshi2489 <shubhankarjoshi2489@gmail.com>
+Shubhankar Joshi <shubhankarjoshi2489@gmail.com>

--- a/sympy/functions/special/tests/test_zeta_functions.py
+++ b/sympy/functions/special/tests/test_zeta_functions.py
@@ -11,7 +11,7 @@ from sympy.functions.special.zeta_functions import (dirichlet_eta, lerchphi, pol
 from sympy.series.order import O
 from sympy.core.function import ArgumentIndexError
 from sympy.functions.combinatorial.numbers import bernoulli, factorial, genocchi, harmonic
-from sympy.testing.pytest import raises
+from sympy.testing.pytest import raises, slow
 from sympy.core.random import (test_derivative_numerically as td,
                       random_complex_number as randcplx, verify_numerically)
 
@@ -182,6 +182,7 @@ def test_polylog_series():
         - sqrt(3)*z**3/9 + z**4/8 + O(z**5)
 
 
+@slow
 def test_issue_8404():
     i = Symbol('i', integer=True)
     assert Abs(Sum(1/(3*i + 1)**2, (i, 0, S.Infinity)).doit().n(4)

--- a/sympy/logic/algorithms/z3_wrapper.py
+++ b/sympy/logic/algorithms/z3_wrapper.py
@@ -93,7 +93,7 @@ def encoded_cnf_to_z3_solver(enc_cnf, z3):
 
         symbols |= pred.free_symbols
         pred = pred_str
-        assertion = f"(assert  (implies d{enc} {pred}))"
+        assertion = f"(assert (= d{enc} {pred}))"
         assertions.append(assertion)
 
     for sym in symbols:

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -371,7 +371,7 @@ def test_z3():
 
 
 def test_z3_predicate_equivalence():
-    #Regression Test for Issue 29851
+    # https://github.com/sympy/sympy/issues/29851
     z3 = import_module("z3")
     if z3 is None:
         skip("Z3 is not installed")

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -1,11 +1,10 @@
 """For more tests on satisfiability, see test_dimacs"""
 from __future__ import annotations
 
-import pytest
 from sympy.assumptions.ask import Q
 from sympy.core.symbol import symbols
 from sympy.core.relational import Ne, Eq, Unequality
-from sympy.logic.boolalg import And, Or, Implies, Equivalent, true, false,Not
+from sympy.logic.boolalg import And, Or, Implies, Equivalent, true, false, Not
 from sympy.logic.inference import literal_symbol, \
      pl_true, satisfiable, valid, entails, PropKB
 from sympy.logic.algorithms.dpll import dpll, dpll_satisfiable, \
@@ -23,7 +22,6 @@ from sympy.testing.pytest import raises, skip
 from sympy.external import import_module
 
 from sympy.core.function import Function
-
 
 
 
@@ -372,6 +370,16 @@ def test_z3():
     assert z3_satisfiable(expr) is False
 
 
+def test_z3_predicate_equivalence():
+    #Regression Test for Issue 29851
+    z3 = import_module("z3")
+    if z3 is None:
+        skip("Z3 is not installed")
+    x = symbols('x')
+    expr = Not(Implies(Q.eq(x, 0),Q.ge(x, 0)))
+    assert z3_satisfiable(expr) is False
+
+
 def test_z3_vs_lra_dpll2():
     z3 = import_module("z3")
     if z3 is None:
@@ -443,12 +451,3 @@ def test_issue_27733_second_fix():
     encoding = {Q.gt(x0, x1): 1, Q.lt(x1, x0): 2, Q.le(x1, x0): 3, Q.ge(x0, x1): 4}
     cnf = EncodedCNF(clauses, encoding)
     assert satisfiable(cnf, use_lra_theory=True) is False
-
-
-def test_issue_z3_predicate_equivalence():
-    z3 = import_module("z3")
-    if z3 is None:
-        pytest.skip("Z3 is not installed")
-    x = symbols('x')
-    expr = Not(Implies(Q.eq(x, 0),Q.ge(x, 0)))
-    assert z3_satisfiable(expr) is False

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -1,7 +1,7 @@
 """For more tests on satisfiability, see test_dimacs"""
 from __future__ import annotations
-from ast import expr
 
+from ast import expr
 from sympy.assumptions.ask import Q
 from sympy.core.symbol import symbols
 from sympy.core.relational import Ne, Eq, Unequality

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -1,7 +1,6 @@
 """For more tests on satisfiability, see test_dimacs"""
 from __future__ import annotations
 
-from ast import expr
 from sympy.assumptions.ask import Q
 from sympy.core.symbol import symbols
 from sympy.core.relational import Ne, Eq, Unequality

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -1,6 +1,7 @@
 """For more tests on satisfiability, see test_dimacs"""
 from __future__ import annotations
 
+import pytest
 from sympy.assumptions.ask import Q
 from sympy.core.symbol import symbols
 from sympy.core.relational import Ne, Eq, Unequality
@@ -445,6 +446,9 @@ def test_issue_27733_second_fix():
 
 
 def test_issue_z3_predicate_equivalence():
+    z3 = import_module("z3")
+    if z3 is None:
+        pytest.skip("Z3 is not installed")
     x = symbols('x')
     expr = Not(Implies(Q.eq(x, 0),Q.ge(x, 0)))
     assert z3_satisfiable(expr) is False

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -1,10 +1,11 @@
 """For more tests on satisfiability, see test_dimacs"""
 from __future__ import annotations
+from ast import expr
 
 from sympy.assumptions.ask import Q
 from sympy.core.symbol import symbols
 from sympy.core.relational import Ne, Eq, Unequality
-from sympy.logic.boolalg import And, Or, Implies, Equivalent, true, false
+from sympy.logic.boolalg import And, Or, Implies, Equivalent, true, false,Not
 from sympy.logic.inference import literal_symbol, \
      pl_true, satisfiable, valid, entails, PropKB
 from sympy.logic.algorithms.dpll import dpll, dpll_satisfiable, \
@@ -22,6 +23,7 @@ from sympy.testing.pytest import raises, skip
 from sympy.external import import_module
 
 from sympy.core.function import Function
+
 
 
 
@@ -441,3 +443,9 @@ def test_issue_27733_second_fix():
     encoding = {Q.gt(x0, x1): 1, Q.lt(x1, x0): 2, Q.le(x1, x0): 3, Q.ge(x0, x1): 4}
     cnf = EncodedCNF(clauses, encoding)
     assert satisfiable(cnf, use_lra_theory=True) is False
+
+
+def test_issue_z3_predicate_equivalence():
+    x = symbols('x')
+    expr = Not(Implies(Q.eq(x, 0),Q.ge(x, 0)))
+    assert z3_satisfiable(expr) is False

--- a/sympy/utilities/_compilation/tests/test_compilation.py
+++ b/sympy/utilities/_compilation/tests/test_compilation.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import tempfile
 from sympy.external import import_module
-from sympy.testing.pytest import skip, skip_under_pyodide
+from sympy.testing.pytest import skip, skip_under_pyodide, slow
 
 from sympy.utilities._compilation.compilation import compile_link_import_py_ext, compile_link_import_strings, compile_sources, get_abspath
 
@@ -66,6 +66,7 @@ def test_compile_link_import_strings():
             shutil.rmtree(info['build_dir'])
 
 
+@slow
 @skip_under_pyodide("Emscripten does not support subprocesses")
 def test_compile_sources():
     tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes  #29851
#### Brief description of what is fixed or changed
The Z3 encoding used a one-way implication:

# Before
assertion = f"(assert (implies d{enc} {pred}))"

This encoding only enforced one-way implication, allowing the Boolean variable to not fully reflect the predicate’s truth value.

This PR replaces it with equivalence:

# After
assertion = f"(assert (= d{enc} {pred}))"
so that the Boolean variable always matches the truth value of the predicate.

Both d{enc} and {pred} are Boolean expressions in this encoding, so equivalence correctly preserves the truth value.

A regression test has been added to verify 
assert Not(Implies(Q.eq(x, 0), Q.ge(x, 0))) is False

#### Other comments
None

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
ChatGPT was used for understanding the issue and drafting test ideas. Final implementation and verification were done manually.
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* logic
  * Fixed incorrect predicate encoding in the Z3 satisfiability backend that could produce invalid satisfiable models.
<!-- END RELEASE NOTES -->
