### PR TITLE
BUG: assumptions: add non zero guards for ask(Q.real(I * x))

### DIFF
--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -289,7 +289,11 @@ def _(expr, assumptions):
         else:
             break
     else:
-        return result
+        if result:
+            return True
+        # if we cannot deduce expr is real,
+        # expr is imaginary only if no arg is zero
+        return ask(Q.zero(expr), assumptions)
 
 @RealPredicate.register(Pow)
 def _(expr, assumptions):

--- a/sympy/assumptions/sathandlers.py
+++ b/sympy/assumptions/sathandlers.py
@@ -258,7 +258,7 @@ def _(expr):
     # General Case: Odd number of imaginary args implies mul is imaginary(To be implemented)
     allargs_imag_or_real = allargs(x, Q.imaginary(x) | Q.real(x), expr)
     onearg_imaginary = exactlyonearg(x, Q.imaginary(x), expr)
-    return Implies(allargs_imag_or_real, Implies(onearg_imaginary, Q.imaginary(expr)))
+    return Implies(allargs_imag_or_real & allargs(x, ~Q.zero(x), expr), Implies(onearg_imaginary, Q.imaginary(expr)))
 
 @class_fact_registry.register(Mul)
 def _(expr):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2040,14 +2040,14 @@ def test_real_basic():
     assert ask(Q.real(x), Q.prime(x)) is True
 
     assert ask(Q.real(x/sqrt(2)), Q.real(x)) is True
-    assert ask(Q.real(x/sqrt(-2)), Q.real(x)) is False
+    assert ask(Q.real(x/sqrt(-2)), Q.real(x)) is None # x can be zero
 
     assert ask(Q.real(x + 1), Q.real(x)) is True
     assert ask(Q.real(x + I), Q.real(x)) is False
     assert ask(Q.real(x + I), Q.complex(x)) is None
 
     assert ask(Q.real(2*x), Q.real(x)) is True
-    assert ask(Q.real(I*x), Q.real(x)) is False
+    assert ask(Q.real(I*x), Q.real(x)) is None
     assert ask(Q.real(I*x), Q.imaginary(x)) is True
     assert ask(Q.real(I*x), Q.complex(x)) is None
 

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -259,7 +259,7 @@ def test_abs():
 def test_imaginary():
     assert satask(Q.imaginary(2*I)) is True
     assert satask(Q.imaginary(x*y), Q.imaginary(x)) is None
-    assert satask(Q.imaginary(x*y), Q.imaginary(x) & Q.real(y)) is True
+    assert satask(Q.imaginary(x*y), Q.imaginary(x) & Q.real(y)) is None # y could be 0
     assert satask(Q.imaginary(x), Q.real(x)) is False
     assert satask(Q.imaginary(1)) is False
     assert satask(Q.imaginary(x*y), Q.real(x) & Q.real(y)) is False
@@ -271,7 +271,7 @@ def test_real():
     assert satask(Q.real(x + y), Q.real(x) & Q.real(y)) is True
     assert satask(Q.real(x*y*z), Q.real(x) & Q.real(y) & Q.real(z)) is True
     assert satask(Q.real(x*y*z), Q.real(x) & Q.real(y)) is None
-    assert satask(Q.real(x*y*z), Q.real(x) & Q.real(y) & Q.imaginary(z)) is False
+    assert satask(Q.real(x*y*z), Q.real(x) & Q.real(y) & Q.imaginary(z)) is None # x or y could be 0
     assert satask(Q.real(x + y + z), Q.real(x) & Q.real(y) & Q.real(z)) is True
     assert satask(Q.real(x + y + z), Q.real(x) & Q.real(y)) is None
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes https://github.com/sympy/sympy/issues/27443

#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Clause was used as a review tool

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
