### PR TITLE
limits: fix Piecewise leading term at a boundary condition

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1689,6 +1689,7 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
@@ -1697,7 +1698,6 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
-Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
 Vedant Kadam <vedantkadam3498@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1697,6 +1697,7 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
+Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
 Vedant Kadam <vedantkadam3498@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -224,9 +224,37 @@ class Piecewise(DefinedFunction):
         return piecewise_simplify(self, **kwargs)
 
     def _eval_as_leading_term(self, x, logx, cdir):
+        # Pick the piece that applies in the punctured neighborhood of 0 on the
+        # side given by cdir, rather than the one whose condition merely holds
+        # *at* 0.  A boundary condition such as ``x <= 0`` is true at 0 but false
+        # just to the right of it, so testing at exactly 0 selects the wrong
+        # piece for a directional limit (see issue #29835).
+        from sympy.sets.sets import Interval
+        d = cdir if cdir != 0 else 1
+        nbhd = Interval.open(0, S.Infinity) if d > 0 else Interval.open(S.NegativeInfinity, 0)
         for e, c in self.args:
-            if c == True or c.subs(x, 0) == True:
-                return e.as_leading_term(x)
+            if c == True:
+                return e.as_leading_term(x, logx=logx, cdir=cdir)
+            holds = None
+            if c.free_symbols <= {x}:
+                try:
+                    sol = c.as_set()
+                except (NotImplementedError, TypeError):
+                    sol = None
+                if sol is not None:
+                    gap = nbhd - sol
+                    if gap.is_empty:
+                        holds = True
+                    elif d > 0:
+                        holds = bool(gap.inf.is_positive)
+                    else:
+                        holds = bool(gap.sup.is_negative)
+            if holds is None:
+                # Fall back to evaluating the condition at 0 (e.g. when the
+                # condition involves other symbols and ``as_set`` can't be used).
+                holds = c.subs(x, 0) == True
+            if holds:
+                return e.as_leading_term(x, logx=logx, cdir=cdir)
 
     def _eval_adjoint(self):
         return self.func(*[(e.adjoint(), c) for e, c in self.args])

--- a/sympy/series/tests/test_limits.py
+++ b/sympy/series/tests/test_limits.py
@@ -164,6 +164,20 @@ def test_piecewise2():
     assert limit(func3, x, -1) == 2
 
 
+def test_piecewise_boundary_condition():
+    # https://github.com/sympy/sympy/issues/29835
+    # A boundary condition such as ``y <= 0`` holds at 0 but not just to the
+    # right of it, so the right-hand limit must use the other piece.
+    f = Piecewise((0, y <= 0), (-6/y**2, True))
+    assert limit(f, y, 0, "+") is -oo
+    assert limit(f, y, 0, "-") == 0
+    assert limit(f, y, 0) is -oo
+    # ``<`` already worked; check both forms now agree
+    g = Piecewise((0, y < 0), (-6/y**2, True))
+    assert limit(g, y, 0, "+") is -oo
+    assert limit(g, y, 0, "-") == 0
+
+
 def test_basic5():
     class my(Function):
         @classmethod


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29835

#### Brief description of what is fixed or changed

A directional limit of a `Piecewise` picked the wrong piece when a condition was true *at* the limit point but not just to one side of it:

```python
>>> from sympy import Piecewise, limit, symbols
>>> y = symbols("y")
>>> f = Piecewise((0, y <= 0), (-6/y**2, True))
>>> limit(f, y, 0, "+")
0       # should be -oo
```

For `y > 0` the first condition `y <= 0` is false, so the right-hand limit should come from the `-6/y**2` piece. `Piecewise._eval_as_leading_term` was choosing the piece by testing `c.subs(x, 0)`, which is true for the boundary condition `y <= 0` at `0`, so it returned the wrong piece. (The strict form `y < 0` happened to work because `0 < 0` is false.)

The method now takes the solution set of each condition and checks whether the punctured neighbourhood of `0` on the `cdir` side lies inside it, so the piece that is actually active in the direction of approach is used. This also handles `And`/`Or` conditions, since `as_set` does. When a condition involves other symbols (so `as_set` does not apply) it falls back to the previous behaviour.

#### Other comments

Added a regression test; `test_piecewise2` and `test_piecewise_as_leading_term` continue to pass, and the full `sympy/series` and `test_piecewise` suites are green locally.

#### AI Generation Disclosure

OpenAI Codex was used to draft the implementation and PR description. I reviewed and tested the changes. AI-assisted changes are in `sympy/functions/elementary/piecewise.py` and the related regression test.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* series
  * Fixed the one-sided limit of a `Piecewise` at a point lying on a non-strict boundary condition (e.g. `x <= 0`), which previously returned the value of the wrong piece.
<!-- END RELEASE NOTES -->