### PR TITLE
[GSoC 2026] Implements ConjugateDomain and Domain.conjugate

### DIFF
--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import cached_property
 from sympy.core.add import Add
 from sympy.core.mul import Mul
 from sympy.core.singleton import S
@@ -26,8 +27,13 @@ Alg = ANP[MPQ]
 
 
 @public
-class AlgebraicField(Field[Alg], CharacteristicZero, SimpleDomain[Alg],
-                     ConjugateDomain[Alg], RingExtension[Alg, MPQ]):
+class AlgebraicField(
+    Field[Alg],
+    CharacteristicZero,
+    SimpleDomain[Alg],
+    ConjugateDomain[Alg],
+    RingExtension[Alg, MPQ]
+):
     r"""Algebraic number field :ref:`QQ(a)`
 
     A :ref:`QQ(a)` domain represents an `algebraic number field`_
@@ -339,7 +345,6 @@ class AlgebraicField(Field[Alg], CharacteristicZero, SimpleDomain[Alg],
 
         self._maximal_order = None
         self._discriminant = None
-        self._ext_conjugate = None
         self._nilradicals_mod_p: dict = {}
 
     def new(self, element):
@@ -554,26 +559,27 @@ class AlgebraicField(Field[Alg], CharacteristicZero, SimpleDomain[Alg],
         rad = self._nilradicals_mod_p.get(p)
         return prime_decomp(p, ZK=ZK, dK=dK, radical=rad)
 
-    def conjugate(self, a):
+    @cached_property
+    def conjugate(self):
         """Returns the complex conjugate of ``a``. """
-        conj = self._ext_conjugate
-        if conj is None:
-            try:
-                # the conjugate of ext has the same minpoly as ext
-                z = self.ext.func((self.ext.minpoly, self.ext.conjugate()))
-                conj = self.from_sympy(z)
-            except CoercionFailed:
-                raise CoercionFailed("the algebraic field is not closed under conjugation")
-            self._ext_conjugate = conj
+        try:
+            # the conjugate of ext has the same minpoly as ext
+            z = self.ext.func((self.ext.minpoly, self.ext.conjugate()))
+            conj = self.from_sympy(z)
+        except CoercionFailed:
+            raise CoercionFailed("the algebraic field is not closed under conjugation")
 
         if conj.rep == [1, 0]:
             # conj == ext implies ext is real
-            return a
+            return lambda a: a
 
-        v = self.zero
-        for c in a.rep:
-            v = v * conj + c
-        return v
+        def conjugate(a):
+            v = self.zero
+            for c in a.rep:
+                v = v * conj + c
+            return v
+
+        return conjugate
 
     def galois_group(self, by_name=False, max_tries=30, randomize=False):
         """

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -10,6 +10,7 @@ from sympy.external.gmpy import MPQ
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.domains.conjugatedomain import ConjugateDomain
 from sympy.polys.domains.ringextension import RingExtension
 from sympy.polys.polyclasses import ANP, DMP
 from sympy.polys.polyerrors import CoercionFailed, DomainError, NotAlgebraic, IsomorphismFailed
@@ -25,7 +26,8 @@ Alg = ANP[MPQ]
 
 
 @public
-class AlgebraicField(Field[Alg], CharacteristicZero, SimpleDomain[Alg], RingExtension[Alg, MPQ]):
+class AlgebraicField(Field[Alg], CharacteristicZero, SimpleDomain[Alg],
+                     ConjugateDomain[Alg], RingExtension[Alg, MPQ]):
     r"""Algebraic number field :ref:`QQ(a)`
 
     A :ref:`QQ(a)` domain represents an `algebraic number field`_
@@ -337,6 +339,7 @@ class AlgebraicField(Field[Alg], CharacteristicZero, SimpleDomain[Alg], RingExte
 
         self._maximal_order = None
         self._discriminant = None
+        self._ext_conjugate = None
         self._nilradicals_mod_p: dict = {}
 
     def new(self, element):
@@ -550,6 +553,27 @@ class AlgebraicField(Field[Alg], CharacteristicZero, SimpleDomain[Alg], RingExte
         dK = self.discriminant()
         rad = self._nilradicals_mod_p.get(p)
         return prime_decomp(p, ZK=ZK, dK=dK, radical=rad)
+
+    def conjugate(self, a):
+        """Returns the complex conjugate of ``a``. """
+        conj = self._ext_conjugate
+        if conj is None:
+            try:
+                # the conjugate of ext has the same minpoly as ext
+                z = self.ext.func((self.ext.minpoly, self.ext.conjugate()))
+                conj = self.from_sympy(z)
+            except CoercionFailed:
+                raise CoercionFailed("the algebraic field is not closed under conjugation")
+            self._ext_conjugate = conj
+
+        if conj.rep == [1, 0]:
+            # conj == ext implies ext is real
+            return a
+
+        v = self.zero
+        for c in a.rep:
+            v = v * conj + c
+        return v
 
     def galois_group(self, by_name=False, max_tries=30, randomize=False):
         """

