### PR TITLE
radsimp: fix a fraction() bug when strict=True

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1554,6 +1554,7 @@ Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpa
 Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> “sidhantnagpal” <sidhantnagpal97@gmail.com>
 Sidharth Mundhra <sidharthmundhra16@gmail.com> Sidharth Mundhra <56464077+0sidharth@users.noreply.github.com>
+Simon Allais <simon.allais.prepa@gmail.com>
 Simon Sørensen <simonblsoerensen@gmail.com>
 Simon Sørensen <simonblsoerensen@gmail.com> Simon Sørensen <61250140+zarstensen@users.noreply.github.com>
 SirJohnFranklin <sirjfu@googlemail.com>

--- a/sympy/simplify/radsimp.py
+++ b/sympy/simplify/radsimp.py
@@ -1116,7 +1116,7 @@ def fraction(expr, exact=False):
                     denom.append(b)
                 elif exact:
                     if ex.is_constant():
-                        denom.append(Pow(b, -ex))
+                        denom.append(Pow(b, -ex, evaluate=False))
                     else:
                         numer.append(term)
                 else:

--- a/sympy/simplify/tests/test_radsimp.py
+++ b/sympy/simplify/tests/test_radsimp.py
@@ -445,6 +445,9 @@ def test_fraction():
     assert fraction(m, exact=True) == \
             (Mul(1, 1, evaluate=False), Mul(2, 2, 1, evaluate=False))
 
+    u = Pow(2, -2, evaluate=False)
+    assert fraction(u, exact=True) == (1, Pow(2, 2, evaluate=False))
+
 
 def test_issue_5615():
     aA, Re, a, b, D = symbols('aA Re a b D')


### PR DESCRIPTION
When called with the option strict=True, fraction was still evaluating Pow expressions. This commit fixes it and adds a regression test.

Example:

In [1]: from sympy import Pow, fraction

In [2]: u = Pow(2, -2, evaluate=False)

In [3]: fraction(u, exact=True)
Out[3]: (1, 2**2)

Previously last output was (1, 4).

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Fixed a bug with fraction of unevaluated negative powers : they were evaluated when strict=True. 
<!-- END RELEASE NOTES -->
