### PR TITLE
BUG: Fix a case in P + (-P) for Elliptic curves.

### DIFF
--- a/sympy/ntheory/elliptic_curve.py
+++ b/sympy/ntheory/elliptic_curve.py
@@ -323,7 +323,7 @@ class EllipticCurvePoint:
             slope = (y1 - y2) / (x1 - x2)
             yint = (y1 * x2 - y2 * x1) / (x2 - x1)
         else:
-            if (y1 + y2) == 0:
+            if (y1 + y2 + a1 * x1 + a3) == 0:
                 return self.point_at_infinity(self._curve)
             slope = (3 * x1**2 + 2*a2*x1 + a4 - a1*y1) / (a1 * x1 + a3 + 2 * y1)
             yint = (-x1**3 + a4*x1 + 2*a6 - a3*y1) / (a1*x1 + a3 + 2*y1)

--- a/sympy/ntheory/tests/test_elliptic_curve.py
+++ b/sympy/ntheory/tests/test_elliptic_curve.py
@@ -22,3 +22,6 @@ def test_elliptic_curve():
     # Issue 28546: -O should return canonical infinity point
     O = EllipticCurvePoint.point_at_infinity(e3)
     assert (-O).x == O.x and (-O).y == O.y and (-O).z == O.z
+    # Issue 28529
+    curv = EllipticCurve(0, 0, 0, 1, 1, 0)
+    assert (curv(0,0,1) + -curv(0,0,1)).z == 0


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Original issue: https://github.com/sympy/sympy/issues/28529
Looks like other PRs are abandoned
https://github.com/sympy/sympy/pull/28532
https://github.com/sympy/sympy/pull/29681
#### Brief description of what is fixed or changed
Fixed a condition to return point at infinity.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
