### PR TITLE
Collect besselsimp output by Bessel function order

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1699,6 +1699,7 @@ Vasiliy Dommes <vasdommes@gmail.com>
 Vasily Povalyaev <vapovalyaev@gmail.com>
 Vatsal Srivastava <alstav.trivas.sava@gmail.com> sava-1729 <alstav.trivas.sava@gmail.com>
 Vedant Dusane <dusanev4@gmail.com> vedantdusane <dusanev4@gmail.com>
+Vedant Jawandhia <vedant.jawandhia@gmail.com> vedjaw <vedant.jawandhia@gmail.com>
 Vedant Kadam <vedantkadam3498@gmail.com>
 Vedant Rathore <vedantr1998@gmail.com>
 Vedarth Sharma <vedarth.sharma@gmail.com>
@@ -1894,7 +1895,6 @@ tttc3 <T.Coxon2@lboro.ac.uk>
 user202729 <25191436+user202729@users.noreply.github.com>
 vaibhav-patel <vaibhav290797@gmail.com>
 vedantc98 <vedantc98@gmail.com>
-Vedant Jawandhia <vedant.jawandhia@gmail.com> vedjaw <vedant.jawandhia@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1894,6 +1894,7 @@ tttc3 <T.Coxon2@lboro.ac.uk>
 user202729 <25191436+user202729@users.noreply.github.com>
 vaibhav-patel <vaibhav290797@gmail.com>
 vedantc98 <vedantc98@gmail.com>
+Vedant Jawandhia <vedant.jawandhia@gmail.com> vedjaw <vedant.jawandhia@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1338,7 +1338,12 @@ def besselsimp(expr):
     if expr != orig_expr:
         bessels = list(expr.find(
             lambda x: isinstance(x, (besselj, bessely, besseli, besselk))))
-        expr = collect(expand(expr), bessels, func=factor)
+        factored = expr.factor()
+        if len(bessels) > 1:
+            collected = collect(expand(expr), bessels, func=factor)
+            expr = collected if collected != factored else factored
+        else:
+            expr = factored
 
     return expr
 

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -40,7 +40,7 @@ from sympy.simplify.combsimp import combsimp
 from sympy.simplify.cse_opts import sub_pre, sub_post
 from sympy.simplify.hyperexpand import hyperexpand
 from sympy.simplify.powsimp import powsimp
-from sympy.simplify.radsimp import radsimp, fraction, collect_abs
+from sympy.simplify.radsimp import radsimp, fraction, collect_abs, collect
 from sympy.simplify.sqrtdenest import sqrtdenest
 from sympy.simplify.trigsimp import trigsimp, exptrigsimp
 from sympy.utilities.decorator import deprecated
@@ -1239,7 +1239,7 @@ def besselsimp(expr):
     half-integer order are rewritten using trigonometric functions and
     functions of integer order (> 1) are rewritten using functions
     of low order.  Finally, if the expression was changed, compute
-    factorization of the result with factor().
+    factorization of the result, collecting terms by Bessel function order.
 
     >>> from sympy import besselj, besseli, besselsimp, polar_lift, I, S
     >>> from sympy.abc import z, nu
@@ -1336,7 +1336,9 @@ def besselsimp(expr):
 
     expr = _bessel_simp_recursion(expr)
     if expr != orig_expr:
-        expr = expr.factor()
+        bessels = list(expr.find(
+            lambda x: isinstance(x, (besselj, bessely, besseli, besselk))))
+        expr = collect(expand(expr), bessels, func=factor)
 
     return expr
 

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -682,11 +682,11 @@ def test_besselsimp():
     assert besselsimp(besselj(a-1,x) + besselj(a+1, x) + besselj(a, x)) == (2*a + x)*besselj(a, x)/x
 
     assert besselsimp(x**2* besselj(a,x) + x**3*besselj(a+1, x) + besselj(a+2, x)) == \
-    2*a*x*besselj(a + 1, x) + x**3*besselj(a + 1, x) - x**2*besselj(a + 2, x) + 2*x*besselj(a + 1, x) + besselj(a + 2, x)
+        x*(2*a + x**2 + 2)*besselj(a + 1, x) - (x - 1)*(x + 1)*besselj(a + 2, x)
 
     assert besselsimp(besselj(a, x) + besselj(a+1, x) + besselj(a+2, x) + besselj(
-    b, x) + besselj(b+1, x) + besselj(b+2, x)) == (2*a*besselj(a+1,x) + 2*b*besselj(b+1,x) + \
-        x*besselj(a+1,x) + x*besselj(b+1,x) + 2*besselj(a+1,x) + 2*besselj(b+1,x))/x
+    b, x) + besselj(b+1, x) + besselj(b+2, x)) == (2*a + x + 2)*besselj(a + 1, x)/x + \
+        (2*b + x + 2)*besselj(b + 1, x)/x
 
 def test_Piecewise():
     e1 = x*(x + y) - y*(x + y)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29905

#### Brief description of what is fixed or changed

After multi-order Bessel recursion, `besselsimp` called `factor()` on the result, which produced messy partially factorized expressions. This replaces that step with `collect(expand(expr), bessels, func=factor)` so coefficients are grouped cleanly by Bessel function, as suggested in the issue.

#### Other comments

Updated `test_besselsimp` expectations for the affected cases.

#### AI Generation Disclosure

Cursor was used for implementation assistance; the change was reviewed and tested locally.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* simplify
  * Fixed `besselsimp` to collect terms by Bessel function order instead of partially factorizing the result.

<!-- END RELEASE NOTES -->

Made with [Cursor](https://cursor.com)