### PR TITLE
fix(physics.control): drop phantom state in TransferFunction->StateSpace for constant TFs (#29179)

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1460,9 +1460,9 @@ class TransferFunctionBase(SISOLinearTimeInvariant, ABC):
 
         if n == 0:
             return (
-                Matrix([zeros(1)]),
-                Matrix([zeros(1)]),
-                Matrix([zeros(1)]),
+                zeros(0, 0),
+                zeros(0, 1),
+                zeros(1, 0),
                 Matrix([num_coeffs[0] / den_coeffs[0]]),
             )
 
@@ -6607,8 +6607,11 @@ class StateSpace(StateSpaceBase):
         """
         s = Symbol('s')
         n = self.A.shape[0]
-        I = eye(n)
-        G = self.C*(s*I - self.A).solve(self.B) + self.D
+        if n == 0:
+            G = self.D
+        else:
+            I = eye(n)
+            G = self.C*(s*I - self.A).solve(self.B) + self.D
         G = G.simplify()
         to_tf = lambda expr: TransferFunction.from_rational_expression(expr, s)
         tf_mat = [[to_tf(expr) for expr in sublist] for sublist in G.tolist()]
@@ -6744,8 +6747,11 @@ class DiscreteStateSpace(StateSpaceBase):
         """
         z = Symbol('z')
         n = self.A.shape[0]
-        I = eye(n)
-        G = self.C*(z*I - self.A).solve(self.B) + self.D
+        if n == 0:
+            G = self.D
+        else:
+            I = eye(n)
+            G = self.C*(z*I - self.A).solve(self.B) + self.D
         G = G.simplify()
         to_tf = lambda expr: DiscreteTransferFunction.\
             from_rational_expression(expr, z, self.sampling_time)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -18,7 +18,7 @@ from sympy.polys.polytools import factor
 from sympy.polys.rootoftools import CRootOf
 from sympy.simplify.simplify import simplify
 from sympy.core.containers import Tuple
-from sympy.matrices import ImmutableMatrix, Matrix, ShapeError
+from sympy.matrices import ImmutableMatrix, Matrix, ShapeError, zeros
 from sympy.functions.elementary.trigonometric import sin, cos
 from sympy.physics.control.lti import (
     create_transfer_function, TransferFunctionBase, TransferFunction,
@@ -43,7 +43,6 @@ TF5 = TransferFunction(k, p, s)
 TF6 = TransferFunction(k*s + p, k*s + p, s)
 
 
-@XFAIL
 def test_state_space_rewrite_from_pr_27651():
     c0, c1, c2 = symbols('c0, c1, c2', real=True)
     a0, a1, a2, a3 = symbols('a0, a1, a2, a3', real=True)
@@ -3522,7 +3521,7 @@ def test_conversion():
 
     SS2 = TF5.rewrite(StateSpace)
     assert SS2 == \
-        StateSpace(Matrix([[0]]), Matrix([[0]]), Matrix([[0]]), Matrix([[k/p]]))
+        StateSpace(zeros(0, 0), zeros(0, 1), zeros(1, 0), Matrix([[k/p]]))
     assert SS2.rewrite(TransferFunction)[0][0] == TF5
 
     SS3 = TF6.rewrite(StateSpace)


### PR DESCRIPTION
<!-- Issue: #29179 -->

Fixes #29179

## Summary

`TransferFunctionBase._StateSpace_matrices_equivalent` returned a 1×1 zero-state realization (`A=B=C=[[0]]`) for constant (degree-0) transfer functions, which introduced an unobservable/uncontrollable phantom state. `Parallel.doit()` then carried that phantom through `StateSpace.__add__`'s block-diagonal stacking, producing an extra empty state equation in the merged `StateSpace`. The XFAIL test `test_state_space_rewrite_from_pr_27651` in `sympy/physics/control/tests/test_lti.py` already encoded the expected behavior — this PR makes it pass.

## Changes

- `sympy/physics/control/lti.py`:
  - `_StateSpace_matrices_equivalent`: in the `n == 0` branch, return a true 0-state realization — `A = zeros(0, 0)`, `B = zeros(0, 1)`, `C = zeros(1, 0)`, `D = Matrix([[num/den]])` — instead of the phantom 1-state realization.
  - `StateSpace._eval_rewrite_as_TransferFunction` and `DiscreteStateSpace._eval_rewrite_as_DiscreteTransferFunction`: add an `n == 0` guard that short-circuits to `G = self.D`, avoiding a `Matrix.solve` call on a 0×0 system.
- `sympy/physics/control/tests/test_lti.py`:
  - Removed `@XFAIL` from `test_state_space_rewrite_from_pr_27651` so it now serves as the active regression test.
  - Updated the `SS2` expected matrices in `test_StateSpace_rewrite` (the `TransferFunction(k, p, s).rewrite(StateSpace)` case) to the new 0-state form; the round-trip `SS2.rewrite(TransferFunction)[0][0] == TF5` continues to hold thanks to the n==0 guard.
  - Added `zeros` to the `from sympy.matrices import ...` line.

The structurally-similar `num == den` branch (e.g. `TransferFunction(s**2, s**2, s)`) still returns a 1-state phantom realization. As @Woodman04 noted, that's a separable concern; this PR is intentionally minimal and leaves it for a follow-up.

## Test results

```
PATH=.venv/bin:$PATH pytest sympy/physics/control/tests/test_lti.py -x -q
# 61 passed in 13.44s

PATH=.venv/bin:$PATH pytest sympy/physics/control/ -q
# 65 passed, 6 skipped
```

Empirically verified the fix:
- Pre-fix: `t.rewrite(StateSpace).doit().A.shape == (5, 5)` (phantom state)
- Post-fix: `t.rewrite(StateSpace).doit().A.shape == (4, 4)` (matches `expected` in the XFAIL test)

I also confirmed the de-XFAILed test would have failed without the `lti.py` change by stashing the lti.py edit and re-running — the test is XFAILED in that state, demonstrating it genuinely guards the bug.

## Release notes

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Fixed `Parallel(StateSpace, StateSpace).doit()` introducing a spurious zero-row/column when one of the branches was a constant `TransferFunction` rewritten to a `StateSpace`. The conversion now produces a 0-state realization for constant transfer functions.
<!-- END RELEASE NOTES -->
