### PR TITLE
polys: fix cross-type comparisons with int for ANP and Gaussian ground domains

### DIFF
--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -347,7 +347,7 @@ class FracElement(DomainElement, DefaultPrinting, CantSympify, Generic[Er]):
         return f.raw_new(*numer.cancel(denom))
 
     def to_poly(f):
-        if f.denom != 1:
+        if f.denom != f.field.ring.one:
             raise ValueError("f.denom should be 1")
         return f.numer
 

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -1233,7 +1233,7 @@ class PolyElement(
 
     @property
     def is_monomial(self) -> bool:
-        return not self or (len(self) == 1 and self.LC == 1)
+        return not self or (len(self) == 1 and self.ring.domain.is_one(self.LC))
 
     @property
     def is_term(self) -> bool:
@@ -2173,8 +2173,11 @@ class PolyElement(
             return dict.__eq__(self, other)
         elif len(self) > 1:
             return False
-        else:
-            return self.get(self.ring.zero_monom) == other
+        try:
+            other = self.ring.domain_new(other)
+        except CoercionFailed:
+            pass
+        return self.get(self.ring.zero_monom) == other
 
     def __neg__(self) -> PolyElement[Er]:
         # Return (-1) * self in case of python-flint

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from sympy.polys.fields import field, sfield, FracField, FracElement
 from sympy.polys.rings import ring
-from sympy.polys.domains import ZZ, QQ
+from sympy.polys.domains import ZZ, QQ, QQ_I
 from sympy.polys.orderings import lex
 
 from sympy.testing.pytest import raises, XFAIL
@@ -315,6 +315,14 @@ def test_FracElement_diff():
     F, x,y,z = field("x,y,z", ZZ)
 
     assert ((x**2 + y)/(z + 1)).diff(x) == 2*x/(z + 1)
+
+def test_FracElement_to_poly_cross_type_ground():
+    for K in [QQ.algebraic_field(sqrt(2)), QQ_I]:
+        F, z = field("z", K)
+
+        assert z.to_poly() == F.ring.gens[0]
+        assert (z**2).diff(z) == 2*z
+        assert (z**2 + z).subs(z, 1) == 2
 
 @XFAIL
 def test_FracElement___call__():

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -5,7 +5,7 @@ import pytest
 from functools import reduce
 from operator import add, mul
 
-from sympy.polys.domains import ZZ_I
+from sympy.polys.domains import ZZ_I, QQ_I
 from sympy.polys.rings import ring, xring, sring, PolyRing, PolyElement, vring, ninf
 from sympy.polys.fields import field, FracField
 from sympy.polys.domains import ZZ, QQ, RR, FF, EX
@@ -411,6 +411,23 @@ def test_PolyElement___eq__():
 
     assert (t**3*x/x == t**3) == True
     assert (t**3*x/x == t**4) == False
+
+
+def test_PolyElement___eq___cross_type_ground():
+    for K in [QQ.algebraic_field(sqrt(2)), ZZ_I, QQ_I]:
+        R, x = ring("x", K)
+
+        assert (R.one == 1) == True
+        assert (1 == R.one) == True
+        assert (R.one != 1) == False
+        assert (1 != R.one) == False
+
+        assert (R.zero == 0) == True
+        assert (R(2) == 2) == True
+        assert (R(2) == 3) == False
+
+        assert (x == 1) == False
+        assert (x != 1) == True
 
 
 def test_PolyElement__lt_le_gt_ge__():
@@ -1838,6 +1855,18 @@ def test_PolyElement_is_():
     R, = ring("", ZZ)
     assert R(4).is_squarefree is True
     assert R(6).is_irreducible is True
+
+
+def test_PolyElement_is_monomial_cross_type_ground():
+    for K in [QQ.algebraic_field(sqrt(2)), ZZ_I, QQ_I]:
+        R, x = ring("x", K)
+
+        assert R.zero.is_monomial is True
+        assert R.one.is_monomial is True
+        assert x.is_monomial is True
+        assert (x**2).is_monomial is True
+        assert (2*x).is_monomial is False
+        assert (x + 1).is_monomial is False
 
 
 def test_PolyElement_drop():


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Related issues: #29859 and #29860
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
For elements of algebraic fields, `elem == 1` always evaluates to `False`. The following code paths relied on such comparisons:

* `PolyElement.is_monomial`
* `PolyElement.__eq__`
* `FracElement.to_poly`

#### Other comments


#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed comparisons between `PolyElement` and `int` for domains whose elements do not support comparison with Python integers. `R.one == 1` now correctly returns `True`, and `PolyElement.is_monomial` now correctly returns `True` for monomials.
<!-- END RELEASE NOTES -->
