### PR TITLE
simplify/besselsimp: fix _use_recursion sort to avoid SymPy relationa…

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -16,7 +16,7 @@ from sympy.core.function import (expand_log, count_ops, _mexpand,
 from sympy.core.numbers import Float, I, Integer, pi, Rational, equal_valued
 from sympy.core.relational import Relational
 from sympy.core.rules import Transform
-from sympy.core.sorting import ordered
+from sympy.core.sorting import default_sort_key, ordered
 from sympy.core.sympify import _sympify
 from sympy.core.traversal import bottom_up as _bottom_up, walk as _walk
 from sympy.functions import gamma, exp, sqrt, log, exp_polar, re
@@ -1315,8 +1315,45 @@ def besselsimp(expr):
         def _use_recursion(bessel, expr):
             while True:
                 bessels = expr.find(lambda x: isinstance(x, bessel))
+                # Apply the recurrence lowest-order first.
+                #
+                # We must not trigger SymPy's relational machinery
+                # (is_ge / __lt__) to compare symbolic orders: for a
+                # Symbol a with no finiteness assumption, re(a) could
+                # be oo, so is_ge(re(a), re(a)+1) correctly returns
+                # None, and bool() of the resulting unevaluated
+                # Relational raises TypeError.
+                #
+                # Strategy:
+                #  1. Concrete numeric orders (int, Rational, sqrt(17)/4,
+                #     5*I, ...): evalf() yields a plain float; sort numerically.
+                #  2. Symbolic orders of the form (base +/- integer_offset),
+                #     e.g. a-1, a, a+1 or sqrt(b**2)+/-1: extract the offset
+                #     via as_coeff_Add() and sort as
+                #     (canonical_key_of_base, offset).  Pure Python tuple
+                #     comparison -- no SymPy relational involved, never raises.
+                #  3. Everything else: structural canonical key, offset 0.
+                #
+                # The outer try/except is a safety valve for any unexpected
+                # error inside the loop body.
+                def _order_key(b):
+                    v = re(b.args[0])
+                    f = v.evalf()
+                    if f.is_number:
+                        return (0, float(f))
+                    # Symbolic: split off any concrete additive constant
+                    # so that e.g. a-1, a, a+1 sort by offset.
+                    offset = 0.0
+                    base = v
+                    if v.is_Add:
+                        c, base = v.as_coeff_Add()
+                        if c.is_number:
+                            offset = float(c)
+                        else:
+                            base, offset = v, 0.0
+                    return (1, default_sort_key(base), offset)
                 try:
-                    for ba in sorted(bessels, key=lambda x: re(x.args[0])):
+                    for ba in sorted(bessels, key=_order_key):
                         a, x = ba.args
                         bap1 = bessel(a+1, x)
                         bap2 = bessel(a+2, x)


### PR DESCRIPTION
…l machinery

The previous sort (key=lambda x: re(x.args[0])) breaks when SymPy's is_ge returns None for symbolic orders without finiteness assumptions — bool() of the resulting unevaluated Relational raises TypeError.  The PR's workaround (default_sort_key(re(order))) sorts by syntactic class rather than numeric value, putting e.g. sqrt(17)/4+1 (Add) before sqrt(17)/4 (Mul) and corrupting Bessel recurrences for irrational or mixed-symbolic orders.

Replace with a three-tier key that never touches SymPy relations:
  1. Concrete orders (int, Rational, sqrt(17)/4, …): evalf() → float.
  2. Symbolic base ± integer offset (a±1, sqrt(b**2)±1, …): split via as_coeff_Add(), sort as (canonical_key_of_base, float_offset). Pure Python tuple comparison — no is_ge involved, never raises.
  3. Everything else: structural canonical key, offset 0.

Outer try/except (ValueError, TypeError) guards the loop body as before.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Entirely AI written for the most part. (Including PR description above).  I haven't looked at the code much. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

DRAFT

<!-- END RELEASE NOTES -->
