### PR TITLE
docs: clarify unbranched_argument

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1698,6 +1698,7 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
+Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
 Vedant Kadam <vedantkadam3498@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1690,6 +1690,7 @@ V1krant <46847915+V1krant@users.noreply.github.com>
 Vaibhav Bhat <vaibhav.bhat2097@gmail.com> VBhat97 <vaibhav.bhat2097@gmail.com>
 Vaishnav Damani <vaishnavdamani3496@gmail.com>
 Valeriia Gladkova <valeriia.gladkova@gmail.com>
+Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Varenyam Bhardwaj <varenyambhardwaj123@gmail.com>
 Varun Garg <varun.garg03@gmail.com>
 Varun Joshi <joshi.142@osu.edu>
@@ -1698,7 +1699,6 @@ Vasileios Kalos <kalosbasileios@gmail.com> Vasilis <kalosbasileios@gmail.com>
 Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
-Vamshikrishna Ramasamy <161273586+vamshikrishnaramasamy@users.noreply.github.com> Vamshikrishna Ramasamy <vamshikrishnaramasamy@Vamshikrishnas-MacBook-Air-3.local>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
 Vedant Kadam <vedantkadam3498@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -1258,8 +1258,12 @@ class periodic_argument(DefinedFunction):
 
 
 def unbranched_argument(arg):
-    '''
-    Returns periodic argument of arg with period as infinity.
+    """
+    Return the unbranched argument of a polar number.
+
+    This is the argument on the full Riemann surface of the logarithm, without
+    reducing it to a finite branch interval. Equivalently, this returns
+    ``periodic_argument(arg, oo)``.
 
     Examples
     ========
@@ -1271,11 +1275,11 @@ def unbranched_argument(arg):
     >>> unbranched_argument(exp_polar(7*I*pi))
     7*pi
 
-    See also
+    See Also
     ========
 
     periodic_argument
-    '''
+    """
     return periodic_argument(arg, oo)
 
 


### PR DESCRIPTION
#### References to other Issues or PRs

See #11166


#### Brief description of what is fixed or changed

Clarifies the `unbranched_argument` docstring by describing it as the argument on the full Riemann surface of the logarithm and noting that it is equivalent to `periodic_argument(arg, oo)`.


#### Other comments

Tests run:

- `python ./bin/doctest sympy/functions/elementary/complexes.py`
- `python ./bin/test sympy/functions/elementary/tests/test_complexes.py -k periodic_argument`


#### AI Generation Disclosure

OpenAI Codex generated the docstring wording changed in `sympy/functions/elementary/complexes.py` for `unbranched_argument`.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->