### PR TITLE
assumptions: Improve_ask_recursive() consistency and robustness

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -496,6 +496,44 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     from sympy.assumptions.lra_satask import lra_satask
     from sympy.logic.algorithms.lra_theory import UnhandledInput
 
+    # Cheap path first (normalization + known-facts lookup + direct handler
+    # dispatch). This is the same code AssumptionsWrapper uses internally
+    # via _ask_recursive, so is_eq/is_ge/etc. (called from inside
+    # _eval_ask for Q.eq/Q.ge/...) never trigger a nested satask call.
+    # See issue #29863.
+    res = _ask_recursive(proposition, assumptions, context)
+    if res is not None:
+        return res
+
+    proposition = sympify(proposition)
+    assumptions = sympify(assumptions)
+
+    # using satask (still costly) -- the ONLY place satask is invoked
+    res = satask(proposition, assumptions=assumptions, context=context)
+    if res is not None:
+        return res
+
+    try:
+        res = lra_satask(proposition, assumptions=assumptions, context=context)
+    except UnhandledInput:
+        return None
+
+    return res
+
+
+def _ask_recursive(proposition, assumptions=True, context=global_assumptions):
+    """
+    Cheap evaluation of *proposition*: normalization, single-fact lookup
+    against known_facts, and direct (multiple-dispatch) handler resolution.
+
+    This function deliberately never falls through to ``satask`` or
+    ``lra_satask``. It is the function ``AssumptionsWrapper`` (and
+    therefore ``is_eq``, ``is_ge``, etc. in ``sympy.core.relational``)
+    calls internally, so that those functions cannot re-enter the costly
+    SAT solving path of ``ask()`` while ``ask()`` itself is busy
+    evaluating a ``Q.eq``/``Q.ge``/... proposition via those very
+    functions. See #29863.
+    """
     proposition = sympify(proposition)
     assumptions = sympify(assumptions)
 
@@ -536,22 +574,12 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     if res is not None:
         return res
 
-    # direct resolution method, no logic
+    # direct resolution method, no logic, no SAT solver
     res = key(*args)._eval_ask(assumptions)
     if res is not None:
         return bool(res)
 
-    # using satask (still costly)
-    res = satask(proposition, assumptions=assumptions, context=context)
-    if res is not None:
-        return res
-
-    try:
-        res = lra_satask(proposition, assumptions=assumptions, context=context)
-    except UnhandledInput:
-        return None
-
-    return res
+    return None
 
 
 def _ask_single_fact(key, local_facts):

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -497,44 +497,8 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     from sympy.assumptions.lra_satask import lra_satask
     from sympy.logic.algorithms.lra_theory import UnhandledInput
 
-    # Cheap path first (normalization + known-facts lookup + direct handler
-    # dispatch). This is the same code AssumptionsWrapper uses internally
-    # via _ask_recursive, so is_eq/is_ge/etc. (called from inside
-    # _eval_ask for Q.eq/Q.ge/...) never trigger a nested satask call.
-    # See issue #29863.
-    res = _ask_recursive(proposition, assumptions, context)
-    if res is not None:
-        return res
+    assumptions = And(assumptions, *context)
 
-    proposition = sympify(proposition)
-    assumptions = sympify(assumptions)
-
-    # using satask (still costly) -- the ONLY place satask is invoked
-    res = satask(proposition, assumptions=assumptions, context=context)
-    if res is not None:
-        return res
-
-    try:
-        res = lra_satask(proposition, assumptions=assumptions, context=context)
-    except UnhandledInput:
-        return None
-
-    return res
-
-
-def _ask_recursive(proposition, assumptions=True, context=global_assumptions):
-    """
-    Cheap evaluation of *proposition*: normalization, single-fact lookup
-    against known_facts, and direct (multiple-dispatch) handler resolution.
-
-    This function deliberately never falls through to ``satask`` or
-    ``lra_satask``. It is the function ``AssumptionsWrapper`` (and
-    therefore ``is_eq``, ``is_ge``, etc. in ``sympy.core.relational``)
-    calls internally, so that those functions cannot re-enter the costly
-    SAT solving path of ``ask()`` while ``ask()`` itself is busy
-    evaluating a ``Q.eq``/``Q.ge``/... proposition via those very
-    functions. See #29863.
-    """
     proposition = sympify(proposition)
     assumptions = sympify(assumptions)
 
