### PR TITLE
[GSoC] manualintegrate: add singualrity function rule and extended dirac delta rules

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -736,7 +736,7 @@ class DiracDeltaRule(AtomicRule):
             return DiracDelta(a + b*x, n-1)/b
 
         df = Derivative(f, x, n).doit().subs(x, x0)
-        return (-1)**n * df * Heaviside(a + b*x) / Abs(b)**(n+1)
+        return (-1)**n * df * Heaviside(a + b*x) / b**(n+1)
 
 
 class TrigSubstitutionRule(Rule):
@@ -2525,7 +2525,7 @@ def dirac_delta_rule(integral: IntegralInfo):
     if integrand.is_Mul:
         factors = integrand.args
         # delta = next(iter(integrand.atoms(DiracDelta)))  # find the first delta in Mul node
-        delta = list([f for f in factors if f.has(DiracDelta)])[0]  # find a delta in Mul node
+        delta = list([f for f in factors if isinstance(f, DiracDelta)])[0]  # find a delta in Mul node
         coeff = Mul(*[f for f in factors if f is not delta])
 
     if integrand.is_Pow:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -675,11 +675,12 @@ class PiecewiseRule(Rule):
 
 class HeavisideRule(Rule):
 
-    __slots__ = ("harg", "ibnd", "substep")
+    __slots__ = ("harg", "ibnd", "substep", "h0")
 
     harg: Expr
     ibnd: Expr
     substep: Rule
+    h0: Expr
 
     def __init__(
         self,
@@ -687,11 +688,13 @@ class HeavisideRule(Rule):
         variable: Symbol,
         harg: Expr,
         ibnd: Expr,
+        h0: Expr,
         substep: Rule,
     ) -> None:
         super().__init__(integrand, variable)
         self.harg = harg
         self.ibnd = ibnd
+        self.h0 = h0
         self.substep = substep
 
     def eval(self) -> Expr:
@@ -700,7 +703,7 @@ class HeavisideRule(Rule):
         # then there needs to be continuity at -b/m == ibnd,
         # so we subtract the appropriate term.
         result = self.substep.eval()
-        return Heaviside(self.harg) * (result - result.subs(self.variable, self.ibnd))
+        return Heaviside(self.harg, self.h0) * (result - result.subs(self.variable, self.ibnd))
 
     def contains_dont_know(self) -> bool:
         return self.substep.contains_dont_know()
@@ -2237,9 +2240,10 @@ def heaviside_pattern(symbol):
     m = Wild('m', exclude=[symbol])
     b = Wild('b', exclude=[symbol])
     g = Wild('g')
-    pattern = Heaviside(m*symbol + b) * g
+    k = Wild('k')
+    pattern = Heaviside(m*symbol + b, k) * g
 
-    return pattern, m, b, g
+    return pattern, m, b, g, k
 
 def uncurry(func):
     def uncurry_rl(args):
@@ -2439,13 +2443,14 @@ def trig_substitution_rule(integral):
 
 def heaviside_rule(integral):
     integrand, symbol = integral
-    pattern, m, b, g = heaviside_pattern(symbol)
+    pattern, m, b, g, k = heaviside_pattern(symbol)
     match = integrand.match(pattern)
     if match and 0 != match[g]:
         # f = Heaviside(m*x + b)*g
         substep = integral_steps(match[g], symbol)
         m, b = match[m], match[b]
-        return HeavisideRule(integrand, symbol, m*symbol + b, -b/m, substep)
+        k = match[k]
+        return HeavisideRule(integrand, symbol, m*symbol + b, -b/m, k, substep)
 
 
 def dirac_delta_rule(integral: IntegralInfo):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2498,7 +2498,7 @@ def singularity_rule(integral: IntegralInfo):
     if not (order.is_nonnegative or order in (-1, -2, -3, -4)):
         return
 
-    return SingularityRule(integrand, s_var, offset, order)
+    return SingularityRule(integrand, symbol, offset, order)  # type: ignore
 
 
 def heaviside_rule(integral):
