### PR TITLE
[GSoC] Implementation of smtlib parser

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include sympy/utilities/mathml/data/*.xsl
 
 recursive-include sympy/parsing/latex *.g4 *.txt
 recursive-include sympy/parsing/autolev *.g4 *.al
+recursive-include sympy/parsing/smtlib *.lark
 
 include LICENSE
 include TODO

--- a/doc/src/modules/parsing.rst
+++ b/doc/src/modules/parsing.rst
@@ -225,6 +225,35 @@ Lark `\mathrm{\LaTeX}` Parser Classes
 .. autoclass:: sympy.parsing.latex.LaTeXParsingError
    :members:
 
+Experimental SMT-LIB Parsing
+----------------------------
+
+.. warning::
+
+   The SMT-LIB parser is still under heavy development. The ``parse_smtlib``
+   function is entirely experimental, and its API may change in future
+   versions of SymPy.
+
+The SMT-LIB parser is based on `Lark <https://lark-parser.readthedocs.io/en/latest/>`_,
+so the ``lark`` Python package needs to be installed in order to use it.
+
+SMT-LIB Parsing Functions Reference
+-----------------------------------
+
+.. autofunction:: sympy.parsing.smtlib.parse_smtlib
+
+SMT-LIB Parsing Exceptions Reference
+------------------------------------
+
+.. autoclass:: sympy.parsing.smtlib.SMTLibSyntaxError
+   :members:
+
+.. autoclass:: sympy.parsing.smtlib.UnknownSMTLibCommandError
+   :members:
+
+.. autoclass:: sympy.parsing.smtlib.UnknownSMTLibOperatorError
+   :members:
+
 SymPy Expression Reference
 --------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,8 @@ modules = [
     'sympy.parsing.latex',
     'sympy.parsing.latex._antlr',
     'sympy.parsing.latex.lark',
+    'sympy.parsing.smtlib',
+    'sympy.parsing.smtlib.lark',
     'sympy.physics',
     'sympy.physics.biomechanics',
     'sympy.physics.continuum_mechanics',
@@ -338,6 +340,7 @@ if __name__ == '__main__':
                   'test-examples/README.txt',
                   ],
               'sympy.parsing.latex': ['*.txt', '*.g4', 'lark/grammar/*.lark'],
+              'sympy.parsing.smtlib': ['lark/grammar/*.lark'],
               'sympy.plotting.tests': ['test_region_*.png'],
               'sympy': ['py.typed']
               },

--- a/sympy/parsing/smtlib/__init__.py
+++ b/sympy/parsing/smtlib/__init__.py
@@ -1,3 +1,7 @@
 from __future__ import annotations
 
-from .lark.smtlib_parser import parse_smtlib # noqa
+from .lark.smtlib_parser import (parse_smtlib, SMTLibSyntaxError,
+    UnknownSMTLibCommandError, UnknownSMTLibOperatorError)
+
+__all__ = ['parse_smtlib', 'SMTLibSyntaxError', 'UnknownSMTLibCommandError',
+           'UnknownSMTLibOperatorError']

--- a/sympy/parsing/smtlib/__init__.py
+++ b/sympy/parsing/smtlib/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from .lark.smtlib_parser import parse_smtlib # noqa

--- a/sympy/parsing/smtlib/lark/__init__.py
+++ b/sympy/parsing/smtlib/lark/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from .smtlib_parser import parse_smtlib, LarkSMTLibParser # noqa
+from .transformer import SMTLibTransformer # noqa

--- a/sympy/parsing/smtlib/lark/grammar/smtlib.lark
+++ b/sympy/parsing/smtlib/lark/grammar/smtlib.lark
@@ -56,10 +56,10 @@ sort: symbol -> sort_simple
 sorted_var: "(" symbol sort ")"
 var_binding: "(" symbol term ")"
 
-qual_identifier: symbol
-               | "(" "_" symbol numeral+ ")"
-               | "(" "as" symbol sort ")"
-               | "(" "as" "(" "_" symbol numeral+ ")" sort ")"
+qual_identifier: symbol -> qual_id_simple
+               | "(" "_" symbol numeral+ ")" -> qual_id_indexed
+               | "(" "as" symbol sort ")" -> qual_id_as
+               | "(" "as" "(" "_" symbol numeral+ ")" sort ")" -> qual_id_as_indexed
 
 term: spec_constant                       -> term_spec_constant
     | qual_identifier                     -> term_qual_identifier

--- a/sympy/parsing/smtlib/lark/grammar/smtlib.lark
+++ b/sympy/parsing/smtlib/lark/grammar/smtlib.lark
@@ -1,0 +1,99 @@
+// SMT-LIB v2.6 Grammar for Lark
+// Based on the standard SMT-LIB v2 specification
+
+start: script
+
+script: command*
+
+command: "(" "assert" term ")"                 -> cmd_assert
+       | "(" "check-sat" ")"                   -> cmd_check_sat
+       | "(" "declare-const" symbol sort ")"   -> cmd_declare_const
+       | "(" "declare-fun" symbol "(" sort* ")" sort ")" -> cmd_declare_fun
+       | "(" "declare-sort" symbol numeral ")" -> cmd_declare_sort
+       | "(" "define-fun" symbol "(" sorted_var* ")" sort term ")" -> cmd_define_fun
+       | "(" "define-fun-rec" symbol "(" sorted_var* ")" sort term ")" -> cmd_define_fun_rec
+       | "(" "declare-datatype" symbol datatype_dec ")" -> cmd_declare_datatype
+       | "(" "declare-datatypes" "(" sort_dec* ")" "(" datatype_dec* ")" ")" -> cmd_declare_datatypes
+       | "(" "exit" ")"                        -> cmd_exit
+       | "(" "get-assertions" ")"              -> cmd_get_assertions
+       | "(" "get-assignment" ")"              -> cmd_get_assignment
+       | "(" "get-info" keyword ")"            -> cmd_get_info
+       | "(" "get-model" ")"                   -> cmd_get_model
+       | "(" "get-option" keyword ")"          -> cmd_get_option
+       | "(" "get-proof" ")"                   -> cmd_get_proof
+       | "(" "get-unsat-assumptions" ")"       -> cmd_get_unsat_assumptions
+       | "(" "get-unsat-core" ")"              -> cmd_get_unsat_core
+       | "(" "get-value" "(" term+ ")" ")"     -> cmd_get_value
+       | "(" "pop" numeral ")"                 -> cmd_pop
+       | "(" "push" numeral ")"                -> cmd_push
+       | "(" "reset" ")"                       -> cmd_reset
+       | "(" "reset-assertions" ")"            -> cmd_reset_assertions
+       | "(" "set-info" attribute ")"          -> cmd_set_info
+       | "(" "set-logic" symbol ")"            -> cmd_set_logic
+       | "(" "set-option" option ")"           -> cmd_set_option
+       | "(" symbol s_expr* ")"                -> cmd_generic
+
+// Basic tokens
+symbol: SYMBOL | QUOTED_SYMBOL
+keyword: KEYWORD
+numeral: NUMERAL
+decimal: DECIMAL
+hexadecimal: HEXADECIMAL
+binary: BINARY
+string: STRING
+
+s_expr: spec_constant
+      | symbol
+      | keyword
+      | "(" s_expr* ")" -> list
+
+spec_constant: numeral | decimal | hexadecimal | binary | string
+
+sort: symbol -> sort_simple
+    | "(" symbol sort+ ")" -> sort_param
+    | "(" "_" symbol numeral+ ")" -> sort_indexed
+
+sorted_var: "(" symbol sort ")"
+var_binding: "(" symbol term ")"
+
+qual_identifier: symbol
+               | "(" "_" symbol numeral+ ")"
+               | "(" "as" symbol sort ")"
+               | "(" "as" "(" "_" symbol numeral+ ")" sort ")"
+
+term: spec_constant                       -> term_spec_constant
+    | qual_identifier                     -> term_qual_identifier
+    | "(" qual_identifier term+ ")"       -> term_apply
+    | "(" "let" "(" var_binding+ ")" term ")" -> term_let
+    | "(" "forall" "(" sorted_var+ ")" term ")" -> term_forall
+    | "(" "exists" "(" sorted_var+ ")" term ")" -> term_exists
+    | "(" "match" term "(" match_case+ ")" ")" -> term_match
+    | "(" "!" term attribute+ ")"         -> term_annotate
+
+match_case: "(" pattern term ")"
+pattern: symbol | "(" symbol symbol+ ")"
+
+attribute: keyword | keyword attribute_value
+attribute_value: spec_constant | symbol | "(" s_expr* ")"
+
+option: keyword | keyword attribute_value
+
+sort_dec: "(" symbol numeral ")"
+selector_dec: "(" symbol sort ")"
+constructor_dec: "(" symbol selector_dec* ")"
+datatype_dec: "(" constructor_dec+ ")" | "(" "par" "(" symbol+ ")" "(" constructor_dec+ ")" ")"
+
+// Lexer tokens
+SYMBOL: /[a-zA-Z_+\-*\/%?!$&~^<>=@.][a-zA-Z0-9_+\-*\/%?!$&~^<>=@.]*/
+QUOTED_SYMBOL: /\|[^|\\]*\|/
+KEYWORD: /:[a-zA-Z0-9_+\-*\/%?!$&~^<>=@.]+/
+NUMERAL: /0|[1-9][0-9]*/
+DECIMAL: /(0|[1-9][0-9]*)\.[0-9]+/
+HEXADECIMAL: /#x[0-9a-fA-F]+/
+BINARY: /#b[01]+/
+STRING: /"[^"\\]*"/
+
+COMMENT: /;[^\n]*/
+%ignore COMMENT
+%import common.WS
+%ignore WS

--- a/sympy/parsing/smtlib/lark/grammar/smtlib.lark
+++ b/sympy/parsing/smtlib/lark/grammar/smtlib.lark
@@ -7,13 +7,17 @@ script: command*
 
 command: "(" "assert" term ")"                 -> cmd_assert
        | "(" "check-sat" ")"                   -> cmd_check_sat
+       | "(" "check-sat-assuming" "(" prop_literal* ")" ")" -> cmd_check_sat_assuming
        | "(" "declare-const" symbol sort ")"   -> cmd_declare_const
        | "(" "declare-fun" symbol "(" sort* ")" sort ")" -> cmd_declare_fun
        | "(" "declare-sort" symbol numeral ")" -> cmd_declare_sort
+       | "(" "define-const" symbol sort term ")" -> cmd_define_const
        | "(" "define-fun" symbol "(" sorted_var* ")" sort term ")" -> cmd_define_fun
        | "(" "define-fun-rec" symbol "(" sorted_var* ")" sort term ")" -> cmd_define_fun_rec
+       | "(" "define-sort" symbol "(" symbol* ")" sort ")" -> cmd_define_sort
        | "(" "declare-datatype" symbol datatype_dec ")" -> cmd_declare_datatype
        | "(" "declare-datatypes" "(" sort_dec* ")" "(" datatype_dec* ")" ")" -> cmd_declare_datatypes
+       | "(" "echo" string ")"                 -> cmd_echo
        | "(" "exit" ")"                        -> cmd_exit
        | "(" "get-assertions" ")"              -> cmd_get_assertions
        | "(" "get-assignment" ")"              -> cmd_get_assignment
@@ -55,6 +59,7 @@ sort: symbol -> sort_simple
 
 sorted_var: "(" symbol sort ")"
 var_binding: "(" symbol term ")"
+prop_literal: symbol | "(" "not" symbol ")"
 
 qual_identifier: symbol -> qual_id_simple
                | "(" "_" symbol numeral+ ")" -> qual_id_indexed
@@ -91,7 +96,9 @@ NUMERAL: /0|[1-9][0-9]*/
 DECIMAL: /(0|[1-9][0-9]*)\.[0-9]+/
 HEXADECIMAL: /#x[0-9a-fA-F]+/
 BINARY: /#b[01]+/
-STRING: /"[^"\\]*"/
+// A " inside a string is escaped by doubling it; backslash is an ordinary
+// character in SMT-LIB 2.6 strings
+STRING: /"([^"]|"")*"/
 
 COMMENT: /;[^\n]*/
 %ignore COMMENT

--- a/sympy/parsing/smtlib/lark/grammar/smtlib.lark
+++ b/sympy/parsing/smtlib/lark/grammar/smtlib.lark
@@ -92,8 +92,12 @@ datatype_dec: "(" constructor_dec+ ")" | "(" "par" "(" symbol+ ")" "(" construct
 SYMBOL: /[a-zA-Z_+\-*\/%?!$&~^<>=@.][a-zA-Z0-9_+\-*\/%?!$&~^<>=@.]*/
 QUOTED_SYMBOL: /\|[^|\\]*\|/
 KEYWORD: /:[a-zA-Z0-9_+\-*\/%?!$&~^<>=@.]+/
-NUMERAL: /0|[1-9][0-9]*/
-DECIMAL: /(0|[1-9][0-9]*)\.[0-9]+/
+// Standard SMT-LIB has no negative literals (-1 is technically a symbol
+// name, and negative one is written (- 1)), but solvers such as Z3 accept
+// them and SymPy's own SMT-LIB printer emits them, so they are lexed as
+// numbers here (the priority makes them win over SYMBOL)
+NUMERAL.2: /-?(0|[1-9][0-9]*)/
+DECIMAL.2: /-?(0|[1-9][0-9]*)\.[0-9]+/
 HEXADECIMAL: /#x[0-9a-fA-F]+/
 BINARY: /#b[01]+/
 // A " inside a string is escaped by doubling it; backslash is an ordinary

