### PR TITLE
ENH: refine: Add `refine_sec_csc`

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -542,7 +542,7 @@ def refine_sec_csc(expr, assumptions):
     ========
 
     >>> from sympy.assumptions.refine import refine_sec_csc
-    >>> from sympy import Symbol, Q, sec, csc, pi
+    >>> from sympy import Q, sec, csc, pi
     >>> from sympy.abc import x, n
     >>> refine_sec_csc(sec(x + n*pi), Q.integer(n))
     (-1)**n*sec(x)

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -543,8 +543,7 @@ def refine_sec_csc(expr, assumptions):
 
     >>> from sympy.assumptions.refine import refine_sec_csc
     >>> from sympy import Symbol, Q, sec, csc, pi
-    >>> from sympy.abc import x
-    >>> n = Symbol('n')
+    >>> from sympy.abc import x, n
     >>> refine_sec_csc(sec(x + n*pi), Q.integer(n))
     (-1)**n*sec(x)
     >>> refine_sec_csc(csc(x + n*pi), Q.integer(n))
@@ -553,11 +552,16 @@ def refine_sec_csc(expr, assumptions):
     zoo
     """
     from sympy.functions.elementary.trigonometric import sec, csc, cos, sin
+    from sympy.calculus.accumulationbounds import AccumBounds
 
     if not isinstance(expr, (sec, csc)):
         raise TypeError("refine_sec_csc expects a sec or csc function.")
 
     arg = expr.args[0]
+    if (ask(Q.infinite(arg), assumptions) and
+            ask(Q.extended_real(arg), assumptions)):
+        return AccumBounds(S.NegativeInfinity, S.Infinity)
+
     co = cos(arg) if isinstance(expr, sec) else sin(arg)
     refined = refine_sin_cos(co, assumptions)
     if refined == co:
@@ -565,15 +569,7 @@ def refine_sec_csc(expr, assumptions):
     if ask(Q.zero(refined), assumptions):
         return S.ComplexInfinity
 
-    result = (S.One / refined).rewrite(expr.func)
-    sign = S.One
-    rest = S.One
-    for factor in Mul.make_args(result):
-        if isinstance(factor, expr.func):
-            rest *= factor
-        else:
-            sign *= factor
-    return rest / sign
+    return S(refined).replace(cos, sec).replace(sin, csc)
 
 
 def refine_Heaviside(expr, assumptions):

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -536,11 +536,6 @@ def refine_sin_cos(expr, assumptions):
 
 def refine_sec_csc(expr, assumptions):
     """
-    Handler for the sec and csc functions.
-
-    Explanation
-    ===========
-
     Handler for sec and csc functions. The function uses `refine_sin_cos` internally.
 
     Examples

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -565,14 +565,15 @@ def refine_sec_csc(expr, assumptions):
     if ask(Q.zero(refined), assumptions):
         return S.ComplexInfinity
 
+    result = (S.One / refined).rewrite(expr.func)
     sign = S.One
     rest = S.One
-    for factor in Mul.make_args(refined):
-        if factor is S.NegativeOne or (factor.is_Pow and factor.base is S.NegativeOne):
-            sign *= factor
-        else:
+    for factor in Mul.make_args(result):
+        if isinstance(factor, expr.func):
             rest *= factor
-    return sign * (1 / rest).rewrite(expr.func)
+        else:
+            sign *= factor
+    return rest / sign
 
 
 def refine_Heaviside(expr, assumptions):

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -559,8 +559,6 @@ def refine_sec_csc(expr, assumptions):
     (-1)**n*csc(x)
     >>> refine_sec_csc(sec(n*pi/2), Q.odd(n))
     zoo
