### PR TITLE
evalf: evaluate NonElementaryIntegral numerically

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1689,6 +1689,7 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
@@ -1697,7 +1698,6 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
-Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
 Vedant Kadam <vedantkadam3498@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1697,6 +1697,7 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
+Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
 Vedant Kadam <vedantkadam3498@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -1412,6 +1412,7 @@ def _create_evalf_table():
     from sympy.functions.elementary.piecewise import Piecewise
     from sympy.functions.elementary.trigonometric import atan, cos, sin, tan
     from sympy.integrals.integrals import Integral
+    from sympy.integrals.risch import NonElementaryIntegral
     evalf_table = {
         Symbol: evalf_symbol,
         Dummy: evalf_symbol,
@@ -1448,6 +1449,10 @@ def _create_evalf_table():
         ceiling: evalf_ceiling,
 
         Integral: evalf_integral,
+        # NonElementaryIntegral is an Integral subclass; evalf dispatches on the
+        # exact type, so it needs its own entry to be evaluated numerically
+        # instead of being returned unevaluated (see issue #29833).
+        NonElementaryIntegral: evalf_integral,
         Sum: evalf_sum,
         Product: evalf_prod,
         Piecewise: evalf_piecewise,

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -521,6 +521,16 @@ def test_evalf_integral():
     assert Integral(sin(x), (x, -pi, pi + eps)).n(2)._prec == 10
 
 
+def test_evalf_nonelementary_integral():
+    # NonElementaryIntegral is an Integral subclass and must evalf the same way
+    # as Integral rather than being returned unevaluated (issue #29833).
+    from sympy.integrals.risch import NonElementaryIntegral
+    e = (x**x).integrate((x, 2, 5))
+    assert isinstance(e, NonElementaryIntegral)
+    assert e.evalf() == Integral(x**x, (x, 2, 5)).evalf()
+    assert abs(e.evalf() - Float('1238.98283781487')) < 1e-9
+
+
 def test_issue_8821_highprec_from_str():
     s = str(pi.evalf(128))
     p = N(s)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29833

#### Brief description of what is fixed or changed

`evalf` looks up its handler by the exact type of the expression (`evalf_table[type(x)]`). `integrate` sometimes returns a `NonElementaryIntegral`, which is a subclass of `Integral` but is not itself a key in the table, so it missed the integral handler and was returned unevaluated:

```python
>>> from sympy import symbols, Integral
>>> x = symbols("x")
>>> (x**x).integrate((x, 2, 5)).evalf()
Integral(x**x, (x, 2, 5))          # not evaluated
>>> Integral(x**x, (x, 2, 5)).evalf()
1238.98283781487
```

This matches @oscarbenjamin's diagnosis on the issue. Registering `NonElementaryIntegral` in the evalf table makes it use the same numerical integration as `Integral`:

```python
>>> (x**x).integrate((x, 2, 5)).evalf()
1238.98283781487
```

The table is built lazily on the first `evalf` call, so importing `NonElementaryIntegral` there does not introduce an import cycle.

#### Other comments

Added a regression test. `test_evalf`, `test_risch` and `test_integrals` pass locally.

#### AI Generation Disclosure

OpenAI Codex was used to draft the implementation and PR description. I reviewed and tested the changes. AI-assisted changes are in `sympy/core/evalf.py` and the related regression test.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * `evalf`/`N` now numerically evaluate a `NonElementaryIntegral` (returned by `integrate` for some integrals) instead of leaving it unevaluated.
<!-- END RELEASE NOTES -->