--- a/sympy/parsing/smtlib/lark/smtlib_parser.py
+++ b/sympy/parsing/smtlib/lark/smtlib_parser.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+import os
+import logging
+from pathlib import Path
+
+from sympy.external import import_module
+
+_lark = import_module("lark")
+
+class SMTLibSyntaxError(Exception):
+    def __init__(self, message, line, col):
+        super().__init__(f"{message} at line {line}, column {col}")
+        self.line = line
+        self.col = col
+
+class UnknownSMTLibCommandError(Exception):
+    pass
+
+class LarkSMTLibParser:
+    r"""Class for converting input SMT-LIB strings into SymPy Expressions.
+    It holds all the necessary internal data for doing so, and exposes hooks for
+    customizing its behavior.
+    """
+    def __init__(self, print_debug_output=False, transform=True, grammar_file=None):
+        grammar_dir_path = os.path.join(os.path.dirname(__file__), "grammar/")
+
+        if grammar_file is None:
+            grammar = Path(os.path.join(grammar_dir_path, "smtlib.lark")).read_text(encoding="utf-8")
+        else:
+            grammar = Path(grammar_file).read_text(encoding="utf-8")
+
+        self.parser = _lark.Lark(
+            grammar,
+            source_path=grammar_dir_path,
+            parser="lalr",
+            start="start",
+            lexer="auto",
+            propagate_positions=False,
+            maybe_placeholders=False,
+            keep_all_tokens=False)
+
+        self.print_debug_output = print_debug_output
+        self.transform_expr = transform
+
+    def doparse(self, s: str):
+        if self.print_debug_output:
+            _lark.logger.setLevel(logging.DEBUG)
+
+        try:
+            parse_tree = self.parser.parse(s)
+        except _lark.exceptions.LarkError as e:
+            line = getattr(e, 'line', 0)
+            col = getattr(e, 'column', 0)
+            raise SMTLibSyntaxError("Syntax error", line, col)
+
+        if not self.transform_expr:
+            return parse_tree
+
+        try:
+            from sympy.parsing.smtlib.lark.transformer import SMTLibTransformer
+            transformer = SMTLibTransformer()
+            transformer.transform(parse_tree)
+            return transformer.get_result()
+        except _lark.exceptions.VisitError as e:
+            if isinstance(e.orig_exc, UnknownSMTLibCommandError):
+                raise e.orig_exc
+            if isinstance(e.orig_exc, NotImplementedError):
+                raise e.orig_exc
+            raise
+
+if _lark is not None:
+    _lark_smtlib_parser = LarkSMTLibParser()
+
+def parse_smtlib(s: str):
+    """
+    Experimental SMT-LIB parser using Lark.
+    """
+    if _lark is None:
+        raise ImportError("Lark is probably not installed")
+    return _lark_smtlib_parser.doparse(s)

--- a/sympy/parsing/smtlib/lark/smtlib_parser.py
+++ b/sympy/parsing/smtlib/lark/smtlib_parser.py
@@ -51,7 +51,7 @@ class LarkSMTLibParser:
         except _lark.exceptions.LarkError as e:
             line = getattr(e, 'line', 0)
             col = getattr(e, 'column', 0)
-            raise SMTLibSyntaxError("Syntax error", line, col)
+            raise SMTLibSyntaxError(f"Syntax error: {str(e)}", line, col)
 
         if not self.transform_expr:
             return parse_tree
@@ -71,10 +71,44 @@ class LarkSMTLibParser:
 if _lark is not None:
     _lark_smtlib_parser = LarkSMTLibParser()
 
-def parse_smtlib(s: str):
+def parse_smtlib(s):
     """
-    Experimental SMT-LIB parser using Lark.
+    Parses an SMT-LIB formatted string or file and returns the declared symbols and
+    the list of assertions.
+
+    Parameters
+    ==========
+
+    s : str
+        The SMT-LIB formatted string or file path to parse.
+
+    Returns
+    =======
+
+    tuple
+        A tuple ``(symbols, assertions)`` where ``symbols`` is a dictionary
+        mapping symbol names to SymPy symbols, and ``assertions`` is a list
+        of SymPy expressions representing the assertions.
+
+    Examples
+    ========
+
+    >>> from sympy.parsing.smtlib import parse_smtlib
+    >>> source = '''
+    ... (declare-const x Int)
+    ... (declare-const y Int)
+    ... (assert (= (+ x y) 10))
+    ... '''
+    >>> symbols, assertions = parse_smtlib(source)
+    >>> symbols['x']
+    x
+    >>> assertions[0]
+    Eq(x + y, 10)
     """
     if _lark is None:
-        raise ImportError("Lark is probably not installed")
+        raise ImportError("Lark is not installed")
+    if isinstance(s, str) and os.path.exists(s):
+        with open(s, "r", encoding="utf-8") as f:
+            s = f.read()
+
     return _lark_smtlib_parser.doparse(s)

--- a/sympy/parsing/smtlib/lark/smtlib_parser.py
+++ b/sympy/parsing/smtlib/lark/smtlib_parser.py
@@ -99,10 +99,10 @@ def parse_smtlib(s):
     ... (declare-const y Int)
     ... (assert (= (+ x y) 10))
     ... '''
-    >>> symbols, assertions = parse_smtlib(source)
-    >>> symbols['x']
+    >>> symbols, assertions = parse_smtlib(source) # doctest: +SKIP
+    >>> symbols['x'] # doctest: +SKIP
     x
-    >>> assertions[0]
+    >>> assertions[0] # doctest: +SKIP
     Eq(x + y, 10)
     """
     if _lark is None:

--- a/sympy/parsing/smtlib/lark/smtlib_parser.py
+++ b/sympy/parsing/smtlib/lark/smtlib_parser.py
@@ -7,14 +7,25 @@ from sympy.external import import_module
 
 _lark = import_module("lark")
 
+__doctest_requires__ = {('parse_smtlib',): ['lark']}
+
+
 class SMTLibSyntaxError(Exception):
-    def __init__(self, message, line, col):
-        super().__init__(f"{message} at line {line}, column {col}")
+    """Raised when the input is not syntactically valid SMT-LIB."""
+    def __init__(self, message, line=None, col=None):
+        super().__init__(message)
         self.line = line
         self.col = col
 
+
 class UnknownSMTLibCommandError(Exception):
-    pass
+    """Raised for SMT-LIB commands that the parser does not recognize."""
+
+
+class UnknownSMTLibOperatorError(Exception):
+    """Raised for operators or functions in a term that the parser does not
+    recognize."""
+
 
 class LarkSMTLibParser:
     r"""Class for converting input SMT-LIB strings into SymPy Expressions.
@@ -43,44 +54,52 @@ class LarkSMTLibParser:
         self.transform_expr = transform
 
     def doparse(self, s: str):
+        prev_log_level = _lark.logger.level
         if self.print_debug_output:
             _lark.logger.setLevel(logging.DEBUG)
 
         try:
-            parse_tree = self.parser.parse(s)
-        except _lark.exceptions.LarkError as e:
-            line = getattr(e, 'line', 0)
-            col = getattr(e, 'column', 0)
-            raise SMTLibSyntaxError(f"Syntax error: {str(e)}", line, col)
+            try:
+                parse_tree = self.parser.parse(s)
+            except _lark.exceptions.LarkError as e:
+                # str(e) already includes the line/column information
+                raise SMTLibSyntaxError(f"Syntax error: {str(e)}",
+                                        getattr(e, 'line', None),
+                                        getattr(e, 'column', None)) from e
 
-        if not self.transform_expr:
-            return parse_tree
+            if not self.transform_expr:
+                return parse_tree
 
-        try:
-            from sympy.parsing.smtlib.lark.transformer import SMTLibTransformer
-            transformer = SMTLibTransformer()
-            transformer.transform(parse_tree)
-            return transformer.get_result()
-        except _lark.exceptions.VisitError as e:
-            if isinstance(e.orig_exc, UnknownSMTLibCommandError):
-                raise e.orig_exc
-            if isinstance(e.orig_exc, NotImplementedError):
-                raise e.orig_exc
-            raise
+            try:
+                from sympy.parsing.smtlib.lark.transformer import SMTLibTransformer
+                transformer = SMTLibTransformer()
+                transformer.transform(parse_tree)
+                return transformer.get_result()
+            except _lark.exceptions.VisitError as e:
+                if isinstance(e.orig_exc, (UnknownSMTLibCommandError,
+                                           UnknownSMTLibOperatorError,
+                                           NotImplementedError)):
+                    raise e.orig_exc from e
+                raise
+        finally:
+            _lark.logger.setLevel(prev_log_level)
 
-if _lark is not None:
-    _lark_smtlib_parser = LarkSMTLibParser()
+
+_lark_smtlib_parser = None
+
 
 def parse_smtlib(s):
     """
-    Parses an SMT-LIB formatted string or file and returns the declared symbols and
-    the list of assertions.
+    Parses a string in the SMT-LIB format and returns the declared symbols
+    and the list of assertions.
 
     Parameters
     ==========
 
     s : str
-        The SMT-LIB formatted string or file path to parse.
+        The SMT-LIB source text to parse. This must be the text itself; to
+        parse a file, read its contents first, e.g. with
+        ``Path(filename).read_text()``.
 
     Returns
     =======
@@ -99,16 +118,27 @@ def parse_smtlib(s):
     ... (declare-const y Int)
     ... (assert (= (+ x y) 10))
     ... '''
-    >>> symbols, assertions = parse_smtlib(source) # doctest: +SKIP
-    >>> symbols['x'] # doctest: +SKIP
+    >>> symbols, assertions = parse_smtlib(source)
+    >>> symbols['x']
     x
-    >>> assertions[0] # doctest: +SKIP
-    Eq(x + y, 10)
+    >>> assertions
+    [Q.integer(x), Q.integer(y), Eq(x + y, 10)]
+
+    Notes
+    =====
+
+    Declaring a constant of sort ``Int`` or ``Real`` appends a corresponding
+    assumption predicate (``Q.integer`` or ``Q.real``) to the returned
+    ``assertions`` list, as shown in the example above. This is intentional:
+    the sort information is part of what the input asserts about each symbol,
+    and including it in the assertions makes it available to functions that
+    consume them, such as :func:`~.satisfiable`. Constants of other sorts
+    (including uninterpreted sorts) produce no assumption predicate.
     """
+    global _lark_smtlib_parser
     if _lark is None:
         raise ImportError("Lark is not installed")
-    if isinstance(s, str) and os.path.exists(s):
-        with open(s, "r", encoding="utf-8") as f:
-            s = f.read()
+    if _lark_smtlib_parser is None:
+        _lark_smtlib_parser = LarkSMTLibParser()
 
     return _lark_smtlib_parser.doparse(s)

--- a/sympy/parsing/smtlib/lark/smtlib_parser.py
+++ b/sympy/parsing/smtlib/lark/smtlib_parser.py
@@ -4,9 +4,14 @@ import logging
 from pathlib import Path
 
 from sympy.external import import_module
+from sympy.utilities.decorator import doctest_depends_on
 
 _lark = import_module("lark")
 
+# __doctest_requires__ is understood by pytest-doctestplus, while the
+# doctest_depends_on decorator is understood by SymPy's own doctest runner
+# (bin/doctest); both are needed to skip the doctests when lark is not
+# installed
 __doctest_requires__ = {('parse_smtlib',): ['lark']}
 
 
@@ -88,6 +93,7 @@ class LarkSMTLibParser:
 _lark_smtlib_parser = None
 
 
+@doctest_depends_on(modules=('lark',))
 def parse_smtlib(s):
     """
     Parses a string in the SMT-LIB format and returns the declared symbols

--- a/sympy/parsing/smtlib/lark/transformer.py
+++ b/sympy/parsing/smtlib/lark/transformer.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from sympy import (
     Symbol, Function, Integer, Float, Eq, Ne, Not, And, Or,
-    Implies, Xor, Piecewise, Add, Mul, StrictLessThan, StrictGreaterThan,
-    LessThan, GreaterThan, Expr
+    Implies, Xor, Piecewise, Add, Mul, Mod, StrictLessThan,
+    StrictGreaterThan, LessThan, GreaterThan, Expr, S, floor
 )
 from sympy.assumptions import Q
 from sympy.functions.elementary.complexes import Abs
 from sympy.external import import_module
-from sympy.parsing.smtlib.lark.smtlib_parser import UnknownSMTLibCommandError
+from sympy.parsing.smtlib.lark.smtlib_parser import (
+    UnknownSMTLibCommandError, UnknownSMTLibOperatorError
+)
 
 lark = import_module("lark")
 
@@ -25,6 +27,23 @@ else:
     class Tree:  # type: ignore
         pass
 