@@ -2526,7 +2526,7 @@ def dirac_delta_rule(integral: IntegralInfo):
         factors = integrand.args
         # delta = next(iter(integrand.atoms(DiracDelta)))  # find the first delta in Mul node
         delta = [f for f in factors if isinstance(f, DiracDelta)][0]  # find a delta in Mul node
-        coeff = Mul(*[f for f in factors if f is not delta])
+        coeff = Mul(*[f for f in factors if f is not delta])  # type: ignore
 
     if integrand.is_Pow:
         base, exp = integrand.as_base_exp()

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2527,6 +2527,12 @@ def dirac_delta_rule(integral: IntegralInfo):
         delta = next(iter(integrand.atoms(DiracDelta)))
         coeff = Mul(*[f for f in factors if f is not delta])
 
+    if integrand.is_Pow:
+        base, exp = integrand.as_base_exp()
+        if isinstance(base, DiracDelta):
+            delta = base
+            coeff = base**(exp - 1)
+
     if len(delta.args) == 1:
         n = S.Zero
     else:
@@ -2742,7 +2748,8 @@ def integral_steps(integrand, symbol, **options):
                         null_safe(quadratic_denom_rule),
                         null_safe(sqrt_quadratic_rule),
                         null_safe(sqrt_fractional_linear_rule),
-                        null_safe(singularity_rewrite_rule)),
+                        null_safe(singularity_rewrite_rule),
+                        null_safe(dirac_delta_rule)),
             Symbol: power_rule,
             exp: exp_rule,
             Add: add_rule,

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2525,7 +2525,7 @@ def dirac_delta_rule(integral: IntegralInfo):
     if integrand.is_Mul:
         factors = integrand.args
         # delta = next(iter(integrand.atoms(DiracDelta)))  # find the first delta in Mul node
-        delta = list([f for f in factors if isinstance(f, DiracDelta)])[0]  # find a delta in Mul node
+        delta = [f for f in factors if isinstance(f, DiracDelta)][0]  # find a delta in Mul node
         coeff = Mul(*[f for f in factors if f is not delta])
 
     if integrand.is_Pow:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2524,7 +2524,8 @@ def dirac_delta_rule(integral: IntegralInfo):
 
     if integrand.is_Mul:
         factors = integrand.args
-        delta = next(iter(integrand.atoms(DiracDelta)))
+        # delta = next(iter(integrand.atoms(DiracDelta)))  # find the first delta in Mul node
+        delta = list([f for f in factors if f.has(DiracDelta)])[0]  # find a delta in Mul node
         coeff = Mul(*[f for f in factors if f is not delta])
 
     if integrand.is_Pow:
@@ -2760,6 +2761,7 @@ def integral_steps(integrand, symbol, **options):
                         null_safe(powsimp_rule),
                         null_safe(trig_cmplx_exp_rule),
                         null_safe(singularity_rewrite_rule),
