### PR TITLE
stats: handle DiracDelta PDFs in scipy sampling instead of crashing

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1689,6 +1689,7 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
@@ -1697,7 +1698,6 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
-Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
 Vedant Kadam <vedantkadam3498@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1697,6 +1697,7 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
+Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
 Vedant Kadam <vedantkadam3498@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>

--- a/sympy/stats/sampling/sample_scipy.py
+++ b/sympy/stats/sampling/sample_scipy.py
@@ -3,6 +3,7 @@ from functools import singledispatch
 
 from sympy.core.symbol import Dummy
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.special.delta_functions import DiracDelta
 from sympy.utilities.lambdify import lambdify
 from sympy.external import import_module
 from sympy.stats import DiscreteDistributionHandmade
@@ -31,7 +32,15 @@ def _(dist: SingleContinuousDistribution, size, seed):
     import scipy.stats
 
     z = Dummy('z')
-    handmade_pdf = lambdify(z, dist.pdf(z), ['numpy', 'scipy'])
+    pdf = dist.pdf(z)
+    if pdf.has(DiracDelta):
+        # A DiracDelta in the PDF describes a degenerate (point mass)
+        # distribution, which scipy cannot sample by integrating a numeric
+        # PDF. Returning None lets the caller raise the standard
+        # NotImplementedError instead of producing an undefined name at
+        # sample time (see issue #29783).
+        return None
+    handmade_pdf = lambdify(z, pdf, ['numpy', 'scipy'])
 
     class scipy_pdf(scipy.stats.rv_continuous):
         def _pdf(dist, x):

--- a/sympy/stats/sampling/tests/test_sample_continuous_rv.py
+++ b/sympy/stats/sampling/tests/test_sample_continuous_rv.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from sympy.core.numbers import oo
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.special.delta_functions import DiracDelta
 from sympy.sets.sets import Interval
 from sympy.external import import_module
 from sympy.stats import Beta, Chi, Normal, Gamma, Exponential, LogNormal, Pareto, ChiSquared, Uniform, sample, \
@@ -98,6 +99,19 @@ def test_sample_pymc():
                 assert sam in X.pspace.domain.set
         raises(NotImplementedError,
                lambda: sample(Chi("C", 1), library='pymc'))
+
+
+def test_sample_continuous_handmade_diracdelta():
+    # A DiracDelta in the PDF describes a degenerate distribution that scipy
+    # cannot sample by integrating a numeric PDF. This used to raise a
+    # confusing ``NameError: name 'DiracDelta' is not defined`` from the
+    # lambdified PDF; it should raise NotImplementedError instead (issue #29783).
+    scipy = import_module('scipy')
+    if not scipy:
+        skip('Scipy is not installed. Abort tests for _sample_scipy.')
+    x = Symbol('x')
+    X = ContinuousRV(x, DiracDelta(x - 2))
+    raises(NotImplementedError, lambda: sample(X, library='scipy'))
 
 
 def test_sampling_gamma_inverse():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29783

#### Brief description of what is fixed or changed

Sampling a continuous random variable whose PDF contains a `DiracDelta` crashed with a confusing error:

```python
from sympy import Symbol, DiracDelta
from sympy.stats import ContinuousRV, sample

x, c = Symbol("x"), Symbol("c")
X = ContinuousRV(x, DiracDelta(x - c))
sample(X)
# NameError: name "DiracDelta" is not defined
```

The `NameError` comes from the lambdified PDF: `DiracDelta` has no numpy/scipy implementation, so `lambdify` emits a literal `DiracDelta(...)` call that is undefined at sample time.

A `DiracDelta` in the PDF describes a degenerate (point mass) distribution, which scipy cannot sample by numerically integrating a PDF. The handmade scipy sampler now detects this and returns `None`, so the caller raises the standard `NotImplementedError` with the distribution and library name, the same way the numpy and pymc backends already report continuous distributions they do not support.

I added a regression test covering this case.

#### Other comments

This only makes the failure clear and consistent; it does not add actual sampling of point-mass distributions. If supporting degenerate distributions is wanted, that could be a separate change.

#### AI Generation Disclosure

OpenAI Codex was used to draft the implementation and PR description. I reviewed and tested the changes. AI-assisted changes are in `sympy/stats/rv.py` and the related regression test.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* stats
  * Sampling a continuous random variable whose PDF contains a `DiracDelta` now raises `NotImplementedError` instead of failing with a `NameError`.
<!-- END RELEASE NOTES -->