### PR TITLE
typing: add type annotations to series/acceleration.py

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -762,6 +762,7 @@ HeeJae Chang <hechang@microsoft.com>
 Heiner Kirchhoffer <Heiner.Kirchhoffer@gmail.com> <kirchhoffer@ipam040138mbp.local>
 Henrik Johansson <henjo2006@gmail.com>
 Henrique Soares <henrique.c.soares@tecnico.ulisboa.pt>
+Henry <henrybrewer00@gmail.com>
 Henry Gebhardt <hsggebhardt@gmail.com>
 Henry Metlov <genrih.metlov@gmail.com>
 Himanshu <hs80941@gmail.com>

--- a/sympy/series/acceleration.py
+++ b/sympy/series/acceleration.py
@@ -10,12 +10,18 @@ extrapolation: pp. 375-377.)
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sympy.core.numbers import Integer
 from sympy.core.singleton import S
 from sympy.functions.combinatorial.factorials import factorial
 
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
+    from sympy.core.symbol import Symbol
 
-def richardson(A, k, n, N):
+
+def richardson(A: Expr, k: Symbol, n: int, N: int) -> Expr:
     """
     Calculate an approximation for lim k->oo A(k) using Richardson
     extrapolation with the terms A(n), A(n+1), ..., A(n+N+1).
@@ -69,7 +75,7 @@ def richardson(A, k, n, N):
     return s
 
 
-def shanks(A, k, n, m=1):
+def shanks(A: Expr, k: Symbol, n: int, m: int = 1) -> Expr:
     """
     Calculate an approximation for lim k->oo A(k) using the n-term Shanks
     transformation S(A)(n). With m > 1, calculate the m-fold recursive


### PR DESCRIPTION
#### References to other Issues or PRs

Issue: https://github.com/sympy/sympy/issues/28806

#### Brief description of what is fixed or changed

Adds type annotations to the two public functions in `sympy/series/acceleration.py`, `richardson` and `shanks`. Both take a SymPy expression `A`, a substitution symbol `k`, integer indices, and return an expression, so the signatures are `(A: Expr, k: Symbol, n: int, N: int) -> Expr` and `(A: Expr, k: Symbol, n: int, m: int = 1) -> Expr`. This is a typing-only change with no behavior change.

#### Other comments

Verified with `# pyright: strict` temporarily added to the file. With the annotations in place pyright infers the return value of both functions as `Expr`, and `reveal_type` on the local variables inside the bodies resolves correctly. The only two remaining strict errors come from `Basic.doit`, whose `**hints` parameter is untyped; that is pre-existing and out of scope here.

`mypy sympy` reports no new errors from this change, and `python -m pytest sympy/series/tests/test_series.py` passes (40 passed). The doctests in the file also pass with `sympy.doctest`.

#### AI Generation Disclosure

AI assistance was used while writing this patch. The type annotations on the two function signatures (the `Expr`/`Symbol`/`int` hints and the two new imports) were drafted with the help of an AI coding assistant. I reviewed and verified the types myself by running pyright in strict mode, checking `reveal_type` of the locals and return values, and running mypy and the test/doctest suite. This PR description was written by me, not generated by AI.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
