### PR TITLE
Add `is_*` properties to `sec` and `csc`

### DIFF
--- a/sympy/functions/elementary/tests/test_trigonometric.py
+++ b/sympy/functions/elementary/tests/test_trigonometric.py
@@ -1709,6 +1709,16 @@ def test_sec():
     assert sec(x).is_finite is None
     assert sec(pi/2, evaluate=False).is_finite == False
 
+    assert sec(z).is_zero is False
+    assert sec(z).is_positive is None
+    assert sec(z).is_negative is None
+    assert sec(pi/4, evaluate=False).is_positive is True
+    assert sec(pi/4, evaluate=False).is_nonnegative is True
+    assert sec(pi/4, evaluate=False).is_nonpositive is False
+    assert sec(pi*Rational(3, 4), evaluate=False).is_negative is True
+    assert sec(pi*Rational(3, 4), evaluate=False).is_nonpositive is True
+    assert sec(pi*Rational(3, 4), evaluate=False).is_extended_negative is True
+
     assert series(sec(x), x, x0=0, n=6) == 1 + x**2/2 + 5*x**4/24 + O(x**6)
 
     # https://github.com/sympy/sympy/issues/7166
@@ -1800,6 +1810,14 @@ def test_csc():
     assert csc(0, evaluate=False).is_finite == False
     assert csc(x).is_finite is None
     assert csc(pi/2, evaluate=False).is_finite == True
+
+    assert csc(z).is_zero is False
+    assert csc(z).is_positive is None
+    assert csc(z).is_negative is None
+    assert csc(pi/4, evaluate=False).is_positive is True
+    assert csc(pi/4, evaluate=False).is_extended_positive is True
+    assert csc(-pi/4, evaluate=False).is_negative is True
+    assert csc(-pi/4, evaluate=False).is_extended_negative is True
 
     assert series(csc(x), x, x0=pi/2, n=6) == \
         1 + (x - pi/2)**2/2 + 5*(x - pi/2)**4/24 + O((x - pi/2)**6, (x, pi/2))

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -1648,6 +1648,8 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
     _reciprocal_of = None       # mandatory, to be defined in subclass
     _singularities = (S.ComplexInfinity,)
 
+    is_zero = False # Assuming that the subclasses are sec and csc
+
     # _is_even and _is_odd are used for correct evaluation of csc(-x), sec(-x)
     # TODO refactor into TrigonometricFunction common parts of
     # trigonometric functions eval() like even/odd, func(x+2*k*pi), etc.
@@ -1760,6 +1762,30 @@ class ReciprocalTrigonometricFunction(TrigonometricFunction):
 
     def _eval_nseries(self, x, n, logx, cdir=0):
         return (1/self._reciprocal_of(self.args[0]))._eval_nseries(x, n, logx)
+
+    def _eval_is_positive(self):
+        return self._reciprocal_of(self.args[0]).is_positive
+
+    def _eval_is_extended_positive(self):
+        return self._reciprocal_of(self.args[0]).is_positive
+
+    def _eval_is_nonnegative(self):
+        return self._reciprocal_of(self.args[0]).is_positive
+
+    def _eval_is_extended_nonnegative(self):
+        return self._reciprocal_of(self.args[0]).is_positive
+
+    def _eval_is_negative(self):
+        return self._reciprocal_of(self.args[0]).is_negative
+
+    def _eval_is_extended_negative(self):
+        return self._reciprocal_of(self.args[0]).is_negative
+
+    def _eval_is_nonpositive(self):
+        return self._reciprocal_of(self.args[0]).is_negative
+
+    def _eval_is_extended_nonpositive(self):
+        return self._reciprocal_of(self.args[0]).is_negative
 
 
 class sec(ReciprocalTrigonometricFunction):


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
#29850
This may provide a superficial fix for the issue, but the underlying precision problem with `evalf` still remains.
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Nine properties, including `is_zero`, have been added to `sec` and `csc`, more precisely, to their parent class, `ReciprocalTrigonometricFunction`. Because these functions are defined as the reciprocals of `sin` and `cos`, the corresponding properties can now be used for them as well. These properties existed before, but due to numerical precision issues, they could sometimes not be evaluated correctly.

#### Other comments


#### AI Generation Disclosure
NO AI USE
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
