### PR TITLE
assumptions: add refine handler for sec and csc

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -931,6 +931,7 @@ Karan <grgkaran03@gmail.com>
 Karan Anand <anandkarancompsci@gmail.com> Karan Anand <119553199+anandkaranubc@users.noreply.github.com>
 Karan Sharma <karan1276@gmail.com>
 Karthik Chintapalli <karthik.chintapalli@students.iiit.ac.in> <karthik.chintapalli@gmail.com>
+Karthik Venugopal <kvenugop@usc.edu>
 Kartik Sethi <kartiks31416@gmail.com> Kartik Sethi <37146279+ks147@users.noreply.github.com>
 Katja Sophie Hotz <katja.sophie.hotz@student.tuwien.ac.at>
 Kaushik Varanasi <kaushik.varanasi1@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -534,6 +534,71 @@ def refine_sin_cos(expr, assumptions):
         return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
 
 
+def refine_sec_csc(expr, assumptions):
+    """
+    Handler for sec and csc functions.
+
+    Explanation
+    ===========
+
+    Since ``sec(x) == 1/cos(x)`` and ``csc(x) == 1/sin(x)``, the reciprocal
+    sin or cos function is refined with :func:`refine_sin_cos` and the result
+    is translated back into sec/csc form.  The leading factor produced by
+    :func:`refine_sin_cos` is always a power of ``-1`` and therefore its own
+    reciprocal, so only the trigonometric factor needs to be inverted.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_sec_csc
+    >>> from sympy import Symbol, Q, sec, csc, pi
+    >>> from sympy.abc import x
+    >>> n = Symbol('n')
+    >>> refine_sec_csc(sec(n*pi), Q.integer(n))
+    (-1)**n
+    >>> refine_sec_csc(csc(n*pi/2), Q.odd(n))
+    (-1)**(n/2 + 3/2)
+    >>> refine_sec_csc(sec(x + n*pi), Q.integer(n))
+    (-1)**n*sec(x)
+    >>> refine_sec_csc(csc(x + n*pi), Q.integer(n))
+    (-1)**n*csc(x)
+    >>> refine_sec_csc(sec(x + n*pi/2), Q.even(n))
+    (-1)**(n/2)*sec(x)
+    """
+    from sympy.functions.elementary.trigonometric import sin, cos, sec, csc
+    from sympy.calculus.accumulationbounds import AccumBounds
+
+    if not isinstance(expr, (sec, csc)):
+        raise TypeError("refine_sec_csc expects a sec or csc function.")
+
+    arg = expr.args[0]
+    expr_is_sec = isinstance(expr, sec)
+
+    # Refine the reciprocal sin/cos function and invert the outcome.
+    reciprocal = cos(arg) if expr_is_sec else sin(arg)
+    refined = refine_sin_cos(reciprocal, assumptions)
+
+    # refine_sin_cos may return a bare python int for the zero-argument case.
+    refined = S(refined)
+
+    if refined == reciprocal or isinstance(refined, AccumBounds):
+        return expr
+
+    # A vanishing cos/sin means the original sec/csc has a pole.
+    if refined.is_zero:
+        return S.ComplexInfinity
+
+    # The refined reciprocal is either a constant or a constant times a single
+    # sin/cos factor.  The constant is +-1, hence its own reciprocal, so only
+    # the trigonometric factor has to be turned into sec/csc.
+    coeff, trig = refined.as_independent(sin, cos)
+    if isinstance(trig, cos):
+        return coeff * sec(trig.args[0])
+    if isinstance(trig, sin):
+        return coeff * csc(trig.args[0])
+    return coeff
+
+
 def refine_Heaviside(expr, assumptions):
     """
     Handler for the Heaviside step function.
@@ -613,6 +678,8 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
+    'sec': refine_sec_csc,
+    'csc': refine_sec_csc,
     'exp': refine_exp,
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 from sympy.assumptions.ask import Q
-from sympy.assumptions.refine import refine, refine_sin_cos
+from sympy.assumptions.refine import refine, refine_sin_cos, refine_sec_csc
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.expr import Expr
-from sympy.core.numbers import (I, Rational, nan, pi)
+from sympy.core.numbers import (I, Rational, nan, pi, zoo)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin, tan)
+from sympy.functions.elementary.trigonometric import (atan, atan2, cos, csc, sec, sin, tan)
 from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
@@ -320,6 +320,58 @@ def test_sin_cos():
     raises(TypeError, lambda: refine_sin_cos(tan(x), Q.real(x)))
     raises(TypeError, lambda: refine_sin_cos(exp(x), Q.real(x)))
     raises(TypeError, lambda: refine_sin_cos(x, Q.real(x)))
+
+
+def test_sec_csc():
+    n = Symbol('n')
+    # integer multiples of pi
+    assert refine(sec(n*pi), Q.integer(n)) == (-1)**n
+    assert refine(sec(n*pi), Q.even(n)) == 1
+    assert refine(sec(n*pi), Q.odd(n)) == -1
+    assert refine(csc(n*pi/2), Q.odd(n)) == (-1)**((n + 3)/2)
+
+    # even multiples of pi/2
+    assert refine(sec(n*pi/2), Q.even(n)) == (-1)**(n/2)
+    assert refine(csc(n*pi/2), Q.odd(n) & Q.even((n - 1)/2)) == 1
+    assert refine(csc(n*pi/2), Q.odd(n) & Q.odd((n - 1)/2)) == -1
+
+    # remaining symbolic terms
+    assert refine(sec(x + n*pi), Q.integer(n)) == ((-1)**n)*sec(x)
+    assert refine(csc(x + n*pi), Q.integer(n)) == ((-1)**n)*csc(x)
+    assert refine(sec(x + n*pi), Q.even(n)) == sec(x)
+    assert refine(csc(x + n*pi), Q.even(n)) == csc(x)
+    assert refine(sec(x + n*pi), Q.odd(n)) == -sec(x)
+    assert refine(csc(x + n*pi), Q.odd(n)) == -csc(x)
+    assert refine(sec(x - n*pi), Q.even(n)) == sec(x)
+    assert refine(sec(x + n*pi/2), Q.even(n)) == ((-1)**(n/2))*sec(x)
+    assert refine(csc(x + n*pi/2), Q.even(n)) == ((-1)**(n/2))*csc(x)
+
+    # sec/csc swap when the shift is an odd multiple of pi/2
+    assert refine(sec(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 1)/2))*csc(x)
+    assert refine(csc(x + n*pi/2), Q.odd(n)) == ((-1)**((n + 3)/2))*sec(x)
+
+    # zero argument
+    assert refine(sec(x), Q.zero(x)) == 1
+    assert refine(csc(x + n*pi), Q.zero(n)) == csc(x)
+
+    # poles of sec/csc
+    assert refine(sec(n*pi/2), Q.odd(n)) is zoo
+    assert refine(csc(n*pi), Q.integer(n)) is zoo
+
+    # infinite argument is left untouched
+    assert refine(sec(x), Q.infinite(x) & Q.extended_real(x)) == sec(x)
+    assert refine(csc(x), Q.infinite(x) & Q.extended_real(x)) == csc(x)
+
+    # cases that should not simplify
+    assert refine(sec(x + n*pi), True) == sec(x + n*pi)
+    assert refine(csc(x), True) == csc(x)
+    assert refine(sec(x), Q.real(x)) == sec(x)
+    assert refine(sec(x + n*pi/2), Q.integer(n)) == sec(x + n*pi/2)
+    assert refine(csc(x + n*pi/2), Q.integer(n)) == csc(x + n*pi/2)
+
+    raises(TypeError, lambda: refine_sec_csc(tan(x), Q.real(x)))
+    raises(TypeError, lambda: refine_sec_csc(sin(x), Q.real(x)))
+    raises(TypeError, lambda: refine_sec_csc(x, Q.real(x)))
 
 
 def test_floor_ceiling():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #27888

#### Brief description of what is fixed or changed

Adds a refine handler `refine_sec_csc` for the `sec` and `csc` functions in
`sympy/assumptions/refine.py`, registered in `handlers_dict` for both. These
functions previously had no refine handler. The handler refines the reciprocal
`cos`/`sin` using the existing `refine_sin_cos` and converts the result back
into sec/csc form (the leading sign factor is a power of `-1`, so it is its own
reciprocal). Poles, where the refined reciprocal is zero, return `zoo`. Tests
are added in `sympy/assumptions/tests/test_refine.py`.

#### Other comments

This is my first contribution to SymPy.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

This patch was developed with substantial assistance from an AI tool (Claude /
Claude Code). The `refine_sec_csc` implementation in
`sympy/assumptions/refine.py`, the `test_sec_csc` tests in
`sympy/assumptions/tests/test_refine.py`, and the initial draft of this
description were AI-generated under my direction. I have reviewed the patch,
understand the implementation and the underlying mathematics, and can explain
and defend it myself.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added refine handlers for `sec` and `csc` (`refine_sec_csc`).
<!-- END RELEASE NOTES -->