+# Operators from SMT-LIB theories (bitvectors, strings, arrays) that have no
+# SymPy representation. These raise NotImplementedError rather than silently
+# producing an uninterpreted Function that looks like a regular expression
+# but has none of the theory's semantics.
+_UNSUPPORTED_THEORY_OPS = frozenset({
+    'concat', 'bvnot', 'bvand', 'bvor', 'bvneg', 'bvadd', 'bvmul',
+    'bvudiv', 'bvurem', 'bvshl', 'bvlshr', 'bvsub', 'bvult', 'bvxor',
+    'bvnand', 'bvnor', 'bvxnor', 'bvcomp', 'bvsdiv', 'bvsrem',
+    'bvsmod', 'bvashr', 'bvule', 'bvugt', 'bvuge', 'bvslt', 'bvsle',
+    'bvsgt', 'bvsge', 'bv2nat', 'bv2int', 'ubv_to_int',
+    'ext_rotate_left', 'ext_rotate_right', 'str.len', 'str.++',
+    'str.at', 'str.contains', 'str.indexof', 'str.replace',
+    'str.substr', 'str.prefixof', 'str.suffixof', 'str.to.int',
+    'int.to.str', 'select', 'store', 'const'
+})
+
+
 class SMTLibTransformer(Transformer):
     """
     Returns a tuple of (symbols, assertions) by evaluating the SMT-LIB AST.
@@ -38,37 +57,36 @@ class SMTLibTransformer(Transformer):
         self._assertions = []
         self._logic = None
         self._sorts = {}
+        self._sort_aliases = {}
         self._options = {}
         self._info = {}
-
-        self._extended_ops = {
-            'to_real', 'to_int', 'is_int',
-            'concat', 'bvnot', 'bvand', 'bvor', 'bvneg', 'bvadd', 'bvmul',
-            'bvudiv', 'bvurem', 'bvshl', 'bvlshr', 'bvsub', 'bvult', 'bvxor',
-            'bvnand', 'bvnor', 'bvxnor', 'bvcomp', 'bvsdiv', 'bvsrem',
-            'bvsmod', 'bvashr', 'bvule', 'bvugt', 'bvuge', 'bvslt', 'bvsle',
-            'bvsgt', 'bvsge', 'bv2nat', 'bv2int', 'ubv_to_int',
-            'ext_rotate_left', 'ext_rotate_right', 'str.len', 'str.++',
-            'str.at', 'str.contains', 'str.indexof', 'str.replace',
-            'str.substr', 'str.prefixof', 'str.suffixof', 'str.to.int',
-            'int.to.str', 'select', 'store', 'div', 'mod', 'const'
-        }
 
         self._assertion_stack = []
         self._symbol_stack = []
         self._macro_stack = []
         self._function_stack = []
         self._sort_stack = []
+        self._sort_alias_stack = []
 
     def get_result(self):
         return self._symbols, self._assertions
+
+    def _resolve_sort(self, sort):
+        # Resolve 0-ary define-sort aliases like (define-sort MyInt () Int)
+        seen = set()
+        while isinstance(sort, str) and sort in self._sort_aliases and sort not in seen:
+            seen.add(sort)
+            sort = self._sort_aliases[sort]
+        return sort
 
     # Tokens
     def SYMBOL(self, token):
         return str(token)
 
     def QUOTED_SYMBOL(self, token):
-        return str(token)
+        # |a b| denotes the symbol "a b"; the pipes are quoting syntax, not
+        # part of the name
+        return str(token)[1:-1]
 
     def KEYWORD(self, token):
         return str(token)
@@ -90,9 +108,9 @@ class SMTLibTransformer(Transformer):
         return Integer(int(str(token).replace('#b', '0b'), 0))
 
     def STRING(self, token):
-        # SMT-LIB strings are quoted. We return them as a Symbol because
-        # SymPy doesn't have a native String type.
-        return Symbol(str(token))
+        # Strip the quotes and undo the "" escape. The result is returned as
+        # a Symbol because SymPy doesn't have a native String type.
+        return Symbol(str(token)[1:-1].replace('""', '"'))
 
     # Non-terminals
     def symbol(self, args):
@@ -146,31 +164,37 @@ class SMTLibTransformer(Transformer):
     def qual_id_simple(self, args):
         return args[0]
 
+    def _indexed_identifier(self, name):
+        # (_ bvN width) is a bitvector literal with value N. The width is
+        # currently discarded, like for #x and #b literals.
+        if name.startswith('bv') and name[2:].isdigit():
+            return Integer(name[2:])
+        raise NotImplementedError(
+            f"Indexed identifier (_ {name} ...) is not supported")
+
     def qual_id_indexed(self, args):
-        name = f"_{args[0]}_{'_'.join(map(str, args[1:]))}"
-        return Function(name)
+        return self._indexed_identifier(str(args[0]))
 
     def qual_id_as(self, args):
         return args[0]
 
     def qual_id_as_indexed(self, args):
-        name = f"_{args[0]}_{'_'.join(map(str, args[1:-1]))}"
-        return Function(name)
+        return self._indexed_identifier(str(args[0]))
 
     def term_qual_identifier(self, args):
         atom = args[0]
-        # If atom is an indexed identifier (Function), return it directly
-        if isinstance(atom, (Function, Expr)):
+        # Indexed identifiers like (_ bv5 32) have already been converted to
+        # SymPy objects
+        if isinstance(atom, Expr):
             return atom
 
         if atom in self._symbols:
             return self._symbols[atom]
 
-        atom_str = str(atom).lower()
-        if atom_str == 'true':
-            return True
-        if atom_str == 'false':
-            return False
+        if atom == 'true':
+            return S.true
+        if atom == 'false':
+            return S.false
 
         return Symbol(str(atom))
 
@@ -179,11 +203,9 @@ class SMTLibTransformer(Transformer):
         op_node = args[0]
         params = args[1:]
 
-        # If the operator is an indexed identifier (FunctionClass), pass it through directly
-        if isinstance(op_node, type) and issubclass(op_node, Function):
-            return op_node(*params)
         if isinstance(op_node, Expr):
-            raise UnknownSMTLibCommandError(f"Cannot apply arguments to expression {op_node}")
+            raise UnknownSMTLibOperatorError(
+                f"Cannot apply arguments to expression {op_node}")
 
         op = str(op_node)
 
@@ -194,26 +216,26 @@ class SMTLibTransformer(Transformer):
         if op in self._functions:
             return self._functions[op](*params)
 
-        op_lower = op.lower()
-
-        if op_lower == 'not':
+        # SMT-LIB symbols are case-sensitive, so operators are matched
+        # exactly
+        if op == 'not':
             return Not(params[0])
-        elif op_lower == 'and':
+        elif op == 'and':
             return And(*params)
-        elif op_lower == 'or':
+        elif op == 'or':
             return Or(*params)
-        elif op_lower == '=>':
+        elif op == '=>':
             result = params[-1]
             for p in reversed(params[:-1]):
                 result = Implies(p, result)
             return result
-        elif op_lower == 'xor':
+        elif op == 'xor':
             return Xor(*params)
-        elif op_lower == '=':
+        elif op == '=':
             if len(params) == 2:
                 return Eq(params[0], params[1])
             return And(*[Eq(params[i], params[i+1]) for i in range(len(params)-1)])
-        elif op_lower == 'distinct':
+        elif op == 'distinct':
             if len(params) == 2:
                 return Ne(params[0], params[1])
             exprs = []
@@ -221,41 +243,60 @@ class SMTLibTransformer(Transformer):
                 for j in range(i + 1, len(params)):
                     exprs.append(Ne(params[i], params[j]))
             return And(*exprs)
-        elif op_lower in ('<', '<=', '>', '>='):
+        elif op in ('<', '<=', '>', '>='):
             if len(params) == 2:
-                if op_lower == '<': return StrictLessThan(params[0], params[1])
-                if op_lower == '<=': return LessThan(params[0], params[1])
-                if op_lower == '>': return StrictGreaterThan(params[0], params[1])
-                if op_lower == '>=': return GreaterThan(params[0], params[1])
+                if op == '<': return StrictLessThan(params[0], params[1])
+                if op == '<=': return LessThan(params[0], params[1])
+                if op == '>': return StrictGreaterThan(params[0], params[1])
+                if op == '>=': return GreaterThan(params[0], params[1])
             exprs = []
             for i in range(len(params) - 1):
-                if op_lower == '<': exprs.append(StrictLessThan(params[i], params[i+1]))
-                elif op_lower == '<=': exprs.append(LessThan(params[i], params[i+1]))
-                elif op_lower == '>': exprs.append(StrictGreaterThan(params[i], params[i+1]))
-                elif op_lower == '>=': exprs.append(GreaterThan(params[i], params[i+1]))
+                if op == '<': exprs.append(StrictLessThan(params[i], params[i+1]))
+                elif op == '<=': exprs.append(LessThan(params[i], params[i+1]))
+                elif op == '>': exprs.append(StrictGreaterThan(params[i], params[i+1]))
+                elif op == '>=': exprs.append(GreaterThan(params[i], params[i+1]))
             return And(*exprs)
-        elif op_lower == '+':
+        elif op == '+':
             return Add(*params)
-        elif op_lower == '-':
+        elif op == '-':
             if len(params) == 1:
                 return -params[0]
             return params[0] - Add(*params[1:])
-        elif op_lower == '*':
+        elif op == '*':
             return Mul(*params)
-        elif op_lower == '/':
+        elif op == '/':
             if len(params) == 2:
                 return params[0] / params[1]
             return params[0] / Mul(*params[1:])
-        elif op_lower == 'ite':
+        elif op == 'div':
+            # SMT-LIB integer division is Euclidean: the remainder is always
+            # nonnegative, which matches floor division only for positive
+            # divisors
+            result = params[0]
+            for p in params[1:]:
+                result = (result - Mod(result, Abs(p))) / p
+            return result
+        elif op == 'mod':
+            return Mod(params[0], Abs(params[1]))
+        elif op == 'ite':
             return Piecewise((params[1], params[0]), (params[2], True))
-        elif op_lower == 'abs':
+        elif op == 'abs':
             return Abs(params[0])
+        elif op == 'to_real':
+            # SymPy does not distinguish an integer from the corresponding
+            # real number
+            return params[0]
+        elif op == 'to_int':
+            return floor(params[0])
+        elif op == 'is_int':
+            return Eq(params[0], floor(params[0]))
 
-        if op_lower in self._extended_ops:
-            return Function(op)(*params)
+        if op in _UNSUPPORTED_THEORY_OPS:
+            raise NotImplementedError(
+                f"The SMT-LIB operator '{op}' has no SymPy equivalent and is "
+                "not supported")
 
-        raise UnknownSMTLibCommandError(f"Unknown operator or function: {op}")
-
+        raise UnknownSMTLibOperatorError(f"Unknown operator or function: {op}")
 
     def term_let(self, args):
         bindings = args[:-1]
@@ -264,17 +305,14 @@ class SMTLibTransformer(Transformer):
         return term.xreplace(subs_dict)
 
     def term_forall(self, args):
-        vars_list = args[:-1]
-        body = args[-1]
-        # vars_list comes from sorted_var nodes, which are (symbol, sort)
-        var_syms = tuple(v[0] for v in vars_list)
-        return Function('forall')(var_syms, body)
+        raise NotImplementedError(
+            "Quantifiers (forall) are not supported since SymPy has no "
+            "representation for them")
 
     def term_exists(self, args):
-        vars_list = args[:-1]
-        body = args[-1]
-        var_syms = tuple(v[0] for v in vars_list)
-        return Function('exists')(var_syms, body)
+        raise NotImplementedError(
+            "Quantifiers (exists) are not supported since SymPy has no "
+            "representation for them")
 
     def term_match(self, args):
         raise NotImplementedError("Match expressions are not fully supported yet.")
@@ -289,6 +327,7 @@ class SMTLibTransformer(Transformer):
     def cmd_declare_const(self, args):
         name, sort = args
         sym = Symbol(name)
+        sort = self._resolve_sort(sort)
 
         if sort == 'Real':
             self._assertions.append(Q.real(sym))
@@ -312,6 +351,14 @@ class SMTLibTransformer(Transformer):
         sort_name, arity = args
         self._sorts[sort_name] = int(arity)
 
+    def cmd_declare_datatype(self, args):
+        raise NotImplementedError(
+            "Algebraic datatypes (declare-datatype) are not supported")
+
+    def cmd_declare_datatypes(self, args):
+        raise NotImplementedError(
+            "Algebraic datatypes (declare-datatypes) are not supported")
+
     def cmd_define_fun(self, args):
         name = args[0]
         sorted_vars = args[1:-2]
@@ -328,6 +375,23 @@ class SMTLibTransformer(Transformer):
     def cmd_define_fun_rec(self, args):
         raise NotImplementedError("Recursive macros are not supported in SymPy because AST generation evaluates bottom-up.")
 
+    def cmd_define_const(self, args):
+        name, _sort, body = args
+        self._symbols[name] = body
+
+    def cmd_define_sort(self, args):
+        name = args[0]
+        params = args[1:-1]
+        sort = args[-1]
+        if params:
+            raise NotImplementedError(
+                "Parametric sort definitions (define-sort with parameters) "
+                "are not supported")
+        self._sort_aliases[name] = self._resolve_sort(sort)
+
+    def cmd_generic(self, args):
+        raise UnknownSMTLibCommandError(f"Unknown SMT-LIB command: {args[0]}")
+
     def cmd_pop(self, args):
         levels = int(args[0]) if args else 1
         for _ in range(levels):
@@ -338,6 +402,7 @@ class SMTLibTransformer(Transformer):
             self._macros = self._macro_stack.pop()
             self._functions = self._function_stack.pop()
             self._sorts = self._sort_stack.pop()
+            self._sort_aliases = self._sort_alias_stack.pop()
 
     def cmd_push(self, args):
         levels = int(args[0]) if args else 1
@@ -347,6 +412,7 @@ class SMTLibTransformer(Transformer):
             self._macro_stack.append(dict(self._macros))
             self._function_stack.append(dict(self._functions))
             self._sort_stack.append(dict(self._sorts))
+            self._sort_alias_stack.append(dict(self._sort_aliases))
 
     def cmd_reset(self, args):
         self.__init__()

--- a/sympy/parsing/smtlib/lark/transformer.py
+++ b/sympy/parsing/smtlib/lark/transformer.py
@@ -268,6 +268,11 @@ class SMTLibTransformer(Transformer):
             if len(params) == 2:
                 return params[0] / params[1]
             return params[0] / Mul(*params[1:])
+        elif op in ('pow', '^'):
+            # Exponentiation is not part of standard SMT-LIB, but ^ is
+            # supported by solvers such as Z3 and pow is what SymPy's own
+            # SMT-LIB printer (sympy.printing.smtlib) emits
+            return params[0] ** params[1]
         elif op == 'div':
             # SMT-LIB integer division is Euclidean: the remainder is always
             # nonnegative, which matches floor division only for positive

--- a/sympy/parsing/smtlib/lark/transformer.py
+++ b/sympy/parsing/smtlib/lark/transformer.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from sympy import (
+    Symbol, Function, Integer, Float, Eq, Ne, Not, And, Or,
+    Implies, Xor, Piecewise, Add, Mul, StrictLessThan, StrictGreaterThan,
+    LessThan, GreaterThan, Expr
+)
+from sympy.assumptions import Q
+from sympy.functions.elementary.complexes import Abs
+from sympy.external import import_module
+from sympy.parsing.smtlib.lark.smtlib_parser import UnknownSMTLibCommandError
+
+lark = import_module("lark")
+
+if lark:
+    from lark import Transformer, Token, Tree  # type: ignore
+else:
+    class Transformer:  # type: ignore
+        def transform(self, *args):
+            pass
+
+    class Token:  # type: ignore
+        pass
+
+    class Tree:  # type: ignore
+        pass
+
+class SMTLibTransformer(Transformer):
+    """
+    Returns a tuple of (symbols, assertions) by evaluating the SMT-LIB AST.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._symbols = {}
+        self._functions = {}
+        self._macros = {}
+        self._assertions = []
+        self._logic = None
+        self._sorts = {}
+        self._options = {}
+        self._info = {}
+
+        self._extended_ops = {
+            'to_real', 'to_int', 'is_int',
+            'concat', 'bvnot', 'bvand', 'bvor', 'bvneg', 'bvadd', 'bvmul',
+            'bvudiv', 'bvurem', 'bvshl', 'bvlshr', 'bvsub', 'bvult', 'bvxor',
+            'bvnand', 'bvnor', 'bvxnor', 'bvcomp', 'bvsdiv', 'bvsrem',
+            'bvsmod', 'bvashr', 'bvule', 'bvugt', 'bvuge', 'bvslt', 'bvsle',
+            'bvsgt', 'bvsge', 'bv2nat', 'bv2int', 'ubv_to_int',
+            'ext_rotate_left', 'ext_rotate_right', 'str.len', 'str.++',
+            'str.at', 'str.contains', 'str.indexof', 'str.replace',
+            'str.substr', 'str.prefixof', 'str.suffixof', 'str.to.int',
+            'int.to.str', 'select', 'store', 'div', 'mod'
+        }
+
+        self._assertion_stack = []
+        self._symbol_stack = []
+        self._macro_stack = []
+        self._function_stack = []
+        self._sort_stack = []
+
+    def get_result(self):
+        return self._symbols, self._assertions
+
+    # Tokens
+    def SYMBOL(self, token):
+        return str(token)
+
+    def QUOTED_SYMBOL(self, token):
+        return str(token)
+
+    def KEYWORD(self, token):
+        return str(token)
+
+    def NUMERAL(self, token):
+        return Integer(token)
+
+    def DECIMAL(self, token):
+        return Float(token)
+
+    def HEXADECIMAL(self, token):
+        return Integer(int(str(token).replace('#x', '0x'), 0))
+
+    def BINARY(self, token):
+        return Integer(int(str(token).replace('#b', '0b'), 0))
+
+    def STRING(self, token):
+        # SMT-LIB strings are quoted. We return them as a Symbol because
+        # SymPy doesn't have a native String type.
+        return Symbol(str(token))
+
+    # Non-terminals
+    def symbol(self, args):
+        return args[0]
+
+    def keyword(self, args):
+        return args[0]
+
+    def numeral(self, args):
+        return args[0]
+
+    def decimal(self, args):
+        return args[0]
+
+    def hexadecimal(self, args):
+        return args[0]
+
+    def binary(self, args):
+        return args[0]
+
+    def string(self, args):
+        return args[0]
+
+    def spec_constant(self, args):
+        return args[0]
+
+    def sort_simple(self, args):
+        return args[0]
+
+    def sort_param(self, args):
+        return tuple(args)
+
+    def sort_indexed(self, args):
+        # args = [symbol, numeral, ...]
+        # We model (_ BitVec 32) as a tuple like parameterised sorts
+        return ("_", args[0]) + tuple(args[1:])
+
+    def sorted_var(self, args):
+        return (args[0], args[1])
+
+    def var_binding(self, args):
+        return (args[0], args[1])
+
+    def list(self, args):
+        return args
+
+    # Term handlers
+    def term_spec_constant(self, args):
+        return args[0]
+
+    def qual_identifier(self, args):
+        # Can be just symbol
+        if len(args) == 1:
+            return args[0]
+        # Or indexed: ("_", symbol, numerals...)
+        if args[0] == '_':
+            return Function("_")(args[1], *args[2:])
+        # Or as: ("as", symbol, sort) or ("as", ("_", ...), sort)
+        if args[0] == 'as':
+            # SymPy doesn't explicitly track sort for expressions in AST,
+            # so we just return the underlying identifier.
+            if args[1] == '_':
+                return Function("_")(args[2], *args[3:-1])
+            return args[1]
+
+    def term_qual_identifier(self, args):
+        atom = args[0]
+        # If atom is an indexed identifier (Function), return it directly
+        if isinstance(atom, (Function, Expr)):
+            return atom
+
+        if atom in self._symbols:
+            return self._symbols[atom]
+
+        atom_str = str(atom).lower()
+        if atom_str == 'true':
+            return True
+        if atom_str == 'false':
+            return False
+
+        return Symbol(str(atom))
+
+    def term_apply(self, args):
+        # args[0] is qual_identifier
+        op_node = args[0]
+        params = args[1:]
+
+        # If the operator is an indexed identifier, pass it through directly
+        # as a Function call
+        if isinstance(op_node, (Function, Expr)):
+            return op_node(*params)
+
+        op = str(op_node)
+
+        if op in self._macros:
+            macro_args, macro_body = self._macros[op]
+            return macro_body.subs(dict(zip(macro_args, params)))
+
+        if op in self._functions:
+            return self._functions[op](*params)
+
+        op_lower = op.lower()
+
+        if op_lower == 'not':
+            return Not(params[0])
+        elif op_lower == 'and':
+            return And(*params)
+        elif op_lower == 'or':
+            return Or(*params)
+        elif op_lower == '=>':
+            return Implies(params[0], params[1])
+        elif op_lower == 'xor':
+            return Xor(*params)
+        elif op_lower == '=':
+            if len(params) == 2:
+                return Eq(params[0], params[1])
+            return And(*[Eq(params[i], params[i+1]) for i in range(len(params)-1)])
+        elif op_lower == 'distinct':
+            if len(params) == 2:
+                return Ne(params[0], params[1])
+            exprs = []
+            for i in range(len(params)):
+                for j in range(i + 1, len(params)):
+                    exprs.append(Ne(params[i], params[j]))
+            return And(*exprs)
+        elif op_lower == '<':
+            return StrictLessThan(params[0], params[1])
+        elif op_lower == '<=':
+            return LessThan(params[0], params[1])
+        elif op_lower == '>':
+            return StrictGreaterThan(params[0], params[1])
+        elif op_lower == '>=':
+            return GreaterThan(params[0], params[1])
+        elif op_lower == '+':
+            return Add(*params)
+        elif op_lower == '-':
+            if len(params) == 1:
+                return -params[0]
+            return params[0] - Add(*params[1:])
+        elif op_lower == '*':
+            return Mul(*params)
+        elif op_lower == '/':
+            if len(params) == 2:
+                return params[0] / params[1]
+            return params[0] / Mul(*params[1:])
+        elif op_lower == 'ite':
+            return Piecewise((params[1], params[0]), (params[2], True))
+        elif op_lower == 'abs':
+            return Abs(params[0])
+
+        if op_lower in self._extended_ops:
+            return Function(op)(*params)
+
+        raise UnknownSMTLibCommandError(f"Unknown operator or function: {op}")
+
+
+    def term_let(self, args):
+        bindings = args[:-1]
+        term = args[-1]
+        for var, val in bindings:
+            term = term.subs(Symbol(var), val)
+        return term
+
+    def term_forall(self, args):
+        vars_list = args[:-1]
+        body = args[-1]
+        # vars_list comes from sorted_var nodes, which are (symbol, sort)
+        var_syms = tuple(v[0] for v in vars_list)
+        return Function('forall')(var_syms, body)
+
+    def term_exists(self, args):
+        vars_list = args[:-1]
+        body = args[-1]
+        var_syms = tuple(v[0] for v in vars_list)
+        return Function('exists')(var_syms, body)
+
+    def term_match(self, args):
+        raise NotImplementedError("Match expressions are not fully supported yet.")
+
+    def term_annotate(self, args):
+        return args[0]
+
+    # Command Handlers
+    def cmd_assert(self, args):
+        self._assertions.append(args[0])
+
+    def cmd_declare_const(self, args):
+        name, sort = args
+        sym = Symbol(name)
+
+        if sort == 'Real':
+            self._assertions.append(Q.real(sym))
+        elif sort == 'Int':
+            self._assertions.append(Q.integer(sym))
+
+        self._symbols[name] = sym
+
+    def cmd_declare_fun(self, args):
+        name = args[0]
+        domain_sorts = args[1:-1]
+        range_sort = args[-1]
+
+        if not domain_sorts:
+            # It's actually a constant
+            return self.cmd_declare_const([name, range_sort])
+
+        self._functions[name] = Function(name)
+
+    def cmd_declare_sort(self, args):
+        sort_name, arity = args
+        self._sorts[sort_name] = int(arity)
+
+    def cmd_define_fun(self, args):
+        name = args[0]
+        sorted_vars = args[1:-2]
+        # range_sort = args[-2]
+        body = args[-1]
+
+        if not sorted_vars:
+            self._symbols[name] = body
+        else:
+            var_names = [v[0] for v in sorted_vars]
+            var_syms = [Symbol(v) for v in var_names]
+            self._macros[name] = (var_syms, body)
+
+    def cmd_define_fun_rec(self, args):
+        # We handle this same as define-fun for now, SymPy will leave
+        # unresolvable recursive invocations as uninterpreted.
+        self.cmd_define_fun(args)
+
+    def cmd_pop(self, args):
+        levels = int(args[0]) if args else 1
+        for _ in range(levels):
+            if not self._assertion_stack:
+                break
+            self._assertions = self._assertion_stack.pop()
+            self._symbols = self._symbol_stack.pop()
+            self._macros = self._macro_stack.pop()
+            self._functions = self._function_stack.pop()
+            self._sorts = self._sort_stack.pop()
+
+    def cmd_push(self, args):
+        levels = int(args[0]) if args else 1
+        for _ in range(levels):
+            self._assertion_stack.append(list(self._assertions))
+            self._symbol_stack.append(dict(self._symbols))
+            self._macro_stack.append(dict(self._macros))
+            self._function_stack.append(dict(self._functions))
+            self._sort_stack.append(dict(self._sorts))
+
+    def cmd_reset(self, args):
+        self.__init__()
+
+    def cmd_reset_assertions(self, args):
+        self._assertions = []

