### PR TITLE
DOC: Use inclusive limit notation in the Product docstring

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1891,6 +1891,7 @@ tnzl <you@example.com>
 tools4origins <tools4origins@gmail.com>
 tttc3 <T.Coxon2@lboro.ac.uk>
 user202729 <25191436+user202729@users.noreply.github.com>
+vaibhav-patel <vaibhav290797@gmail.com>
 vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>

--- a/sympy/concrete/products.py
+++ b/sympy/concrete/products.py
@@ -34,44 +34,49 @@ class Product(ExprWithIntLimits):
     Finite products
     ===============
 
-    For finite products (and products with symbolic limits assumed to be finite)
-    we follow the analogue of the summation convention described by Karr [1],
-    especially definition 3 of section 1.4. The product:
+    For finite products (and products with symbolic limits assumed to be
+    finite), the product
 
     .. math::
 
-        \prod_{m \leq i < n} f(i)
+        P_a^b = \prod_{a \leq i \leq b} f(i)
 
-    has *the obvious meaning* for `m < n`, namely:
-
-    .. math::
-
-        \prod_{m \leq i < n} f(i) = f(m) f(m+1) \cdot \ldots \cdot f(n-2) f(n-1)
-
-    with the upper limit value `f(n)` excluded. The product over an empty set is
-    one if and only if `m = n`:
+    has *the obvious meaning* for `a \leq b`, namely:
 
     .. math::
 
-        \prod_{m \leq i < n} f(i) = 1  \quad \mathrm{for} \quad  m = n
+        P_a^b = \prod_{a \leq i \leq b} f(i) = f(a) f(a+1) \cdot \ldots \cdot f(b-1) f(b) \quad \mathrm{for} \quad a \leq b
 
-    Finally, for all other products over empty sets we assume the following
-    definition:
+    with the lower and upper limit values `f(a)` and `f(b)` included.
 
-    .. math::
-
-        \prod_{m \leq i < n} f(i) = \frac{1}{\prod_{n \leq i < m} f(i)}  \quad \mathrm{for} \quad  m > n
-
-    It is important to note that above we define all products with the upper
-    limit being exclusive. This is in contrast to the usual mathematical notation,
-    but does not affect the product convention. Indeed we have:
+    The convention for products is built upon a single, elegant objective:
+    for any product `P_a^b`, the following multiplicative rule must hold true
+    for all integers `a`, `b` and `c`:
 
     .. math::
 
-        \prod_{m \leq i < n} f(i) = \prod_{i = m}^{n - 1} f(i)
+        P_a^{b-1} \cdot P_b^c = P_a^c
 
-    where the difference in notation is intentional to emphasize the meaning,
-    with limits typeset on the top being inclusive.
+    This property is the multiplicative analogue of the additivity rule for
+    sums.  By enforcing this consistency, the convention naturally extends the
+    definition of a product to cases where the lower bound is not strictly less
+    than the upper bound, i.e. `a \nless b`, resulting in the following
+    generalizations:
+
+    .. math::
+        P_b^{b-1} = 1 \quad \mbox{because} \quad P_a^{b-1} \cdot P_b^{b-1} = P_a^{b-1}
+
+    and
+
+    .. math::
+        P_a^b = \frac{1}{P_{b+1}^{a-1}} \quad \mbox{because} \quad P_a^b \cdot P_{b+1}^{a-1} = P_a^{a-1} = 1
+
+    therefore, in case `a > b`:
+
+    .. math::
+        P_a^b = \frac{1}{P_{b+1}^{a-1}} = \frac{1}{\prod_{b + 1 \leq i \leq a - 1} f(i)}
+
+    with the lower and upper limit values `f(b)` and `f(a)` excluded.
 
     Examples
     ========


### PR DESCRIPTION
## References to other Issues or PRs

Fixes #29849.

## Brief description of what is fixed or changed

The "Finite products" section of the `Product` docstring described the product
convention using an **exclusive** upper limit (`\prod_{m \leq i < n}`) and
explicitly framed it as being "in contrast to the usual mathematical notation".
This was confusing and inconsistent with the `Sum` docstring, which was already
updated to use **inclusive** limits and to derive the convention from an
additivity rule.

This PR rewrites the section to mirror `Sum`:

- uses inclusive notation `\prod_{a \leq i \leq b} f(i)` throughout;
- introduces the notation `P_a^b` and presents the convention as the
  *multiplicative analogue of the additivity rule* (`P_a^{b-1} \cdot P_b^c = P_a^c`),
  from which the empty product (`P_b^{b-1} = 1`) and the `a > b` case
  (`P_a^b = 1 / P_{b+1}^{a-1}`) follow naturally.

Only the docstring prose changes. All worked examples are unchanged and the
docstring's doctests still pass.

## Other comments

The Karr reference ([1]) and the Karr wording in the worked examples are kept,
matching how the `Sum` docstring still references the Karr convention in its
examples.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* concrete
  * The ``Product`` docstring now describes the product convention using
    inclusive limit notation, consistent with the ``Sum`` docstring.
<!-- END RELEASE NOTES -->
