### PR TITLE
BUG: Fix bin/diagnose_imports 

### DIFF
--- a/bin/diagnose_imports
+++ b/bin/diagnose_imports
@@ -11,7 +11,7 @@ import sys
 this_file = abspath(__file__)
 diagnose_imports_filename = join(
     dirname(this_file),
-    '..', 'sympy', 'utilities', 'tests', 'diagnose_imports.py')
+    '..', 'sympy', 'testing', 'tests', 'diagnose_imports.py')
 diagnose_imports_filename = normpath(diagnose_imports_filename)
 
 process = subprocess.Popen(

--- a/sympy/testing/tests/diagnose_imports.py
+++ b/sympy/testing/tests/diagnose_imports.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 if __name__ == "__main__":
 
     import sys
-    import inspect
     import builtins
 
     import optparse
@@ -38,14 +37,14 @@ if __name__ == "__main__":
             'if it imports a symbol that is already present; ' # see ##DUPLICATE##
             'if it imports a symbol '
             'from somewhere other than the defining module.', # see ##ORIGIN##
-        action='count')
+        action='count', default=0)
     option_group.add_option(
         '--origins',
         help=
             'For each imported symbol in each module, '
             'print the module that defined it. '
             '(This is useful for import refactoring.)',
-        action='count')
+        action='count', default=0)
     option_parser.add_option_group(option_group)
     option_group = optparse.OptionGroup(
         option_parser,
@@ -56,11 +55,11 @@ if __name__ == "__main__":
     option_group.add_option(
         '--by-importer',
         help='Sort output lines by name of importing module.',
-        action='count')
+        action='count', default=0)
     option_group.add_option(
         '--by-origin',
         help='Sort output lines by name of imported module.',
-        action='count')
+        action='count', default=0)
     option_parser.add_option_group(option_group)
     (options, args) = option_parser.parse_args()
     if args:
@@ -100,7 +99,12 @@ if __name__ == "__main__":
         def __hash__(self):
             return hash(self.name)
         def __eq__(self, other):
-            return self.name == other.name and self.value == other.value
+            # Compare the value by identity: ``==`` on SymPy objects does not
+            # return a plain bool (and can raise).  Indirect-import detection
+            # only cares whether it is literally the same object re-exported.
+            return (isinstance(other, Definition)
+                    and self.name == other.name
+                    and self.value is other.value)
         def __ne__(self, other):
             return not (self == other)
         def __repr__(self):
@@ -128,7 +132,7 @@ if __name__ == "__main__":
         else:
             sorted_messages.append(msg % args)
 
-    def tracking_import(module, globals=globals(), locals=[], fromlist=None, level=-1):
+    def tracking_import(module, globals=globals(), locals=[], fromlist=None, level=0):
         """__import__ wrapper - does not change imports at all, but tracks them.
 
         Default order is implemented by doing output directly.
@@ -142,19 +146,19 @@ if __name__ == "__main__":
         question was already imported.
 
         Keeps the semantics of __import__ unchanged."""
-        caller_frame = inspect.getframeinfo(sys._getframe(1))
-        importer_filename = caller_frame.filename
-        importer_module = globals['__name__']
-        if importer_filename == caller_frame.filename:
-            importer_reference = '%s line %s' % (
-                importer_filename, str(caller_frame.lineno))
-        else:
-            importer_reference = importer_filename
+        # Use the frame attributes directly rather than inspect.getframeinfo:
+        # the latter reads the source via linecache, which itself triggers
+        # imports and would recurse infinitely through this very hook.
+        caller_frame = sys._getframe(1)
+        importer_filename = caller_frame.f_code.co_filename
+        importer_module = (globals or {}).get('__name__', importer_filename)
+        importer_reference = '%s line %s' % (
+            importer_filename, caller_frame.f_lineno)
         result = builtin_import(module, globals, locals, fromlist, level)
         importee_module = result.__name__
         # We're only interested if importer and importee are in SymPy
         if relevant(importer_module) and relevant(importee_module):
-            for symbol in result.__dict__.iterkeys():
+            for symbol in result.__dict__.keys():
                 definition = Definition(
                     symbol, result.__dict__[symbol], importer_module)
                 if definition not in symbol_definers:
@@ -177,7 +181,7 @@ if __name__ == "__main__":
                         # That's the normal "please copy over its imports to my namespace"
                         symbol_list = []
                     else:
-                        symbol_list = result.__dict__.iterkeys()
+                        symbol_list = result.__dict__.keys()
                 for symbol in symbol_list:
                     if symbol not in result.__dict__:
                         if options.by_origin:


### PR DESCRIPTION

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Found while working on https://github.com/sympy/sympy/issues/29881.

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

#### Brief description of what is fixed or changed

The import-diagnostics helper had bit-rotted and could not run:

- bin/diagnose_imports pointed at sympy/utilities/tests/diagnose_imports.py, but the script was moved to sympy/testing/tests/ in 57ac486db8.
- The optparse ``count`` options defaulted to None, so ``options.origins > 1`` raised TypeError; give them ``default=0``.
- tracking_import used Python 2 constructs: ``level=-1`` default and ``dict.iterkeys()``.
- It called ``inspect.getframeinfo`` for the caller frame, which reads the source via linecache and thereby triggers imports -- recursing infinitely through the very __import__ hook it installs. Use the frame attributes directly instead.
- Definition.__eq__ compared symbol *values* with ``==``; for SymPy objects ``==`` returns a relational (or raises) rather than a bool. Compare by identity, which is what indirect-import detection actually needs.


#### Other comments

Solving the issues reported by the tool is for followup PRs.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Claude was used to make the tool work with current sympy.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