--- a/sympy/parsing/smtlib/lark/transformer.py
+++ b/sympy/parsing/smtlib/lark/transformer.py
@@ -51,7 +51,7 @@ class SMTLibTransformer(Transformer):
             'ext_rotate_left', 'ext_rotate_right', 'str.len', 'str.++',
             'str.at', 'str.contains', 'str.indexof', 'str.replace',
             'str.substr', 'str.prefixof', 'str.suffixof', 'str.to.int',
-            'int.to.str', 'select', 'store', 'div', 'mod'
+            'int.to.str', 'select', 'store', 'div', 'mod', 'const'
         }
 
         self._assertion_stack = []
@@ -80,9 +80,13 @@ class SMTLibTransformer(Transformer):
         return Float(token)
 
     def HEXADECIMAL(self, token):
+        # TODO: Flagged for future BitVector (BV) work.
+        # Currently, bit-width is lost when casting `#x0A` directly to `Integer(10)`.
         return Integer(int(str(token).replace('#x', '0x'), 0))
 
     def BINARY(self, token):
+        # TODO: Flagged for future BitVector (BV) work.
+        # Currently, bit-width is lost when casting `#b1010` directly to `Integer(10)`.
         return Integer(int(str(token).replace('#b', '0b'), 0))
 
     def STRING(self, token):
@@ -139,20 +143,19 @@ class SMTLibTransformer(Transformer):
     def term_spec_constant(self, args):
         return args[0]
 
