### PR TITLE
Assumptions: add refine handler for conjugate

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -895,6 +895,7 @@ Jonathan Miller <jdmiller93@gmail.com>
 Jonathan Warner <warnerjon12@gmail.com>
 Jonty16117 <jonty@DESKTOP-J1O6ANP.localdomain>
 Jorge E. Cardona <jorgeecardona@gmail.com>
+Jorge García Martínez <jorubix@proton.me> Jorge Garcia Martinez <jorubix@proton.me>
 Jorn Baayen <jorn.baayen@gmail.com>
 Jose M. Gomez <chemoki@gmail.com> jmgc <chemoki@gmail.com>
 Joseph Dougherty <Github@JWDougherty.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -343,6 +343,28 @@ def refine_im(expr, assumptions):
         return - S.ImaginaryUnit * arg
     return _refine_reim(expr, assumptions)
 
+def refine_conjugate(expr, assumptions):
+    """
+    Handler for complex conjugate.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_conjugate
+    >>> from sympy import Q, conjugate
+    >>> from sympy.abc import x
+    >>> refine_conjugate(conjugate(x), Q.real(x))
+    x
+    >>> refine_conjugate(conjugate(x), Q.imaginary(x))
+    -x
+    """
+    arg = expr.args[0]
+    if ask(Q.real(arg), assumptions):
+        return arg
+    if ask(Q.imaginary(arg), assumptions):
+        return -arg
+    return None
+
 def refine_arg(expr, assumptions):
     """
     Handler for complex argument
@@ -617,4 +639,5 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
+    'conjugate': refine_conjugate,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -362,4 +362,3 @@ def test_conjugate():
     assert refine(conjugate(x), Q.imaginary(x)) == -x
     assert refine(conjugate(x)) == conjugate(x)
 
-

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -361,5 +361,5 @@ def test_conjugate():
     assert refine(conjugate(x), Q.real(x)) == x
     assert refine(conjugate(x), Q.imaginary(x)) == -x
     assert refine(conjugate(x)) == conjugate(x)
-    
+
 

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -361,4 +361,3 @@ def test_conjugate():
     assert refine(conjugate(x), Q.real(x)) == x
     assert refine(conjugate(x), Q.imaginary(x)) == -x
     assert refine(conjugate(x)) == conjugate(x)
-

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -362,3 +362,4 @@ def test_conjugate():
     assert refine(conjugate(x), Q.imaginary(x)) == -x
     assert refine(conjugate(x)) == conjugate(x)
     
+

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -361,3 +361,4 @@ def test_conjugate():
     assert refine(conjugate(x), Q.real(x)) == x
     assert refine(conjugate(x), Q.imaginary(x)) == -x
     assert refine(conjugate(x)) == conjugate(x)
+    

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -6,7 +6,7 @@ from sympy.core.expr import Expr
 from sympy.core.numbers import (I, Rational, nan, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
-from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
+from sympy.functions.elementary.complexes import (Abs, arg, conjugate, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin, tan)
@@ -354,3 +354,10 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+
+def test_conjugate():
+    x = Symbol('x')
+    assert refine(conjugate(x), Q.real(x)) == x
+    assert refine(conjugate(x), Q.imaginary(x)) == -x
+    assert refine(conjugate(x)) == conjugate(x)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
See #27888

#### Brief description of what is fixed or changed
Added a refine handler for `conjugate` function and the adequate tests in `test_refine.py`. It simplifies `conjugate(x)` to `x` when `x` is assumed to be real, and to `-x` when its imaginary. 

#### Other comments
This is my first open source contribution, so any feedback would be much appreciated!

#### AI Generation Disclosure
Used Gemini to navigate the Sympy codebase, no lines of code were written by AI
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added refine handler for conjugate.
<!-- END RELEASE NOTES -->
