### PR TITLE
[GSoC] manualintegrate: combine exponenetials of the form f(x) * k^(a*x²) * k^(b*x)

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2665,7 +2665,6 @@ def integral_steps(integrand, symbol, **options):
                         null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
                         null_safe(sqrt_quadratic_rule),
                         null_safe(sqrt_fractional_linear_rule),
-                        null_safe(combine_power_rule),
                         null_safe(trig_cmplx_exp_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,
@@ -2686,6 +2685,9 @@ def integral_steps(integrand, symbol, **options):
                 condition(
                     integral_is_subclass(Mul, Pow),
                     cancel_rule),
+                condition(
+                    integral_is_subclass(Mul),
+                    combine_power_rule),
                 condition(
                     integral_is_subclass(Mul, log,
                     *inverse_trig_functions),

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1383,7 +1383,7 @@ def exp_rule(integral):
         return ExpRule(integrand, symbol, E, integrand.args[0])
 
 
-def powsimp_rule(integral):
+def combine_power_rule(integral):
     """
     Strategy that simplifies the exponent of a power.
     exp(a*x**2) * exp(b*x) -> exp((a*x**2 + b*x))
@@ -1393,8 +1393,9 @@ def powsimp_rule(integral):
     a = Wild('a', exclude=[symbol])
     b = Wild('b', exclude=[symbol])
     k = Wild('k', exclude=[symbol])
+    rest = Wild('rest')
 
-    match = integrand.match(k**(a*symbol**2) * k**(b*symbol))
+    match = integrand.match(rest * k**(a*symbol**2) * k**(b*symbol))
 
     if not match:
         return
@@ -2664,7 +2665,7 @@ def integral_steps(integrand, symbol, **options):
                         null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
                         null_safe(sqrt_quadratic_rule),
                         null_safe(sqrt_fractional_linear_rule),
-                        null_safe(powsimp_rule),
+                        null_safe(combine_power_rule),
                         null_safe(trig_cmplx_exp_rule)),
             Derivative: derivative_rule,
             TrigonometricFunction: trig_rule,

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2236,3 +2236,10 @@ def test_issue_15566():
     assert isinstance(result, Piecewise)
 
     assert result.has(erf)
+
+def test_issue_29909():
+    f = x*exp(x)*erf(x)
+    F = x*exp(x)*erf(x) - exp(x)*erf(x) + exp(x)*exp(-x**2)/sqrt(pi) + exp(Rational(1, 4))*erf(x - Rational(1, 2))/2
+
+    assert integrate(f, x) == F
+    assert F.diff(x).equals(f)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -300,6 +300,9 @@ def test_manualintegrate_special():
     assert_is_integral_of(f, F)
     f, F = sqrt(4 + 9*sin(x)**2), 2*elliptic_e(x, Rational(-9, 4))
     assert_is_integral_of(f, F)
+    f = erf(x)*exp(x)*x
+    F = (x*exp(x) - exp(x))*erf(x) - 2*(-sqrt(pi)*exp(1/4)*erf(x - 1/2)/2 + Integral(x*exp(-x**2 + x), x))/sqrt(pi)
+    assert_is_integral_of(f, F)
 
 
 @slow

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -4,6 +4,7 @@ from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.relational import Ne, Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
+from sympy.core.mul import Mul
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.hyperbolic import (asinh, csch, cosh, coth, sech, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -300,8 +301,8 @@ def test_manualintegrate_special():
     assert_is_integral_of(f, F)
     f, F = sqrt(4 + 9*sin(x)**2), 2*elliptic_e(x, Rational(-9, 4))
     assert_is_integral_of(f, F)
-    f = erf(x)*exp(x)*x
-    F = (x*exp(x) - exp(x))*erf(x) - 2*(-sqrt(pi)*exp(1/4)*erf(x - 1/2)/2 + Integral(x*exp(-x**2 + x), x))/sqrt(pi)
+    f = x*exp(x)*erf(x)
+    F = (x*exp(x) - exp(x))*erf(x) - Mul(2, -sqrt(pi)*exp(Rational(1,4))*erf(x - Rational(1,2))*Rational(1,2) + Integral(x*exp(-x**2 + x), x), evaluate=False)/sqrt(pi)
     assert_is_integral_of(f, F)
 
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #29909

#### Brief description of what is fixed or changed
`integrate(x*exp(x)*erf(x))` returned unevaluated because `heurisch`, which handles the residual subintegral `x*exp(x)*exp(-x**2)`, could not recognise `exp(-x**2)*exp(x)` as `exp(-x**2 + x)` and therefore failed to apply the Gaussian integral identity. The fix improves preprocessing step in manualintegrate that rewrites products of the form f(x) * k^(a*x² + b*x) by combining exponents before the expression is returned to `heurisch`, letting the existing machinery see a single exponential factor and allowing `heurisch` to resolve it correctly.

Before:

```python
In [1]: integrate(erf(x)*exp(x)*x, x)
Out[1]:
⌠
⎮    x
⎮ x⋅ℯ ⋅erf(x) dx
⌡

In [2]:
```

After:

```python
In [1]: integrate(erf(x)*exp(x)*x, x)
Out[1]: 
                                2                    
                           x  -x     1/4             
   x           x          ℯ ⋅ℯ      ℯ   ⋅erf(x - 1/2)
x⋅ℯ ⋅erf(x) - ℯ ⋅erf(x) + ─────── + ─────────────────
                            √π              2        

In [2]: 
```

#### Other comments

There could be introduced an approach purely using `manualintegrate` if it could preform completing the square in the exponent then use u-sub. Similar to the following,

<img width="814" height="1988" alt="image" src="https://github.com/user-attachments/assets/b811271e-c00e-48d4-b5c8-584afa93ac6c" />

However, I could not figure how to carry out this in `manualintegrate`.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * add support for product of a error special function, an exponential, and a polynomial integrands e.g. `erf(x)*exp(x)*x`
<!-- END RELEASE NOTES -->
