### PR TITLE
integrals: Fix Meijer integration for negative symbols (#29900)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1536,6 +1536,8 @@ Shiyao Guo <mivikq@gmail.com> Mivik <54128043+Mivik@users.noreply.github.com>
 Shiyao Guo <mivikq@gmail.com> Mivik <mivikq@gmail.com>
 Shravas K Rao <shravas@gmail.com>
 Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
+Shrinivas Bhong <shrinivasbhong2428@gmail.com>
+Shrinivas Bhong <shrinivasbhong2428@gmail.com> Shrinivas Bhong <183748734+SHRINIVAS-BHONG@users.noreply.github.com>
 Shruti Mangipudi <shruti2395@gmail.com>
 Shuai Zhou <shuaivzhou@berkeley.edu>
 Shubham Abhang <shubhamabhang77@gmail.com>

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1733,7 +1733,14 @@ def _meijerint_indefinite_1(f, x):
             place = 0  # Assume we can expand at zero
         else:
             place = None
-        r = hyperexpand(r.subs(t, a*x**b), place=place)
+        if x.is_extended_negative:
+            # The G-function integration formula assumes a positive variable.
+            # Avoid introducing a spurious sign when expanding powers of a
+            # symbol that is known to be negative.
+            xp = Dummy('x', positive=True)
+            r = hyperexpand(r.subs(t, a*xp**b), place=place).subs(xp, x)
+        else:
+            r = hyperexpand(r.subs(t, a*x**b), place=place)
 
         # now substitute back
         # Note: we really do want the powers of x to combine.

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -773,3 +773,10 @@ def test_issue_25949():
     from sympy.core.symbol import symbols
     y = symbols("y", nonzero=True)
     assert integrate(cosh(y*(x + 1)), (x, -1, -0.25), meijerg=True) == sinh(0.75*y)/y
+
+
+def test_issue_29900():
+    from sympy.core.symbol import Symbol
+    xn = Symbol('x', negative=True)
+    xu = Symbol('x')
+    assert integrate(sin(xn**3), xn) == integrate(sin(xu**3), xu).subs(xu, xn)


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->

* integrals

  * Fixed incorrect signs in Meijer-G antiderivatives when the integration variable is assumed negative.

<!-- END RELEASE NOTES -->

### Description

This PR resolves an issue where integrating expressions such as `sin(x**3)` produced an antiderivative with the wrong sign when `x` was declared with `negative=True`.

The Meijer-G integration formula assumes a positive integration variable. Passing a symbol known to be negative directly into `hyperexpand` caused fractional powers to introduce a spurious sign.

### Proposed Changes

#### Meijer-G Integration

* **meijerint.py**: Perform the hypergeometric expansion using a positive dummy variable when the integration variable is known to be negative, then substitute the original variable back into the result.

**Why?**

* The Meijer-G integration formula is derived for a positive variable.
* `hyperexpand` uses symbol assumptions when simplifying powers.
* For negative symbols, this could incorrectly change the sign of the resulting antiderivative.
* The correction is intentionally restricted to strictly negative integration symbols to minimize behavioral changes.

#### Tests

* **test_meijerint.py**: Added a regression test confirming that integrating `sin(x**3)` gives the same correctly signed antiderivative for negative and assumption-free symbols.

### Verification Results

* Passed all tests in `test_meijerint.py`: 30 passed
* Passed the complete integrals test package: 417 passed
* Full SymPy suite: 13,291 passed
* Four unrelated Windows environment tests failed because of temporary-file permissions and Windows `file://` URI handling
* No failures were related to the changed integration code

### AI Disclosure

AI-assisted tools, including ChatGPT, were used during development to understand the issue, explore implementation approaches, review the code.

All code changes, design decisions, testing, validation, and final submitted content were reviewed and verified by me before submission.

Closes #29900