### PR TITLE
Add type casts in quaternion.py to fix pyright inference (#28806)

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, cast, overload
 
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
@@ -459,9 +459,9 @@ class Quaternion(Expr):
         qk = cls.from_axis_angle(e[k], angles[2])
 
         if extrinsic:
-            return trigsimp(qk * qj * qi)
+            return cast(Quaternion, trigsimp(qk * qj * qi))
         else:
-            return trigsimp(qi * qj * qk)
+            return cast(Quaternion, trigsimp(qi * qj * qk))
 
     def to_euler(self, seq: str,
                        angle_addition: bool = True,
@@ -723,7 +723,7 @@ class Quaternion(Expr):
         return self * sympify(other)**-1
 
     def __rtruediv__(self, other: SExpr) -> Quaternion:
-        return sympify(other) * self**-1
+        return cast(Quaternion, sympify(other) * self**-1)
 
     def _eval_Integral(self, *args) -> Quaternion:
         return self.integrate(*args)
@@ -1227,14 +1227,14 @@ class Quaternion(Expr):
             q = q * -1
 
         q = q.normalize()
-        angle = trigsimp(2 * acos(q.a))
+        angle = cast(Expr, trigsimp(2 * acos(q.a)))
 
         # Since quaternion is normalised, q.a is less than 1.
         s = sqrt(1 - q.a*q.a)
 
-        x = trigsimp(q.b / s)
-        y = trigsimp(q.c / s)
-        z = trigsimp(q.d / s)
+        x = cast(Expr, trigsimp(q.b / s))
+        y = cast(Expr, trigsimp(q.c / s))
+        z = cast(Expr, trigsimp(q.d / s))
 
         v = (x, y, z)
         t = (v, angle)
@@ -1698,7 +1698,7 @@ class Quaternion(Expr):
         norm
 
         """
-        return self.norm() * self.axis()
+        return cast(Quaternion, self.norm() * self.axis())
 
     def mensor(self) -> Expr:
         """


### PR DESCRIPTION
#### References to other Issues or PRs

See #28806


#### Brief description of what is fixed or changed

Added `typing.cast` to the return values of `trigsimp` and `sympify` in `sympy/algebras/quaternion.py` to fix Pyright type inference errors where the return types were incorrectly inferred as `Any` or `Expr` instead of `Quaternion`. 


#### Other comments

Both `mypy` and `pyright` now pass with 0 errors on `quaternion.py`. The unit tests in `pytest sympy/algebras/tests/test_quaternion.py` continue to pass successfully.


#### AI Generation Disclosure

An AI coding assistant (Google Gemini) was used to help me set up the workspace, run Pyright, and generate the 5 `typing.cast` lines added in `sympy/algebras/quaternion.py`. 


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
