### PR TITLE
perf(diff): avoid redundant traversals in Derivative.__new__

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1614,6 +1614,7 @@ Suraj Channappanavar <surajchannappanavar@gmail.com> Suraj Channappanavar <14525
 Suraj Channappanavar <surajchannappanavar@gmail.com> suraj channappanavar <surajchannappanavar@MacBook-Pro.local>
 Suryam Arnav Kalra <suryamkalra35@gmail.com> suryam35 <suryamkalra35@gmail.com>
 Sushant Hiray <hiraysushant@gmail.com>
+Susi Lehtola <susi.lehtola@gmail.com> <susi.lehtola@alumni.helsinki.fi>
 Susumu Ishizuka <susumu.ishizuka@kii.com>
 Swapnil Agarwal <swapnilag29@gmail.com>
 Szymon Mieszczak <szymon.mieszczak@gmail.com>

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1380,6 +1380,11 @@ class Derivative(Expr):
         if evaluate:
             if isinstance(expr, Derivative):
                 expr = expr.canonical
+                free = expr.free_symbols
+            else:
+                # expr is unchanged since __new__ computed its free_symbols
+                # above, so reuse that set rather than traversing again.
+                free = symbols_or_none
             variable_count = [
                 (v.canonical if isinstance(v, Derivative) else v, c)
                 for v, c in variable_count]
@@ -1389,7 +1394,6 @@ class Derivative(Expr):
             # Derivatives as those can be created by intermediate
             # derivatives.
             zero = False
-            free = expr.free_symbols
             from sympy.matrices.expressions.matexpr import MatrixExpr, MatrixElement
 
             for v, c in variable_count:
@@ -1496,9 +1500,13 @@ class Derivative(Expr):
             expr = obj
 
         # what we have so far can be made canonical
-        expr = expr.replace(
-            lambda x: isinstance(x, Derivative),
-            lambda x: x.canonical)
+        # (only walk/rebuild the tree if it actually contains a
+        # Derivative subexpression; for fully evaluated derivatives of
+        # elementary expressions this avoids a full traversal+rebuild)
+        if expr.has(Derivative):
+            expr = expr.replace(
+                lambda x: isinstance(x, Derivative),
+                lambda x: x.canonical)
 
         if unhandled:
             if isinstance(expr, Derivative):


### PR DESCRIPTION
Hi again! This is a small, self-contained performance follow-up to #29946,
split out as its own PR as requested. It speeds up `diff()` for large
elementary expressions, which is the other half of the bottleneck I hit while
generating high-order derivatives for Libxc's density-functional code
generator.

#### References to other Issues or PRs

Companion to #29946 (CSE performance). Independent — touches only
`Derivative.__new__`.

#### Brief description of what is fixed or changed

Two output-preserving optimizations in `sympy/core/function.py`,
`Derivative.__new__`:

1. **Reuse the already-computed `free_symbols` set.** At the top of `__new__`,
   `symbols_or_none = getattr(expr, "free_symbols", None)` is computed (and
   guaranteed to be a `set`). The `evaluate` branch then recomputed
   `expr.free_symbols` a second time. `expr` is unchanged there unless it is
   itself a `Derivative` (handled separately via `expr.canonical`), so the set
   is identical — we now reuse `symbols_or_none` and only recompute in the
   `Derivative` case. `free_symbols` is a full recursive traversal, so this
   removes a second walk of the entire expression.

2. **Guard the final canonicalizing `replace`.** `__new__` ends with
   ```python
   expr = expr.replace(lambda x: isinstance(x, Derivative),
                       lambda x: x.canonical)
   ```
   For a fully evaluated derivative of an elementary expression there are no
   `Derivative` subexpressions, so `replace` walks and rebuilds the whole tree
   only to return an identical object. Gating it on `expr.has(Derivative)`
   skips that traversal + rebuild in the common case.

**No change to results** — this is purely a performance change. Verified
byte-identical output on differentiation workloads.

#### Timing

Differentiating an 8-variable PBE/meta-GGA-like functional to 3rd order
(399 derivative expressions), same machine, `origin/master` vs. this branch:

| | run 1 | run 2 |
|---|------:|------:|
| before (master) | 25.65 s | 25.50 s |
| after (this PR)  | 19.57 s | 17.86 s |

≈ **1.4×** faster (~30%). The win grows with expression size and depth, since
both changes remove a full traversal of the expression tree.

#### Other comments

`Derivative.__new__` is exercised by essentially the whole test suite; the
core function/arith/args tests pass locally, and CI runs the full matrix.

**Note on `.mailmap`:** this PR adds a `.mailmap` entry for me (new
contributor), and so does its companion #29946 — the *same* one line. Whichever
of the two merges second will hit a trivial one-line conflict/duplicate on that
entry; it can simply be dropped from the second merge. The `.mailmap` change is
in its own commit here to make that easy.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * `Derivative` (and hence `diff`) is faster for large expressions: redundant
    `free_symbols` recomputation and an unnecessary full-tree `replace` are
    avoided in `Derivative.__new__`. Its output is unchanged.
<!-- END RELEASE NOTES -->

