### PR TITLE
added one check — if a term is something raised to the power 1.0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -379,6 +379,7 @@ Arnab Nandi <arnabnandi2002@gmail.com>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in> Arpan612 <f20180319@pilani.bits-pilani.ac.in>
 Arpit Goyal <agmps18@gmail.com>
+Arsh <niteshtulshyan998@gmail.com> Arsh <152091964+ash01825@users.noreply.github.com>
 Arshdeep Singh <singh.arshdeep1999@gmail.com>
 Arthur Milchior <arthur@milchior.fr>
 Arthur Ryman <arthur.ryman@gmail.com>

--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -307,6 +307,10 @@ class Add(Expr, AssocOp):
                 # everything else
                 c = S.One
                 s = o
+            if s.is_Pow:
+                b, e = s.as_base_exp()
+                if e == 1.0:
+                    s = b
 
             # now we have:
             # o = c*s, where

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -2525,3 +2525,9 @@ def test_Mul_is_zero_with_zero_factor():
     # No zero
     assert Mul(x, x, evaluate=False).is_zero is None
     assert Mul(1, x, evaluate=False).is_zero is None
+
+def test_pow_float_one_in_add():
+    # Pow(x, Float(1.0)) should be treated as x during Add.flatten
+    x = Symbol('x')
+    assert x + Pow(x, Float(1.0)) == 2*x
+    assert x**0.5 * x**0.5 + x == 2*x


### PR DESCRIPTION
#### References to other Issues or PRs

#### Brief description of what is fixed or changed
`x**1.0` isn't being simplified to x. This causes issue when trying out below for eg.
```
from sympy import Pow, Float, symbols

x = symbols('x')

print(x + Pow(x, Float(1.0)))
print(x ** 0.5 * x ** 0.5 + x)
```

Produces output
` 
x**1.0 + x 
x**1.0 + x
`
After fix output
`
2*x
2*x
`

Made changes to add.py and added tests for the same issue.

#### Other comments
Encountered this issue while trying to solve #29823 but were not able to reproduce and get the exact given output.

#### AI Generation Disclosure

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. --> Only used gemini for test validation.

<!-- BEGIN RELEASE NOTES -->
#### Release Notes
NO ENTRY