### PR TITLE
DOC: Document group and return type in Basic.find

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -845,6 +845,7 @@ Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
 Jay Vijan <jvijan@umich.edu> Jay Sun Vijan <145924415+jvijan@users.noreply.github.com>
+Jaya Prajapati <jayaprajapati8755@gmail.com>
 Jayesh Lahori <jlahori92@gmail.com>
 Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>
 Jean-François B <2589111+jfbu@users.noreply.github.com>

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1802,7 +1802,63 @@ class Basic(Printable):
         return (rv, mapping) if map else rv # type: ignore
 
     def find(self, query, group=False):
-        """Find all subexpressions matching a query."""
+        """Find all subexpressions matching a query.
+
+        Parameters
+        ==========
+        
+        The ``query`` argument can be:
+
+        - a class such as ``Pow`` or ``exp``, to match all instances of that class
+        - a specific expression, to match occurrences equal to it
+        - a :class:`~.Wild`-containing pattern
+        - any callable taking one argument and returning a bool, used as a custom
+        test on each subexpression
+
+        group : bool, optional
+
+            Controls the form of the result. With the default value
+            of ``False``, duplicates are discarded and a ``set`` is
+            returned. Setting this to ``True`` keeps track of how
+            often each subexpression was found, returning a ``dict``
+            instead.
+
+        Returns
+        =======
+
+        set or dict
+
+            All distinct subexpressions matching ``query``. This is a
+            plain ``set`` unless ``group=True``, in which case a
+            ``dict`` is returned where each key is a match and the
+            corresponding value is the number of times it appeared in
+            ``self``.
+
+        Examples
+        ========
+
+        >>> from sympy import exp, log
+        >>> from sympy.abc import a, b
+
+        Default behaviour returns a set of unique matches:
+
+        >>> expr = exp(a) + log(b) + exp(a)*log(b)
+        >>> expr.find(exp)
+        {exp(a)}
+
+        With ``group=True``, a dict mapping matches to their counts
+        is returned instead:
+
+        >>> expr.find(log, group=True)
+        {log(b): 2}
+
+        A callable can be used for custom matching, e.g. to find
+        every power in an expression:
+
+        >>> (a**2 + b**3).find(lambda s: s.is_Pow)
+        {a**2, b**3}
+        """
+        
         query = _make_find_query(query)
         results = list(filter(query, _preorder_traversal(self)))
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1804,61 +1804,78 @@ class Basic(Printable):
     def find(self, query, group=False):
         """Find all subexpressions matching a query.
 
+        Traverses the expression tree and collects every node that
+        matches ``query``. The query may be given in several forms:
+
+        - a **type** (class), e.g. ``sin`` or ``Integer``, which matches
+          all nodes that are instances of that type;
+        - an **expression**, which matches structurally identical
+          subexpressions; if it contains ``Wild`` symbols, pattern
+          matching is used;
+        - a **callable** (e.g. a lambda), which matches every node for
+          which the callable returns ``True``.
+
         Parameters
         ==========
-        
+
         query : type, Basic, or callable
-
-            - a class such as ``Pow`` or ``exp``, to match all instances of that class
-            - a specific expression, to match occurrences equal to it
-            - a :class:`~.Wild`-containing pattern
-            - any callable taking one argument and returning a bool, used as a custom
-              test on each subexpression
-
+            The pattern used to test each node of the expression tree.
         group : bool, optional
-
-            Controls the form of the result. With the default value
-            of ``False``, duplicates are discarded and a ``set`` is
-            returned. Setting this to ``True`` keeps track of how
-            often each subexpression was found, returning a ``dict``
-            instead.
+            If ``False`` (default), return a set of the unique matching
+            subexpressions. If ``True``, return a dict mapping each
+            matching subexpression to the number of times it occurs
+            in the tree.
 
         Returns
         =======
 
         set or dict
-
-            All distinct subexpressions matching ``query``. This is a
-            plain ``set`` unless ``group=True``, in which case a
-            ``dict`` is returned where each key is a match and the
-            corresponding value is the number of times it appeared in
-            ``self``.
+            The matching subexpressions, or a mapping from each match
+            to its multiplicity when ``group=True``.
 
         Examples
         ========
 
-        >>> from sympy import exp, log
-        >>> from sympy.abc import a, b
+        >>> from sympy import sin, cos, Wild, Function
+        >>> from sympy.abc import x, y
 
-        Default behaviour returns a set of unique matches:
+        Match by type:
 
-        >>> expr = exp(a) + log(b) + exp(a)*log(b)
-        >>> expr.find(exp)
-        {exp(a)}
+        >>> expr = sin(x) + sin(y)*cos(x)
+        >>> expr.find(sin)
+        {sin(x), sin(y)}
 
-        With ``group=True``, a dict mapping matches to their counts
-        is returned instead:
+        Count occurrences with ``group=True``:
 
-        >>> expr.find(log, group=True)
-        {log(b): 2}
+        >>> (sin(x) + sin(x)*cos(x)).find(sin(x), group=True)
+        {sin(x): 2}
 
-        A callable can be used for custom matching, e.g. to find
-        every power in an expression:
+        Match a pattern using ``Wild`` symbols:
 
-        >>> (a**2 + b**3).find(lambda s: s.is_Pow)
-        {a**2, b**3}
+        >>> a = Wild('a')
+        >>> expr.find(sin(a))
+        {sin(x), sin(y)}
+
+        Match with a callable predicate:
+
+        >>> expr.find(lambda e: e.is_Symbol)
+        {x, y}
+
+        See Also
+        ========
+
+        count : count the number of matching subexpressions
+        has : test whether any matching subexpression exists
+        match : pattern-match the whole expression
+
+        Notes
+        =====
+
+        The search visits every node of the tree, including the
+        expression itself, so ``expr.find(type(expr))`` will include
+        ``expr`` in the result.
         """
