### PR TITLE
Fix Pauli left-multiplication with scalar prefix (FIXME in paulialgebra.py)

### DIFF
--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -162,7 +162,6 @@ def evaluate_pauli_product(arg):
     ========
 
     >>> from sympy.physics.paulialgebra import Pauli, evaluate_pauli_product
-    >>> from sympy import I
     >>> from sympy.abc import x
     >>> evaluate_pauli_product(x**2*Pauli(2)*Pauli(1))
     -I*x**2*sigma3

--- a/sympy/physics/paulialgebra.py
+++ b/sympy/physics/paulialgebra.py
@@ -11,7 +11,10 @@ References
 """
 from __future__ import annotations
 
+import threading
+
 from sympy.core.add import Add
+from sympy.core.basic import Basic
 from sympy.core.mul import Mul
 from sympy.core.numbers import I
 from sympy.core.power import Pow
@@ -78,14 +81,6 @@ class Pauli(Symbol):
     optional parameter ``label="sigma"``. Pauli matrices with different
     ``label`` attributes cannot multiply together.
 
-    If the left multiplication of symbol or number with Pauli matrix is needed,
-    please use parentheses  to separate Pauli and symbolic multiplication
-    (for example: 2*I*(Pauli(3)*Pauli(2))).
-
-    Another variant is to use evaluate_pauli_product function to evaluate
-    the product of Pauli matrices and other symbols (with commutative
-    multiply rules).
-
     See Also
     ========
 
@@ -115,14 +110,7 @@ class Pauli(Symbol):
     I*tau3
 
     >>> from sympy import I
-    >>> I*(Pauli(2)*Pauli(3))
-    -sigma1
-
-    >>> from sympy.physics.paulialgebra import evaluate_pauli_product
-    >>> f = I*Pauli(2)*Pauli(3)
-    >>> f
-    I*sigma2*sigma3
-    >>> evaluate_pauli_product(f)
+    >>> I*Pauli(2)*Pauli(3)
     -sigma1
     """
 
@@ -142,7 +130,6 @@ class Pauli(Symbol):
     def _hashable_content(self):
         return (self.i, self.label)
 
-    # FIXME don't work for -I*Pauli(2)*Pauli(3)
     def __mul__(self, other):
         if isinstance(other, Pauli):
             j = self.i
@@ -176,9 +163,6 @@ def evaluate_pauli_product(arg):
 
     >>> from sympy.physics.paulialgebra import Pauli, evaluate_pauli_product
     >>> from sympy import I
-    >>> evaluate_pauli_product(I*Pauli(1)*Pauli(2))
-    -sigma3
-
     >>> from sympy.abc import x
     >>> evaluate_pauli_product(x**2*Pauli(2)*Pauli(1))
     -I*x**2*sigma3
@@ -230,3 +214,21 @@ def evaluate_pauli_product(arg):
         end = tmp[0]*keeper*sigma_product*com_product
         if end == arg: break
     return end
+
+
+_pauli_postprocessor_guard = threading.local()
+
+
+def _pauli_mul_postprocessor(expr):
+    if getattr(_pauli_postprocessor_guard, 'active', False):
+        return expr
+    _pauli_postprocessor_guard.active = True
+    try:
+        return evaluate_pauli_product(expr)
+    finally:
+        _pauli_postprocessor_guard.active = False
+
+
+Basic._constructor_postprocessor_mapping[Pauli] = {
+    "Mul": [_pauli_mul_postprocessor],
+}

--- a/sympy/physics/tests/test_paulialgebra.py
+++ b/sympy/physics/tests/test_paulialgebra.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from sympy.core.numbers import I
 from sympy.core.symbol import symbols
 from sympy.physics.paulialgebra import Pauli
-from sympy.testing.pytest import XFAIL
 from sympy.physics.quantum import TensorProduct
 
 sigma1 = Pauli(1)
@@ -53,6 +52,14 @@ def test_evaluate_pauli_product():
     ) == 1 -I + I*sigma3*tau1*sigma2 - 1 - sigma3 - I*TensorProduct(1,1)
 
 
-@XFAIL
 def test_Pauli_should_work():
     assert sigma1*sigma3*sigma1 == -sigma3
