### PR TITLE
[GSoC] lra_theory: update random problem generation to get balanced testcase for `sat` vs `unsat`

### DIFF
--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -147,6 +147,15 @@ def test_random_problems():
     special_cases.append([x1 + 5*x2 >= -6, 9*x1 - 3*x2 >= -9, 6*x1 + 6*x2 < -10, -3*x1 + 3*x2 < -7])
     special_cases.append([-9*x1 < 7, -5*x1 - 7*x2 < -1, 3*x1 + 7*x2 > 1, -6*x1 - 6*x2 > 9])
     special_cases.append([9*x1 - 6*x2 >= -7, 9*x1 + 4*x2 < -8, -7*x2 <= 1, 10*x2 <= -7])
+    special_cases.append([x1 >= 0, x1 <= 10, x2 >= -5, x2 <= 5, x1 + x2 >= -3, x1 - x2 <= 12])
+    special_cases.append([x1 + x2 <= 20, x1 - x2 >= -10, x1 >= 0])
+    special_cases.append([Eq(x1, 3), x2 >= 0, x2 <= 10])
+    special_cases.append([x1 > 0, x1 < 1, x2 > -1, x2 < 1])
+    special_cases.append([x1 >= -1, x1 <= 5, x2 >= -3, x1 + x2 <= 10, 2*x1 - x2 >= -8, x2 <= 6])
+    special_cases.append([3*x1 - 2*x2 <= 10, x1 >= 0, x2 >= 0, x1 + x2 >= 1])
+    special_cases.append([Eq(2*x1, 4), x2 > -1, x2 < 5])
+    special_cases.append([x1 + x2 + x3 <= 10, x1 >= 0, x2 >= 0, x3 >= 0, x1 - x3 >= -5])
+    special_cases.append([5*x1 - 3*x2 >= -6, x1 <= 4, x2 >= -2, x2 <= 7])
 
     feasible_count = 0
     for i in range(50):
@@ -159,6 +168,8 @@ def test_random_problems():
             constraints = make_random_problem(num_variables=2, num_constraints=4, rational=False, disable_strict=True)
         elif i % 8 == 3:
             constraints = make_random_problem(num_variables=3, num_constraints=12, rational=False)
+        elif i % 8 == 4:
+            constraints = make_random_problem(num_variables=3, num_constraints=4, rational=False)
         else:
             constraints = make_random_problem(num_variables=3, num_constraints=6, rational=False)
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs


<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Updated `test_random_problems()` in `test_lra_theory.py` to have a balance between sat and unsat problems generated.
These are the final metrics: 
Metric | Before | After
-- | -- | --
SAT % | 38.4% | 51.3%
Avg SAT | 18.4 | 24.8
Avg UNSAT | 29.5 | 23.5

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Generated more `special_cases` problems using Gemini 3.1 Pro.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
