### PR TITLE
[GSoC] refactor `ask` by removing all instances of `context`

### DIFF
--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -7,6 +7,7 @@ from sympy.assumptions.cnf import CNF, EncodedCNF, Literal
 from sympy.core import sympify
 from sympy.core.kind import BooleanKind
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
+from sympy.logic.boolalg import And
 from sympy.logic.inference import satisfiable
 from sympy.logic.boolalg import And
 from sympy.utilities.decorator import memoize_property
@@ -539,17 +540,18 @@ def ask(proposition, assumptions=True, context=global_assumptions):
         return res
 
     # direct resolution method, no logic
-    res = key(*args)._eval_ask(assumptions)
+    combined_assumptions = And(assumptions, *context)
+    res = key(*args)._eval_ask(combined_assumptions)
     if res is not None:
         return bool(res)
 
     # using satask (still costly)
-    res = satask(proposition, assumptions=assumptions)
+    res = satask(proposition, assumptions=assump_cnf)
     if res is not None:
         return res
 
     try:
-        res = lra_satask(proposition, assumptions=assumptions)
+        res = lra_satask(proposition, assumptions=assump_cnf)
     except UnhandledInput:
         return None
 

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -9,7 +9,6 @@ from sympy.core.kind import BooleanKind
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
 from sympy.logic.boolalg import And
 from sympy.logic.inference import satisfiable
-from sympy.logic.boolalg import And
 from sympy.utilities.decorator import memoize_property
 
 
@@ -540,18 +539,17 @@ def ask(proposition, assumptions=True, context=global_assumptions):
         return res
 
     # direct resolution method, no logic
-    combined_assumptions = And(assumptions, *context)
-    res = key(*args)._eval_ask(combined_assumptions)
+    res = key(*args)._eval_ask(assumptions)
     if res is not None:
         return bool(res)
 
     # using satask (still costly)
-    res = satask(proposition, assumptions=assump_cnf)
+    res = satask(proposition, assumptions=assumptions)
     if res is not None:
         return res
 
     try:
-        res = lra_satask(proposition, assumptions=assump_cnf)
+        res = lra_satask(proposition, assumptions=assumptions)
     except UnhandledInput:
         return None
 

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -7,8 +7,8 @@ from sympy.assumptions.cnf import CNF, EncodedCNF, Literal
 from sympy.core import sympify
 from sympy.core.kind import BooleanKind
 from sympy.core.relational import Eq, Ne, Gt, Lt, Ge, Le
-from sympy.logic.boolalg import And
 from sympy.logic.inference import satisfiable
+from sympy.logic.boolalg import And
 from sympy.utilities.decorator import memoize_property
 
 

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.assumptions.ask import Q
 from sympy.logic.inference import satisfiable

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -23,10 +23,7 @@ def lra_satask(proposition, assumptions=True):
     props = CNF.from_prop(proposition)
     _props = CNF.from_prop(~proposition)
 
-    if isinstance(assumptions, CNF):
-        cnf = assumptions
-    else:
-        cnf = CNF.from_prop(assumptions)
+    cnf = CNF.from_prop(assumptions)
     assumptions = EncodedCNF()
     assumptions.from_cnf(cnf)
 

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from sympy.assumptions.assume import global_assumptions
+
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.assumptions.ask import Q
 from sympy.logic.inference import satisfiable
@@ -11,7 +11,7 @@ from sympy.core.mul import Mul
 from sympy.core.singleton import S
 
 
-def lra_satask(proposition, assumptions=True, context=global_assumptions):
+def lra_satask(proposition, assumptions=True):
     """
     Function to evaluate the proposition with assumptions using SAT algorithm
     in conjunction with an Linear Real Arithmetic theory solver.
@@ -26,12 +26,6 @@ def lra_satask(proposition, assumptions=True, context=global_assumptions):
     cnf = CNF.from_prop(assumptions)
     assumptions = EncodedCNF()
     assumptions.from_cnf(cnf)
-
-    context_cnf = CNF()
-    if context:
-        context_cnf = context_cnf.extend(context)
-
-    assumptions.add_from_cnf(context_cnf)
 
     return check_satisfiability(props, _props, assumptions)
 

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -23,7 +23,10 @@ def lra_satask(proposition, assumptions=True):
     props = CNF.from_prop(proposition)
     _props = CNF.from_prop(~proposition)
 
-    cnf = CNF.from_prop(assumptions)
+    if isinstance(assumptions, CNF):
+        cnf = assumptions
+    else:
+        cnf = CNF.from_prop(assumptions)
     assumptions = EncodedCNF()
     assumptions.from_cnf(cnf)
 

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -7,7 +7,7 @@ from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.kind import NumberKind, UndefinedKind
 from sympy.assumptions.ask_generated import get_all_known_matrix_facts, get_all_known_number_facts
-from sympy.assumptions.assume import global_assumptions, AppliedPredicate
+from sympy.assumptions.assume import AppliedPredicate
 from sympy.assumptions.sathandlers import class_fact_registry
 from sympy.core import oo
 from sympy.logic.inference import satisfiable
@@ -15,8 +15,7 @@ from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.matrices.kind import MatrixKind
 
 
-def satask(proposition, assumptions=True, context=global_assumptions,
-        use_known_facts=True, iterations=oo):
+def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
     """
     Function to evaluate the proposition with assumptions using SAT algorithm.
 
