### PR TITLE
Mathematica parser extended to calculus functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1554,6 +1554,7 @@ Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpa
 Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> “sidhantnagpal” <sidhantnagpal97@gmail.com>
 Sidharth Mundhra <sidharthmundhra16@gmail.com> Sidharth Mundhra <56464077+0sidharth@users.noreply.github.com>
+Simon Harrington <simon.a.harrington@gmail.com>
 Simon Sørensen <simonblsoerensen@gmail.com>
 Simon Sørensen <simonblsoerensen@gmail.com> Simon Sørensen <61250140+zarstensen@users.noreply.github.com>
 SirJohnFranklin <sirjfu@googlemail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,7 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+Simon Harrington <52795409+catpotato42@users.noreply.github.com>
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -185,7 +185,6 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
-Simon Harrington <52795409+catpotato42@users.noreply.github.com>
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -1555,6 +1554,7 @@ Sidhant Nagpal <sidhantnagpal97@gmail.com> Sidhant Nagpal <36465988+sidhantnagpa
 Sidhant Nagpal <sidhantnagpal97@gmail.com> sidhantnagpal <sidhantnagpal97@gmail.com>
 Sidhant Nagpal <sidhantnagpal97@gmail.com> “sidhantnagpal” <sidhantnagpal97@gmail.com>
 Sidharth Mundhra <sidharthmundhra16@gmail.com> Sidharth Mundhra <56464077+0sidharth@users.noreply.github.com>
+Simon Harrington <52795409+catpotato42@users.noreply.github.com>
 Simon Harrington <simon.a.harrington@gmail.com>
 Simon Sørensen <simonblsoerensen@gmail.com>
 Simon Sørensen <simonblsoerensen@gmail.com> Simon Sørensen <61250140+zarstensen@users.noreply.github.com>

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -105,38 +105,27 @@ def _parse_Function(*args):
         raise SyntaxError("Function node expects 1 or 2 arguments")
 
 def _parse_D(*args):
-    if len(args) == 2 and not isinstance(args[1], Tuple):
-        return Derivative(args[0], args[1])
-    return Function('D')(*args)
+    return Derivative(args[0], *args[1:])
 
 
 def _parse_Integrate(*args):
-    f = args[0]
-    if len(args) == 2 and isinstance(args[1], Tuple):
-        return Integral(f, tuple(args[1]))
-    return Integral(f, *args[1:])
+    return Integral(args[0], *args[1:])
 
 
 def _parse_Sum(*args):
-    f = args[0]
-    if len(args) == 2 and isinstance(args[1], Tuple):
-        return Sum(f, tuple(args[1]))
-    return Function('Sum')(*args)
+    return Sum(args[0], *args[1:])
 
 
 def _parse_Product(*args):
-    f = args[0]
-    if len(args) == 2 and isinstance(args[1], Tuple):
-        return Product(f, tuple(args[1]))
-    return Function('Product')(*args)
+    return Product(args[0], *args[1:])
 
 
 def _parse_Limit(*args):
-    if len(args) == 2:
-        f = args[0]
-        rule = args[1]
-        return Limit(f, rule.args[0], rule.args[1])
-    return Function('Limit')(*args)
+    f = args[0]
+    point = args[1]
+    if isinstance(point, Tuple):
+        return Limit(f, point[0], point[1])
+    return Limit(f, point.args[0], point.args[1])
 
 
 def _deco(cls):

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -9,11 +9,14 @@ from sympy import Mul, Add, Pow, Rational, log, exp, sqrt, cos, sin, tan, asin, 
     acosh, atanh, acoth, asech, acsch, expand, im, flatten, polylog, cancel, expand_trig, sign, simplify, \
     UnevaluatedExpr, S, atan, atan2, Mod, Max, Min, rf, Ei, Si, Ci, airyai, airyaiprime, airybi, primepi, prime, \
     isprime, cot, sec, csc, csch, sech, coth, Function, E, I, pi, Tuple, GreaterThan, StrictGreaterThan, StrictLessThan, \
