### PR TITLE
BUG: Fix PygletPlot.__iter__ (Python 2 dict.itervalues)

### DIFF
--- a/sympy/plotting/pygletplot/plot.py
+++ b/sympy/plotting/pygletplot/plot.py
@@ -363,7 +363,7 @@ class PygletPlot:
         """
         Allows iteration of the function list.
         """
-        return self._functions.itervalues()
+        return iter(self._functions.values())
 
     def __repr__(self):
         return str(self)

--- a/sympy/plotting/pygletplot/tests/test_plotting.py
+++ b/sympy/plotting/pygletplot/tests/test_plotting.py
@@ -86,3 +86,13 @@ def test_plot_integral():
     from sympy.integrals.integrals import Integral
     p = PygletPlot(Integral(z*x, (x, 1, z), (z, 1, y)), visible=False)
     p.wait_for_calculations()
+
+
+def test_plot_iter():
+    # regression: __iter__ used the Python 2 dict.itervalues()
+    from sympy.plotting.pygletplot import PygletPlot
+    p = PygletPlot(x, [x, -5, 5, 4], visible=False)
+    p.wait_for_calculations()
+    funcs = list(p)
+    assert len(funcs) == len(p) == 1
+    assert all(f is p[i] for i, f in enumerate(funcs))


### PR DESCRIPTION
#### Brief description of what is fixed or changed

`PygletPlot.__iter__` returned `self._functions.itervalues()`, a Python 2 dict method that does not exist on Python 3, so iterating a plot (`list(plot)`, `for f in plot`) raised `AttributeError`. The method was never covered by a test, so the breakage went unnoticed since the Python 3 port.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* plotting
  * Fixed `PygletPlot.__iter__` raising `AttributeError` on Python 3.
<!-- END RELEASE NOTES -->