### PR TITLE
polys: fix cross-type comparison in `polys/matrices/normalforms.py`

### DIFF
--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -222,7 +222,7 @@ def _smith_normal_decomp(m, domain, shape, full):
     def to_domain_matrix(m):
         return DomainMatrix(m, shape=(len(m), len(m[0])), domain=domain)
 
-    if m[0][0] != 0:
+    if m[0][0] != zero:
         c = domain.canonical_unit(m[0][0])
         if domain.is_Field:
             c = 1 / m[0][0]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None


#### Brief description of what is fixed or changed
There is a cross-type comparison in line 225 of `sympy/polys/matrices/normalforms.py` .

https://github.com/sympy/sympy/blob/06f6e3a8cf4a1a9a8323722c74fb38394f5aa8e4/sympy/polys/matrices/normalforms.py#L222-L225

 `m[0][0]` is an `ANP` element, but `0` is a Python `int`.

Therefore, I made this change in `sympy/polys/matrices/normalforms.py` :


```diff
# line 225
- if m[0][0] != 0:
+ if m[0][0] != zero:

```

#### Other comments
The following two lines inspired this fix.

https://github.com/sympy/sympy/blob/06f6e3a8cf4a1a9a8323722c74fb38394f5aa8e4/sympy/polys/matrices/normalforms.py#L137
https://github.com/sympy/sympy/blob/06f6e3a8cf4a1a9a8323722c74fb38394f5aa8e4/sympy/polys/matrices/normalforms.py#L185


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
DeepSeek assisted in finding the cross-type comparison.
All code was written manually.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed cross-type comparison in `polys/matrices/normalforms.py`.
<!-- END RELEASE NOTES -->