-        
+  
         query = _make_find_query(query)
         results = list(filter(query, _preorder_traversal(self)))
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1836,7 +1836,7 @@ class Basic(Printable):
         Examples
         ========
 
-        >>> from sympy import sin, cos, Wild, Function
+        >>> from sympy import sin, cos, Wild
         >>> from sympy.abc import x, y
 
         Match by type:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1807,13 +1807,13 @@ class Basic(Printable):
         Parameters
         ==========
         
-        The ``query`` argument can be:
+        query : type, Basic, or callable
 
-        - a class such as ``Pow`` or ``exp``, to match all instances of that class
-        - a specific expression, to match occurrences equal to it
-        - a :class:`~.Wild`-containing pattern
-        - any callable taking one argument and returning a bool, used as a custom
-        test on each subexpression
+            - a class such as ``Pow`` or ``exp``, to match all instances of that class
+            - a specific expression, to match occurrences equal to it
+            - a :class:`~.Wild`-containing pattern
+            - any callable taking one argument and returning a bool, used as a custom
+              test on each subexpression
 
         group : bool, optional
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #29864
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
---

#### Brief description of what is fixed or changed

**The Problem:**

The docstring for `Basic.find` previously contained only a single line ("Find all subexpressions matching a query.") with no explanation of the `query` argument's accepted forms, no description of how the `group` parameter changes the return type, and no examples.

**The Fix:**

This PR adds Parameters, Returns, and Examples sections to the docstring, clarifying that `find` returns a `set` of matches by default, or a `dict` mapping each match to its occurrence count when `group=True`.

---

#### Other comments

* Verified the documentation with `bin/doctest sympy/core/basic.py` and `make html` .
---

#### AI Generation Disclosure

* AI was used in documentation build and in understanding the `group` parameter.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
---

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * Documented the `group` parameter and return type (set/dict) of `Basic.find`, with examples.

<!-- END RELEASE NOTES -->
