### PR TITLE
Performance improvements to Common Subexpression Elimination

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1613,6 +1613,7 @@ Suraj Channappanavar <surajchannappanavar@gmail.com> Suraj Channappanavar <14525
 Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
+Susi Lehtola <susi.lehtola@gmail.com> <susi.lehtola@alumni.helsinki.fi>
 Susumu Ishizuka <susumu.ishizuka@kii.com>
 Swapnil Agarwal <swapnilag29@gmail.com>
 Szymon Mieszczak <szymon.mieszczak@gmail.com>

--- a/sympy/core/containers.py
+++ b/sympy/core/containers.py
@@ -8,7 +8,6 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
 from collections.abc import MutableSet
 
 from .basic import Basic
@@ -338,10 +337,14 @@ _sympy_converter[dict] = lambda d: Dict(*d.items())
 
 class OrderedSet(MutableSet):
     def __init__(self, iterable=None):
+        # A plain dict preserves insertion order (Python >= 3.7) and is
+        # faster to build and iterate than OrderedDict; the only ordered
+        # operation that needs special handling is popping the first item
+        # (see ``pop`` below).
         if iterable:
-            self.map = OrderedDict((item, None) for item in iterable)
+            self.map = dict.fromkeys(iterable)
         else:
-            self.map = OrderedDict()
+            self.map = {}
 
     def __len__(self):
         return len(self.map)
@@ -356,7 +359,13 @@ class OrderedSet(MutableSet):
         self.map.pop(key)
 
     def pop(self, last=True):
-        return self.map.popitem(last=last)[0]
+        if not self.map:
+            raise KeyError('pop from an empty set')
+        if last:
+            return self.map.popitem()[0]
+        key = next(iter(self.map))
+        del self.map[key]
+        return key
 
     def __iter__(self):
         yield from self.map.keys()