+                        null_safe(dirac_delta_expand_rule),
                         null_safe(dirac_delta_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2628,7 +2628,7 @@ trig_expand_rule = rewriter(
 
 singularity_rewrite_rule = rewriter(
     lambda integrand, symbol: integrand.has(SingularityFunction) and not isinstance(integrand, SingularityFunction),
-    lambda integrand, symbol: integrand.expand(singularity=True, wrt=symbol))
+    lambda integrand, symbol: integrand.rewrite(DiracDelta))
 
 dirac_delta_expand_rule = rewriter(
     lambda integrand, symbol: integrand.has(DiracDelta),

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -50,6 +50,7 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
     cos, sin, tan, cot, csc, sec, acos, asin, atan, acot, acsc, asec)
 from sympy.functions.special.delta_functions import Heaviside, DiracDelta
+from sympy.functions.special.singularity_functions import SingularityFunction
 from sympy.functions.special.error_functions import (erf, erfc, erfi, fresnelc,
     fresnels, Ci, Chi, Si, Shi, Ei, li)
 from sympy.functions.special.gamma_functions import uppergamma
@@ -1143,6 +1144,40 @@ class EllipticERule(AtomicRule):
 
     def eval(self) -> Expr:
         return elliptic_e(self.variable, self.d/self.a)*sqrt(self.a)
+
+
+class SingularityRule(AtomicRule):
+
+    __slots__ = ("offset", "order")
+
+    offset: Expr
+    order: Expr
+
+    def __init__(
+        self,
+        integrand: Expr,
+        variable: Symbol,
+        offset: Expr,
+        order: Expr,
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.offset = offset
+        self.order = order
+
+    def eval(self) -> Expr:
+        x = self.variable
+        a = self.offset
+        n = self.order
+
+        if n.is_nonnegative:
+            return SingularityFunction(x, a, n + 1)/(n + 1)
+
+        if n in (-1, -2, -3, -4):
+            return SingularityFunction(x, a, n + 1)
+
+        raise ValueError(
+            f"Unsupported singularity order for SingularityRule: {n}"
+        )
 
 
 class IntegralInfo(NamedTuple):
@@ -2441,6 +2476,43 @@ def trig_substitution_rule(integral):
                     return TrigSubstitutionRule(integrand, symbol,
                         theta, x_func, replaced, substep, restriction)
 
+
+def singularity_rule(integral: IntegralInfo):
+    integrand, symbol = integral
+    s_var, offset, order = integrand.args
+
+    # Only apply if the singularity is with respect to the variable of
+    # integration
+    if s_var != symbol:
+        return
+
+    # Only apply if the order of the singularity is a nonnegative integer or
+    # -1, -2, -3, or -4 (corresponding to delta functions and their
+    # derivatives)
+    if not (order.is_nonnegative or order in (-1, -2, -3, -4)):
+        return
+
+    return SingularityRule(integrand, s_var, offset, order)
+
+
+def singularity_rewrite_rule(integral: IntegralInfo):
+    """
+    Rewrite a SingularityFunction in terms of Heaviside/DiracDelta functions.
+    This should only be triggered when we cannot integrate the
+    SingularityFunction directly, usually in a multiplication or an exponent
+    node.
+    """
+    integrand, symbol = integral
+
+    if not integrand.has(SingularityFunction) or isinstance(integrand, SingularityFunction):
+        return None
+
+    rewritten = integrand.rewrite(DiracDelta)
+    if rewritten != integrand:
+        substep = integral_steps(rewritten, symbol)
+        return RewriteRule(integrand, symbol, rewritten, substep)
+
+
 def heaviside_rule(integral):
     integrand, symbol = integral
     pattern, m, b, g, k = heaviside_pattern(symbol)
@@ -2661,7 +2733,9 @@ def integral_steps(integrand, symbol, **options):
             Pow: do_one(null_safe(power_rule), null_safe(inverse_trig_rule),
                         null_safe(quadratic_denom_rule),
                         null_safe(sqrt_quadratic_rule),
-                        null_safe(sqrt_fractional_linear_rule)),
+                        null_safe(sqrt_fractional_linear_rule),
+                        null_safe(singularity_rewrite_rule)
+                        ),
             Symbol: power_rule,
             exp: exp_rule,
             Add: add_rule,
@@ -2670,11 +2744,13 @@ def integral_steps(integrand, symbol, **options):
                         null_safe(sqrt_quadratic_rule),
                         null_safe(sqrt_fractional_linear_rule),
                         null_safe(powsimp_rule),
-                        null_safe(trig_cmplx_exp_rule)),
+                        null_safe(trig_cmplx_exp_rule),
+                        null_safe(singularity_rewrite_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
             Heaviside: heaviside_rule,
             DiracDelta: dirac_delta_rule,
+            SingularityFunction: singularity_rule,
             OrthogonalPolynomial: orthogonal_poly_rule,
             Number: constant_rule
         })),

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -712,25 +712,31 @@ class HeavisideRule(Rule):
 
 class DiracDeltaRule(AtomicRule):
 
-    __slots__ = ("n", "a", "b")
+    __slots__ = ("n", "a", "b", "f")
 
     n: Expr
     a: Expr
     b: Expr
+    f: Expr
 
     def __init__(
-        self, integrand: Expr, variable: Symbol, n: Expr, a: Expr, b: Expr
+        self, integrand: Expr, variable: Symbol, n: Expr, a: Expr, b: Expr, f: Expr
     ) -> None:
         super().__init__(integrand, variable)
         self.n = n
         self.a = a
         self.b = b