-    LessThan, Equality, Or, And, Lambda, Integer, Dummy, symbols, Not, factorial
+    LessThan, Equality, Or, And, Lambda, Integer, Dummy, symbols, Not, factorial, Abs, Derivative, Integral, Limit, Sum, Product
 from sympy.core.sympify import sympify, _sympify
 from sympy.functions.special.bessel import airybiprime
 from sympy.functions.special.error_functions import li
 from sympy.utilities.exceptions import sympy_deprecation_warning
+from sympy.functions.elementary.integers import floor, ceiling
+from sympy.functions.combinatorial.factorials import binomial
+from sympy.functions.special.gamma_functions import gamma
 
 
 def mathematica(s, additional_translations=None):
@@ -100,6 +103,40 @@ def _parse_Function(*args):
         return Lambda(variables, body)
     else:
         raise SyntaxError("Function node expects 1 or 2 arguments")
+
+def _parse_D(*args):
+    if len(args) == 2 and not isinstance(args[1], Tuple):
+        return Derivative(args[0], args[1])
+    return Function('D')(*args)
+
+
+def _parse_Integrate(*args):
+    f = args[0]
+    if len(args) == 2 and isinstance(args[1], Tuple):
+        return Integral(f, tuple(args[1]))
+    return Integral(f, *args[1:])
+
+
+def _parse_Sum(*args):
+    f = args[0]
+    if len(args) == 2 and isinstance(args[1], Tuple):
+        return Sum(f, tuple(args[1]))
+    return Function('Sum')(*args)
+
+
+def _parse_Product(*args):
+    f = args[0]
+    if len(args) == 2 and isinstance(args[1], Tuple):
+        return Product(f, tuple(args[1]))
+    return Function('Product')(*args)
+
+
+def _parse_Limit(*args):
+    if len(args) == 2:
+        f = args[0]
+        rule = args[1]
+        return Limit(f, rule.args[0], rule.args[1])
+    return Function('Limit')(*args)
 
 
 def _deco(cls):
@@ -1143,6 +1180,17 @@ class MathematicaParser:
         "Not": Not,
         "Function": _parse_Function,
         "Factorial": factorial,