+
+
+def test_Pauli_left_mul():
+    # Products where a scalar/imaginary prefactor appears to the left of Pauli
+    # matrices are now automatically evaluated via the Mul postprocessor.
+    assert I*sigma2*sigma3 == -sigma1
+    assert -I*sigma2*sigma3 == sigma1
+    assert I*sigma1*sigma2*sigma3 == -1
+    assert -I*sigma1*sigma2 == sigma3


### PR DESCRIPTION
## Summary

Fixes the long-standing `# FIXME don't work for -I*Pauli(2)*Pauli(3)` comment in `sympy/physics/paulialgebra.py`.

**Disclaimer:** This fix was generated entirely by [Claude](https://claude.ai/) (Anthropic's AI assistant). It has been submitted here to get feedback from people who know SymPy well. The human author does not know enough about SymPy internals to vouch for it beyond: the tests pass, and attaching a callback to `Mul` construction makes intuitive sense as an approach.

---

## Root cause

`Pauli.__mul__` is only invoked when Python's operator dispatch directly calls it — i.e. when the left operand is a `Pauli` instance. For an expression like `-I*Pauli(2)*Pauli(3)`, Python evaluates left-to-right:

1. `-I * Pauli(2)` → `Mul.__mul__` is called (not `Pauli.__mul__`), producing `Mul(-1, I, sigma2)`
2. `Mul(-1, I, sigma2) * Pauli(3)` → again `Mul.__mul__`, producing `Mul(-1, I, sigma2, sigma3)`

At no point does `Pauli.__mul__` see a `Pauli` on its right-hand side. SymPy's `Mul.flatten` only combines adjacent non-commutative factors when they share the same base (for power merging); it does not call `__mul__` between arbitrary adjacent nc factors.

The existing `evaluate_pauli_product` function handles this correctly but must be called explicitly. The previous workaround documented in the docstring was to use parentheses: `I*(Pauli(2)*Pauli(3))`.

## Fix

Register a **constructor postprocessor** (via `Basic._constructor_postprocessor_mapping`) for the `Pauli` class targeting `"Mul"`. Whenever SymPy constructs a `Mul` that contains a `Pauli` argument, the postprocessor automatically calls `evaluate_pauli_product` on the result.

A `threading.local` **reentrance guard** prevents infinite recursion: `evaluate_pauli_product` itself performs multiplications that create new `Mul` objects, which would re-trigger the postprocessor without the guard.

## Changes

- `sympy/physics/paulialgebra.py`
  - Add `import threading` and `from sympy.core.basic import Basic`
  - Remove the `# FIXME` comment
  - Update `Pauli` docstring: remove the parentheses workaround note; update example to show `-I*Pauli(2)*Pauli(3)` now auto-evaluates
  - Add `_pauli_postprocessor_guard` (`threading.local`) and `_pauli_mul_postprocessor`
  - Register `_pauli_mul_postprocessor` in `Basic._constructor_postprocessor_mapping[Pauli]`

- `sympy/physics/tests/test_paulialgebra.py`
  - Remove `@XFAIL` from `test_Pauli_should_work` — `sigma1*sigma3*sigma1 == -sigma3` now passes as a bonus
  - Add `test_Pauli_left_mul` covering the `-I*Pauli(2)*Pauli(3)` family of cases

## Open questions for reviewers

- Is `_constructor_postprocessor_mapping` (marked "experimental" in the source) appropriate to use here, or is there a more canonical extension point?
- Are there performance implications of calling `evaluate_pauli_product` on every `Mul` that contains a Pauli factor (including simple ones like `2*Pauli(1)` where no simplification is needed)?
- Are there edge cases — e.g. with `TensorProduct`, symbolic exponents, or mixed labels — where the postprocessor could produce incorrect results?

<!-- BEGIN RELEASE NOTES -->
* physics.paulialgebra
  * `Pauli` matrices now automatically simplify products where a scalar or imaginary prefix appears to the left, e.g. `-I*Pauli(2)*Pauli(3)` now evaluates to `sigma1` directly without needing `evaluate_pauli_product` or parentheses grouping.
<!-- END RELEASE NOTES -->