### PR TITLE
use _sympify before calling Poly._from_expr in GroebnerBasis.reduce to handle raw Python integers

### DIFF
--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -8160,6 +8160,7 @@ class GroebnerBasis(Basic):
         ([Poly(2*x, x, y, domain='ZZ'), Poly(1, x, y, domain='ZZ')], Poly(x**2 + y**2 + y, x, y, domain='ZZ'))
 
         """
+        expr = _sympify(expr)
         if isinstance(expr, Poly):
 
             if expr.gens != self._options.gens:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -4309,3 +4309,11 @@ def test_schur_conditions():
 
     assert any(c <= 0 for c in p6.set_domain(QQ).schur_conditions())
     assert any(c <= 0 for c in p6.set_domain(EXRAW).schur_conditions())
+
+
+def test_groebner_reduce_scalar():
+
+    # test for issue https://github.com/sympy/sympy/issues/29828
+    B = groebner([t**2], t, order="lex")
+    assert B.reduce(7) == ([0], 7)
+    assert B.reduce(Integer(7)) == ([0], Integer(7))


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #29828


#### Brief description of what is fixed or changed
This PR fixes the `AttributeError: 'int' object has no attribute 'is_commutative'` that occurs when a raw python int is passed to the Groebner reduction method.

Previously the crash happened inside 'Poly._from_expr' . This PR adds a `_sympify` call at the beginning of `reduce()` method in 'sympy/polys/polytools.py' converting the raw python integers into a Sympy integers ,thus preventing the attribute error.

Also added a regression test  `test_groebner_reduce_scalar` to  `sympy/polys/tests/test_polytools.py` to ensure both of `B.reduce(7)` and `B.reduce(integer(7))` pass correctly. 

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Gemini was used to understand the 'reduce()' method initially

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->



<!-- BEGIN RELEASE NOTES -->
* polys
    * Fixed a bug in `GroebnerBasis.reduce` that cause 'AttributeError' when raw python integers were passed to the function.

<!-- END RELEASE NOTES -->