+        self.f = f
 
     def eval(self) -> Expr:
-        n, a, b, x = self.n, self.a, self.b, self.variable
-        if n == 0:
-            return Heaviside(a+b*x)/b
-        return DiracDelta(a+b*x, n-1)/b
+        n, a, b, f, x = self.n, self.a, self.b, self.f, self.variable
+        x0 = -a/b
+
+        if S(f).is_constant() and n > 0:
+            return DiracDelta(a + b*x, n-1)/b
+
+        df = Derivative(f, x, n).doit().subs(x, x0)
+        return (-1)**n * df * Heaviside(a + b*x) / Abs(b)**(n+1)
 
 
 class TrigSubstitutionRule(Rule):
@@ -2495,24 +2501,6 @@ def singularity_rule(integral: IntegralInfo):
     return SingularityRule(integrand, s_var, offset, order)
 
 
-def singularity_rewrite_rule(integral: IntegralInfo):
-    """
-    Rewrite a SingularityFunction in terms of Heaviside/DiracDelta functions.
-    This should only be triggered when we cannot integrate the
-    SingularityFunction directly, usually in a multiplication or an exponent
-    node.
-    """
-    integrand, symbol = integral
-
-    if not integrand.has(SingularityFunction) or isinstance(integrand, SingularityFunction):
-        return None
-
-    rewritten = integrand.rewrite(DiracDelta)
-    if rewritten != integrand:
-        substep = integral_steps(rewritten, symbol)
-        return RewriteRule(integrand, symbol, rewritten, substep)
-
-
 def heaviside_rule(integral):
     integrand, symbol = integral
     pattern, m, b, g, k = heaviside_pattern(symbol)
@@ -2527,14 +2515,26 @@ def heaviside_rule(integral):
 
 def dirac_delta_rule(integral: IntegralInfo):
     integrand, x = integral
-    if len(integrand.args) == 1:
+
+    if not integrand.has(DiracDelta):
+        return
+
+    coeff = S.One
+    delta = integrand
+
+    if integrand.is_Mul:
+        factors = integrand.args
+        delta = next(iter(integrand.atoms(DiracDelta)))
+        coeff = Mul(*[f for f in factors if f is not delta])
+
+    if len(delta.args) == 1:
         n = S.Zero
     else:
-        n = integrand.args[1] # type: ignore
+        n = delta.args[1] # type: ignore
     if not n.is_Integer or n < 0:
         return
     a, b = Wild('a', exclude=[x]), Wild('b', exclude=[x, 0])
-    match = integrand.args[0].match(a+b*x)
+    match = delta.args[0].match(a+b*x)
     if not match:
         return
     a, b = match[a], match[b]
@@ -2543,7 +2543,7 @@ def dirac_delta_rule(integral: IntegralInfo):
         degenerate_step = None
     else:
         degenerate_step = ConstantRule(DiracDelta(a, n), x)
-    generic_step = DiracDeltaRule(integrand, x, n, a, b)
+    generic_step = DiracDeltaRule(delta, x, n, a, b, coeff)
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
@@ -2618,6 +2618,14 @@ trig_expand_rule = rewriter(
     lambda integrand, symbol: (
         len({a.args[0] for a in integrand.atoms(TrigonometricFunction)}) > 1),
     lambda integrand, symbol: integrand.expand(trig=True))
+
+singularity_rewrite_rule = rewriter(
+    lambda integrand, symbol: integrand.has(SingularityFunction) and not isinstance(integrand, SingularityFunction),
+    lambda integrand, symbol: integrand.expand(singularity=True, wrt=symbol))
+
+dirac_delta_expand_rule = rewriter(
+    lambda integrand, symbol: integrand.has(DiracDelta),
+    lambda integrand, symbol: integrand.expand(diracdelta=True, wrt=symbol))
 
 def derivative_rule(integral):
     integrand = integral[0]
@@ -2734,8 +2742,7 @@ def integral_steps(integrand, symbol, **options):
                         null_safe(quadratic_denom_rule),
                         null_safe(sqrt_quadratic_rule),
                         null_safe(sqrt_fractional_linear_rule),
