### PR TITLE
MAINT: Remove the deprecated RawMatrix

### DIFF
--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1022,21 +1022,6 @@ However, this new behavior was considered confusing, as discussed in issue
 Now, `sample_iter` should be used if a iterator is needed. Consequently, the
 `numsamples` parameter is no longer needed for `sample()`.
 
-(deprecated-rawmatrix)=
-### `sympy.polys.solvers.RawMatrix`
-
-The `RawMatrix` class is deprecated. The `RawMatrix` class was a subclass
-of `Matrix` that used domain elements instead of `Expr` as the elements of
-the matrix. This breaks a key internal invariant of `Matrix` and this kind
-of subclassing limits improvements to the `Matrix` class.
-
-The only part of SymPy that documented the use of the `RawMatrix` class was
-the Smith normal form code, and that has now been changed to use
-`DomainMatrix` instead. It is recommended that anyone using `RawMatrix` with
-the previous Smith Normal Form code should switch to using `DomainMatrix` as
-shown in issue [#21402](https://github.com/sympy/sympy/pull/21402). A better
-API for the Smith normal form will be added later.
-
 (deprecated-non-expr-in-matrix)=
 ### Non-`Expr` objects in a Matrix
 

--- a/doc/src/explanation/active-deprecations.md
+++ b/doc/src/explanation/active-deprecations.md
@@ -1046,7 +1046,7 @@ The main reason for making this possible was that there were a number of
 `Matrix` subclasses in the SymPy codebase that wanted to work with objects
 from the polys module, e.g.
 
-1. `RawMatrix` (see [above](deprecated-rawmatrix)) was used in `solve_lin_sys`
+1. `RawMatrix` was used in `solve_lin_sys`
    which was part of `heurisch` and was also used by `smith_normal_form`. The
    `NewMatrix` class used domain elements as the elements of the Matrix rather
    than `Expr`.

--- a/sympy/matrices/tests/test_normalforms.py
+++ b/sympy/matrices/tests/test_normalforms.py
@@ -55,33 +55,6 @@ def test_smith_normal():
                 t.inv()
 
 
-def test_smith_normal_deprecated():
-    from sympy.polys.solvers import RawMatrix as Matrix
-
-    with warns_deprecated_sympy():
-        m = Matrix([[12, 6, 4,8],[3,9,6,12],[2,16,14,28],[20,10,10,20]])
-    setattr(m, 'ring', ZZ)
-    with warns_deprecated_sympy():
-        smf = Matrix([[1, 0, 0, 0], [0, 10, 0, 0], [0, 0, 30, 0], [0, 0, 0, 0]])
-    assert smith_normal_form(m) == smf
-
-    x = Symbol('x')
-    with warns_deprecated_sympy():
-        m = Matrix([[Poly(x-1), Poly(1, x),Poly(-1,x)],
-                    [0, Poly(x), Poly(-1,x)],
-                    [Poly(0,x),Poly(-1,x),Poly(x)]])
-    setattr(m, 'ring', QQ[x])
-    invs = (Poly(1, x, domain='QQ'), Poly(x - 1, domain='QQ'), Poly(x**2 - 1, domain='QQ'))
-    assert invariant_factors(m) == invs
-
-    with warns_deprecated_sympy():
-        m = Matrix([[2, 4]])
-    setattr(m, 'ring', ZZ)
-    with warns_deprecated_sympy():
-        smf = Matrix([[2, 0]])
-    assert smith_normal_form(m) == smf
-
-
 def test_hermite_normal():
     m = Matrix([[2, 7, 17, 29, 41], [3, 11, 19, 31, 43], [5, 13, 23, 37, 47]])
     hnf = Matrix([[1, 0, 0], [0, 2, 1], [0, 0, 1]])

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -3,13 +3,9 @@ from __future__ import annotations
 
 from itertools import pairwise
 
-from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import connected_components
 
-from sympy.core.sympify import sympify
-from sympy.core.numbers import Integer, Rational
-from sympy.matrices.dense import MutableDenseMatrix
-from sympy.polys.domains import ZZ, QQ
+from sympy.polys.domains import ZZ
 
 from sympy.polys.domains import EX
 from sympy.polys.rings import sring
@@ -20,57 +16,6 @@ from sympy.polys.domainmatrix import DomainMatrix
 class PolyNonlinearError(Exception):
     """Raised by solve_lin_sys for nonlinear equations"""
     pass
-
-
-class RawMatrix(MutableDenseMatrix):
-    """
-    .. deprecated:: 1.9
-
-       This class fundamentally is broken by design. Use ``DomainMatrix`` if
-       you want a matrix over the polys domains or ``Matrix`` for a matrix
-       with ``Expr`` elements. The ``RawMatrix`` class will be removed/broken
-       in future in order to reestablish the invariant that the elements of a
-       Matrix should be of type ``Expr``.
-
-    """
-    _sympify = staticmethod(lambda x, *args, **kwargs: x) # type: ignore
-
-    def __init__(self, *args, **kwargs):
-        sympy_deprecation_warning(
-            """
-            The RawMatrix class is deprecated. Use either DomainMatrix or
-            Matrix instead.
-            """,
-            deprecated_since_version="1.9",
-            active_deprecations_target="deprecated-rawmatrix",
-        )
-
-        domain = ZZ
-        for i in range(self.rows):
-            for j in range(self.cols):
-                val = self[i,j]
-                if getattr(val, 'is_Poly', False):
-                    K = val.domain[val.gens]
-                    val_sympy = val.as_expr()
-                elif hasattr(val, 'parent'):
-                    K = val.parent()
-                    val_sympy = K.to_sympy(val)
-                elif isinstance(val, (int, Integer)):
-                    K = ZZ
-                    val_sympy = sympify(val)
-                elif isinstance(val, Rational):
-                    K = QQ
-                    val_sympy = val
-                else:
-                    for K in ZZ, QQ:
-                        if K.of_type(val):
-                            val_sympy = K.to_sympy(val)
-                            break
-                    else:
-                        raise TypeError
-                domain = domain.unify(K)
-                self[i,j] = val_sympy
-        self.ring = domain
 
 
 def eqs_to_matrix(eqs_coeffs, eqs_rhs, gens, domain):

--- a/sympy/polys/solvers.py
+++ b/sympy/polys/solvers.py
@@ -5,7 +5,6 @@ from itertools import pairwise
 
 from sympy.utilities.iterables import connected_components
 
-from sympy.polys.domains import ZZ
 
 from sympy.polys.domains import EX
 from sympy.polys.rings import sring


### PR DESCRIPTION

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Identified while working on reducing import cycles (see https://github.com/sympy/sympy/issues/29881).

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

``sympy.polys.solvers.RawMatrix`` was deprecated in SymPy 1.9 (2021-09-30), roughly 4.7 years ago. We  remove the class and its lazy ``__getattr__`` shim from ``polys.solvers`` (which also drops the only ``matrices`` import from that module), the ``test_smith_normal_deprecated`` test that exercised it, and the ``deprecated-rawmatrix`` entry in the active-deprecations docs.


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Claude was used in the investigations and preparation of the PR.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
   * Removed the deprecated ``sympy.polys.solvers.RawMatrix``
   
<!-- END RELEASE NOTES -->