--- a/sympy/core/exprtools.py
+++ b/sympy/core/exprtools.py
@@ -1216,9 +1216,24 @@ def factor_terms(expr: Expr | complex, radical=False, clear=False, fraction=Fals
     gcd_terms, sympy.polys.polytools.terms_gcd
 
     """
+    # SymPy expressions are DAGs: a subexpression shared k times is the same
+    # object encountered k times during recursion.  ``do`` is a pure function
+    # of its argument, so memoizing it makes each distinct subexpression be
+    # processed once instead of once per occurrence -- a large win for the
+    # highly shared expressions produced by e.g. repeated differentiation.
+    # The cache is keyed by the (non-atomic) Basic argument and the result is
+    # stored at the single exit below; atoms are cheap and left uncached.
+    _memo: dict = {}
+
     def do(expr):
         from sympy.concrete.summations import Sum
         from sympy.integrals.integrals import Integral
+
+        if isinstance(expr, Basic):
+            cached = _memo.get(expr)
+            if cached is not None:
+                return cached
+
         is_iterable = iterable(expr)
 
         if not isinstance(expr, Basic) or expr.is_Atom:
@@ -1231,13 +1246,18 @@ def factor_terms(expr: Expr | complex, radical=False, clear=False, fraction=Fals
             args = expr.args
             newargs = tuple([do(i) for i in args])
             if newargs == args:
-                return expr
-            return expr.func(*newargs)
+                rv = expr
+            else:
+                rv = expr.func(*newargs)
+            _memo[expr] = rv
+            return rv
 
         if isinstance(expr, (Sum, Integral)):
-            return _factor_sum_int(expr,
+            rv = _factor_sum_int(expr,
                 radical=radical, clear=clear,
                 fraction=fraction, sign=sign)
+            _memo[expr] = rv
+            return rv
 
         cont, p = expr.as_content_primitive(radical=radical, clear=clear)
         if p.is_Add:
@@ -1264,6 +1284,7 @@ def factor_terms(expr: Expr | complex, radical=False, clear=False, fraction=Fals
             p = p.func(
                 *[do(a) for a in p.args])
         rv = _keep_coeff(cont, p, clear=clear, sign=sign)
+        _memo[expr] = rv
         return rv
     expr2 = sympify(expr)
     return do(expr2)

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -7,7 +7,8 @@ from sympy.core import Basic, Mul, Add, Pow, sympify
 from sympy.core.containers import Tuple, OrderedSet
 from sympy.core.exprtools import factor_terms
 from sympy.core.singleton import S
-from sympy.core.sorting import ordered
+from sympy.core.function import Derivative
+from sympy.core.sorting import ordered, default_sort_key
 from sympy.core.symbol import symbols, Symbol
 from sympy.matrices import (MatrixBase, Matrix, ImmutableMatrix,
                             SparseMatrix, ImmutableSparseMatrix)
@@ -659,6 +660,44 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
 
     subs = {}
 
+    # Memoized node counter used as the ``ordered`` sort key below.  The
+    # default key (``sympy.core.sorting._nodes``) recomputes the node count
+    # of a subexpression every time it appears as an argument, so shared
+    # subexpressions (exactly what CSE deals with) get recounted at every
+    # Add/Mul during _rebuild.  Caching the counts -- which are pure
+    # functions of immutable expressions -- makes the whole pass count each
+    # distinct subtree once.  This mirrors ``_nodes``/``_node_count``: the
+    # Derivative special case is only applied at the top level, with the
+    # plain (cached) node count used for the subtree.
+    _node_count_cache = {}
+
+    def _cached_node_count(e):
+        v = _node_count_cache.get(e)
+        if v is None:
+            if e.is_Float:
+                v = 0.5
+            else:
+                v = 1 + sum(_cached_node_count(a) for a in e.args)
+            _node_count_cache[e] = v
+        return v
+
+    def _cached_nodes(e):
+        if isinstance(e, Basic):
+            if isinstance(e, Derivative):
+                return _cached_nodes(e.expr) + sum(
+                    i[1] if i[1].is_Number else _cached_nodes(i[1])
+                    for i in e.variable_count)
+            return _cached_node_count(e)
+        elif iterable(e):
+            return 1 + sum(_cached_nodes(ei) for ei in e)
+        elif isinstance(e, dict):
+            return 1 + sum(_cached_nodes(k) + _cached_nodes(v)
+                           for k, v in e.items())
+        else:
+            return 1
+
+    _node_key = (_cached_nodes, default_sort_key)
+
     def _rebuild(expr):
         if not isinstance(expr, (Basic, Unevaluated)):
             return expr
@@ -685,9 +724,9 @@ def tree_cse(exprs, symbols, opt_subs=None, order='canonical', ignore=()):
                 if c == [1]:
                     args = nc
                 else:
-                    args = list(ordered(c)) + nc
+                    args = list(ordered(c, _node_key, default=False)) + nc
             elif isinstance(expr, (Add, MatAdd)):
-                args = list(ordered(expr.args))
+                args = list(ordered(expr.args, _node_key, default=False))
             else:
                 args = expr.args
         else:

--- a/sympy/simplify/tests/bench_cse_scaling.py
+++ b/sympy/simplify/tests/bench_cse_scaling.py
@@ -1,0 +1,80 @@
+"""Reproducible timing benchmark for ``sympy.cse`` on large inputs.
+
+This is NOT a pytest test (it is slow); run it directly::
+
+    python sympy/simplify/tests/bench_cse_scaling.py
+
+It builds a meta-GGA / PBE-correlation-like scalar expression in 8
+variables, differentiates it to a requested order to obtain expression
+sets with up to millions of nodes, and times ``cse`` for both
+``optimizations=[]`` (the default, fast path) and ``optimizations='basic'``
+(the factor_terms preprocessing path).
+
+The benchmark was used to evaluate two performance changes:
+
+* memoizing ``factor_terms`` over shared (DAG) subexpressions
+  (``sympy/core/exprtools.py``), and
+* backing ``OrderedSet`` with a plain ``dict`` instead of ``OrderedDict``
+  (``sympy/core/containers.py``).
+
+Neither changes the output of ``cse``.
+"""
+
+import time
+
+from sympy import symbols, sqrt, log, exp, cbrt, Rational, cse, count_ops
+
+
+def build_functional():
+    """A deeply nested rational+power expression in 8 variables."""
+    ra, rb, saa, sab, sbb, ta, tb, _lap = symbols(
+        'rho_a rho_b sigma_aa sigma_ab sigma_bb tau_a tau_b lapl',
+        positive=True)
+    rho = ra + rb
+    zeta = (ra - rb)/rho
+    sig = saa + 2*sab + sbb
+    rs = cbrt(Rational(3, 4)/Rational(314159, 100000)/rho)
+    t2 = sig/rho**Rational(7, 3)
+    phi = (cbrt(1 + zeta) + cbrt(1 - zeta))/2
+    A = 1/(exp(-1/phi**3) - 1 + Rational(1, 100))
+    H = phi**3*log(1 + t2/(1 + A*t2)*(1 + A*t2)/(1 + A*t2 + A**2*t2**2))
+    tau = ta + tb
+    tw = sig/(8*rho)
+    alpha = (tau - tw)/(rho**Rational(5, 3) + Rational(1, 1000))
+    fa = 1/(1 + alpha**2)
+    eps = -rs/(1 + rs + rs**2) + H*fa + log(1 + rho)*sqrt(1 + t2)
+    return rho*eps, (ra, rb, saa, sab, sbb, ta, tb)
+
+
+def make_exprs(order, nvars):
+    f, dvars = build_functional()
+    dvars = dvars[:nvars]
+    exprs = [f]
+    cur = [f]
+    for _ in range(order):
+        nxt = [e.diff(v) for e in cur for v in dvars]
+        exprs.extend(nxt)
+        cur = nxt
+    return exprs
+
+
+def bench(order, nvars, do_basic=True):
+    exprs = make_exprs(order, nvars)
+    nops = sum(count_ops(e) for e in exprs)
+    print(f"order={order} nvars={nvars} nexprs={len(exprs)} ops={nops}")
+    t0 = time.perf_counter()
+    cse(exprs, optimizations=[])
+    print(f"    optimizations=[]      {time.perf_counter()-t0:8.3f} s")
+    if do_basic:
+        t0 = time.perf_counter()
+        cse(exprs, optimizations='basic')
+        print(f"    optimizations='basic' {time.perf_counter()-t0:8.3f} s")
+
+
+if __name__ == '__main__':
+    # 'basic' becomes very slow on the larger sizes on stock sympy, so only
+    # run it on the smaller inputs.
+    bench(1, 4, do_basic=True)
+    bench(2, 3, do_basic=True)
+    bench(2, 4, do_basic=False)
+    bench(3, 2, do_basic=False)

--- a/sympy/simplify/tests/bench_cse_scaling.py
+++ b/sympy/simplify/tests/bench_cse_scaling.py
@@ -20,6 +20,8 @@ The benchmark was used to evaluate two performance changes:
 Neither changes the output of ``cse``.
 """
 
+from __future__ import annotations
+
 import time
 
 from sympy import symbols, sqrt, log, exp, cbrt, Rational, cse, count_ops


### PR DESCRIPTION
Hi! I am the lead developer of the Libxc library of density functionals, which is now used by over 50 program packages for electronic structure. We have been so far relied on Maple to generate analytical derivative expressions with symbolic math, and now with AI I have started to look into switching to a fully open source stack.

Claude has been very succesful in porting our generator to SymPy and I hope to soon be able to switch over to an open source stack that gives better and more compact code that is also more numerically stable.

However, sympy is still unusably slow for our purposes: the slowest functional expressions take a day or more to generate, and this is a huge problem for our plan to extend to richer functional families with more input parameters.

The bottleneck in our use case is the generation of expressions of up to 4th derivatives of complicated non-linear functions. Even when one could easily speed up the diff() code in sympy by a factor of 4 or so, it's not the bottleneck; the common-subexpression elimination *is*.

Our application is a case where one needs to be very careful about maintaining numerical precision. Everything must be generated in a numerically stable manner, e.g. 1-z^2 = (1-z)*(1+z). The lhs and rhs are equivalent, but the latter is more stable by an order of magnitude.

I am hoping to expand on the mathematical analysis of our engine with artificial intelligence, and may reach out to you again with other PR suggestions.

This PR is the result of letting Claude optimize the CSE in sympy, since it is thought to be the bottleneck in our application. The changes pass the tests, so they should work. The changes looked reasonable from a quick look. Feedback is welcomed, but I may or may not have Claude respond to the reviews ;) 