--- a/sympy/polys/domains/complexfield.py
+++ b/sympy/polys/domains/complexfield.py
@@ -9,12 +9,13 @@ from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.gaussiandomains import QQ_I
 from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.domains.conjugatedomain import ConjugateDomain
 from sympy.polys.polyerrors import DomainError, CoercionFailed
 from sympy.utilities import public
 
 
 @public
-class ComplexField(Field, CharacteristicZero, SimpleDomain):
+class ComplexField(Field, CharacteristicZero, SimpleDomain, ConjugateDomain):
     """Complex numbers up to the given precision. """
 
     rep = 'CC'
@@ -194,5 +195,10 @@ class ComplexField(Field, CharacteristicZero, SimpleDomain):
         slightly inaccurate due to floating point rounding error.
         """
         return a ** 0.5
+
+    def conjugate(self, a):
+        """Returns the complex conjugate of ``a``. """
+        return self.dtype(a.real, -a.imag)
+
 
 CC = ComplexField()

--- a/sympy/polys/domains/conjugatedomain.py
+++ b/sympy/polys/domains/conjugatedomain.py
@@ -1,0 +1,16 @@
+"""Implementation of :class:`ConjugateDomain` class. """
+from __future__ import annotations
+
+
+from sympy.polys.domains.domain import Domain, Er
+from sympy.utilities import public
+
+@public
+class ConjugateDomain(Domain[Er]):
+    """Base class for domains supporting conjugation. """
+
+    is_ConjugateDomain = True
+
+    def conjugate(self, a: Er) -> Er:
+        """Returns the complex conjugate of ``a``."""
+        raise NotImplementedError

--- a/sympy/polys/domains/domain.py
+++ b/sympy/polys/domains/domain.py
@@ -495,6 +495,9 @@ class Domain(Generic[Er]):
     is_Simple: bool = False
     """Boolean flag indicating if the domain is a simple domain."""
 
+    is_ConjugateDomain: bool = False
+    """Boolean flag indicating if the domain supports conjugation."""
+
     is_Composite: bool = False
     """Boolean flag indicating if the domain is a composite domain."""
 

--- a/sympy/polys/domains/expressiondomain.py
+++ b/sympy/polys/domains/expressiondomain.py
@@ -7,6 +7,7 @@ from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.domains.conjugatedomain import ConjugateDomain
 from sympy.polys.polyutils import PicklableWithSlots
 from sympy.utilities import public
 
@@ -14,7 +15,7 @@ eflags = {"deep": False, "mul": True, "power_exp": False, "power_base": False,
               "basic": False, "multinomial": False, "log": False}
 
 @public
-class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
+class ExpressionDomain(Field, CharacteristicZero, SimpleDomain, ConjugateDomain):
     """A class for arbitrary expressions. """
 
     is_SymbolicDomain = is_EX = True
@@ -277,6 +278,10 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
 
     def lcm(self, a, b):
         return a.lcm(b)
+
+    def conjugate(self, a):
+        """Returns the complex conjugate of ``a``."""
+        return self.dtype(a.ex.conjugate())
 
 
 EX = ExpressionDomain()

--- a/sympy/polys/domains/expressionrawdomain.py
+++ b/sympy/polys/domains/expressionrawdomain.py
@@ -6,12 +6,13 @@ from sympy.core import Expr, S, sympify, Add
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.domains.conjugatedomain import ConjugateDomain
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
 
 
 @public
-class ExpressionRawDomain(Field, CharacteristicZero, SimpleDomain):
+class ExpressionRawDomain(Field, CharacteristicZero, SimpleDomain, ConjugateDomain):
     """A class for arbitrary expressions but without automatic simplification. """
 
     is_SymbolicRawDomain = is_EXRAW = True
@@ -53,6 +54,10 @@ class ExpressionRawDomain(Field, CharacteristicZero, SimpleDomain):
 
     def sum(self, items):
         return Add(*items)
+
+    def conjugate(self, a):
+        """Returns the complex conjugate of ``a``."""
+        return a.conjugate()
 
 
 EXRAW = ExpressionRawDomain()

--- a/sympy/polys/domains/gaussiandomains.py
+++ b/sympy/polys/domains/gaussiandomains.py
@@ -14,6 +14,7 @@ from sympy.polys.domains.domainelement import DomainElement
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.ring import Ring
 from sympy.polys.domains.ringextension import RingExtension
+from sympy.polys.domains.conjugatedomain import ConjugateDomain
 
 
 Tdom = TypeVar('Tdom', MPZ, MPQ)
@@ -275,7 +276,7 @@ class GaussianRational(GaussianElement[MPQ]):
             return self/other, self._parent.zero
 
 
-class GaussianDomain(RingExtension[Telem, Tdom]):
+class GaussianDomain(RingExtension[Telem, Tdom], ConjugateDomain):
     """Base class for Gaussian domains."""
     dom: Domain
     units: tuple[Telem, Telem, Telem, Telem]
@@ -360,6 +361,10 @@ class GaussianDomain(RingExtension[Telem, Tdom]):
         if K0.ext.args[0] == I:
             return K1.from_sympy(K0.to_sympy(a))
         return None
+
+    def conjugate(self, a: Telem) -> Telem:
+        """Returns the complex conjugate of ``a``."""
+        return self.dtype(a.x, -a.y)
 
 
 class GaussianIntegerRing(GaussianDomain[GaussianInteger, MPZ], Ring[MPZ]):

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -13,13 +13,14 @@ from sympy.polys.domains.groundtypes import (
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.ring import Ring
 from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.domains.conjugatedomain import ConjugateDomain
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
 
 import math
 
 @public
-class IntegerRing(Ring[MPZ], CharacteristicZero, SimpleDomain):
+class IntegerRing(Ring[MPZ], CharacteristicZero, SimpleDomain, ConjugateDomain):
     r"""The domain ``ZZ`` representing the integers `\mathbb{Z}`.
 
     The :py:class:`IntegerRing` class represents the ring of integers as a
