### PR TITLE
Trigintegrate noninteger power

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -782,6 +782,7 @@ Idan Pazi <idan.kp@gmail.com>
 Ilya Pchelintsev <ilya.pchelintsev@outlook.com> ILLIA PCHALINTSAU <ilya.pchelintsev@outlook.com>
 Imran Ahmed Manzoor <imran.manzoor31@gmail.com>
 Ishan Joshi <ishanaj98@gmail.com>
+Ishan Karpe <ishan.k.abhijeet@gmail.com>
 Ishan Khan <ishan372or@gmail.com> ishan372or <ishan372or@gmail.com>
 Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>
 Ishan Pandhare <91841626+Ishanned@users.noreply.github.com>

--- a/sympy/integrals/tests/test_trigonometry.py
+++ b/sympy/integrals/tests/test_trigonometry.py
@@ -97,3 +97,23 @@ def test_trigintegrate_symbolic():
     assert trigintegrate(cos(x)**n, x) is None
     assert trigintegrate(sin(x)**n, x) is None
     assert trigintegrate(cot(x)**n, x) is None
+
+
+def test_trigintegrate_noninteger_power():
+    # issue #29882: one power a positive odd integer, the other non-integer
+    assert trigintegrate(sin(x)**3*cos(x)**Rational(3, 2), x) == \
+        2*cos(x)**Rational(9, 2)/9 - 2*cos(x)**Rational(5, 2)/5
+    assert trigintegrate(sin(x)**Rational(3, 2)*cos(x)**3, x) == \
+        -2*sin(x)**Rational(9, 2)/9 + 2*sin(x)**Rational(5, 2)/5
+    assert trigintegrate(sin(x)**5*cos(x)**Rational(5, 2), x) == \
+        -2*cos(x)**Rational(15, 2)/15 + 4*cos(x)**Rational(11, 2)/11 \
+        - 2*cos(x)**Rational(7, 2)/7
+    assert trigintegrate(sin(x)**3*cos(x)**Rational(-1, 2), x) == \
+        2*cos(x)**Rational(5, 2)/5 - 2*cos(x)**Rational(1, 2)
+
+    # other non-integer combinations are not handled here, must return None
+    assert trigintegrate(sin(x)**2*cos(x)**Rational(3, 2), x) is None
+    assert trigintegrate(
+        sin(x)**Rational(7, 2)*cos(x)**Rational(3, 2), x) is None
+    k = Symbol('k')
+    assert trigintegrate(sin(x)**3*cos(x)**k, x) is None

--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from sympy.core import cacheit, Dummy, Ne, Integer, Rational, S, Wild
+from sympy.core import cacheit, Dummy, Ne, Rational, S, Wild
 from sympy.functions import binomial, sin, cos, Piecewise, Abs
 from .integrals import integrate
 
@@ -11,16 +11,10 @@ from .integrals import integrate
 #
 # so we cache the pattern
 
-# need to use a function instead of lamda since hash of lambda changes on
-# each call to _pat_sincos
-def _integer_instance(n):
-    return isinstance(n, Integer)
-
 @cacheit
 def _pat_sincos(x):
     a = Wild('a', exclude=[x])
-    n, m = [Wild(s, exclude=[x], properties=[_integer_instance])
-                for s in 'nm']
+    n, m = [Wild(s, exclude=[x]) for s in 'nm']
     pat = sin(a*x)**n * cos(a*x)**m
     return pat, a, n, m
 
@@ -75,6 +69,18 @@ def trigintegrate(f, x, conds='piecewise'):
     zz = x if n.is_zero else S.Zero
 
     a = M[a]
+
+    # A non-integer power is still integrable when the other power is a
+    # positive odd integer: the odd-power substitution below then gives a
+    # finite sum of powers of u. The later branches need both powers to be
+    # concrete integers, so bail out on any other non-integer case.
+    if not (n.is_Integer and m.is_Integer):
+        n_pos_odd = bool(n.is_Integer and n.is_odd and n.is_positive)
+        m_pos_odd = bool(m.is_Integer and m.is_odd and m.is_positive)
+        other = m if n_pos_odd else n
+        if not ((n_pos_odd or m_pos_odd)
+                and other.is_number and other.is_integer is False):
+            return None
 
     if n.is_odd or m.is_odd:
         u = _u


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

partially fixes #29882 


#### Brief description of what is fixed or changed

Trigintegrate used to require both n and m to be integers. This PR removes that limitation when one exponent is a positive and odd integer and the other is rational number that may not be an integer (such as a fraction).

When the exponent is a positive and odd integer, using the standard U-substitution (u = cos(x) or u = sin (x)) simplifies the integrand to a sum of rational powers of u, allowing for integration. The fix eliminates the limitation Wild constraints that were integer only (allows for fractions), and None is returned for non-integer cases that do not fit this pattern (for instance, both exponents being non-integer).

#### Other comments
hyper geometric anti derivatives are explicitly out of scope for this PR with multiple fractions (may be included within a later follow-up PR)

#### AI Generation Disclosure

Claude was used for code review, and spell checking, and also variations to test from based on the original example in the issue. The algorithm and code implementation are my own.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* integrals
  * trigintegrate now handles the product of sin(x)**n*cos(x)**m when one exponent is a positive odd integer and the other is not an integer.

<!-- END RELEASE NOTES -->