Anyway, I am happy to join the community; I hope that we will be able to switch over to sympy for good!

---

#### Summary of changes

Three independent, output-preserving changes (the input expression sets are
large DAGs with heavy subexpression sharing, which exposes spots where the
same immutable subexpression is reprocessed once per occurrence):

* **`core.exprtools.factor_terms`** — memoize the inner `do` recursion. It is
  a pure function of its (immutable) argument, so a subexpression shared *k*
  times was factored *k* times; caching makes each distinct subtree be
  processed once. Single-frame (no added recursion depth). Dominant win on the
  `optimizations='basic'` path.
* **`simplify.cse_main.tree_cse`** — the `ordered(...)` calls in `_rebuild`
  used the default `_nodes` sort key, which recomputes a subexpression's node
  count at every parent `Add`/`Mul`. A memoized node-count key (mirroring
  `_nodes`/`_node_count`, including the `Derivative` special case) counts each
  distinct subtree once. Ordering is unchanged.
* **`core.containers.OrderedSet`** — back it with a plain `dict`
  (insertion-ordered since Python 3.7) instead of `OrderedDict`; faster to
  build and iterate. `pop(last=False)` is handled explicitly.

**Output of `cse()` is unchanged** — verified byte-identical for both
`optimizations=[]` and `optimizations='basic'` via MD5 of the returned
replacements and reduced expressions on large inputs. No public API or
default-behavior change, and `factor_terms` is *not* made more aggressive.

A reproducible benchmark is added at `sympy/simplify/tests/bench_cse_scaling.py`
(run directly, not under pytest).

#### Timing

From `bench_cse_scaling.py` on an 8-variable PBE/meta-GGA-like functional
differentiated to high order (same machine, master vs. this branch):

| input | path | before | after | speedup |
|-------|------|-------:|------:|--------:|
| 55 509 ops | `optimizations='basic'` | 16.13 s | 3.35 s | **4.8×** |
| 572 471 ops | `optimizations=[]` | 1.173 s | 0.411 s | **2.9×** |
| 79 938 ops | `optimizations=[]` | 0.279 s | 0.123 s | **2.3×** |

Tests: `sympy/simplify/tests/test_cse.py` passes, plus a broad run across
`sympy/core/`, `integrals/test_integrals.py`, `series/test_series.py`,
`polys/test_polytools.py` and all of `sympy/simplify/` (2693 passed, 0 failed).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * `factor_terms` now memoizes over shared subexpressions, making it
    significantly faster on large expressions with repeated subtrees.
  * `OrderedSet` is now backed by a plain `dict` instead of `OrderedDict`.
* simplify
  * `cse` is significantly faster on large inputs with heavily shared
    subexpressions (its output is unchanged).
<!-- END RELEASE NOTES -->