@@ -574,12 +538,22 @@ def _ask_recursive(proposition, assumptions=True, context=global_assumptions):
     if res is not None:
         return res
 
-    # direct resolution method, no logic, no SAT solver
+    # direct resolution method, no logic
     res = key(*args)._eval_ask(assumptions)
     if res is not None:
         return bool(res)
 
-    return None
+    # using satask (still costly)
+    res = satask(proposition, assumptions=assumptions)
+    if res is not None:
+        return res
+
+    try:
+        res = lra_satask(proposition, assumptions=assumptions)
+    except UnhandledInput:
+        return None
+
+    return res
 
 
 def _ask_single_fact(key, local_facts):
@@ -669,13 +643,29 @@ def _ask_recursive(proposition, assumptions):
     """
     Answers query by relying only on recursive handlers and `_ask_single_fact`
     and avoiding expensive SAT solver queries.
+
+    This function deliberately never falls through to ``satask`` or
+    ``lra_satask``, and deliberately skips the satisfiability check that
+    ``ask()`` performs -- that check itself requires a SAT call, which would
+    defeat the purpose of this fast path. It is the function
+    ``AssumptionsWrapper`` (and therefore ``is_eq``, ``is_ge``, etc. in
+    ``sympy.core.relational``) calls internally, so that those functions
+    cannot re-enter the costly SAT solving path of ``ask()`` while ``ask()``
+    itself is busy evaluating a ``Q.eq``/``Q.ge``/... proposition via those
+    very functions. See #29863.
     """
+    proposition = sympify(proposition)
+    assumptions = sympify(assumptions)
+
+    proposition = _normalize_expr(proposition)
+    assumptions = _normalize_expr(assumptions)
+
     if isinstance(proposition, AppliedPredicate):
         key, args = proposition.function, proposition.arguments
     else:
         key, args = Q.is_true, (proposition,)
 
-    assump_cnf = CNF.from_prop(assumptions)
+    assump_cnf = CNF.from_prop(And(assumptions, *global_assumptions))
     local_facts = _extract_all_facts(assump_cnf, args)
 
     res = _ask_single_fact(key, local_facts)
@@ -685,6 +675,8 @@ def _ask_recursive(proposition, assumptions):
     res = key(*args)._eval_ask(assumptions)
     if res is not None:
         return bool(res)