-    >>> refine_sec_csc(csc(n*pi/2), Q.even(n))
-    zoo
     """
     from sympy.functions.elementary.trigonometric import sec, csc, cos, sin
 

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -534,6 +534,57 @@ def refine_sin_cos(expr, assumptions):
         return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
 
 
+def refine_sec_csc(expr, assumptions):
+    """
+    Handler for the sec and csc functions.
+
+    Explanation
+    ===========
+
+    Since ``sec`` and ``csc`` are the reciprocals of ``cos`` and ``sin``,
+    the simplification is delegated to :func:`refine_sin_cos` and the
+    result is reciprocated. Any ``(-1)**k`` sign factor is kept rather than
+    inverted, since it is a unit under the assumptions that produced it.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_sec_csc
+    >>> from sympy import Symbol, Q, sec, csc, pi
+    >>> from sympy.abc import x
+    >>> n = Symbol('n')
+    >>> refine_sec_csc(sec(x + n*pi), Q.integer(n))
+    (-1)**n*sec(x)
+    >>> refine_sec_csc(csc(x + n*pi), Q.integer(n))
+    (-1)**n*csc(x)
+    >>> refine_sec_csc(sec(n*pi/2), Q.odd(n))
+    zoo
+    >>> refine_sec_csc(csc(n*pi/2), Q.even(n))
+    zoo
+    """
+    from sympy.functions.elementary.trigonometric import sec, csc, cos, sin
+
+    if not isinstance(expr, (sec, csc)):
+        raise TypeError("refine_sec_csc expects a sec or csc function.")
+
+    arg = expr.args[0]
+    co = cos(arg) if isinstance(expr, sec) else sin(arg)
+    refined = refine_sin_cos(co, assumptions)
+    if refined == co:
+        return expr
+    if ask(Q.zero(refined), assumptions):
+        return S.ComplexInfinity
+
+    sign = S.One
+    rest = S.One
+    for factor in Mul.make_args(refined):
+        if factor is S.NegativeOne or (factor.is_Pow and factor.base is S.NegativeOne):
+            sign *= factor
+        else:
+            rest *= factor
+    return sign * (1 / rest).rewrite(expr.func)
+
+
 def refine_Heaviside(expr, assumptions):
     """
     Handler for the Heaviside step function.
@@ -613,6 +664,8 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
+    'sec': refine_sec_csc,
+    'csc': refine_sec_csc,
     'exp': refine_exp,
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -541,10 +541,7 @@ def refine_sec_csc(expr, assumptions):
     Explanation
     ===========
 
-    Since ``sec`` and ``csc`` are the reciprocals of ``cos`` and ``sin``,
-    the simplification is delegated to :func:`refine_sin_cos` and the
-    result is reciprocated. Any ``(-1)**k`` sign factor is kept rather than
-    inverted, since it is a unit under the assumptions that produced it.
+    Handler for sec and csc functions. The function uses `refine_sin_cos` internally.
 
     Examples
     ========

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -324,28 +324,74 @@ def test_sin_cos():
 
 def test_sec_csc():
     n = Symbol('n')
-
-    assert refine(sec(x + n*pi), Q.integer(n)) == (-1)**n*sec(x)
-    assert refine(csc(x + n*pi), Q.integer(n)) == (-1)**n*csc(x)
-    assert refine(sec(x + n*pi), Q.odd(n)) == -sec(x)
-    assert refine(sec(x + n*pi/2), Q.even(n)) == (-1)**(n/2)*sec(x)
-    assert refine(csc(x + n*pi/2), Q.even(n)) == (-1)**(n/2)*csc(x)
-    assert refine(sec(n*pi/2), Q.even(n)) == (-1)**(n/2)
-
     assert refine(sec(n*pi/2), Q.odd(n)) == zoo
-    assert refine(csc(n*pi/2), Q.even(n)) == zoo
+    assert refine(sec(n*pi), Q.even(n)) == 1
+    assert refine(sec(n*pi), Q.odd(n)) == -1
     assert refine(csc(n*pi), Q.integer(n)) == zoo