-    def qual_identifier(self, args):
-        # Can be just symbol
-        if len(args) == 1:
-            return args[0]
-        # Or indexed: ("_", symbol, numerals...)
-        if args[0] == '_':
-            return Function("_")(args[1], *args[2:])
-        # Or as: ("as", symbol, sort) or ("as", ("_", ...), sort)
-        if args[0] == 'as':
-            # SymPy doesn't explicitly track sort for expressions in AST,
-            # so we just return the underlying identifier.
-            if args[1] == '_':
-                return Function("_")(args[2], *args[3:-1])
-            return args[1]
+    def qual_id_simple(self, args):
+        return args[0]
+
+    def qual_id_indexed(self, args):
+        name = f"_{args[0]}_{'_'.join(map(str, args[1:]))}"
+        return Function(name)
+
+    def qual_id_as(self, args):
+        return args[0]
+
+    def qual_id_as_indexed(self, args):
+        name = f"_{args[0]}_{'_'.join(map(str, args[1:-1]))}"
+        return Function(name)
 
     def term_qual_identifier(self, args):
         atom = args[0]
@@ -176,16 +179,17 @@ class SMTLibTransformer(Transformer):
         op_node = args[0]
         params = args[1:]
 
-        # If the operator is an indexed identifier, pass it through directly
-        # as a Function call
-        if isinstance(op_node, (Function, Expr)):
+        # If the operator is an indexed identifier (FunctionClass), pass it through directly
+        if isinstance(op_node, type) and issubclass(op_node, Function):
             return op_node(*params)
+        if isinstance(op_node, Expr):
+            raise UnknownSMTLibCommandError(f"Cannot apply arguments to expression {op_node}")
 
         op = str(op_node)
 
         if op in self._macros:
             macro_args, macro_body = self._macros[op]
-            return macro_body.subs(dict(zip(macro_args, params)))
+            return macro_body.xreplace(dict(zip(macro_args, params)))
 
         if op in self._functions:
             return self._functions[op](*params)
@@ -199,7 +203,10 @@ class SMTLibTransformer(Transformer):
         elif op_lower == 'or':
             return Or(*params)
         elif op_lower == '=>':
-            return Implies(params[0], params[1])
+            result = params[-1]
+            for p in reversed(params[:-1]):
+                result = Implies(p, result)
+            return result
         elif op_lower == 'xor':
             return Xor(*params)
         elif op_lower == '=':
@@ -214,14 +221,19 @@ class SMTLibTransformer(Transformer):
                 for j in range(i + 1, len(params)):
                     exprs.append(Ne(params[i], params[j]))
             return And(*exprs)
-        elif op_lower == '<':
-            return StrictLessThan(params[0], params[1])
-        elif op_lower == '<=':
-            return LessThan(params[0], params[1])
-        elif op_lower == '>':
-            return StrictGreaterThan(params[0], params[1])
-        elif op_lower == '>=':
-            return GreaterThan(params[0], params[1])
+        elif op_lower in ('<', '<=', '>', '>='):
+            if len(params) == 2:
+                if op_lower == '<': return StrictLessThan(params[0], params[1])
+                if op_lower == '<=': return LessThan(params[0], params[1])
+                if op_lower == '>': return StrictGreaterThan(params[0], params[1])
+                if op_lower == '>=': return GreaterThan(params[0], params[1])
+            exprs = []
+            for i in range(len(params) - 1):
+                if op_lower == '<': exprs.append(StrictLessThan(params[i], params[i+1]))
+                elif op_lower == '<=': exprs.append(LessThan(params[i], params[i+1]))
+                elif op_lower == '>': exprs.append(StrictGreaterThan(params[i], params[i+1]))
+                elif op_lower == '>=': exprs.append(GreaterThan(params[i], params[i+1]))
+            return And(*exprs)
         elif op_lower == '+':
             return Add(*params)
         elif op_lower == '-':
@@ -248,9 +260,8 @@ class SMTLibTransformer(Transformer):
     def term_let(self, args):
         bindings = args[:-1]
         term = args[-1]
-        for var, val in bindings:
-            term = term.subs(Symbol(var), val)
-        return term
+        subs_dict = {Symbol(var): val for var, val in bindings}
+        return term.xreplace(subs_dict)
 
     def term_forall(self, args):
         vars_list = args[:-1]
@@ -315,9 +326,7 @@ class SMTLibTransformer(Transformer):
             self._macros[name] = (var_syms, body)
 
     def cmd_define_fun_rec(self, args):
-        # We handle this same as define-fun for now, SymPy will leave
-        # unresolvable recursive invocations as uninterpreted.
-        self.cmd_define_fun(args)
+        raise NotImplementedError("Recursive macros are not supported in SymPy because AST generation evaluates bottom-up.")
 
     def cmd_pop(self, args):
         levels = int(args[0]) if args else 1
@@ -344,3 +353,15 @@ class SMTLibTransformer(Transformer):
 
     def cmd_reset_assertions(self, args):
         self._assertions = []
+
+    def cmd_set_logic(self, args):
+        if args:
+            self._logic = str(args[0])
+
+    def cmd_set_info(self, args):
+        if len(args) >= 2:
+            self._info[str(args[0])] = args[1]
+
+    def cmd_set_option(self, args):
+        if len(args) >= 2:
+            self._options[str(args[0])] = args[1]

--- a/sympy/parsing/tests/test_smtlib_parser.py
+++ b/sympy/parsing/tests/test_smtlib_parser.py
@@ -610,3 +610,101 @@ def test_parse_datatypes_not_supported():
         parse_smtlib('''
         (declare-datatypes ((Color 0)) (((red) (green) (blue))))
         ''')
+
+
+def test_parse_negative_literals():
+    # Standard SMT-LIB has no negative literals, but solvers such as Z3
+    # accept them and SymPy's own SMT-LIB printer emits them
+    parsed_symbols, assertions = parse_smtlib('''
+    (declare-const x Real)
+    (assert (= x -1))
+    (assert (< x -2.5))
+    (assert (= (- 1) -1))
+    ''')
+    x = parsed_symbols['x']
+    assert assertions[1] == Eq(x, -1)
+    assert assertions[2] == StrictLessThan(x, -2.5)
+    assert assertions[3] is S.true
+
+    # Symbols merely containing a - are unaffected
+    parsed_symbols, _ = parse_smtlib('(declare-const a-1 Int)')
+    assert 'a-1' in parsed_symbols
+
+
+def test_parse_pow():
+    # Exponentiation is not standard SMT-LIB, but ^ is supported by solvers
+    # such as Z3 and pow is what SymPy's SMT-LIB printer emits
+    parsed_symbols, assertions = parse_smtlib('''
+    (declare-const x Real)
+    (assert (= (pow x 2) 4))
+    (assert (= (^ x 3) 8))
+    ''')
+    x = parsed_symbols['x']
+    assert assertions[1] == Eq(x**2, 4)
+    assert assertions[2] == Eq(x**3, 8)
+
+
+# Round-trip tests between the SMT-LIB printer (sympy.printing.smtlib) and
+# the parser, for the subset of SymPy that both support.
+
+def _check_roundtrip(exprs, **printer_kwargs):
+    """Print ``exprs`` with smtlib_code, parse the result back, and check
+    that both the expressions and a second printing are unchanged."""
+    from sympy.assumptions.assume import AppliedPredicate
+    from sympy.printing.smtlib import smtlib_code
+
+    code = smtlib_code(exprs, log_warn=lambda _: None, **printer_kwargs)
+    _, assertions = parse_smtlib(code)
+
+    # declare-const of an Int/Real constant produces a Q.integer/Q.real
+    # entry; use it to restore the assumptions that smtlib_code needs on
+    # the symbols, then drop it
+    replacements = {}
+    parsed = []
+    for a in assertions:
+        if isinstance(a, AppliedPredicate):
+            sym = a.arguments[0]
+            if a.function == Q.real:
+                replacements[sym] = Symbol(sym.name, real=True)
+            elif a.function == Q.integer:
+                replacements[sym] = Symbol(sym.name, integer=True)
+        else:
+            parsed.append(a)
+    parsed = [a.xreplace(replacements) for a in parsed]
+
+    assert parsed == exprs
+    assert smtlib_code(parsed, log_warn=lambda _: None, **printer_kwargs) == code
+
+
+def test_roundtrip_arithmetic():
+    from sympy import Rational, Float, symbols
+    x, y = symbols('x y', real=True)
+    n = Symbol('n', integer=True)
+    _check_roundtrip([Eq(x + 2*y, 2)])
+    _check_roundtrip([x/y < 5])
+    _check_roundtrip([Eq(x**2, 4)])
+    _check_roundtrip([n >= 5, Eq(x, Rational(1, 3)), x <= Float(2.5)])
+    _check_roundtrip([x >= -5, Eq(x, Float(-2.5))])
+
+
+def test_roundtrip_boolean():
+    from sympy import symbols
+    x = Symbol('x', real=True)
+    b1, b2 = symbols('b1 b2')
+    _check_roundtrip([Implies(Eq(x, 1), Xor(b1, b2))])
+    _check_roundtrip([Not(And(b1, Or(b2, x > 0)))])
+    _check_roundtrip([Ne(x, Symbol('y', real=True))])
+
+
+def test_roundtrip_piecewise_abs():
+    x = Symbol('x', real=True)
+    _check_roundtrip([StrictLessThan(Piecewise((x, x > 0), (-x, True)), 2)])
+    _check_roundtrip([Eq(Abs(x), 1)])
+
+
+def test_roundtrip_uninterpreted_function():
+    import typing
+    n = Symbol('n', integer=True)
+    f = Function('f')
+    _check_roundtrip([Eq(f(n), 0)],
+                     symbol_table={f: typing.Callable[[int], int]})