+
+        "D":         _parse_D,
+        "Integrate": _parse_Integrate,
+        "Sum":       _parse_Sum,
+        "Product":   _parse_Product,
+        "Limit":     _parse_Limit,
+        "Abs":       Abs,
+        "Floor":     floor,
+        "Ceiling":   ceiling,
+        "Gamma":     gamma,
+        "Binomial":  binomial,
     }
 
     _atom_conversions = {

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
-from sympy import sin, Function, symbols, Dummy, Lambda, cos, Symbol, factorial, S
+from sympy import sin, Function, symbols, Dummy, Lambda, cos, Symbol, factorial, S, \
+    Derivative, Integral, Limit, Sum, Product, Abs
 from sympy.parsing.mathematica import parse_mathematica, MathematicaParser
 from sympy.core.sympify import sympify
 from sympy.abc import n, w, x, y, z
 from sympy.testing.pytest import raises
 from sympy.logic.boolalg import And, Or, Not
+from sympy.functions.elementary.integers import floor, ceiling
+from sympy.functions.special.gamma_functions import gamma
+from sympy.functions.combinatorial.factorials import binomial
 
 
 def test_mathematica():
@@ -339,6 +343,37 @@ def test_parser_mathematica_exp_alt():
     assert convert_chain3(full_form1) == sin(x*y)
     assert convert_chain3(full_form2) == x*y + z
     assert convert_chain3(full_form3) == sin(x*(y + z)*w**n)
+
+def test_mathematica_operators():
+    x, n, k, i = symbols('x n k i')
+
+    assert parse_mathematica("D[x^2, x]") == Derivative(x**2, x)
+    assert parse_mathematica("Integrate[x^2, x]") == Integral(x**2, x)
+    assert parse_mathematica("Integrate[x^2, {x, 0, 1}]") == Integral(x**2, (x, 0, 1))
+    assert parse_mathematica("Sum[i, {i, 1, n}]") == Sum(i, (i, 1, n))
+    assert parse_mathematica("Product[i, {i, 1, n}]") == Product(i, (i, 1, n))
+    assert parse_mathematica("Limit[Sin[x]/x, x -> 0]") == Limit(sin(x)/x, x, 0)
+    assert parse_mathematica("Floor[x]") == floor(x)
+    assert parse_mathematica("Ceiling[x]") == ceiling(x)
+    assert parse_mathematica("Gamma[x]") == gamma(x)
+    assert parse_mathematica("Binomial[n, k]") == binomial(n, k)
+    assert parse_mathematica("Abs[x]") == Abs(x)
+
+def test_mathematica_operators_out_of_scope():
+    x, y, n = symbols('x y n')
+
+    assert parse_mathematica("F[7, 5, 3]") == Function('F')(7, 5, 3)
+    assert parse_mathematica("5!") == 120
+    assert parse_mathematica("x + y") == x + y
+    assert parse_mathematica("x * y") == x * y
+
+    # nth-order D falls back to Function node
+    result = parse_mathematica("D[x^2, {x, 2}]")
+    assert result.func.__name__ == 'D'
+
+    # multi-iterator Sum falls back to Function node
+    result = parse_mathematica("Sum[i, {i, 1, n}, {j, 1, n}]")
+    assert result.func.__name__ == 'Sum'
 
 
 def test_Mathematica_literal_regex():

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -345,12 +345,14 @@ def test_parser_mathematica_exp_alt():
     assert convert_chain3(full_form3) == sin(x*(y + z)*w**n)
 
 def test_mathematica_operators():
-    x, n, k, i = symbols('x n k i')
+    x, n, k, i, j = symbols('x n k i j')
 
     assert parse_mathematica("D[x^2, x]") == Derivative(x**2, x)
+    assert parse_mathematica("D[x^2, {x, 2}]") == Derivative(x**2, (x, 2))
     assert parse_mathematica("Integrate[x^2, x]") == Integral(x**2, x)
     assert parse_mathematica("Integrate[x^2, {x, 0, 1}]") == Integral(x**2, (x, 0, 1))
     assert parse_mathematica("Sum[i, {i, 1, n}]") == Sum(i, (i, 1, n))
+    assert parse_mathematica("Sum[i, {i, 1, n}, {j, 1, n}]") == Sum(i, (i, 1, n), (j, 1, n))
     assert parse_mathematica("Product[i, {i, 1, n}]") == Product(i, (i, 1, n))
     assert parse_mathematica("Limit[Sin[x]/x, x -> 0]") == Limit(sin(x)/x, x, 0)
     assert parse_mathematica("Floor[x]") == floor(x)
@@ -359,21 +361,14 @@ def test_mathematica_operators():
     assert parse_mathematica("Binomial[n, k]") == binomial(n, k)
     assert parse_mathematica("Abs[x]") == Abs(x)
 
-def test_mathematica_operators_out_of_scope():
-    x, y, n = symbols('x y n')
+
+def test_mathematica_operators_regressions():
+    x, y = symbols('x y')
 
     assert parse_mathematica("F[7, 5, 3]") == Function('F')(7, 5, 3)
     assert parse_mathematica("5!") == 120
     assert parse_mathematica("x + y") == x + y
     assert parse_mathematica("x * y") == x * y
-
-    # nth-order D falls back to Function node
-    result = parse_mathematica("D[x^2, {x, 2}]")
-    assert result.func.__name__ == 'D'
-
-    # multi-iterator Sum falls back to Function node
-    result = parse_mathematica("Sum[i, {i, 1, n}, {j, 1, n}]")
-    assert result.func.__name__ == 'Sum'
 
 
 def test_Mathematica_literal_regex():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
See #3260

#### Brief description of what is fixed or changed
Added simple parsing for mathematica calculus (Derivative, Integral, Sum, Product, and Limit) as well as scalar functions (Floor, Ceiling, Gamma, Binomial).

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Claude was used to generate the tests in lines 347-377 of sympy/parsing/tests/test_mathematica.py

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Added simple parsing for mathematica calculus operators.
<!-- END RELEASE NOTES -->