@@ -37,10 +36,6 @@ def satask(proposition, assumptions=True, context=global_assumptions,
 
     assumptions : Any boolean expression, optional.
         Local assumptions to evaluate the *proposition*.
-
-    context : AssumptionsContext, optional.
-        Default assumptions to evaluate the *proposition*. By default,
-        this is ``sympy.assumptions.global_assumptions`` variable.
 
     use_known_facts : bool, optional.
         If ``True``, facts from ``sympy.assumptions.ask_generated``
@@ -70,15 +65,9 @@ def satask(proposition, assumptions=True, context=global_assumptions,
 
     assumptions = CNF.from_prop(assumptions)
 
-    context_cnf = CNF()
-    if context:
-        context_cnf = context_cnf.extend(context)
-
-    sat = get_all_relevant_facts(props, assumptions, context_cnf,
+    sat = get_all_relevant_facts(props, assumptions,
         use_known_facts=use_known_facts, iterations=iterations)
     sat.add_from_cnf(assumptions)
-    if context:
-        sat.add_from_cnf(context_cnf)
 
     return check_satisfiability(props, _props, sat)
 
@@ -107,7 +96,7 @@ def check_satisfiability(prop, _prop, factbase):
         raise ValueError("Inconsistent assumptions")
 
 
-def extract_predargs(proposition, assumptions=None, context=None):
+def extract_predargs(proposition, assumptions=None):
     """
     Extract every expression in the argument of predicates from *proposition*,
     *assumptions* and *context*.
@@ -118,9 +107,6 @@ def extract_predargs(proposition, assumptions=None, context=None):
     proposition : sympy.assumptions.cnf.CNF
 
     assumptions : sympy.assumptions.cnf.CNF, optional.
-
-    context : sympy.assumptions.cnf.CNF, optional.
-        CNF generated from assumptions context.
 
     Examples
     ========
@@ -141,8 +127,6 @@ def extract_predargs(proposition, assumptions=None, context=None):
     lkeys = set()
     if assumptions:
         lkeys |= assumptions.all_predicates()
-    if context:
-        lkeys |= context.all_predicates()
 
     lkeys = lkeys - {S.true, S.false}
     tmp_keys = None
@@ -267,7 +251,7 @@ def get_relevant_clsfacts(exprs, relevant_facts=None):
     return newexprs - exprs, relevant_facts
 
 
-def get_all_relevant_facts(proposition, assumptions, context,
+def get_all_relevant_facts(proposition, assumptions,
         use_known_facts=True, iterations=oo):
     """
     Extract all relevant facts from *proposition* and *assumptions*.
@@ -284,9 +268,6 @@ def get_all_relevant_facts(proposition, assumptions, context,
 
     assumptions : sympy.assumptions.cnf.CNF
         CNF generated from assumption expression.
-
-    context : sympy.assumptions.cnf.CNF
-        CNF generated from assumptions context.
 
     use_known_facts : bool, optional.
         If ``True``, facts from ``sympy.assumptions.ask_generated``
@@ -310,8 +291,7 @@ def get_all_relevant_facts(proposition, assumptions, context,
     >>> from sympy.abc import x, y
     >>> props = CNF.from_prop(Q.nonzero(x*y))
     >>> assump = CNF.from_prop(Q.nonzero(x))
-    >>> context = CNF.from_prop(Q.nonzero(y))
-    >>> get_all_relevant_facts(props, assump, context) #doctest: +SKIP
+    >>> get_all_relevant_facts(props, assump) #doctest: +SKIP
     <sympy.assumptions.cnf.EncodedCNF at 0x7f09faa6ccd0>
 
     """
@@ -324,7 +304,7 @@ def get_all_relevant_facts(proposition, assumptions, context,
     all_exprs = set()
     while True:
         if i == 0:
-            exprs = extract_predargs(proposition, assumptions, context)
+            exprs = extract_predargs(proposition, assumptions)
         all_exprs |= exprs
         exprs, relevant_facts = get_relevant_clsfacts(exprs, relevant_facts)
         i += 1

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -63,8 +63,7 @@ def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
     props = CNF.from_prop(proposition)
     _props = CNF.from_prop(~proposition)
 
-    if not isinstance(assumptions, CNF):
-        assumptions = CNF.from_prop(assumptions)
+    assumptions = CNF.from_prop(assumptions)
 
     sat = get_all_relevant_facts(props, assumptions,
         use_known_facts=use_known_facts, iterations=iterations)

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -63,7 +63,8 @@ def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
     props = CNF.from_prop(proposition)
     _props = CNF.from_prop(~proposition)
 
-    assumptions = CNF.from_prop(assumptions)
+    if not isinstance(assumptions, CNF):
+        assumptions = CNF.from_prop(assumptions)
 
     sat = get_all_relevant_facts(props, assumptions,
         use_known_facts=use_known_facts, iterations=iterations)

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 from sympy.assumptions.ask import Q
-from sympy.assumptions.assume import assuming, global_assumptions
 from sympy.core.numbers import (I, pi, E)
 from sympy.core.relational import (Eq, Gt)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols, Dummy
 from sympy.functions.elementary.complexes import Abs
-from sympy.logic.boolalg import Implies, And
+from sympy.logic.boolalg import Implies
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.assumptions.cnf import CNF, Literal
 from sympy.assumptions.satask import (satask, extract_predargs,
@@ -31,13 +30,6 @@ def test_satask():
     assert satask(Q.positive(x), ~Q.real(x)) is False
 
     raises(ValueError, lambda: satask(Q.real(x), Q.real(x) & ~Q.real(x)))
-
-    with assuming(Q.positive(x)):
-        context_assump = And(*global_assumptions)
-        assert satask(Q.real(x), context_assump) is True
-        assert satask(~Q.positive(x), context_assump) is False
-        raises(ValueError,
-               lambda: satask(Q.real(x), And(~Q.positive(x), context_assump)))
 
     assert satask(Q.zero(x), Q.nonzero(x)) is False
     assert satask(Q.positive(x), Q.zero(x)) is False

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 from sympy.assumptions.ask import Q
-from sympy.assumptions.assume import assuming
+from sympy.assumptions.assume import assuming, global_assumptions
 from sympy.core.numbers import (I, pi, E)
 from sympy.core.relational import (Eq, Gt)
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols, Dummy
 from sympy.functions.elementary.complexes import Abs
-from sympy.logic.boolalg import Implies
+from sympy.logic.boolalg import Implies, And
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.assumptions.cnf import CNF, Literal
 from sympy.assumptions.satask import (satask, extract_predargs,
@@ -33,9 +33,11 @@ def test_satask():
     raises(ValueError, lambda: satask(Q.real(x), Q.real(x) & ~Q.real(x)))
 
     with assuming(Q.positive(x)):
-        assert satask(Q.real(x)) is True
-        assert satask(~Q.positive(x)) is False
-        raises(ValueError, lambda: satask(Q.real(x), ~Q.positive(x)))
+        context_assump = And(*global_assumptions)
+        assert satask(Q.real(x), context_assump) is True
+        assert satask(~Q.positive(x), context_assump) is False
+        raises(ValueError,
+               lambda: satask(Q.real(x), And(~Q.positive(x), context_assump)))
 
     assert satask(Q.zero(x), Q.nonzero(x)) is False
     assert satask(Q.positive(x), Q.zero(x)) is False

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -364,7 +364,8 @@ def test_extract_predargs():
     context = CNF.from_prop(Q.zero(y))
     assert extract_predargs(props) == {Abs(x*y), x*y}
     assert extract_predargs(props, assump) == {Abs(x*y), x*y, x}
-    assert extract_predargs(props, assump, context) == {Abs(x*y), x*y, x, y}
+    assump.add_clauses(context.clauses)
+    assert extract_predargs(props, assump) == {Abs(x*y), x*y, x, y}
 
     props = CNF.from_prop(Eq(x, y))
     assump = CNF.from_prop(Gt(y, z))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Refactored `ask`, `satask` and `lra_satask` to remove all instances of `context` to speed up ask. This PR is a further improvement to #29921 by removing redundancy.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
