### PR TITLE
printing: fix mathematica_code for floor, ceiling, sign, re, im, frac

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -799,6 +799,7 @@ Ivan Tkachenko <me@ratijas.tk> ivan tkachenko <ratijas@users.noreply.github.com>
 Ivan Tkachenko <me@ratijas.tk> ratijas <ratijas@users.noreply.github.com>
 JDBetteridge <jack@devitocodes.com> <43041811+JDBetteridge@users.noreply.github.com>
 JMSS-Unknown <31131631+JMSS-Unknown@users.noreply.github.com>
+JSap0914 <JSap0914@users.noreply.github.com>
 Jack Kemp <metaknightdrake-git@yahoo.co.uk>
 Jack Kemp <metaknightdrake-git@yahoo.co.uk> <kempj@tplxdt003.nat.physics.ox.ac.uk>
 Jack McCaffery <jpmccaffery@gmail.com>

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -118,6 +118,13 @@ known_functions = {
     "Heaviside": [(lambda x: True, "HeavisideTheta")],
     "KroneckerDelta": [(lambda *x: True, "KroneckerDelta")],
     "sqrt": [(lambda x: True, "Sqrt")],  # For automatic rewrites
+    "floor": [(lambda x: True, "Floor")],
+    "ceiling": [(lambda x: True, "Ceiling")],
+    "sign": [(lambda x: True, "Sign")],
+    "re": [(lambda x: True, "Re")],
+    "im": [(lambda x: True, "Im")],
+    "frac": [(lambda x: True, "FractionalPart")],
+    "Abs": [(lambda x: True, "Abs")],
 }
 
 

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -11,7 +11,8 @@ from sympy.functions import (exp, sin, cos, fresnelc, fresnels, conjugate, Max,
                              FallingFactorial, harmonic, atan2, sec, acsc,
                              hermite, laguerre, assoc_laguerre, jacobi,
                              gegenbauer, chebyshevt, chebyshevu, legendre,
-                             assoc_legendre, Li, LambertW)
+                             assoc_legendre, Li, LambertW,
+                             floor, ceiling, sign, re, im, frac, Abs)
 
 from sympy.printing.mathematica import mathematica_code as mcode
 
@@ -82,6 +83,14 @@ def test_Function():
     assert mcode(LambertW(x)) == "ProductLog[x]"
     assert mcode(LambertW(x, -1)) == "ProductLog[-1, x]"
     assert mcode(LambertW(x, y)) == "ProductLog[y, x]"
+    assert mcode(floor(x)) == "Floor[x]"
+    assert mcode(ceiling(x)) == "Ceiling[x]"
+    assert mcode(sign(x)) == "Sign[x]"
+    assert mcode(re(x)) == "Re[x]"
+    assert mcode(im(x)) == "Im[x]"
+    assert mcode(frac(x)) == "FractionalPart[x]"
+    assert mcode(Abs(x)) == "Abs[x]"
+
 
 
 def test_special_polynomials():


### PR DESCRIPTION
## Problem
`mathematica_code()` prints `floor`, `ceiling`, `sign`, `re`, `im`, and `frac` using their lowercase SymPy names (e.g. `floor[x]`), which is invalid Wolfram Language syntax. These six functions were missing from `known_functions` in `MCodePrinter`, so the fallback emits `expr.func.__name__ + '[...]'`.

## Fix
Add the correct Wolfram mappings: `floor->Floor`, `ceiling->Ceiling`, `sign->Sign`, `re->Re`, `im->Im`, `frac->FractionalPart` (plus an explicit `Abs->Abs`).

## Verification
`pytest sympy/printing/tests/test_mathematica.py` -> 16 passed (includes new assertions for all six functions).

> Prepared with AI assistance; I have reviewed and verified the change and tests.