### PR TITLE
polys: fix cross-type comparison in `polys/matrices/normalforms.py`

### DIFF
--- a/sympy/polys/matrices/normalforms.py
+++ b/sympy/polys/matrices/normalforms.py
@@ -200,13 +200,13 @@ def _smith_normal_decomp(m, domain, shape, full):
 
     # permute the rows and columns until m[0,0] is non-zero if possible
     ind = [i for i in range(rows) if m[i][0] != zero]
-    if ind and ind[0] != zero:
+    if ind and ind[0] != 0:
         m[0], m[ind[0]] = m[ind[0]], m[0]
         if full:
             s[0], s[ind[0]] = s[ind[0]], s[0]
     else:
         ind = [j for j in range(cols) if m[0][j] != zero]
-        if ind and ind[0] != zero:
+        if ind and ind[0] != 0:
             for row in m:
                 row[0], row[ind[0]] = row[ind[0]], row[0]
             if full:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None


#### Brief description of what is fixed or changed
There are cross-type comparisons in lines 203 and 209 of `sympy/polys/matrices/normalforms.py`.

https://github.com/sympy/sympy/blob/06f6e3a8cf4a1a9a8323722c74fb38394f5aa8e4/sympy/polys/matrices/normalforms.py#L203-L209

`ind[0]` is a Python `int`, but `zero` is an `ANP` element.

Therefore, I made these changes in `sympy/polys/matrices/normalforms.py` :


```diff
# line 203
-    if ind and ind[0] != zero:
+    if ind and ind[0] != 0:

# line 209
-    if ind and ind[0] != zero:
+    if ind and ind[0] != 0:
```

#### Other comments
None.


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
DeepSeek assisted in finding the cross-type comparison.
All code was written manually.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