+    assert refine(csc(n*pi/2), Q.odd(n) & Q.even((n-1)/2)) == 1
+    assert refine(csc(n*pi/2), Q.odd(n) & Q.odd((n-1)/2)) == -1
+    assert refine(sec(n*pi), Q.integer(n)) == (-1)**n
+    assert refine(csc(n*pi/2), Q.even(n)) == zoo
+    assert refine(sec(n*pi/2), Q.even(n)) == (-1)**(n/2)
+    assert refine(csc(n*pi/2), Q.odd(n)) == (-1)**((n + 3)/2)
+    assert refine(sec(n*pi/2), Q.odd(n)) == zoo
+    assert refine(csc(x + n*pi), Q.integer(n)) == ((-1)**n) * csc(x)
+    assert refine(sec(x + n*pi), Q.integer(n)) == ((-1)**n) * sec(x)
+    assert refine(csc(x + n*pi), Q.even(n)) == csc(x)
+    assert refine(sec(x + n*pi), Q.even(n)) == sec(x)
+    assert refine(csc(x + n*pi), Q.odd(n)) == -csc(x)
+    assert refine(sec(x + n*pi), Q.odd(n)) == -sec(x)
+    assert refine(csc(x - n*pi), Q.odd(n)) == -csc(x)
+    assert refine(sec(x - n*pi), Q.even(n)) == sec(x)
+    assert refine(csc(x + n*pi/2), Q.even(n)) == ((-1)**(n/2)) * csc(x)
+    assert refine(sec(x + n*pi/2), Q.even(n)) == ((-1)**(n/2)) * sec(x)
+    assert refine(csc(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 3)/2)) * sec(x)
+    assert refine(sec(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 1)/2)) * csc(x)
+    assert refine(csc(x - n*pi/2), Q.odd(n)) == ((-1)**((n + 3)/2)) * -sec(x)
+    assert refine(sec(x - n*pi / 2), Q.even(n)) == ((-1)**(n/2)) * sec(x)
+    assert refine(csc(x + y + 2*n*pi), Q.integer(n)) == csc(x + y)
+    assert refine(sec(x + y + 2*n*pi), Q.integer(n)) == sec(x + y)
+    assert refine(csc(x + n*pi), Q.zero(n)) == csc(x)
+    assert refine(csc(x + n*pi), Q.zero(-n)) == csc(x)
+    assert refine(sec(x + n*pi/2), Q.integer(n)) == sec(x + n*pi/2)
+    assert refine(sec(x + y + n*pi/2), Q.integer(n)) == sec(x + y + n*pi/2)
+    m = Symbol('m')
+    assert refine(sec(x + n*pi + m*pi / 2), Q.integer(n) & Q.even(m)) == \
+        (-1)**(n + m / 2) * sec(x)
+    assert refine(sec(x + n*pi + m*pi / 2), Q.integer(n) & Q.odd(m)) == \
+        (-1)**(n + (m + 1)/2) * csc(x)
+    assert refine(sec(x + n*pi + m*pi / 2), Q.integer(n) & Q.integer(m)) == \
+        (-1)**(n) * sec(x + m*pi / 2)
+    assert refine(sec(x + (2*n + 1)*pi + m*pi / 2), \
+        Q.integer(n) & Q.integer(m)) == \
+        - sec(x + m*pi / 2)
+    assert refine(csc(x - (2*n)*pi + m*pi/2), \
+        Q.integer(n) & Q.integer(m)) == \
+        csc(x + m*pi / 2)
+    k = Symbol('k')
+    assert refine(sec(x + n*pi + k*pi/2 + m*pi/2), \
+                  Q.integer(n) & Q.odd(k) & Q.integer(m)) == \
+        (-1)**(n + (k + 1)/2) * csc(x + m*pi/2)
+    assert refine(csc(x + n*pi + k*pi/2 + m*pi/2), \
+                  Q.integer(n) & Q.odd(k) & Q.integer(m)) == \
+        (-1)**(n + (k + 3)/2) * sec(x + m*pi/2)
+    assert refine(sec(x + n*pi/2 + k*pi/2 + m*pi/2), \
+                  Q.odd(n) & Q.odd(k) & Q.integer(m)) == \
+        (-1)**((n + k)/2) * sec(x + m*pi/2)
+
+    assert refine(sec(x), Q.zero(x)) == 1
     assert refine(csc(x), Q.zero(x)) == zoo
 