-                        null_safe(singularity_rewrite_rule)
-                        ),
+                        null_safe(singularity_rewrite_rule)),
             Symbol: power_rule,
             exp: exp_rule,
             Add: add_rule,
@@ -2745,11 +2752,13 @@ def integral_steps(integrand, symbol, **options):
                         null_safe(sqrt_fractional_linear_rule),
                         null_safe(powsimp_rule),
                         null_safe(trig_cmplx_exp_rule),
-                        null_safe(singularity_rewrite_rule)),
+                        null_safe(singularity_rewrite_rule),
+                        null_safe(dirac_delta_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
             Heaviside: heaviside_rule,
-            DiracDelta: dirac_delta_rule,
+            DiracDelta: do_one(null_safe(dirac_delta_rule),
+                               null_safe(dirac_delta_expand_rule)),
             SingularityFunction: singularity_rule,
             OrthogonalPolynomial: orthogonal_poly_rule,
             Number: constant_rule

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from sympy.core.expr import Expr
 
 x, y, z, u, n, a, b, c, d, e = symbols('x y z u n a b c d e')
+x_1, x_2 = symbols("x_1 x_2")
 f = Function('f')
 
 
@@ -418,6 +419,64 @@ def test_manualintegrate_Heaviside():
 
     assert manualintegrate(sin(y + x)*Heaviside(3*x - y), x) == \
             (cos(y*Rational(4, 3)) - cos(x + y))*Heaviside(3*x - y)
+
+
+def test_manualintegrate_DiracDelta():
+    assert manualintegrate(DiracDelta(x, 0), x) == Heaviside(x)
+    for n in range(10):
+        assert manualintegrate(DiracDelta(x, n + 1), x) == DiracDelta(x, n)
+    assert manualintegrate(DiracDelta(x), x) == Heaviside(x)
+    assert manualintegrate(DiracDelta(-x), x) == Heaviside(x)
+    assert manualintegrate(DiracDelta(x - y), x) == Heaviside(x - y)
+
+    assert manualintegrate(x*DiracDelta(x), x) == 0
+    assert manualintegrate((x - y)*DiracDelta(x - y), x) == 0
+
+    assert manualintegrate(DiracDelta(x)**2, x) == DiracDelta(0)*Heaviside(x)
+    assert manualintegrate(y*DiracDelta(x)**2, x) == \
+        y*DiracDelta(0)*Heaviside(x)
+    assert manualintegrate(DiracDelta(x, 1), x) == DiracDelta(x, 0)
+    assert manualintegrate(y*DiracDelta(x, 1), x) == y*DiracDelta(x, 0)
+    assert manualintegrate(DiracDelta(x, 1)**2, x) == -DiracDelta(0, 2)*Heaviside(x)
+    assert manualintegrate(y*DiracDelta(x, 1)**2, x) == -y*DiracDelta(0, 2)*Heaviside(x)
+
+
+    assert manualintegrate(DiracDelta(x) * f(x), x) == f(0) * Heaviside(x)
+    assert manualintegrate(DiracDelta(-x) * f(x), x) == f(0) * Heaviside(x)
+    assert manualintegrate(DiracDelta(x - 1) * f(x), x) == f(1) * Heaviside(x - 1)
+    assert manualintegrate(DiracDelta(x**2 + x - 2), x) == \
+        Heaviside(x - 1)/3 + Heaviside(x + 2)/3
+
+    p = cos(x)*(DiracDelta(x) + DiracDelta(x**2 - 1))*sin(x)*(x - pi)
+    assert manualintegrate(p, x) == -pi*sin(1)*cos(1)*Heaviside(x - 1)/2 \
+        + sin(1)*cos(1)*Heaviside(x - 1)/2  \
+        + sin(1)*cos(1)*Heaviside(x + 1)/2 \
+        + pi*sin(1)*cos(1)*Heaviside(x + 1)/2
+
+
+    # # TODO: the following test is currently failing because of the way the code
+    # # handles the DiracDelta. The problem is that the code does not recognize
+    # # that the delta function is zero unless its argument is zero, and so it
+    # # does not simplify the expression correctly.
+    # p = x_2*DiracDelta(x - x_2)*DiracDelta(x_2 - x_1)
+    # assert manualintegrate(p, x_2) == x*DiracDelta(x - x_1)*Heaviside(x_2 - x)
+
+    p = x*y**2*z*DiracDelta(y - x)*DiracDelta(y - z)*DiracDelta(x - z)
+    assert manualintegrate(p, y) == x**3*z*DiracDelta(x - z)**2*Heaviside(y - x)
+    assert manualintegrate((x + 1)*DiracDelta(2*x), x) == S.Half * Heaviside(x)
+    assert manualintegrate((x + 1)*DiracDelta(x*Rational(2, 3) + Rational(4, 9)), x) == \
+        S.Half * Heaviside(x + Rational(2, 3))
+
+    a, b, c = symbols('a b c', commutative=False)
+    assert manualintegrate(DiracDelta(x - y)*f(x - b)*f(x - a), x) == \
+        f(y - b)*f(y - a)*Heaviside(x - y)
+
+    p = f(x - a)*DiracDelta(x - y)*f(x - c)*f(x - b)
+    assert manualintegrate(p, x) == f(y - a)*f(y - c)*f(y - b)*Heaviside(x - y)
+
+    p = DiracDelta(x - z)*f(x - b)*f(x - a)*DiracDelta(x - y)
+    assert manualintegrate(p, x) == DiracDelta(y - z)*f(y - b)*f(y - a) * \
+        Heaviside(x - y)
 
 
 def test_manualintegrate_orthogonal_poly():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

https://github.com/sympy/sympy/issues/28945#issuecomment-4635133996

#### Brief description of what is fixed or changed

1. Manual integrate module did not use to be able to handle Heaviside expressions where H0 is not the default (1/2). It simply propagates to the result.

$$
\int \theta(x-a, H_0) dx = (x-a)\theta(x-a, H_0)
$$

2. Add singularity function rule and rewrite expression to DiracDelta/Heaviside, when it cannot solve it as is, to manual integrate module.

$$
\int \langle x-1 \rangle^n dx = \frac{\langle x-1 \rangle^{n+1}}{n+1}
$$

3. Extend Dirac delta rule to cover more complex expressions in manual integrate module.

$$
\int f(x) \delta(x-y) dx = f(y) \theta(x-y)
$$


#### Other comments

1. Currently this code is not ready to replace `deltaintegrate`. When removed, the test `sympy/integrals/tests/test_failing_integrals.py::test_integrate_DiracDelta_no_meijerg` fails.

Faulty behaviour:

```python
In [5]: integrate(integrate(integrate(
   ...:         DiracDelta(x - y - z), (z, 0, oo)), (y, 0, 1), meijerg=False), (x, 0, 1))
Out[5]: 1
```

Correct behaviour:

```python
In [2]: integrate(integrate(integrate(
   ...:         DiracDelta(x - y - z), (z, 0, oo)), (y, 0, 1), meijerg=False), (x, 0, 1))
Out[2]: 1/2
```

I could not figure out what is the issue with the internal code. When I checked the indefinite integral before and after the changes, the results are the same. The issue only happens with definite integrals.

2. Also it is not ready to replace `singularityintegrate` because it cannot write back the result in terms of Singularity function. What's needed to achieve this is a sort of a flag that turns on only when `SingualrityRule` is called. If any pattern matching rule were applied at the end of `manualintegrate` (similar to what's done with `_has_erf_trig_mul`), then it would complicate other integrals that started with only DiracDelta/Heaviside.  

```python
In [12]: p = SingularityFunction(x, 1, -1) * f(x)

In [13]: manualintegrate(p, x)
Out[13]: f(1)⋅θ(x - 1)

In [14]: singularityintegrate(p, x)
Out[14]: 
            0
f(1)⋅<x - 1> 


```

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Copilot was used for code auto-completion while writing this code i.e. minimal AI use.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Handle Heaviside H0 parameter
  * Improved Singularity function handling.
  * Improved Dirac delta function handling.
<!-- END RELEASE NOTES -->