--- a/sympy/parsing/tests/test_smtlib_parser.py
+++ b/sympy/parsing/tests/test_smtlib_parser.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+from sympy.assumptions import Q
+from sympy.core.add import Add
+from sympy.core.function import Function
+from sympy.core.mul import Mul
+from sympy.core.relational import (
+    Eq, GreaterThan, LessThan, Ne, StrictGreaterThan, StrictLessThan
+)
+from sympy.core.symbol import Symbol
+from sympy.external import import_module
+from sympy.functions.elementary.complexes import Abs
+from sympy.functions.elementary.piecewise import Piecewise
+from sympy.logic.boolalg import And, Implies, Not, Or, Xor
+from sympy.parsing.smtlib.lark.smtlib_parser import (
+    SMTLibSyntaxError, UnknownSMTLibCommandError, parse_smtlib
+)
+from sympy.testing.pytest import raises
+
+lark = import_module('lark')
+
+# disable tests if lark is not present
+disabled = lark is None
+
+
+def test_parse_qf_uf_equalities_or_chain():
+    source = """
+    (set-option :print-success false)
+    (set-logic QF_UF)
+    (declare-sort x5 0)
+    (declare-fun x4 () x5)
+    (declare-fun x2 () Bool)
+    (declare-fun x1 () x5)
+    (declare-fun x3 () x5)
+    (assert x2)
+    (assert (not (= x4 x3)))
+    (assert (not (or (= x4 x1) (= x1 x3))))
+    (check-sat)
+    (exit)
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+
+    x1 = parsed_symbols['x1']
+    x2 = parsed_symbols['x2']
+    x3 = parsed_symbols['x3']
+    x4 = parsed_symbols['x4']
+
+    assert len(assertions) == 3
+    assert assertions[0] == x2
+    assert assertions[1] == Not(Eq(x4, x3))
+    assert assertions[2] == Not(Or(Eq(x4, x1), Eq(x1, x3)))
+
+
+def test_parse_qf_lra_implies_and_lessthan():
+    source = """
+    (set-option :print-success false)
+    (set-logic QF_LRA)
+    (declare-fun x2 () Real)
+    (declare-fun x1 () Real)
+    (assert (not (=> (and (= 0 x1) (= 16 x2)) (<= x2 16))))
+    (check-sat)
+    (exit)
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+
+    x1 = parsed_symbols['x1']
+    x2 = parsed_symbols['x2']
+
+    assert len(assertions) == 3
+    assert assertions[0] == Q.real(x2)
+    assert assertions[1] == Q.real(x1)
+    assert assertions[2] == Not(
+        Implies(And(Eq(0, x1), Eq(16, x2)), LessThan(x2, 16))
+    )
+
+
+def test_parse_qf_lra_implies_and_greaterthan():
+    source = """
+    (set-option :print-success false)
+    (set-logic QF_LRA)
+    (declare-fun x2 () Real)
+    (declare-fun x1 () Real)
+    (assert (not (=> (and (= 0 x1) (= 16 x2)) (>= x1 0))))
+    (check-sat)
+    (exit)
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+
+    x1 = parsed_symbols['x1']
+    x2 = parsed_symbols['x2']
+
+    assert len(assertions) == 3
+    assert assertions[0] == Q.real(x2)
+    assert assertions[1] == Q.real(x1)
+    assert assertions[2] == Not(
+        Implies(And(Eq(0, x1), Eq(16, x2)), GreaterThan(x1, 0))
+    )
+
+
+def test_parse_qf_lra_nested_conditions():
+    source = """
+    (set-option :print-success false)
+    (set-logic QF_LRA)
+    (declare-fun x2 () Real)
+    (declare-fun x1 () Real)
+    (assert (not (=>
+        (and (and (>= x2 1) (and (= 10 x2) (= 0 x1))) (<= x2 12))
+        (or (or (= 3 x1) (= x1 1)) (>= 10 x2)))))
+    (check-sat)
+    (exit)
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+
+    x1 = parsed_symbols['x1']
+    x2 = parsed_symbols['x2']
+
+    assert len(assertions) == 3
+    assert assertions[0] == Q.real(x2)
+    assert assertions[1] == Q.real(x1)
+
+    assert assertions[2] == Not(
+        Implies(
+            And(
+                And(GreaterThan(x2, 1), And(Eq(10, x2), Eq(0, x1))),
+                LessThan(x2, 12)
+            ),
+            Or(
+                Or(Eq(3, x1), Eq(x1, 1)),
+                GreaterThan(10, x2)
+            )
+        )
+    )
+
+
+def test_parse_qf_uf_double_negations():
+    source = """
+    (set-option :print-success false)
+    (set-logic QF_UF)
+    (declare-fun x1 () Bool)
+    (declare-fun x2 () Bool)
+    (declare-fun x4 () Bool)
+    (declare-fun x3 () Bool)
+    (assert (not x1))
+    (assert x3)
+    (assert x2)
+    (assert (not (not x4)))
+    (check-sat)
+    (exit)
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+
+    x1 = parsed_symbols['x1']
+    x2 = parsed_symbols['x2']
+    x3 = parsed_symbols['x3']
+    x4 = parsed_symbols['x4']
+
+    assert len(assertions) == 4
+    assert assertions[0] == Not(x1)
+    assert assertions[1] == x3
+    assert assertions[2] == x2
+    assert assertions[3] == Not(Not(x4))
+
+
+def test_parse_qf_uf_implies_double_negations_equalities():
+    source = """
+    (set-option :print-success false)
+    (set-logic QF_UF)
+    (declare-sort x3 0)
+    (declare-fun x2 () x3)
+    (declare-fun x4 () x3)
+    (declare-fun x6 () Bool)
+    (declare-fun x1 () Bool)
+    (declare-fun x5 () Bool)
+    (assert (not (not x1)))
+    (assert (=> x1 (not x5)))
+    (assert (not (= x2 x4)))
+    (assert x6)
+    (check-sat)
+    (exit)
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+
+    x1 = parsed_symbols['x1']
+    x2 = parsed_symbols['x2']
+    x4 = parsed_symbols['x4']
+    x5 = parsed_symbols['x5']
+    x6 = parsed_symbols['x6']
+
+    assert len(assertions) == 4
+    assert assertions[0] == Not(Not(x1))
+    assert assertions[1] == Implies(x1, Not(x5))
+    assert assertions[2] == Not(Eq(x2, x4))
+    assert assertions[3] == x6
+
+
+def test_parse_smtlib_syntax_errors():
+    # Missing closing parenthesis
+    with raises(SMTLibSyntaxError):
+        parse_smtlib("(assert (= x 1)")
+
+    # Unmatched closing parenthesis
+    with raises(SMTLibSyntaxError):
+        parse_smtlib("(assert (= x 1)))")
+
+
+def test_parse_let_bindings():
+    source = """
+    (set-logic LRA)
+    (declare-fun x () Real)
+    (declare-fun y () Real)
+    (assert (let ((a (+ x 1)) (b (- y 1))) (and (> a 0) (< b 0))))
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+    x = parsed_symbols['x']
+    y = parsed_symbols['y']
+    assert len(assertions) == 3
+    assert assertions[0] == Q.real(x)
+    assert assertions[1] == Q.real(y)
+    assert assertions[2] == And(
+        StrictGreaterThan(Add(x, 1), 0), StrictLessThan(y - 1, 0)
+    )
+
+
+def test_parse_quantifiers():
+    source = """
+    (set-logic LRA)
+    (declare-fun x () Real)
+    (assert (forall ((a Real) (b Real)) (=> (> a b) (> (+ a x) (+ b x)))))
+    (assert (exists ((c Real)) (= c (* x 2))))
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+    x = parsed_symbols['x']
+    a = Symbol('a')
+    b = Symbol('b')
+    c = Symbol('c')
+    assert len(assertions) == 3
+    assert assertions[0] == Q.real(x)
+    assert assertions[1] == Function('forall')(
+        (a, b),
+        Implies(
+            StrictGreaterThan(a, b), StrictGreaterThan(Add(a, x), Add(b, x))
+        )
+    )
+    assert assertions[2] == Function('exists')((c,), Eq(c, Mul(x, 2)))
+
+
+def test_parse_macro_definition():
+    source = """
+    (set-logic LRA)
+    (define-fun max ((a Real) (b Real)) Real (ite (> a b) a b))
+    (declare-fun x () Real)
+    (declare-fun y () Real)
+    (assert (= (max x y) 10))
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+    x = parsed_symbols['x']
+    y = parsed_symbols['y']
+    assert len(assertions) == 3
+    assert assertions[0] == Q.real(x)
+    assert assertions[1] == Q.real(y)
+    assert assertions[2] == Eq(
+        Piecewise((x, StrictGreaterThan(x, y)), (y, True)), 10
+    )
+
+
+def test_parse_bitvector_fallback():
+    source = """
+    (set-logic QF_BV)
+    (declare-fun a () (_ BitVec 32))
+    (declare-fun b () (_ BitVec 32))
+    (assert (= (bvadd a b) #x00000000))
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+    a = parsed_symbols['a']
+    b = parsed_symbols['b']
+    assert len(assertions) == 1
+    assert assertions[0] == Eq(Function('bvadd')(a, b), 0)
+
+
+def test_parse_lexer_edge_cases():
+    # Test strings
+    source = '''
+    (declare-fun |a b| () String)
+    (assert (= |a b| "hello world"))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    assert assertions[0] == Eq(parsed_symbols['|a b|'], Symbol('"hello world"'))
+
+    # Unclosed string error
+    with raises(SMTLibSyntaxError):
+        parse_smtlib('(assert (= x "unclosed))')
+
+    # Unclosed quoted symbol error
+    with raises(SMTLibSyntaxError):
+        parse_smtlib('(declare-fun |unclosed () Bool)')
+
+
+def test_parse_hex_and_binary():
+    source = '''
+    (assert (= #x0A 10))
+    (assert (= #b1010 10))
+    '''
+    _, assertions = parse_smtlib(source)
+    assert assertions[0] == Eq(10, 10)
+    assert assertions[1] == Eq(10, 10)
+
+
+def test_parse_type_and_errors():
+    source = '''
+    (declare-sort A 0)
+    (declare-fun y () A)
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    assert 'y' in parsed_symbols
+
+    # Just coverage for invalid arity
+    with raises(SMTLibSyntaxError):
+        parse_smtlib('(declare-sort B 1 2)')
+
+
+def test_parse_recursive_functions():
+    source = '''
+    (define-fun-rec f ((x Int)) Int (ite (> x 0) 1 0))
+    (assert (= (f 1) 1))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    # Recursion is unrolled conceptually but here just checking it parsed
+    assert len(assertions) == 1
+
+
+def test_parse_unknown_and_syntax_errors():
+    with raises(UnknownSMTLibCommandError):
+        parse_smtlib('(assert (unknown-op x y))')
+
+    # Extra or missing parentheses
+    with raises(SMTLibSyntaxError):
+        parse_smtlib('(assert (= x 1)))')
+
+
+def test_parse_extra_coverage():
+    # Test division with multiple params and 'false' bool
+    source1 = '''
+    (declare-fun x () Real)
+    (declare-fun y () Real)
+    (declare-fun z () Real)
+    (assert (= (/ x y z) 1.0))
+    (assert false)
+    '''
+    parsed_symbols, assertions = parse_smtlib(source1)
+    x = parsed_symbols['x']
+    y = parsed_symbols['y']
+    z = parsed_symbols['z']
+    assert len(assertions) == 5
+    assert assertions[0] == Q.real(x)
+    assert assertions[1] == Q.real(y)
+    assert assertions[2] == Q.real(z)
+    assert assertions[3] == Eq(x / (y * z), 1.0)
+    assert assertions[4] is False
+
+    # Test and with 1 param and => with nested
+    source2 = '''
+    (assert (and true))
+    '''
+    _, assertions = parse_smtlib(source2)
+    assert assertions[0] == And(True)
+
+
+def test_parse_multi_arg_and_unary():
+    source = '''
+    (declare-fun x () Int)
+    (declare-fun y () Int)
+    (declare-fun z () Int)
+    (assert (= x y z))
+    (assert (distinct x y z))
+    (assert (xor x y z))
+    (assert (= (- x) (abs y)))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    x, y, z = parsed_symbols['x'], parsed_symbols['y'], parsed_symbols['z']
+
+    assert len(assertions) == 7
+    assert assertions[0] == Q.integer(x)
+    assert assertions[1] == Q.integer(y)
+    assert assertions[2] == Q.integer(z)
+    assert assertions[3] == And(Eq(x, y), Eq(y, z))
+    assert assertions[4] == And(Ne(x, y), Ne(x, z), Ne(y, z))
+    assert assertions[5] == Xor(x, y, z)
+    assert assertions[6] == Eq(-x, Abs(y))
+
+
+def test_parse_state_and_config():
+    source = '''
+    (set-info :smt-lib-version 2.6)
+    (set-logic QF_LIA)
+    (declare-fun x () Int)
+    (push 1)
+    (assert (> x 0))
+    (pop 1)
+    (get-info :name)
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    x = parsed_symbols['x']
+    assert len(assertions) == 1
+    assert assertions[0] == Q.integer(x)
+
+
+def test_parse_zero_arity_and_rec():
+    source = '''
+    (define-fun a () Int 10)
+    (define-fun-rec f ((x Int)) Int (ite (> x 0) 1 0))
+    (assert (= (f 1) 1))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    assert parsed_symbols['a'] == 10
+    assert len(assertions) == 1
+    assert assertions[0] == True
+
+
+def test_parse_reset():
+    source = '''
+    (declare-fun x () Int)
+    (assert (= x 10))
+    (reset-assertions)
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    assert len(assertions) == 0  # reset-assertions clears assertions
+    assert 'x' in parsed_symbols # but keeps parsed_symbols
+
+    source_reset = '''
+    (declare-fun y () Int)
+    (reset)
+    '''
+    parsed_symbols_r, assertions_r = parse_smtlib(source_reset)
+    assert len(assertions_r) == 0
+    assert 'y' not in parsed_symbols_r  # reset clears everything
+
+def test_parse_match_fallback():
+    with raises(NotImplementedError):
+        parse_smtlib('(assert (match 10 ((x 20))))')

--- a/sympy/parsing/tests/test_smtlib_parser.py
+++ b/sympy/parsing/tests/test_smtlib_parser.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 from sympy.assumptions import Q
 from sympy.core.add import Add
 from sympy.core.function import Function
-from sympy.core.mul import Mul
+from sympy.core.mod import Mod
 from sympy.core.relational import (
     Eq, GreaterThan, LessThan, Ne, StrictGreaterThan, StrictLessThan
 )
+from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.external import import_module
 from sympy.functions.elementary.complexes import Abs
+from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.logic.boolalg import And, Implies, Not, Or, Xor
-from sympy.parsing.smtlib.lark.smtlib_parser import (
-    SMTLibSyntaxError, UnknownSMTLibCommandError, parse_smtlib
+from sympy.parsing.smtlib import (
+    SMTLibSyntaxError, UnknownSMTLibCommandError, UnknownSMTLibOperatorError,
+    parse_smtlib
 )
 from sympy.testing.pytest import raises
 
@@ -119,27 +122,20 @@ def test_parse_let_bindings():
     )
 
 
-def test_parse_quantifiers():
-    source = """
-    (set-logic LRA)
-    (declare-fun x () Real)
-    (assert (forall ((a Real) (b Real)) (=> (> a b) (> (+ a x) (+ b x)))))
-    (assert (exists ((c Real)) (= c (* x 2))))
-    """
-    parsed_symbols, assertions = parse_smtlib(source)
-    x = parsed_symbols['x']
-    a = Symbol('a')
-    b = Symbol('b')
-    c = Symbol('c')
-    assert len(assertions) == 3
-    assert assertions[0] == Q.real(x)
-    assert assertions[1] == Function('forall')(
-        (a, b),
-        Implies(
-            StrictGreaterThan(a, b), StrictGreaterThan(Add(a, x), Add(b, x))
-        )
-    )
-    assert assertions[2] == Function('exists')((c,), Eq(c, Mul(x, 2)))
+def test_parse_quantifiers_not_supported():
+    # SymPy has no representation for quantifiers
+    with raises(NotImplementedError):
+        parse_smtlib("""
+        (set-logic LRA)
+        (declare-fun x () Real)
+        (assert (forall ((a Real) (b Real)) (=> (> a b) (> (+ a x) (+ b x)))))
+        """)
+    with raises(NotImplementedError):
+        parse_smtlib("""
+        (set-logic LRA)
+        (declare-fun x () Real)
+        (assert (exists ((c Real)) (= c (* x 2))))
+        """)
 
 
 def test_parse_macro_definition():
@@ -161,28 +157,40 @@ def test_parse_macro_definition():
     )
 
 
-def test_parse_bitvector_fallback():
-    source = """
-    (set-logic QF_BV)
-    (declare-fun a () (_ BitVec 32))
-    (declare-fun b () (_ BitVec 32))
-    (assert (= (bvadd a b) #x00000000))
-    """
-    parsed_symbols, assertions = parse_smtlib(source)
-    a = parsed_symbols['a']
-    b = parsed_symbols['b']
-    assert len(assertions) == 1
-    assert assertions[0] == Eq(Function('bvadd')(a, b), 0)
+def test_parse_bitvector_not_supported():
+    # Bitvector operators have no SymPy equivalent, so they raise rather
+    # than silently producing an uninterpreted Function
+    with raises(NotImplementedError):
+        parse_smtlib("""
+        (set-logic QF_BV)
+        (declare-fun a () (_ BitVec 32))
+        (declare-fun b () (_ BitVec 32))
+        (assert (= (bvadd a b) #x00000000))
+        """)
+
+    # (_ bvN width) bitvector literals are supported (the width is
+    # discarded, like for #x and #b literals)
+    parsed_symbols, assertions = parse_smtlib("""
+    (declare-const x Int)
+    (assert (= x (_ bv5 32)))
+    """)
+    x = parsed_symbols['x']
+    assert assertions[-1] == Eq(x, 5)
 
 
 def test_parse_lexer_edge_cases():
-    # Test strings
+    # |a b| denotes the symbol "a b"; the pipes are quoting syntax, not part
+    # of the name
     source = '''
     (declare-fun |a b| () String)
     (assert (= |a b| "hello world"))
     '''
     parsed_symbols, assertions = parse_smtlib(source)
-    assert assertions[0] == Eq(parsed_symbols['|a b|'], Symbol('"hello world"'))
+    assert assertions[0] == Eq(parsed_symbols['a b'], Symbol('hello world'))
+
+    # A " inside a string is escaped by doubling it
+    _, assertions = parse_smtlib('(assert (= |x| "say ""hi"""))')
+    assert assertions[0] == Eq(Symbol('x'), Symbol('say "hi"'))
 
     # Unclosed string error
     with raises(SMTLibSyntaxError):
@@ -216,25 +224,6 @@ def test_parse_type_and_errors():
         parse_smtlib('(declare-sort B 1 2)')
 
 
-def test_parse_smtlib_file():
-    import os
-
-    source = '''
-    (declare-const x Int)
-    (assert (= x 10))
-    '''
-
-    temp_path = "test.smt2"
-    with open(temp_path, "w", encoding="utf-8") as f:
-        f.write(source)
-
-    parsed_symbols, assertions = parse_smtlib(temp_path)
-    assert len(assertions) == 2
-    assert assertions[-1] == Eq(parsed_symbols['x'], 10)
-
-    os.remove(temp_path)
-
-
 def test_parse_recursive_functions():
     source = '''
     (define-fun-rec f ((x Int)) Int (ite (> x 0) 1 0))
@@ -244,8 +233,15 @@ def test_parse_recursive_functions():
 
 
 def test_parse_unknown_and_syntax_errors():
-    with raises(UnknownSMTLibCommandError):
+    with raises(UnknownSMTLibOperatorError):
         parse_smtlib('(assert (unknown-op x y))')
+
+    # Unknown (or misspelled) commands raise instead of being silently
+    # ignored
+    with raises(UnknownSMTLibCommandError):
+        parse_smtlib('(asssert (= x 1))')
+    with raises(UnknownSMTLibCommandError):
+        parse_smtlib('(some-unknown-command 1 2)')
 
     # Extra or missing parentheses
     with raises(SMTLibSyntaxError):
@@ -270,14 +266,14 @@ def test_parse_extra_coverage():
     assert assertions[1] == Q.real(y)
     assert assertions[2] == Q.real(z)
     assert assertions[3] == Eq(x / (y * z), 1.0)
-    assert assertions[4] is False
+    assert assertions[4] is S.false
 
     # Test and with 1 param and => with nested
     source2 = '''
     (assert (and true))
     '''
     _, assertions = parse_smtlib(source2)
-    assert assertions[0] == And(True)
+    assert assertions[0] is S.true
 
 
 def test_parse_multi_arg_and_unary():
@@ -393,22 +389,28 @@ def test_parse_semantic_simultaneous_let():
 
 
 def test_parse_indexed_and_as_identifiers():
-    source = '''
-    (declare-sort S 0)
-    (declare-fun x () S)
-    (assert (= ((_ extract 7 0) x) 0))
-    '''
-    parsed_symbols, assertions = parse_smtlib(source)
-    x = parsed_symbols['x']
-    extract_func = Function("_extract_7_0")
-    assert assertions[0] == Eq(extract_func(x), 0)
+    # Indexed identifiers other than bitvector literals belong to theories
+    # (e.g. bitvectors) that have no SymPy equivalent
+    with raises(NotImplementedError):
+        parse_smtlib('''
+        (declare-sort S 0)
+        (declare-fun x () S)
+        (assert (= ((_ extract 7 0) x) 0))
+        ''')
 
-    source_as = '''
-    (assert (= ((as const Array) 1) 1))
-    '''
-    parsed_symbols, assertions = parse_smtlib(source_as)
-    const_func = Function("const")
-    assert assertions[0] == Eq(const_func(1), 1)
+    # (as const Array) is the array theory's constant-array constructor
+    with raises(NotImplementedError):
+        parse_smtlib('(assert (= ((as const Array) 1) 1))')
+
+    # A plain "as" sort ascription on an uninterpreted symbol is dropped
+    parsed_symbols, assertions = parse_smtlib('''
+    (declare-sort S 0)
+    (declare-fun f (S) S)
+    (declare-fun x () S)
+    (assert (= (f (as x S)) x))
+    ''')
+    x = parsed_symbols['x']
+    assert assertions[0] == Eq(Function('f')(x), x)
 
 
 def test_parse_complex_nested_logic():
@@ -498,3 +500,113 @@ def test_parse_variadic_inequalities():
     assert assertions[3] == And(LessThan(x, y), LessThan(y, z))
     assert assertions[4] == And(StrictGreaterThan(x, y), StrictGreaterThan(y, z))
     assert assertions[5] == And(GreaterThan(x, y), GreaterThan(y, z))
+
+
+def test_parse_define_const():
+    source = '''
+    (define-const n Int 5)
+    (declare-const x Int)
+    (assert (= x n))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    x = parsed_symbols['x']
+    assert assertions[-1] == Eq(x, 5)
+
+
+def test_parse_define_sort():
+    # 0-ary sort aliases resolve to the underlying sort
+    source = '''
+    (define-sort MyReal () Real)
+    (define-sort AlsoMyReal () MyReal)
+    (declare-const x AlsoMyReal)
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    x = parsed_symbols['x']
+    assert assertions == [Q.real(x)]
+
+    # Parametric sort definitions are not supported
+    with raises(NotImplementedError):
+        parse_smtlib('(define-sort MyArray (T) (Array Int T))')
+
+
+def test_parse_euclidean_div_mod():
+    # SMT-LIB integer division is Euclidean: the remainder is always
+    # nonnegative
+    _, assertions = parse_smtlib('''
+    (assert (= (div 7 2) 0))
+    (assert (= (div (- 7) 2) 0))
+    (assert (= (div 7 (- 2)) 0))
+    (assert (= (mod 7 2) 0))
+    (assert (= (mod (- 7) 2) 0))
+    (assert (= (mod 7 (- 2)) 0))
+    ''')
+    assert assertions[0] == Eq(3, 0)
+    assert assertions[1] == Eq(-4, 0)
+    assert assertions[2] == Eq(-3, 0)
+    assert assertions[3] == Eq(1, 0)
+    assert assertions[4] == Eq(1, 0)
+    assert assertions[5] == Eq(1, 0)
+
+    parsed_symbols, assertions = parse_smtlib('''
+    (declare-const a Int)
+    (declare-const b Int)
+    (assert (= (mod a b) 0))
+    ''')
+    a, b = parsed_symbols['a'], parsed_symbols['b']
+    assert assertions[-1] == Eq(Mod(a, Abs(b)), 0)
+
+
+def test_parse_int_real_conversions():
+    parsed_symbols, assertions = parse_smtlib('''
+    (declare-const x Real)
+    (assert (= (to_int x) 0))
+    (assert (= (to_real 5) 5.0))
+    (assert (is_int x))
+    ''')
+    x = parsed_symbols['x']
+    assert assertions[1] == Eq(floor(x), 0)
+    assert assertions[2] == Eq(5, 5.0)
+    assert assertions[3] == Eq(x, floor(x))
+
+
+def test_parse_bool_constants():
+    # true and false map to SymPy's boolean singletons
+    _, assertions = parse_smtlib('''
+    (assert true)
+    (assert (let ((a 1)) true))
+    ''')
+    assert assertions[0] is S.true
+    assert assertions[1] is S.true
+
+
+def test_parse_case_sensitivity():
+    # SMT-LIB symbols are case-sensitive: AND is an ordinary symbol, not
+    # the boolean operator, and True is not the boolean constant
+    with raises(UnknownSMTLibOperatorError):
+        parse_smtlib('(assert (AND x y))')
+
+    parsed_symbols, assertions = parse_smtlib('''
+    (declare-const True Int)
+    (assert (= True 1))
+    ''')
+    assert assertions[-1] == Eq(Symbol('True'), 1)
+
+
+def test_parse_misc_commands():
+    # check-sat-assuming and echo parse but have no effect on the result
+    parsed_symbols, assertions = parse_smtlib('''
+    (declare-const p Int)
+    (check-sat-assuming (p (not p)))
+    (echo "hello")
+    ''')
+    p = parsed_symbols['p']
+    assert assertions == [Q.integer(p)]
+
+
+def test_parse_datatypes_not_supported():
+    with raises(NotImplementedError):
+        parse_smtlib('(declare-datatype Color ((red) (green) (blue)))')
+    with raises(NotImplementedError):
+        parse_smtlib('''
+        (declare-datatypes ((Color 0)) (((red) (green) (blue))))
+        ''')

--- a/sympy/parsing/tests/test_smtlib_parser.py
+++ b/sympy/parsing/tests/test_smtlib_parser.py
@@ -23,16 +23,17 @@ lark = import_module('lark')
 disabled = lark is None
 
 
-def test_parse_qf_uf_equalities_or_chain():
+def test_parse_equalities_or_chain():
     source = """
     (set-option :print-success false)
     (set-logic QF_UF)
     (declare-sort x5 0)
     (declare-fun x4 () x5)
-    (declare-fun x2 () Bool)
+    (declare-fun x6 () x5)
+    (declare-fun x7 () x5)
     (declare-fun x1 () x5)
     (declare-fun x3 () x5)
-    (assert x2)
+    (assert (= x6 x7))
     (assert (not (= x4 x3)))
     (assert (not (or (= x4 x1) (= x1 x3))))
     (check-sat)
@@ -41,156 +42,53 @@ def test_parse_qf_uf_equalities_or_chain():
     parsed_symbols, assertions = parse_smtlib(source)
 
     x1 = parsed_symbols['x1']
-    x2 = parsed_symbols['x2']
+    x6 = parsed_symbols['x6']
+    x7 = parsed_symbols['x7']
     x3 = parsed_symbols['x3']
     x4 = parsed_symbols['x4']
 
     assert len(assertions) == 3
-    assert assertions[0] == x2
+    assert assertions[0] == Eq(x6, x7)
     assert assertions[1] == Not(Eq(x4, x3))
     assert assertions[2] == Not(Or(Eq(x4, x1), Eq(x1, x3)))
 
 
-def test_parse_qf_lra_implies_and_lessthan():
-    source = """
-    (set-option :print-success false)
-    (set-logic QF_LRA)
-    (declare-fun x2 () Real)
-    (declare-fun x1 () Real)
-    (assert (not (=> (and (= 0 x1) (= 16 x2)) (<= x2 16))))
-    (check-sat)
-    (exit)
-    """
-    parsed_symbols, assertions = parse_smtlib(source)
-
-    x1 = parsed_symbols['x1']
-    x2 = parsed_symbols['x2']
-
-    assert len(assertions) == 3
-    assert assertions[0] == Q.real(x2)
-    assert assertions[1] == Q.real(x1)
-    assert assertions[2] == Not(
-        Implies(And(Eq(0, x1), Eq(16, x2)), LessThan(x2, 16))
-    )
-
-
-def test_parse_qf_lra_implies_and_greaterthan():
-    source = """
-    (set-option :print-success false)
-    (set-logic QF_LRA)
-    (declare-fun x2 () Real)
-    (declare-fun x1 () Real)
-    (assert (not (=> (and (= 0 x1) (= 16 x2)) (>= x1 0))))
-    (check-sat)
-    (exit)
-    """
-    parsed_symbols, assertions = parse_smtlib(source)
-
-    x1 = parsed_symbols['x1']
-    x2 = parsed_symbols['x2']
-
-    assert len(assertions) == 3
-    assert assertions[0] == Q.real(x2)
-    assert assertions[1] == Q.real(x1)
-    assert assertions[2] == Not(
-        Implies(And(Eq(0, x1), Eq(16, x2)), GreaterThan(x1, 0))
-    )
-
-
-def test_parse_qf_lra_nested_conditions():
-    source = """
-    (set-option :print-success false)
-    (set-logic QF_LRA)
-    (declare-fun x2 () Real)
-    (declare-fun x1 () Real)
-    (assert (not (=>
-        (and (and (>= x2 1) (and (= 10 x2) (= 0 x1))) (<= x2 12))
-        (or (or (= 3 x1) (= x1 1)) (>= 10 x2)))))
-    (check-sat)
-    (exit)
-    """
-    parsed_symbols, assertions = parse_smtlib(source)
-
-    x1 = parsed_symbols['x1']
-    x2 = parsed_symbols['x2']
-
-    assert len(assertions) == 3
-    assert assertions[0] == Q.real(x2)
-    assert assertions[1] == Q.real(x1)
-
-    assert assertions[2] == Not(
-        Implies(
-            And(
-                And(GreaterThan(x2, 1), And(Eq(10, x2), Eq(0, x1))),
-                LessThan(x2, 12)
-            ),
-            Or(
-                Or(Eq(3, x1), Eq(x1, 1)),
-                GreaterThan(10, x2)
-            )
-        )
-    )
-
-
-def test_parse_qf_uf_double_negations():
+def test_parse_implies_double_negations_equalities():
     source = """
     (set-option :print-success false)
     (set-logic QF_UF)
-    (declare-fun x1 () Bool)
-    (declare-fun x2 () Bool)
-    (declare-fun x4 () Bool)
-    (declare-fun x3 () Bool)
-    (assert (not x1))
-    (assert x3)
-    (assert x2)
-    (assert (not (not x4)))
-    (check-sat)
-    (exit)
-    """
-    parsed_symbols, assertions = parse_smtlib(source)
-
-    x1 = parsed_symbols['x1']
-    x2 = parsed_symbols['x2']
-    x3 = parsed_symbols['x3']
-    x4 = parsed_symbols['x4']
-
-    assert len(assertions) == 4
-    assert assertions[0] == Not(x1)
-    assert assertions[1] == x3
-    assert assertions[2] == x2
-    assert assertions[3] == Not(Not(x4))
-
-
-def test_parse_qf_uf_implies_double_negations_equalities():
-    source = """
-    (set-option :print-success false)
-    (set-logic QF_UF)
-    (declare-sort x3 0)
-    (declare-fun x2 () x3)
-    (declare-fun x4 () x3)
-    (declare-fun x6 () Bool)
-    (declare-fun x1 () Bool)
-    (declare-fun x5 () Bool)
-    (assert (not (not x1)))
-    (assert (=> x1 (not x5)))
+    (declare-sort x0 0)
+    (declare-fun x2 () x0)
+    (declare-fun x4 () x0)
+    (declare-fun x7 () x0)
+    (declare-fun x8 () x0)
+    (declare-fun x1 () x0)
+    (declare-fun x3 () x0)
+    (declare-fun x5 () x0)
+    (declare-fun x6 () x0)
+    (assert (not (not (= x1 x3))))
+    (assert (=> (= x1 x3) (not (= x5 x6))))
     (assert (not (= x2 x4)))
-    (assert x6)
+    (assert (= x7 x8))
     (check-sat)
     (exit)
     """
     parsed_symbols, assertions = parse_smtlib(source)
 
     x1 = parsed_symbols['x1']
+    x3 = parsed_symbols['x3']
     x2 = parsed_symbols['x2']
     x4 = parsed_symbols['x4']
     x5 = parsed_symbols['x5']
     x6 = parsed_symbols['x6']
+    x7 = parsed_symbols['x7']
+    x8 = parsed_symbols['x8']
 
     assert len(assertions) == 4
-    assert assertions[0] == Not(Not(x1))
-    assert assertions[1] == Implies(x1, Not(x5))
+    assert assertions[0] == Not(Not(Eq(x1, x3)))
+    assert assertions[1] == Implies(Eq(x1, x3), Not(Eq(x5, x6)))
     assert assertions[2] == Not(Eq(x2, x4))
-    assert assertions[3] == x6
+    assert assertions[3] == Eq(x7, x8)
 
 
 def test_parse_smtlib_syntax_errors():
@@ -292,7 +190,7 @@ def test_parse_lexer_edge_cases():
 
     # Unclosed quoted symbol error
     with raises(SMTLibSyntaxError):
-        parse_smtlib('(declare-fun |unclosed () Bool)')
+        parse_smtlib('(declare-fun |unclosed () S)')
 
 
 def test_parse_hex_and_binary():
@@ -318,14 +216,31 @@ def test_parse_type_and_errors():
         parse_smtlib('(declare-sort B 1 2)')
 
 
+def test_parse_smtlib_file():
+    import os
+
+    source = '''
+    (declare-const x Int)
+    (assert (= x 10))
+    '''
+
+    temp_path = "test.smt2"
+    with open(temp_path, "w", encoding="utf-8") as f:
+        f.write(source)
+
+    parsed_symbols, assertions = parse_smtlib(temp_path)
+    assert len(assertions) == 2
+    assert assertions[-1] == Eq(parsed_symbols['x'], 10)
+
+    os.remove(temp_path)
+
+
 def test_parse_recursive_functions():
     source = '''
     (define-fun-rec f ((x Int)) Int (ite (> x 0) 1 0))
-    (assert (= (f 1) 1))
     '''
-    parsed_symbols, assertions = parse_smtlib(source)
-    # Recursion is unrolled conceptually but here just checking it parsed
-    assert len(assertions) == 1
+    with raises(NotImplementedError):
+        parse_smtlib(source)
 
 
 def test_parse_unknown_and_syntax_errors():
@@ -404,18 +319,6 @@ def test_parse_state_and_config():
     assert assertions[0] == Q.integer(x)
 
 
-def test_parse_zero_arity_and_rec():
-    source = '''
-    (define-fun a () Int 10)
-    (define-fun-rec f ((x Int)) Int (ite (> x 0) 1 0))
-    (assert (= (f 1) 1))
-    '''
-    parsed_symbols, assertions = parse_smtlib(source)
-    assert parsed_symbols['a'] == 10
-    assert len(assertions) == 1
-    assert assertions[0] == True
-
-
 def test_parse_reset():
     source = '''
     (declare-fun x () Int)
@@ -434,6 +337,164 @@ def test_parse_reset():
     assert len(assertions_r) == 0
     assert 'y' not in parsed_symbols_r  # reset clears everything
 
+
 def test_parse_match_fallback():
     with raises(NotImplementedError):
         parse_smtlib('(assert (match 10 ((x 20))))')
+
+
+def test_parse_semantic_variadic_implies():
+    source = '''
+    (declare-sort S 0)
+    (declare-fun a () S)
+    (declare-fun b () S)
+    (declare-fun c () S)
+    (assert (=> a b c))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    a, b, c = parsed_symbols['a'], parsed_symbols['b'], parsed_symbols['c']
+    assert assertions[0] == Implies(a, Implies(b, c))
+
+
+def test_parse_semantic_chained_comparisons():
+    source = '(assert (< 1 2 0))'
+    parsed_symbols, assertions = parse_smtlib(source)
+    assert assertions[0] == And(StrictLessThan(1, 2), StrictLessThan(2, 0))
+
+
+def test_parse_semantic_simultaneous_macro():
+    source = '''
+    (declare-fun a () Int)
+    (declare-fun b () Int)
+    (define-fun f ((a Int)(b Int)) Int (- a b))
+    (assert (= (f b a) 0))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    a, b = parsed_symbols['a'], parsed_symbols['b']
+    assert len(assertions) == 3
+    assert assertions[0] == Q.integer(a)
+    assert assertions[1] == Q.integer(b)
+    assert assertions[2] == Eq(b - a, 0)
+
+
+def test_parse_semantic_simultaneous_let():
+    source = '''
+    (declare-fun a () Int)
+    (declare-fun b () Int)
+    (assert (let ((b a) (a 1)) (= b 1)))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    a, b = parsed_symbols['a'], parsed_symbols['b']
+
+    assert len(assertions) == 3
+    assert assertions[0] == Q.integer(a)
+    assert assertions[1] == Q.integer(b)
+    assert assertions[2] == Eq(a, 1)
+
+
+def test_parse_indexed_and_as_identifiers():
+    source = '''
+    (declare-sort S 0)
+    (declare-fun x () S)
+    (assert (= ((_ extract 7 0) x) 0))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source)
+    x = parsed_symbols['x']
+    extract_func = Function("_extract_7_0")
+    assert assertions[0] == Eq(extract_func(x), 0)
+
+    source_as = '''
+    (assert (= ((as const Array) 1) 1))
+    '''
+    parsed_symbols, assertions = parse_smtlib(source_as)
+    const_func = Function("const")
+    assert assertions[0] == Eq(const_func(1), 1)
+
+
+def test_parse_complex_nested_logic():
+    source = """
+    (set-option :print-success false)
+    (set-logic QF_LRA)
+    (declare-fun x1 () Real)
+    (declare-fun x3 () Real)
+    (declare-fun x2 () Real)
+    (assert (not (=> (and (<= x3 (+ 10 x2)) (and (and (>= x3 1) (and (= 10 x3) (= 0 x1))) (<= x3 12))) (or (>= 10 x3) (= x1 3)))))
+    (check-sat)
+    (exit)
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+    x1 = parsed_symbols['x1']
+    x2 = parsed_symbols['x2']
+    x3 = parsed_symbols['x3']
+
+    assert len(assertions) == 4
+    assert assertions[0] == Q.real(x1)
+    assert assertions[1] == Q.real(x3)
+    assert assertions[2] == Q.real(x2)
+    assert assertions[3] == Not(Implies(And(Eq(0, x1), Eq(10, x3), GreaterThan(x3, 1), LessThan(x3, 12), LessThan(x3, x2 + 10)), Or(Eq(x1, 3), GreaterThan(10, x3))))
+
+
+def test_parse_complex_nested_arithmetic():
+    source = """
+    (set-option :print-success false)
+    (set-logic QF_LRA)
+    (declare-fun x1 () Real)
+    (declare-fun x3 () Real)
+    (declare-fun x2 () Real)
+    (assert (not (=> (and (and (and (>= x3 1) (and (= 5 x3) (= 2 x2))) (<= x3 12)) (>= x3 (- 5 (* 2 x1)))) (or (>= x3 5) (= x2 1)))))
+    (check-sat)
+    (exit)
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+    x1 = parsed_symbols['x1']
+    x2 = parsed_symbols['x2']
+    x3 = parsed_symbols['x3']
+
+    assert len(assertions) == 4
+    assert assertions[0] == Q.real(x1)
+    assert assertions[1] == Q.real(x3)
+    assert assertions[2] == Q.real(x2)
+    assert assertions[3] == Not(Implies(And(Eq(2, x2), Eq(5, x3), GreaterThan(x3, 1), LessThan(x3, 12), GreaterThan(x3, 5 - 2*x1)), Or(Eq(x2, 1), GreaterThan(x3, 5))))
+
+
+def test_parse_2_args():
+    source = """
+    (set-logic QF_LRA)
+    (declare-fun x () Real)
+    (declare-fun y () Real)
+    (assert (distinct x y))
+    (assert (= (/ x y) 10.0))
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+    x = parsed_symbols['x']
+    y = parsed_symbols['y']
+
+    assert len(assertions) == 4
+    assert assertions[0] == Q.real(x)
+    assert assertions[1] == Q.real(y)
+    assert assertions[2] == Ne(x, y)
+    assert assertions[3] == Eq(x / y, 10.0)
+
+
+def test_parse_variadic_inequalities():
+    source = """
+    (set-logic QF_LRA)
+    (declare-fun x () Real)
+    (declare-fun y () Real)
+    (declare-fun z () Real)
+    (assert (<= x y z))
+    (assert (> x y z))
+    (assert (>= x y z))
+    """
+    parsed_symbols, assertions = parse_smtlib(source)
+    x = parsed_symbols['x']
+    y = parsed_symbols['y']
+    z = parsed_symbols['z']
+
+    assert len(assertions) == 6
+    assert assertions[0] == Q.real(x)
+    assert assertions[1] == Q.real(y)
+    assert assertions[2] == Q.real(z)
+    assert assertions[3] == And(LessThan(x, y), LessThan(y, z))
+    assert assertions[4] == And(StrictGreaterThan(x, y), StrictGreaterThan(y, z))
+    assert assertions[5] == And(GreaterThan(x, y), GreaterThan(y, z))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This PR implements a smtlib parser for SymPy. The parser requires lark to create the AST. The tests for the parser are a bunch of small smt-lib benchmark files and more tests added because of coverage testing. These are few results:

## Z3 Execution tests:
The parser was tested against standard SMT-LIBv2 files provided by @TiloRC in https://github.com/sympy/sympy/pull/29844#issuecomment-4683126043 and more small benchmark files. Only the files without `Bool` construct were used because it is not something we should worry about.

**Directory: `QF_LRA`**
* Total Tested: 18
* Passed (Z3 execution successful): 18
* Errors: 0

**Directory: `small_files`**
* Total Tested: 3
* Passed (Z3 execution successful): 3
* Errors: 0

**Directory: `QF_UF`**
* Total Tested: 4
* Passed (Z3 execution successful): 4
* Errors: 0

## Coverage Testing

The unit tests written in `test_smtlib_parser.py` was run to check the line coverage across the main parser logic and transformers.
```text
Name                                         Stmts   Miss  Cover
----------------------------------------------------------------
sympy/parsing/smtlib/__init__.py                 2      0   100%
sympy/parsing/smtlib/lark/__init__.py            3      0   100%
sympy/parsing/smtlib/lark/smtlib_parser.py      52      5    92%
sympy/parsing/smtlib/lark/transformer.py       255     20    92%
----------------------------------------------------------------
TOTAL                                          312     25    92%
```
The missing lines are a little redundant to the execution and should not be worried about.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

The code for the parser and tests were written by Gemini 3.1 Pro and was reviewed manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Implemented a new lark-based SMT-LIB parser.
<!-- END RELEASE NOTES -->
