### PR TITLE
assumptions: handle infinite values on eq

### DIFF
--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -159,6 +159,10 @@ def test_equality():
     # test transitivity
     assert ask(Q.eq(x,z), Q.eq(x,y) & Q.eq(y,z)) is True
 
+    # issue 29861
+    a = Symbol('a')
+    assert ask(Q.eq(a, a + 1)) is None
+
 
 @XFAIL
 def test_equality_failing():

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -11,7 +11,7 @@ from .numbers import int_valued
 from .singleton import S
 from .sympify import _sympify, SympifyError
 from .parameters import global_parameters
-from .logic import fuzzy_bool, fuzzy_xor, fuzzy_and, fuzzy_not
+from .logic import fuzzy_bool, fuzzy_xor, fuzzy_and, fuzzy_not, fuzzy_or
 from sympy.logic.boolalg import Boolean, BooleanAtom
 from sympy.utilities.iterables import sift
 from sympy.utilities.misc import filldedent
@@ -1592,19 +1592,20 @@ def is_eq(lhs: Basic, rhs: Basic, assumptions=None) -> bool | None:
             return fuzzy_bool(is_eq(arglhs, argrhs, assumptions))
 
     if isinstance(lhs, Expr) and isinstance(rhs, Expr):
+        finite = fuzzy_or([_lhs.is_finite, _rhs.is_finite])
         # see if the difference evaluates
         dif = lhs - rhs
         _dif = AssumptionsWrapper(dif, assumptions)
         z = _dif.is_zero
         if z is not None:
-            if z is False and _dif.is_commutative:  # issue 10728
+            if z is False and _dif.is_commutative and finite:
                 return False
             if z:
                 return True
 
         # is_zero cannot help decide integer/rational with Float
         c, t = dif.as_coeff_Add()
-        if c.is_Float:
+        if c.is_Float and finite:
             if int_valued(c):
                 if t.is_integer is False:
                     return False
@@ -1643,6 +1644,8 @@ def is_eq(lhs: Basic, rhs: Basic, assumptions=None) -> bool | None:
             # (inf or nan)/x != 0
             rv = False
         if rv is not None:
+            if rv is False and not finite:
+                return None
             return rv
 
     return None

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -1200,6 +1200,11 @@ def test_is_eq():
     assert is_neq(x, S(0), assumptions=~Q.zero(x))
     assert is_neq(x, S(0), assumptions=Q.nonzero(x))
 
+    # issue 29861
+    assert is_eq(x, x + 1) is None
+    assert is_eq(x, x + 1, Q.finite(x)) is False
+    assert is_eq(oo, oo + 1)
+
     # test registration
     class PowTest(Expr):
         def __new__(cls, base, exp):

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -415,7 +415,7 @@ def test_Range_symbolic():
     raises(ValueError, lambda: sr.size)
     # bool
     assert bool(Range(0)) == False
-    assert bool(xr)
+    raises(ValueError, lambda: bool(xr))
     assert bool(ir)
     assert bool(ipr)
     assert bool(inr)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -766,7 +766,8 @@ def test_is_subset():
 
     assert FiniteSet(x).is_subset(FiniteSet(y)) is None
     assert FiniteSet(x).is_subset(FiniteSet(y).subs(y, x)) is True
-    assert FiniteSet(x).is_subset(FiniteSet(y).subs(y, x+1)) is False
+    # holds for x = oo
+    assert FiniteSet(x).is_subset(FiniteSet(y).subs(y, x+1)) is None
 
     assert Interval(0, 1).is_subset(Interval(0, 1, left_open=True)) is False
     assert Interval(-2, 3).is_subset(Union(Interval(-oo, -2), Interval(3, oo))) is False
@@ -844,7 +845,9 @@ def test_contains():
     raises(TypeError, lambda: x in FiniteSet(y))
     assert FiniteSet({x, y})._contains({x}) == Eq({x, y}, {x}, evaluate=False)
     assert FiniteSet({x, y}).subs(y, x)._contains({x}) is S.true
-    assert FiniteSet({x, y}).subs(y, x+1)._contains({x}) is S.false
+    # holds for x = oo
+    assert FiniteSet({x, y}).subs(y, x+1)._contains({x}) == \
+        Eq({x, x + 1}, {x}, evaluate=False)
 
     # issue 8197
     from sympy.abc import a, b
@@ -1306,8 +1309,11 @@ def test_Eq():
     assert unchanged(Eq, FiniteSet({x, y}), FiniteSet({x}))
     assert Eq(FiniteSet({x, y}).subs(y, x), FiniteSet({x})) is S.true
     assert Eq(FiniteSet({x, y}), FiniteSet({x})).subs(y, x) is S.true
-    assert Eq(FiniteSet({x, y}).subs(y, x+1), FiniteSet({x})) is S.false
-    assert Eq(FiniteSet({x, y}), FiniteSet({x})).subs(y, x+1) is S.false
+    # holds for x = oo
+    assert Eq(FiniteSet({x, y}).subs(y, x+1), FiniteSet({x})) == \
+        Eq(FiniteSet({x, x + 1}), FiniteSet({x}), evaluate=False)
+    assert Eq(FiniteSet({x, y}), FiniteSet({x})).subs(y, x+1) == \
+        Eq(FiniteSet({x, x + 1}), FiniteSet({x}), evaluate=False)
 
     assert Eq(ProductSet({1}, {2}), Interval(1, 2)) is S.false
     assert Eq(ProductSet({1}), ProductSet({1}, {2})) is S.false

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1631,7 +1631,7 @@ def test_linear_eq_to_matrix():
     # 4) Eq being used to represent equations autoevaluates
     # (use unevaluated Eq instead)
     raises(ValueError, lambda: linear_eq_to_matrix(Eq(x, x), x))
-    raises(ValueError, lambda: linear_eq_to_matrix(Eq(x, x + 1), x))
+    assert linear_eq_to_matrix(Eq(x, x + 1), x) == (Matrix([[0]]), Matrix([[1]]))
 
 
     # if non-symbols are passed, the user is responsible for interpreting


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
https://github.com/sympy/sympy/issues/29861

#### Brief description of what is fixed or changed
Add a guard on the dif logic of eq for infinite values

#### Other comments
I think one of the sides being finite is enough and necessary for this.

I might make another PR for the set changes
#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Claude was used for the tests
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
