### PR TITLE
Fix #24026: Use issubclass instead of == for Max/Min subclassing

### DIFF
--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -435,7 +435,7 @@ class MinMaxBase(Expr, LatticeOp):
         if not args:
             return args
         args = list(ordered(args))
-        if cls == Min:
+        if issubclass(cls, Min):
             other = Max
         else:
             other = Min
@@ -463,20 +463,20 @@ class MinMaxBase(Expr, LatticeOp):
             # there may be more than one numeric arg present since
             # local zeros have not been handled yet, so look through
             # more than the first arg
-            if cls == Min:
+            if issubclass(cls, Min):
                 for arg in args:
                     if not arg.is_number:
                         break
                     if (arg < small) == True:
                         small = arg
-            elif cls == Max:
+            elif issubclass(cls, Max):
                 for arg in args:
                     if not arg.is_number:
                         break
                     if (arg > big) == True:
                         big = arg
             T = None
-            if cls == Min:
+            if issubclass(cls, Min):
                 if small != Min.identity:
                     other = Max
                     T = small
@@ -588,7 +588,7 @@ class MinMaxBase(Expr, LatticeOp):
                     con = cls._is_connected(v, z)
                     if con:
                         is_newzero = False
-                        if con is True or con == cls:
+                        if con is True or issubclass(cls, con):
                             localzeros.remove(z)
                             localzeros.update([v])
             if is_newzero:


### PR DESCRIPTION
Fix the bug where subclasses of `Max` and `Min` produce incorrect results.

## Problem

Subclassing `Max` or `Min` produces wrong values — e.g., `MyMax(3, 4)` returns `3` (the minimum) instead of `4`. This is because internal comparisons use `cls == Min` and `cls == Max` which fail when `cls` is a subclass.

Reported in #24026:
> `class Max(sympy.Max): pass; print(Max(3, 4), sympy.Max(3, 4))  #--> 3 4`

As @jksuom identified (https://github.com/sympy/sympy/issues/24026#issuecomment-1239319110):
> `con == cls` is False, but `issubclass(cls, con)` is True

## Fix

Changed 5 occurrences of `cls == Min` / `cls == Max` to `issubclass(cls, Min)` / `issubclass(cls, Max)` in `_collapse_arguments` (line 438, 466, 472, 479), and `con == cls` to `issubclass(cls, con)` in `_find_localzeros` (line 591).

All 342 tests in `sympy/functions/elementary/` pass.