-    assert refine(sec(x), Q.infinite(x) & Q.extended_real(x)) == \
-        AccumBounds(S.NegativeInfinity, S.Infinity)
-    assert refine(csc(x), Q.infinite(x) & Q.extended_real(x)) == \
-        AccumBounds(S.NegativeInfinity, S.Infinity)
+    assert (refine(csc(x), Q.infinite(x) & Q.extended_real(x)) ==
+        AccumBounds(S.NegativeInfinity, S.Infinity))
+    assert (refine(sec(x), Q.infinite(x) & Q.extended_real(x)) ==
+        AccumBounds(S.NegativeInfinity, S.Infinity))
+    assert refine(csc(x), Q.infinite(x)) == csc(x)
+    assert refine(sec(x), Q.infinite(x)) == sec(x)
 
-    assert refine(sec(x)) == sec(x)
-    assert refine(sec(x + n*pi)) == sec(x + n*pi)
-
-    raises(TypeError, lambda: refine_sec_csc(sin(x), Q.real(x)))
+    raises(TypeError, lambda: refine_sec_csc(tan(x), Q.real(x)))
+    raises(TypeError, lambda: refine_sec_csc(exp(x), Q.real(x)))
+    raises(TypeError, lambda: refine_sec_csc(x, Q.real(x)))
 
 
 def test_floor_ceiling():

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 from sympy.assumptions.ask import Q
-from sympy.assumptions.refine import refine, refine_sin_cos
+from sympy.assumptions.refine import refine, refine_sin_cos, refine_sec_csc
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.expr import Expr
-from sympy.core.numbers import (I, Rational, nan, pi)
+from sympy.core.numbers import (I, Rational, nan, pi, zoo)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin, tan)
+from sympy.functions.elementary.trigonometric import (atan, atan2, cos, csc, sec, sin, tan)
 from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
@@ -320,6 +320,32 @@ def test_sin_cos():
     raises(TypeError, lambda: refine_sin_cos(tan(x), Q.real(x)))
     raises(TypeError, lambda: refine_sin_cos(exp(x), Q.real(x)))
     raises(TypeError, lambda: refine_sin_cos(x, Q.real(x)))
+
+
+def test_sec_csc():
+    n = Symbol('n')
+
+    assert refine(sec(x + n*pi), Q.integer(n)) == (-1)**n*sec(x)
+    assert refine(csc(x + n*pi), Q.integer(n)) == (-1)**n*csc(x)
+    assert refine(sec(x + n*pi), Q.odd(n)) == -sec(x)
+    assert refine(sec(x + n*pi/2), Q.even(n)) == (-1)**(n/2)*sec(x)
+    assert refine(csc(x + n*pi/2), Q.even(n)) == (-1)**(n/2)*csc(x)
+    assert refine(sec(n*pi/2), Q.even(n)) == (-1)**(n/2)
+
+    assert refine(sec(n*pi/2), Q.odd(n)) == zoo
+    assert refine(csc(n*pi/2), Q.even(n)) == zoo
+    assert refine(csc(n*pi), Q.integer(n)) == zoo
+    assert refine(csc(x), Q.zero(x)) == zoo
+
+    assert refine(sec(x), Q.infinite(x) & Q.extended_real(x)) == \
+        AccumBounds(S.NegativeInfinity, S.Infinity)
+    assert refine(csc(x), Q.infinite(x) & Q.extended_real(x)) == \
+        AccumBounds(S.NegativeInfinity, S.Infinity)
+
+    assert refine(sec(x)) == sec(x)
+    assert refine(sec(x + n*pi)) == sec(x + n*pi)
+
+    raises(TypeError, lambda: refine_sec_csc(sin(x), Q.real(x)))
 
 
 def test_floor_ceiling():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Partially fixes https://github.com/sympy/sympy/issues/27888

#### Brief description of what is fixed or changed
Introduce `refine_sec_csc`

#### Other comments
Not sure if it is favored to use `refine_sin_cos` like this here, but it works.
#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Tests were mirror of `test_sin_cos` by Claude
~Docs are AI generated~
~L573-579  are AI generated~
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Enable refine to perform simplifications of sec and csc functions.
<!-- END RELEASE NOTES -->
