### PR TITLE
Allow non-integer Rational exponents in trigintegrate (#29882)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1910,3 +1910,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Italo Ruan <italoruan8@gmail.com>

--- a/sympy/functions/special/beta_functions.py
+++ b/sympy/functions/special/beta_functions.py
@@ -7,6 +7,7 @@ from sympy.external.mpmath import local_workprec
 from sympy.functions.special.gamma_functions import gamma, digamma
 from sympy.functions.combinatorial.numbers import catalan
 from sympy.functions.elementary.complexes import conjugate
+from sympy.functions.elementary.exponential import log
 
 
 ###############################################################################
@@ -244,7 +245,17 @@ class betainc(DefinedFunction):
 
     def fdiff(self, argindex):
         a, b, x1, x2 = self.args
-        if argindex == 3:
+        if argindex == 1:
+            # Diff wrt a: integral of t^{a-1}*(1-t)^{b-1}*ln(t) dt
+            from sympy.integrals.integrals import Integral
+            t = Dummy(uniquely_named_symbol('t', [a, b, x1, x2]).name)
+            return Integral(t**(a - 1)*(1 - t)**(b - 1)*log(t), (t, x1, x2))
+        elif argindex == 2:
+            # Diff wrt b: integral of t^{a-1}*(1-t)^{b-1}*ln(1-t) dt
+            from sympy.integrals.integrals import Integral
+            t = Dummy(uniquely_named_symbol('t', [a, b, x1, x2]).name)
+            return Integral(t**(a - 1)*(1 - t)**(b - 1)*log(1 - t), (t, x1, x2))
+        elif argindex == 3:
             # Diff wrt x1
             return -(1 - x1)**(b - 1)*x1**(a - 1)
         elif argindex == 4:
@@ -263,7 +274,13 @@ class betainc(DefinedFunction):
         return Expr._from_mpmath(res, prec)
 
     def _eval_is_real(self):
+        a, b, x1, x2 = self.args
+        # If all args are real, the integral is real
         if all(arg.is_real for arg in self.args):
+            return True
+        # If a, b are known positive and x1, x2 are real,
+        # the integrand t^{a-1}*(1-t)^{b-1} is real-valued
+        if a.is_positive and b.is_positive and x1.is_real and x2.is_real:
             return True
 
     def _eval_conjugate(self):

--- a/sympy/functions/special/tests/test_beta_functions.py
+++ b/sympy/functions/special/tests/test_beta_functions.py
@@ -73,6 +73,36 @@ def test_betainc():
 
     assert betainc(1, 2, 3, 3).evalf() == 0
 
+    # fdiff: derivatives wrt x1 (argindex=3) and x2 (argindex=4) return closed-form
+    assert betainc(a, b, x1, x2).fdiff(3) == -(1 - x1)**(b - 1)*x1**(a - 1)
+    assert betainc(a, b, x1, x2).fdiff(4) == (1 - x2)**(b - 1)*x2**(a - 1)
+
+    # fdiff: derivatives wrt a (argindex=1) and b (argindex=2) return Integral
+    da = betainc(a, b, x1, x2).fdiff(1)
+    assert isinstance(da, Integral)
+    db = betainc(a, b, x1, x2).fdiff(2)
+    assert isinstance(db, Integral)
+
+    # fdiff: invalid argindex raises
+    raises(ArgumentIndexError, lambda: betainc(a, b, x1, x2).fdiff(5))
+
+    # diff through chain rule still works for the integration use case
+    from sympy.functions.elementary.trigonometric import sin
+    x = symbols('x')
+    expr = betainc(Rational(3, 4), Rational(5, 4), 0, sin(x)**2) / 2
+    d = diff(expr, x)
+    assert d is not None
+    # Numeric check: d/dx at pi/6 should equal sin^(1/2)*cos^(3/2) at pi/6
+    from sympy.core.numbers import pi as sym_pi
+    val = float(d.subs(x, sym_pi / 6).evalf())
+    expected = float((sin(x)**Rational(1, 2) * (1 - sin(x)**2)**Rational(3, 4)).subs(x, sym_pi / 6).evalf())
+    assert abs(val - expected) < 1e-10
+
+    # _eval_is_real: positive a, b with real limits
+    xr = symbols('xr', real=True)
+    assert betainc(Rational(3, 4), Rational(5, 4), 0, xr).is_real == True
+    assert betainc(Rational(3, 4), Rational(5, 4), 0, sin(xr)**2).is_real == True
+
 
 def test_betainc_regularized():
     a, b, x1, x2 = symbols('a b x1 x2')

--- a/sympy/integrals/tests/test_trigonometry.py
+++ b/sympy/integrals/tests/test_trigonometry.py
@@ -97,3 +97,38 @@ def test_trigintegrate_symbolic():
     assert trigintegrate(cos(x)**n, x) is None
     assert trigintegrate(sin(x)**n, x) is None
     assert trigintegrate(cot(x)**n, x) is None
+
+
+def test_trigintegrate_rational_exponents():
+    """Regression test for issue #29882:
+    trigintegrate should handle Rational exponents via Incomplete Beta."""
+    from sympy.functions.special.beta_functions import betainc
+
+    # Basic case from the issue report: sin(x)**(1/2) * cos(x)**(3/2)
+    result = trigintegrate(sin(x)**Rational(1, 2) * cos(x)**Rational(3, 2), x)
+    assert result is not None
+    expected = betainc(Rational(3, 4), Rational(5, 4), 0, sin(x)**2) / 2
+    assert result == expected
+
+    # Both exponents rational: sin(x)**(1/3) * cos(x)**(2/3)
+    result2 = trigintegrate(sin(x)**Rational(1, 3) * cos(x)**Rational(2, 3), x)
+    assert result2 is not None
+    expected2 = betainc(Rational(2, 3), Rational(5, 6), 0, sin(x)**2) / 2
+    assert result2 == expected2
+
+    # One integer, one rational: sin(x)**2 * cos(x)**(1/2)
+    result3 = trigintegrate(sin(x)**2 * cos(x)**Rational(1, 2), x)
+    assert result3 is not None
+    expected3 = betainc(Rational(3, 2), Rational(3, 4), 0, sin(x)**2) / 2
+    assert result3 == expected3
+
+    # Negative rational exponent (still > -1): sin(x)**(-1/2) * cos(x)**(3/2)
+    result4 = trigintegrate(sin(x)**Rational(-1, 2) * cos(x)**Rational(3, 2), x)
+    assert result4 is not None
+    expected4 = betainc(Rational(1, 4), Rational(5, 4), 0, sin(x)**2) / 2
+    assert result4 == expected4
+
+    # Integer exponents should NOT be rerouted (still handled by original path)
+    assert trigintegrate(sin(x)**2 * cos(x)**3, x) == \
+        sin(x)**3/3 - sin(x)**5/5
+

--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from sympy.core import cacheit, Dummy, Ne, Integer, Rational, S, Wild
 from sympy.functions import binomial, sin, cos, Piecewise, Abs
+from sympy.functions.special.beta_functions import betainc
 from .integrals import integrate
 
 # TODO sin(a*x)*cos(b*x) -> sin((a+b)x) + sin((a-b)x) ?
@@ -20,6 +21,17 @@ def _integer_instance(n):
 def _pat_sincos(x):
     a = Wild('a', exclude=[x])
     n, m = [Wild(s, exclude=[x], properties=[_integer_instance])
+                for s in 'nm']
+    pat = sin(a*x)**n * cos(a*x)**m
+    return pat, a, n, m
+
+def _rational_instance(n):
+    return isinstance(n, (Integer, Rational))
+
+@cacheit
+def _pat_sincos_rational(x):
+    a = Wild('a', exclude=[x])
+    n, m = [Wild(s, exclude=[x], properties=[_rational_instance])
                 for s in 'nm']
     pat = sin(a*x)**n * cos(a*x)**m
     return pat, a, n, m
@@ -67,7 +79,8 @@ def trigintegrate(f, x, conds='piecewise'):
     M = f.match(pat)
 
     if M is None:
-        return
+        # Integer pattern failed; try rational exponents
+        return _trigintegrate_rational(f, x, conds)
 
     n, m = M[n], M[m]
     if n.is_zero and m.is_zero:
@@ -334,3 +347,45 @@ def _cos_pow_integrate(n, x):
         # n == 0
         #Recursion Break.
         return x
+
+
+def _trigintegrate_rational(f, x, conds='piecewise'):
+    """Handle sin(a*x)**n * cos(a*x)**m for non-integer (Rational) exponents.
+
+    Uses the substitution u = sin^2(x) to convert the integral into the
+    Incomplete Beta function:
+
+        integrate(sin(x)**n * cos(x)**m, x)
+            = (1/2) * betainc((n+1)/2, (m+1)/2, 0, sin(a*x)**2) / a
+
+    This is valid when (n+1)/2 > 0 and (m+1)/2 > 0, i.e. n > -1 and m > -1.
+    """
+    pat, a, n, m = _pat_sincos_rational(x)
+    M = f.match(pat)
+    if M is None:
+        return None
+
+    n, m = M[n], M[m]
+    a = M[a]
+
+    # If both are integers, the main trigintegrate path should have handled it.
+    # Return None so other integration strategies can try.
+    if n.is_Integer and m.is_Integer:
+        return None
+
+    # We need at least Rational exponents for this strategy.
+    if not (n.is_Rational and m.is_Rational):
+        return None
+
+    # Convergence guard: need (n+1)/2 > 0 and (m+1)/2 > 0
+    alpha = (n + S.One) / 2
+    beta_param = (m + S.One) / 2
+    if not (alpha.is_positive and beta_param.is_positive):
+        return None
+
+    result = betainc(alpha, beta_param, S.Zero, sin(a*x)**2) / 2
+
+    if conds == 'piecewise':
+        zz = x if n.is_zero else S.Zero
+        return Piecewise((result / a, Ne(a, 0)), (zz, True))
+    return result / a


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This PR addresses the issue where product of sine and cosine with fractional exponents failed to integrate. It uses a substitution to express the result using the incomplete Beta function.
Fixes #29882

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.
NO AI USE
DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. --> 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- integrals: `integrate` now supports `sin(x)**n * cos(x)**m` with non-integer `Rational` exponents.

<!-- END RELEASE NOTES -->