@@ -271,6 +272,10 @@ class IntegerRing(Ring[MPZ], CharacteristicZero, SimpleDomain):
     def factorial(self, a):
         """Compute factorial of ``a``. """
         return factorial(a)
+
+    def conjugate(self, a: MPZ) -> MPZ:
+        """Returns the complex conjugate of ``a``."""
+        return a
 
 
 ZZ = IntegerRing()

--- a/sympy/polys/domains/rationalfield.py
+++ b/sympy/polys/domains/rationalfield.py
@@ -9,11 +9,12 @@ from sympy.polys.domains.groundtypes import SymPyRational, is_square, sqrtrem
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.domains.conjugatedomain import ConjugateDomain
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
 
 @public
-class RationalField(Field[MPQ], CharacteristicZero, SimpleDomain):
+class RationalField(Field[MPQ], CharacteristicZero, SimpleDomain, ConjugateDomain):
     r"""Abstract base class for the domain :ref:`QQ`.
 
     The :py:class:`RationalField` class represents the field of rational
@@ -197,5 +198,10 @@ class RationalField(Field[MPQ], CharacteristicZero, SimpleDomain):
         if q_rem != 0:
             return None
         return MPQ(p_sqrt, q_sqrt)
+
+    def conjugate(self, a):
+        """Returns the complex conjugate of ``a``."""
+        return a
+
 
 QQ = RationalField()

--- a/sympy/polys/domains/realfield.py
+++ b/sympy/polys/domains/realfield.py
@@ -7,6 +7,7 @@ from sympy.external.mpmath import to_rational as _mpmath_to_rational, MPContext
 from sympy.core.numbers import Float
 from sympy.polys.domains.field import Field
 from sympy.polys.domains.simpledomain import SimpleDomain
+from sympy.polys.domains.conjugatedomain import ConjugateDomain
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities import public
@@ -51,7 +52,7 @@ def to_rational(s, max_denom, limit=True):
 
 
 @public
-class RealField(Field, CharacteristicZero, SimpleDomain):
+class RealField(Field, CharacteristicZero, SimpleDomain, ConjugateDomain):
     """Real numbers up to the given precision. """
 
     rep = 'RR'
@@ -214,6 +215,10 @@ class RealField(Field, CharacteristicZero, SimpleDomain):
         rounding error.
         """
         return a ** 0.5 if a >= 0 else None
+
+    def conjugate(self, a):
+        """Returns the complex conjugate of ``a``."""
+        return a
 
 
 RR = RealField()

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1463,3 +1463,23 @@ def test_Domain_conjugate():
     ]
     for domain in domains:
         assert not domain.is_ConjugateDomain