+
+    return None
 
 
 from sympy.assumptions.ask_generated import (get_all_known_facts,

--- a/sympy/assumptions/wrapper.py
+++ b/sympy/assumptions/wrapper.py
@@ -44,8 +44,7 @@ False
 """
 from __future__ import annotations
 
-from sympy.assumptions import Q
-from sympy.assumptions.ask import _ask_recursive
+from sympy.assumptions import ask, Q
 from sympy.core.basic import Basic
 from sympy.core.sympify import _sympify
 
@@ -53,8 +52,7 @@ from sympy.core.sympify import _sympify
 def make_eval_method(fact):
     def getit(self):
         pred = getattr(Q, fact)
-        # _ask_recursive (not ask) so is_eq/is_ge can't recurse back  into the costly satask path of ask() (issue #29863)
-        ret = _ask_recursive(pred(self.expr), self.assumptions)
+        ret = ask(pred(self.expr), self.assumptions)
         return ret
     return getit
 
@@ -152,16 +150,16 @@ class AssumptionsWrapper(Basic):
 def is_infinite(obj, assumptions=None):
     if assumptions is None:
         return obj.is_infinite
-    return _ask_recursive(Q.infinite(obj), assumptions)
+    return ask(Q.infinite(obj), assumptions)
 
 
 def is_extended_real(obj, assumptions=None):
     if assumptions is None:
         return obj.is_extended_real
-    return _ask_recursive(Q.extended_real(obj), assumptions)
+    return ask(Q.extended_real(obj), assumptions)
 
 
 def is_extended_nonnegative(obj, assumptions=None):
     if assumptions is None:
         return obj.is_extended_nonnegative
-    return _ask_recursive(Q.extended_nonnegative(obj), assumptions)
+    return ask(Q.extended_nonnegative(obj), assumptions)

--- a/sympy/assumptions/wrapper.py
+++ b/sympy/assumptions/wrapper.py
@@ -44,7 +44,7 @@ False
 """
 from __future__ import annotations
 
-from sympy.assumptions import ask, Q
+from sympy.assumptions import Q
 from sympy.assumptions.ask import _ask_recursive
 from sympy.core.basic import Basic
 from sympy.core.sympify import _sympify

--- a/sympy/assumptions/wrapper.py
+++ b/sympy/assumptions/wrapper.py
@@ -45,6 +45,7 @@ False
 from __future__ import annotations
 
 from sympy.assumptions import ask, Q
+from sympy.assumptions.ask import _ask_recursive
 from sympy.core.basic import Basic
 from sympy.core.sympify import _sympify
 
@@ -52,7 +53,8 @@ from sympy.core.sympify import _sympify
 def make_eval_method(fact):
     def getit(self):
         pred = getattr(Q, fact)
-        ret = ask(pred(self.expr), self.assumptions)
+        # _ask_recursive (not ask) so is_eq/is_ge can't recurse back  into the costly satask path of ask() (issue #29863 )
+        ret = _ask_recursive(pred(self.expr), self.assumptions)
         return ret
     return getit
 
@@ -150,16 +152,16 @@ class AssumptionsWrapper(Basic):
 def is_infinite(obj, assumptions=None):
     if assumptions is None:
         return obj.is_infinite
-    return ask(Q.infinite(obj), assumptions)
+    return _ask_recursive(Q.infinite(obj), assumptions)
 
 
 def is_extended_real(obj, assumptions=None):
     if assumptions is None:
         return obj.is_extended_real
-    return ask(Q.extended_real(obj), assumptions)
+    return _ask_recursive(Q.extended_real(obj), assumptions)
 
 
 def is_extended_nonnegative(obj, assumptions=None):
     if assumptions is None:
         return obj.is_extended_nonnegative
-    return ask(Q.extended_nonnegative(obj), assumptions)
+    return _ask_recursive(Q.extended_nonnegative(obj), assumptions)

--- a/sympy/assumptions/wrapper.py
+++ b/sympy/assumptions/wrapper.py
@@ -53,7 +53,7 @@ from sympy.core.sympify import _sympify
 def make_eval_method(fact):
     def getit(self):
         pred = getattr(Q, fact)
-        # _ask_recursive (not ask) so is_eq/is_ge can't recurse back  into the costly satask path of ask() (issue #29863 )
+        # _ask_recursive (not ask) so is_eq/is_ge can't recurse back  into the costly satask path of ask() (issue #29863)
         ret = _ask_recursive(pred(self.expr), self.assumptions)
         return ret
     return getit


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

Improves _ask_recursive() consistency and robustness

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This PR enhances the internal _ask_recursive() helper by aligning its preprocessing with ask(), including input normalization and support for global assumptions, while keeping it free of SAT-based reasoning.

Advantages-

1) Ensures consistent behavior between ask() and _ask_recursive().
2) Correctly incorporates global assumptions during recursive evaluation.
3) Avoids recursive entry into expensive SAT/LRA solvers, improving efficiency.
4) Preserves the lightweight recursive evaluation path without changing the public ask() API.

#### Other comments

None.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

ChatGPT and Claude were used for problem understanding and discussion. The final code changes were implemented and reviewed by me.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