+
+    # algebraic fields
+    K = QQ.algebraic_field(sqrt(2))
+    a = K.from_sympy(sqrt(2) + 1)
+    assert K.is_ConjugateDomain
+    assert K.conjugate(a) == a
+
+    K = QQ.algebraic_field((-1 + sqrt(5)*I)/4)
+    a = K.from_sympy((-7 + 3*sqrt(5)*I)/2)
+    b = K.from_sympy((-7 - 3*sqrt(5)*I)/2)
+    assert K.conjugate(a) == b
+
+    K = QQ.cyclotomic_field(7)
+    a = K.dtype([0, 1, 2, 3, 4, 5, 6], K.mod.to_list(), QQ)
+    b = K.dtype([5, 4, 3, 2, 1, 0, 6], K.mod.to_list(), QQ)
+    assert K.conjugate(a) == b
+
+    a = Poly(x**3 - x + 1, x, domain=ZZ).all_roots()[-1]
+    K = QQ.algebraic_field(a)
+    raises(CoercionFailed, lambda: K.conjugate(K.from_sympy(a)))

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1163,6 +1163,7 @@ def test_gaussian_domains():
         assert 2*i + r == q
         i, r = divmod(2, q)
         assert q*i + r == G(2, 0)
+        assert G.conjugate(q) == G(3, -4)
 
         a, b = G(2, 0), G(1, -1)
         c, d, g = G.gcdex(a, b)
@@ -1433,3 +1434,32 @@ def test_exsqrt():
     assert F7.exsqrt(F7(3)) is None
     assert F7.is_square(F7(0)) is True
     assert F7.exsqrt(F7(0)) == F7(0)
+
+
+def test_Domain_conjugate():
+    domains = [ZZ, QQ, RR, CC, ZZ_I, QQ_I, EX, EXRAW]
+    for domain in domains:
+        a = domain(7)
+        assert domain.is_ConjugateDomain
+        assert domain.of_type(domain.conjugate(a))
+        assert domain.conjugate(a) == a
+
+        if domain.is_Field:
+            b = domain(-5)
+            assert domain.of_type(domain.conjugate(a / b))
+            assert domain.conjugate(a / b) == domain(a / b)
+
+    domains = [CC, ZZ_I, QQ_I, EX, EXRAW]
+    for domain in domains:
+        a = domain.from_sympy(7 + 3*I)
+        b = domain.from_sympy(7 - 3*I)
+        assert domain.of_type(domain.conjugate(a))
+        assert domain.conjugate(a) == b
+        assert domain.conjugate(b) == a
+
+    domains = [
+        FF(2), FF(11), ZZ[x], QQ[x], QQ[x, y], RR[z], CC[z],
+        ZZ_I[x], QQ_I[x, y], QQ_I.frac_field(x, y), EXRAW[z],
+    ]
+    for domain in domains:
+        assert not domain.is_ConjugateDomain


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Related to #27436

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

This PR introduces a `ConjugateDomain` class in `sympy/polys/domains/conjugatedomain.py` and domains that support conjugation subclass `ConjugateDomain`. Currently, `ZZ,QQ,RR,CC,ZZ_I,QQ_I,EX,EXRAW` and `AlgebraicField` inherit from `ConjugateDomain`. These classes implement `Domain.conjugate(self, a)` to compute the complex conjugate of a domain element.

The `ConjugateDomain` naming is suggested by ChatGPT. 

**AlgebraicFields**

With this PR, AlgebraicField is a subclass of `ConjugateDomain`. But for algebraic fields that are not closed under conjugation, the function raises CoercionFailed when calling `conjugate`.  For algebraic fields that are closed under conjugation, it precomputes the conjugate of the generator $x$ and then computes the conjugate of a domain element $a$ by

$$\overline a = c_0 +c_1\overline x+\cdots +c_{n-1}\overline x^{n-1}.$$

The evaluation uses Horner's algorithm for efficiency.

#### Other comments

One might imagine implementing a `ConjugateAlgebraicField` so that calling `__new__` decides whether the returned instance should be  `ConjugateAlgebraicField` dynamically. But I avoid doing so for these reasons:
1. It is expensive to decide whether an algebraic field is closed under conjugation. Since many users work with algebraic fields without needing conjugation. So I don't think it is a good idea to check whether it is closed under conjugation when creating the instance.
2. If we write code like `QQ.algebraic_field(a).conjugate(b)`, it would be unfriendly for static type checkers to decide whether the algebraic field has the `conjugate` method if we do not implement it for all algebraic fields.


#### AI Generation Disclosure

All code is handwritten.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added a `ConjugateDomain` and `Domain.conjugate` method for domains supporting complex conjugation.
<!-- END RELEASE NOTES -->
