### PR TITLE
ENH: assumptions: lra_theory: Improve Preprocessing

### DIFF
--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -841,7 +841,7 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
 
     order_pos = {v: i for i, v in enumerate(sorted_col_order)}
     # every basic should have -1 coefficent by convention, and rref gives 1 coeff.
-    # to all the basic variables.
+    # to all the basic variables. So we have to negative B.
     A = -B[keep_rows, [order_pos[v] for v in new_nonbasic + new_basic]]
     if testing_mode:
         # all the nonaotm_vars should be removed

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -832,9 +832,9 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
     # Basic vars are also in the form of block matrix -I_m and the rank of that identity
     # matrix makes so that we never touch kept_nonbasic block matrix
     sorted_col_order = list(nonatom_vars) + basic + kept_nonbasic
-    col_of_nonsorted = {v: i for i, v in enumerate(nonbasic + basic)}
+    var_to_col_orig = {v: i for i, v in enumerate(nonbasic + basic)}
     # reorder the columns of A by the list sorted_col_order
-    A = A[:, [col_of_nonsorted[v] for v in sorted_col_order]]
+    A = A[:, [var_to_col_orig[v] for v in sorted_col_order]]
 
     B, pivots = A.rref()
 
@@ -843,10 +843,10 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
     basic_set = set(new_basic)
     new_nonbasic = [v for v in kept_nonbasic + basic if v not in basic_set]
 
-    col_of_sorted = {v: i for i, v in enumerate(sorted_col_order)}
+    var_to_col_sorted = {v: i for i, v in enumerate(sorted_col_order)}
     # every basic should have -1 coefficent by convention, and rref gives 1 coeff.
     # to all the basic variables. So we have to negative B.
-    A = -B[keep_rows, [col_of_sorted[v] for v in new_nonbasic + new_basic]]
+    A = -B[keep_rows, [var_to_col_sorted[v] for v in new_nonbasic + new_basic]]
     if testing_mode:
         # all the nonaotm_vars should be removed
         assert set(nonatom_vars).isdisjoint(new_basic + new_nonbasic)

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -740,13 +740,26 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
 
     Therefore, any information about dependent, or to be more precise, non atom variables
     in the matrix A is not necessary and can be safely discarded without any correctness worries.
-
     E.g in,
-
         x >= 0 & x+y >= 1 -> Phi' := (x >= 0 & s1 >= 1), Phi_A := x + y = s1
-
     Since y is dependent, solving Phi' alone is enough, and _reduce_matrix should reduce Phi_A
     into collapsed matrix since it stores no useful information.
+
+    Returns
+    =======
+
+    (A, basic, nonbasic)
+
+    A : Matrix
+        The reduced tableau with every variable in nonatom_vars removed.
+        Has one row per new basic variable and one column per new basic + nonbasic
+        variables. In case of empty basic, the matrix collapses.
+
+    basic : list
+        The new list of basic variables.
+
+    nonbasic : list
+        The new list of nonbasic variables.
 
     Example
     =======

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -104,7 +104,6 @@ TODO:
  - Handle non-rational real numbers
  - Handle positive and negative infinity
  - Implement backtracking and theory proposition
- - Simplify matrix by removing unused variables using Gaussian elimination
 
 References
 ==========
@@ -726,15 +725,20 @@ def _sep_const_terms(expr):
                       lambda t: len(t.free_symbols) == 0,
                       binary=True)
     return Add(*var), Add(*const)
+
+
 def _reduce_matrix(A, basic, nonbasic, elim):
     """
     """
     if not elim:
         return A, basic, nonbasic
 
-    order = list(elim) + basic + [v for v in nonbasic if v not in elim]
+    kept_nonbasic = [v for v in nonbasic if v not in elim]
+    # order starts with the variables we want to eliminate
+    # in rref, these variables will become pivots
+    order = list(elim) + basic + kept_nonbasic
     col_of = {v: i for i, v in enumerate(nonbasic + basic)}
-    pos = {v: i for i, v in enumerate(order)}
+    # reorder the matrix for the rref
     A = A[:, [col_of[v] for v in order]]
 
     B, pivots = A.rref()
@@ -742,11 +746,10 @@ def _reduce_matrix(A, basic, nonbasic, elim):
     keep_rows = [r for r, pc in enumerate(pivots) if pc >= len(elim)]
     new_basic = [order[pivots[r]] for r in keep_rows]
     basic_set = set(new_basic)
-    new_nonbasic = [v for v in nonbasic + basic
-                    if v not in elim and v not in basic_set]
+    new_nonbasic = [v for v in kept_nonbasic + basic if v not in basic_set]
 
-    final_order = new_nonbasic + new_basic
-    A = -B[keep_rows, [pos[v] for v in final_order]]
+    order_pos = {v: i for i, v in enumerate(order)}
+    A = -B[keep_rows, [order_pos[v] for v in new_nonbasic + new_basic]]
     return A, new_basic, new_nonbasic
 
 

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -253,6 +253,7 @@ class LRASolver():
         s_count = 0
         s_subs = {}
         nonbasic = []
+        atom_vars = set()
 
         if testing_mode:
             # sort to reduce nondeterminism
@@ -328,6 +329,8 @@ class LRASolver():
             else:
                 var = terms[0]
 
+            atom_vars.add(var)
+
             assert var_coeff != 0
 
             equality = prop.function == Q.eq
@@ -348,7 +351,8 @@ class LRASolver():
             raise UnhandledInput("Nonlinearity is not handled")
 
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
-        A, basic, nonbasic = _simplify_matrix(A, basic, nonbasic)
+        elim = [i for i in nonbasic if i not in atom_vars]
+        A, basic, nonbasic = _simplify_matrix(A, basic, nonbasic, elim)
         nonbasic = [var_to_lra_var[nb] for nb in nonbasic]
         basic = [var_to_lra_var[b] for b in basic]
         for idx, var in enumerate(nonbasic + basic):
@@ -721,10 +725,34 @@ def _sep_const_terms(expr):
                       lambda t: len(t.free_symbols) == 0,
                       binary=True)
     return Add(*var), Add(*const)
-def _simplify_matrix(A, basic, nonbasic):
+def _simplify_matrix(A, basic, nonbasic, elim):
     """
     Simplifies the matrix by eliminating free variables with Gaussian elimination.
     """
+    elim = set(elim)
+    if not elim:
+        return A, basic, nonbasic
+
+    all_var = nonbasic + basic
+    elim_vars = [v for v in nonbasic if v in elim]
+    keep_vars = [v for v in all_var if v not in elim]
+
+    order = elim_vars + basic + [v for v in nonbasic if v not in elim]
+    pos = {v: i for i, v in enumerate(order)}
+    col_of = {v: i for i, v in enumerate(all_var)}
+    A = A[:, [col_of[v] for v in order]]
+
+    B, pivots = A.rref()
+    n_elim = len(elim_vars)
+
+    keep_rows = [r for r, pc in enumerate(pivots) if pc >= n_elim]
+    basic = [order[pivots[r]] for r in keep_rows]
+    basic_set = set(basic)
+    nonbasic = [v for v in keep_vars if v not in basic_set]
+
+    final_order = nonbasic + basic
+    A = -B[keep_rows, [pos[v] for v in final_order]]
+    return A, basic, nonbasic
 
 
 class Boundary:

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -352,6 +352,8 @@ class LRASolver():
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
         # matrix A is guaranteed to able to be simplified
         # by removing the original non-atom variables from it
+        # these removed variables will be replaced by linear
+        # equation of existing variables.
         elim = {i for i in nonbasic if i not in atom_vars}
         A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, elim)
         nonbasic = [var_to_lra_var[nb] for nb in nonbasic]

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -739,6 +739,11 @@ def _reduce_matrix(A, basic, nonbasic, elim):
         x >= 0 and z <= 1 and (x + y <= 5 or z + y >= 2)
 
     Here y is the only non-atom variable, so only y is removed.
+    >>> from sympy.abc import x, y, z
+    >>> from sympy import symbols
+    >>> from sympy.solvers.solveset import linear_eq_to_matrix
+    >>> from sympy.logic.algorithms.lra_theory import _reduce_matrix
+    >>> s1, s2 = symbols('s1 s2')
     >>> nonbasic, basic = [x, y, z], [s1, s2]
     >>> A, _ = linear_eq_to_matrix([x + y - s1, z + y - s2], nonbasic + basic)
     >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y})

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -832,9 +832,9 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
     # Basic vars are also in the form of block matrix -I_m and the rank of that identity
     # matrix makes so that we never touch kept_nonbasic block matrix
     sorted_col_order = list(nonatom_vars) + basic + kept_nonbasic
-    col_of = {v: i for i, v in enumerate(nonbasic + basic)}
-    # reorder the columns of A by the list order
-    A = A[:, [col_of[v] for v in sorted_col_order]]
+    col_of_nonsorted = {v: i for i, v in enumerate(nonbasic + basic)}
+    # reorder the columns of A by the list sorted_col_order
+    A = A[:, [col_of_nonsorted[v] for v in sorted_col_order]]
 
     B, pivots = A.rref()
 
@@ -843,10 +843,10 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
     basic_set = set(new_basic)
     new_nonbasic = [v for v in kept_nonbasic + basic if v not in basic_set]
 
-    order_pos = {v: i for i, v in enumerate(sorted_col_order)}
+    col_of_sorted = {v: i for i, v in enumerate(sorted_col_order)}
     # every basic should have -1 coefficent by convention, and rref gives 1 coeff.
     # to all the basic variables. So we have to negative B.
-    A = -B[keep_rows, [order_pos[v] for v in new_nonbasic + new_basic]]
+    A = -B[keep_rows, [col_of_sorted[v] for v in new_nonbasic + new_basic]]
     if testing_mode:
         # all the nonaotm_vars should be removed
         assert set(nonatom_vars).isdisjoint(new_basic + new_nonbasic)

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -352,7 +352,7 @@ class LRASolver():
 
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
         elim = [i for i in nonbasic if i not in atom_vars]
-        A, basic, nonbasic = _simplify_matrix(A, basic, nonbasic, elim)
+        A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, elim)
         nonbasic = [var_to_lra_var[nb] for nb in nonbasic]
         basic = [var_to_lra_var[b] for b in basic]
         for idx, var in enumerate(nonbasic + basic):
@@ -725,7 +725,7 @@ def _sep_const_terms(expr):
                       lambda t: len(t.free_symbols) == 0,
                       binary=True)
     return Add(*var), Add(*const)
-def _simplify_matrix(A, basic, nonbasic, elim):
+def _reduce_matrix(A, basic, nonbasic, elim):
     """
     Simplifies the matrix by eliminating free variables with Gaussian elimination.
     """

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -731,21 +731,19 @@ def _sep_const_terms(expr):
 
 def _reduce_matrix(A, basic, nonbasic, nonatom_vars):
     """
-    Remove every non-atom variable (or, every ) from the tableu A. This is discussed in
+    Remove every non-atom variable from the tableu A. This is discussed in
     Preprocessing part of the paper [1]_ as the "Gaussian Eliminaton".
 
-    The tableu A stores information about the linear dependence between basic and nonbasic
-    variables. The idea is that, all non-atom variables are dependent of atom variables,
-    which consistent-wise means if atom variables satisfy the formula, we are done i.e
-    non-atom variables do not store information.
+    The idea is that, all non-atom variables are dependent of atom variables,
+    which consistent-wise means that solving for atom variables should directly
+    give solutions for non-atom variables
 
-    E.g,
+    E.g in,
 
-        x >= 0 & x+y >= 1
+        x >= 0 & x+y >= 1 -> Phi' := (x >= 0 & s1 >= 1), Phi_A := x + y = s1
 
-    Method
-    ======
-
+    Since y is dependent, solving Phi' alone is enough, and _reduce_matrix should reduce Phi_A
+    into collapsed matrix since it stores no useful information.
 
     Example
     =======
@@ -783,7 +781,6 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars):
          (x >= 0) & ((x + y <= 2) | (x + 2 * y - z >= 6)) & (Eq(x + y, 2) | (x + 2 * y - z > 4))
 
     only x is the atom variable so only y and z is removed, s1 = x+y and s2 = x+2*y-z.
-    >>> nonbasic, basic = [x, y, z], [s1, s2]
     >>> A, _ = linear_eq_to_matrix([x + y - s1, x + 2 * y - z - s2], nonbasic + basic)
     >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y, z})
     >>> basic, nonbasic
@@ -793,20 +790,20 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars):
     >>> A.shape
     (0,3)
     """
-    if not elim:
+    if not nonatom_vars:
         return A, basic, nonbasic
 
-    kept_nonbasic = [v for v in nonbasic if v not in elim]
+    kept_nonbasic = [v for v in nonbasic if v not in nonatom_vars]
     # order starts with the variables we want to eliminate
     # in rref, these variables will become pivots
-    order = list(elim) + basic + kept_nonbasic
+    order = list(nonatom_vars) + basic + kept_nonbasic
     col_of = {v: i for i, v in enumerate(nonbasic + basic)}
     # reorder the matrix for the rref
     A = A[:, [col_of[v] for v in order]]
 
     B, pivots = A.rref()
 
-    keep_rows = [r for r, pc in enumerate(pivots) if pc >= len(elim)]
+    keep_rows = [r for r, pc in enumerate(pivots) if pc >= len(nonatom_vars)]
     new_basic = [order[pivots[r]] for r in keep_rows]
     basic_set = set(new_basic)
     new_nonbasic = [v for v in kept_nonbasic + basic if v not in basic_set]

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -752,14 +752,17 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
 
     A : Matrix
         The reduced tableau with every variable in nonatom_vars removed.
-        Has one row per new basic variable and one column per new basic + nonbasic
-        variables. In case of empty basic, the matrix collapses.
+        Has one row per basic and one column per (basic + nonbasic).
+        In case of empty basic, the matrix collapses.
 
     basic : list
-        The new list of basic variables.
+        The new list of basic variables. The elements (pivots) are basic if and only if
+        the pivots survived elimination. These pivots are new basic becuase they are
+        definitions at this point.
 
     nonbasic : list
-        The new list of nonbasic variables.
+        The new list of nonbasic variables. Old basic variables can become nonbasic,
+        however nonbasic elements cannot become basic.
 
     Example
     =======
@@ -819,21 +822,21 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
         nonatom_vars = sorted(nonatom_vars, key=str)
 
     kept_nonbasic = [v for v in nonbasic if v not in nonatom_vars]
-    # order starts with the variables we want to eliminate
-    # in rref, these variables will become pivots
-    order = list(nonatom_vars) + basic + kept_nonbasic
+    # the order starts with the variables we want to eliminate,
+    # continues with all the basic variables
+    sorted_col_order = list(nonatom_vars) + basic + kept_nonbasic
     col_of = {v: i for i, v in enumerate(nonbasic + basic)}
-    # reorder the matrix for the rref
-    A = A[:, [col_of[v] for v in order]]
+    # reorder the columns of A by the list order
+    A = A[:, [col_of[v] for v in sorted_col_order]]
 
     B, pivots = A.rref()
 
     keep_rows = [r for r, pc in enumerate(pivots) if pc >= len(nonatom_vars)]
-    new_basic = [order[pivots[r]] for r in keep_rows]
+    new_basic = [sorted_col_order[pivots[r]] for r in keep_rows]
     basic_set = set(new_basic)
     new_nonbasic = [v for v in kept_nonbasic + basic if v not in basic_set]
 
-    order_pos = {v: i for i, v in enumerate(order)}
+    order_pos = {v: i for i, v in enumerate(sorted_col_order)}
     A = -B[keep_rows, [order_pos[v] for v in new_nonbasic + new_basic]]
     return A, new_basic, new_nonbasic
 

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -350,7 +350,8 @@ class LRASolver():
             raise UnhandledInput("Nonlinearity is not handled")
 
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
-        # matrix A can be simplified by removing nonbasic, nonatom variables
+        # matrix A is guaranteed to able to be simplified
+        # by removing the original non-atom variables from it
         elim = {i for i in nonbasic if i not in atom_vars}
         A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, elim)
         nonbasic = [var_to_lra_var[nb] for nb in nonbasic]
@@ -729,7 +730,8 @@ def _sep_const_terms(expr):
 
 def _reduce_matrix(A, basic, nonbasic, elim):
     """
-    Remove every non-atom variable from the matrix A.
+    Remove every non-atom variable from the matrix A. This is discussed in
+    Preprocessing part of the paper [1]_ as the "Gaussian Eliminaton".
 
     Example
     =======

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -820,6 +820,10 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
         return A, basic, nonbasic
     if testing_mode:
         nonatom_vars = sorted(nonatom_vars, key=str)
+        # precondition for all tableu matrices A
+        m = len(basic)
+        n = len(nonbasic+basic)
+        assert A[:, n-m:] == -eye(m)
 
     kept_nonbasic = [v for v in nonbasic if v not in nonatom_vars]
     # The order is important because:
@@ -850,6 +854,10 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
         assert set(new_basic) <= set(basic)
         # new nonbasic variables should be a subset of union of old basic and non-atom nonbasics
         assert set(new_nonbasic) <= set(kept_nonbasic) | set(basic)
+        # precondition for all tableu matrices A
+        m = len(new_basic)
+        n = len(new_nonbasic+new_basic)
+        assert A[:, n-m:] == -eye(m)
     return A, new_basic, new_nonbasic
 
 

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -736,7 +736,10 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars):
 
     The idea is that, all non-atom variables are dependent of atom variables,
     which consistent-wise means that solving for atom variables should directly
-    give solutions for non-atom variables
+    give solutions for non-atom variables.
+
+    Therefore, any information about dependent, or to be more precise, non atom variables
+    in the matrix A is not necessary and can be safely discarded without any correctness worries.
 
     E.g in,
 
@@ -781,7 +784,12 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars):
          (x >= 0) & ((x + y <= 2) | (x + 2 * y - z >= 6)) & (Eq(x + y, 2) | (x + 2 * y - z > 4))
 
     only x is the atom variable so only y and z is removed, s1 = x+y and s2 = x+2*y-z.
+    >>> nonbasic, basic = [x, y, z], [s1, s2]
     >>> A, _ = linear_eq_to_matrix([x + y - s1, x + 2 * y - z - s2], nonbasic + basic)
+    >>> A
+    Matrix([
+    [1, 1,  0, -1,  0],
+    [1, 2, -1,  0, -1]])
     >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y, z})
     >>> basic, nonbasic
     ([], [x, s1, s2])

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -348,6 +348,7 @@ class LRASolver():
             raise UnhandledInput("Nonlinearity is not handled")
 
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
+        A, basic, nonbasic = _simplify_matrix(A, basic, nonbasic)
         nonbasic = [var_to_lra_var[nb] for nb in nonbasic]
         basic = [var_to_lra_var[b] for b in basic]
         for idx, var in enumerate(nonbasic + basic):
@@ -720,6 +721,10 @@ def _sep_const_terms(expr):
                       lambda t: len(t.free_symbols) == 0,
                       binary=True)
     return Add(*var), Add(*const)
+def _simplify_matrix(A, basic, nonbasic):
+    """
+    Simplifies the matrix by eliminating free variables with Gaussian elimination.
+    """
 
 
 class Boundary:

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -354,7 +354,7 @@ class LRASolver():
         # by removing the non-basic (e.g original) non-atom variables from it
         # these removed variables will be replaced by linear equation of existing variables.
         nonatom_vars = {i for i in nonbasic if i not in atom_vars}
-        A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, nonatom_vars)
+        A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode)
         nonbasic = [var_to_lra_var[nb] for nb in nonbasic]
         basic = [var_to_lra_var[b] for b in basic]
         for idx, var in enumerate(nonbasic + basic):
@@ -729,7 +729,7 @@ def _sep_const_terms(expr):
     return Add(*var), Add(*const)
 
 
-def _reduce_matrix(A, basic, nonbasic, nonatom_vars):
+def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
     """
     Remove every non-atom variable from the tableu A. This is discussed in
     Preprocessing part of the paper [1]_ as the "Gaussian Eliminaton".
@@ -767,7 +767,8 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars):
     Matrix([
     [1, 1, 0, -1,  0],
     [0, 1, 1,  0, -1]])
-    >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y})
+    >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y},
+    ...                                     testing_mode=True)
     >>> basic, nonbasic
     ([s1], [x, z, s2])
 
@@ -790,16 +791,19 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars):
     Matrix([
     [1, 1,  0, -1,  0],
     [1, 2, -1,  0, -1]])
-    >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y, z})
+    >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y, z},
+    ...                                     testing_mode=True)
     >>> basic, nonbasic
     ([], [x, s1, s2])
 
     Basic is empty, which in result should mean A has collapsed.
     >>> A.shape
-    (0,3)
+    (0, 3)
     """
     if not nonatom_vars:
         return A, basic, nonbasic
+    if testing_mode:
+        nonatom_vars = sorted(nonatom_vars, key=str)
 
     kept_nonbasic = [v for v in nonbasic if v not in nonatom_vars]
     # order starts with the variables we want to eliminate

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -732,26 +732,22 @@ def _reduce_matrix(A, basic, nonbasic, elim):
     if not elim:
         return A, basic, nonbasic
 
-    all_var = nonbasic + basic
-    elim_vars = [v for v in nonbasic if v in elim]
-    keep_vars = [v for v in all_var if v not in elim]
-
-    order = elim_vars + basic + [v for v in nonbasic if v not in elim]
+    order = list(elim) + basic + [v for v in nonbasic if v not in elim]
+    col_of = {v: i for i, v in enumerate(nonbasic + basic)}
     pos = {v: i for i, v in enumerate(order)}
-    col_of = {v: i for i, v in enumerate(all_var)}
     A = A[:, [col_of[v] for v in order]]
 
     B, pivots = A.rref()
-    n_elim = len(elim_vars)
 
-    keep_rows = [r for r, pc in enumerate(pivots) if pc >= n_elim]
-    basic = [order[pivots[r]] for r in keep_rows]
-    basic_set = set(basic)
-    nonbasic = [v for v in keep_vars if v not in basic_set]
+    keep_rows = [r for r, pc in enumerate(pivots) if pc >= len(elim)]
+    new_basic = [order[pivots[r]] for r in keep_rows]
+    basic_set = set(new_basic)
+    new_nonbasic = [v for v in nonbasic + basic
+                    if v not in elim and v not in basic_set]
 
-    final_order = nonbasic + basic
+    final_order = new_nonbasic + new_basic
     A = -B[keep_rows, [pos[v] for v in final_order]]
-    return A, basic, nonbasic
+    return A, new_basic, new_nonbasic
 
 
 class Boundary:

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -822,8 +822,11 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
         nonatom_vars = sorted(nonatom_vars, key=str)
 
     kept_nonbasic = [v for v in nonbasic if v not in nonatom_vars]
-    # the order starts with the variables we want to eliminate,
-    # continues with all the basic variables
+    # The order is important because:
+    # 1) rref starts pivoting from left to right, so nonatom_vars should come first
+    # 2) basic var should come after them and possibly reduce them too
+    # Basic vars are also in the form of block matrix -I_m and the rank of that identity
+    # matrix makes so that we never touch kept_nonbasic block matrix
     sorted_col_order = list(nonatom_vars) + basic + kept_nonbasic
     col_of = {v: i for i, v in enumerate(nonbasic + basic)}
     # reorder the columns of A by the list order
@@ -837,7 +840,16 @@ def _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode):
     new_nonbasic = [v for v in kept_nonbasic + basic if v not in basic_set]
 
     order_pos = {v: i for i, v in enumerate(sorted_col_order)}
+    # every basic should have -1 coefficent by convention, and rref gives 1 coeff.
+    # to all the basic variables.
     A = -B[keep_rows, [order_pos[v] for v in new_nonbasic + new_basic]]
+    if testing_mode:
+        # all the nonaotm_vars should be removed
+        assert set(nonatom_vars).isdisjoint(new_basic + new_nonbasic)
+        # new basic variables should be a subset of old basic variables
+        assert set(new_basic) <= set(basic)
+        # new nonbasic variables should be a subset of union of old basic and non-atom nonbasics
+        assert set(new_nonbasic) <= set(kept_nonbasic) | set(basic)
     return A, new_basic, new_nonbasic
 
 

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -103,7 +103,7 @@ but these are not currently implemented.
 TODO:
  - Handle non-rational real numbers
  - Handle positive and negative infinity
- - Implement backtracking and theory proposition
+ - Implement backtracking and theory propagation
 
 References
 ==========
@@ -351,11 +351,10 @@ class LRASolver():
 
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
         # matrix A is guaranteed to able to be simplified
-        # by removing the original non-atom variables from it
-        # these removed variables will be replaced by linear
-        # equation of existing variables.
-        elim = {i for i in nonbasic if i not in atom_vars}
-        A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, elim)
+        # by removing the non-basic (e.g original) non-atom variables from it
+        # these removed variables will be replaced by linear equation of existing variables.
+        nonatom_vars = {i for i in nonbasic if i not in atom_vars}
+        A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, nonatom_vars)
         nonbasic = [var_to_lra_var[nb] for nb in nonbasic]
         basic = [var_to_lra_var[b] for b in basic]
         for idx, var in enumerate(nonbasic + basic):
@@ -730,19 +729,32 @@ def _sep_const_terms(expr):
     return Add(*var), Add(*const)
 
 
-def _reduce_matrix(A, basic, nonbasic, elim):
+def _reduce_matrix(A, basic, nonbasic, nonatom_vars):
     """
-    Remove every non-atom variable from the matrix A. This is discussed in
+    Remove every non-atom variable (or, every ) from the tableu A. This is discussed in
     Preprocessing part of the paper [1]_ as the "Gaussian Eliminaton".
+
+    The tableu A stores information about the linear dependence between basic and nonbasic
+    variables. The idea is that, all non-atom variables are dependent of atom variables,
+    which consistent-wise means if atom variables satisfy the formula, we are done i.e
+    non-atom variables do not store information.
+
+    E.g,
+
+        x >= 0 & x+y >= 1
+
+    Method
+    ======
+
 
     Example
     =======
 
     Consider the formula:
 
-        x >= 0 and z <= 1 and (x + y <= 5 or z + y >= 2)
+        x >= 0 & z <= 1 & (x + y <= 5 | z + y >= 2)
 
-    Here y is the only non-atom variable, so only y is removed.
+    Here y is the only non-atom variable, so only y is removed, s1 = x+y, s2 = z+y.
     >>> from sympy.abc import x, y, z
     >>> from sympy import symbols
     >>> from sympy.solvers.solveset import linear_eq_to_matrix
@@ -750,6 +762,10 @@ def _reduce_matrix(A, basic, nonbasic, elim):
     >>> s1, s2 = symbols('s1 s2')
     >>> nonbasic, basic = [x, y, z], [s1, s2]
     >>> A, _ = linear_eq_to_matrix([x + y - s1, z + y - s2], nonbasic + basic)
+    >>> A
+    Matrix([
+    [1, 1, 0, -1,  0],
+    [0, 1, 1,  0, -1]])
     >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y})
     >>> basic, nonbasic
     ([s1], [x, z, s2])
@@ -759,7 +775,23 @@ def _reduce_matrix(A, basic, nonbasic, elim):
     >>> A
     Matrix([[1, -1, 1, -1]])
 
-    It is possible for the matrix A to collapse entirely.
+    It is possible for the matrix A to collapse entirely, which happens when
+    all the remaining terms are linearly independent. Or in other terms, The matrix A
+    is no longer "stores" information about variables as there are no information to store.
+    E.g,
+
+         (x >= 0) & ((x + y <= 2) | (x + 2 * y - z >= 6)) & (Eq(x + y, 2) | (x + 2 * y - z > 4))
+
+    only x is the atom variable so only y and z is removed, s1 = x+y and s2 = x+2*y-z.
+    >>> nonbasic, basic = [x, y, z], [s1, s2]
+    >>> A, _ = linear_eq_to_matrix([x + y - s1, x + 2 * y - z - s2], nonbasic + basic)
+    >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y, z})
+    >>> basic, nonbasic
+    ([], [x, s1, s2])
+
+    Basic is empty, which in result should mean A has collapsed.
+    >>> A.shape
+    (0,3)
     """
     if not elim:
         return A, basic, nonbasic

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -351,7 +351,8 @@ class LRASolver():
             raise UnhandledInput("Nonlinearity is not handled")
 
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
-        elim = [i for i in nonbasic if i not in atom_vars]
+        # matrix A can be simplified by removing nonbasic, nonatom variables
+        elim = {i for i in nonbasic if i not in atom_vars}
         A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, elim)
         nonbasic = [var_to_lra_var[nb] for nb in nonbasic]
         basic = [var_to_lra_var[b] for b in basic]
@@ -727,9 +728,7 @@ def _sep_const_terms(expr):
     return Add(*var), Add(*const)
 def _reduce_matrix(A, basic, nonbasic, elim):
     """
-    Simplifies the matrix by eliminating free variables with Gaussian elimination.
     """
-    elim = set(elim)
     if not elim:
         return A, basic, nonbasic
 

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -729,6 +729,28 @@ def _sep_const_terms(expr):
 
 def _reduce_matrix(A, basic, nonbasic, elim):
     """
+    Remove every non-atom variable from the matrix A.
+
+    Example
+    =======
+
+    Consider the formula:
+
+        x >= 0 and z <= 1 and (x + y <= 5 or z + y >= 2)
+
+    Here y is the only non-atom variable, so only y is removed.
+    >>> nonbasic, basic = [x, y, z], [s1, s2]
+    >>> A, _ = linear_eq_to_matrix([x + y - s1, z + y - s2], nonbasic + basic)
+    >>> A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, {y})
+    >>> basic, nonbasic
+    ([s1], [x, z, s2])
+
+    Notice that s2 became nonbasic.
+
+    >>> A
+    Matrix([[1, -1, 1, -1]])
+
+    It is possible for the matrix A to collapse entirely.
     """
     if not elim:
         return A, basic, nonbasic

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -82,6 +82,12 @@ def find_rational_assignment(constr, assignment, iter=20):
     return None
 
 def substitute_slack(cons, s_subs):
+    """
+    helps to rewrite Phi in terms of basic/slack variables (Phi' in the paper)
+    since _reduce_matrix can remove non-atom vars from Phi, which causes some
+    problems on the tests where it tries to substitute values to original Phi. E.g
+    Phi = x >= 0 & x+y >= 1 -> Phi' := (x >= 0 & s1 >= 1)
+    """
     expr = cons.lhs - cons.rhs
     var, const = _sep_const_terms(expr)
     var, coeff = _sep_const_coeff(var)

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -12,7 +12,8 @@ from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.functions.elementary.trigonometric import cos
 from sympy.external import import_module
 
-from sympy.logic.algorithms.lra_theory import LRASolver, UnhandledInput, LRARational, HANDLE_NEGATION
+from sympy.logic.algorithms.lra_theory import LRASolver, UnhandledInput, LRARational, HANDLE_NEGATION, \
+    _sep_const_terms, _sep_const_coeff
 from sympy.core.random import random, choice, randint
 from sympy.core.sympify import sympify
 from sympy.ntheory.generate import randprime
@@ -79,6 +80,16 @@ def find_rational_assignment(constr, assignment, iter=20):
             eps = eps/2
 
     return None
+
+def substitute_slack(cons, s_subs):
+    expr = cons.lhs - cons.rhs
+    var, const = _sep_const_terms(expr)
+    var, coeff = _sep_const_coeff(var)
+    if var in s_subs:
+        return cons.func(coeff*s_subs[var] + const, 0)
+    if -var in s_subs:
+        return cons.func(-coeff*s_subs[-var] + const, 0)
+    return cons
 
 def boolean_formula_to_encoded_cnf(bf):
     cnf = CNF.from_prop(bf)
@@ -208,6 +219,8 @@ def test_random_problems():
             cons_funcs = [cons.func for cons in constraints]
             assignment = feasible[1]
             assignment = {key.var : value for key, value in assignment.items()}
+            constraints = [substitute_slack(cons, s_subs) for cons in constraints]
+
             if not (StrictLessThan in cons_funcs or StrictGreaterThan in cons_funcs):
                 assignment = {key: value[0] for key, value in assignment.items()}
                 for cons in constraints:

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -95,11 +95,10 @@ def test_from_encoded_cnf():
     phi = (x >= 0) & ((x + y <= 2) | (x + 2 * y - z >= 6)) & (Eq(x + y, 2) | (x + 2 * y - z > 4))
     enc = boolean_formula_to_encoded_cnf(phi)
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
-    assert lra.A.shape == (2, 5)
-    assert str(lra.slack) == '[_s1, _s2]'
-    assert str(lra.nonslack) == '[x, y, z]'
-    assert lra.A == Matrix([[ 1,  1, 0, -1,  0],
-                            [-1, -2, 1,  0, -1]])
+    assert lra.A.shape == (0, 3)
+    assert str(lra.slack) == '[]'
+    assert str(lra.nonslack) == '[x, _s1, _s2]'
+    assert lra.A == Matrix(0,3, [])
     actual = {tuple(sorted((str(b.var), b.bound, b.upper, b.strict) for b in bs)) for bs in lra.atom_id_to_boundaries.values()}
     expected = {
         (('_s1', 2, False, False), ('_s1', 2, True, False)), # Eq(x + y, 2)
@@ -495,7 +494,7 @@ def test_example_from_paper():
 
     # Extracts the variables stored in the solver
     var_x = next(v for v in lra.all_var if str(v.var) == 'x')
-    var_y = next(v for v in lra.all_var if str(v.var) == 'y')
+    # var_y has been removed from A after the simplification
     # var_s1 is a slack variable which corresponds for -x + y <= 1
     # var_s2 is a slack variable which corresponds for -x - y <= 3
     _s1 = lra.s_subs[-x + y]
@@ -505,7 +504,6 @@ def test_example_from_paper():
 
     # State A_0
     assert var_x.assign == LRARational(0, 0)
-    assert var_y.assign == LRARational(0, 0)
     assert var_s1.assign == LRARational(0, 0)
     assert var_s2.assign == LRARational(0, 0)
 
@@ -517,9 +515,8 @@ def test_example_from_paper():
     # State A_1
     assert var_x.upper == LRARational(-4, 0)
     assert var_x.assign == LRARational(-4, 0)
-    assert var_y.assign == LRARational(0, 0)
-    assert var_s1.assign == LRARational(4, 0)
-    assert var_s2.assign == LRARational(4, 0)
+    assert var_s1.assign == LRARational(0, 0)
+    assert var_s2.assign == LRARational(8, 0)
 
     # Assert x >= -8
     lra.assert_lit(2)
@@ -530,13 +527,10 @@ def test_example_from_paper():
     assert var_x.lower == LRARational(-8, 0)
     assert var_x.upper == LRARational(-4, 0)
     assert var_x.assign == LRARational(-4, 0)
-    assert var_y.assign == LRARational(0, 0)
-    assert var_s1.assign == LRARational(4, 0)
-    assert var_s2.assign == LRARational(4, 0)
+    assert var_s1.assign == LRARational(0, 0)
+    assert var_s2.assign == LRARational(8, 0)
 
     # Asserts -x + y <= 1
-    # Check is invoked to pivot s1 and y
-    # y's range is (-inf, -3]
     lra.assert_lit(3)
     is_sat, _ = lra.check()
     assert is_sat is True
@@ -546,9 +540,8 @@ def test_example_from_paper():
     assert var_x.lower == LRARational(-8, 0)
     assert var_x.upper == LRARational(-4, 0)
     assert var_x.assign == LRARational(-4, 0)
-    assert var_y.assign == LRARational(-3, 0)
-    assert var_s1.assign == LRARational(1, 0)
-    assert var_s2.assign == LRARational(7, 0)
+    assert var_s1.assign == LRARational(0, 0)
+    assert var_s2.assign == LRARational(8, 0)
 
     # Assert -x - y <= 3 (s2)
     # s2 and s1 are conflicting assertions as for both to be true
@@ -568,9 +561,8 @@ def test_example_from_paper():
     assert var_x.lower == LRARational(-8, 0)
     assert var_x.upper == LRARational(-4, 0)
     assert var_x.assign == LRARational(-4, 0)
-    assert var_y.assign == LRARational(-3, 0)
-    assert var_s1.assign == LRARational(1, 0)
-    assert var_s2.assign == LRARational(7, 0)
+    assert var_s1.assign == LRARational(0, 0)
+    assert var_s2.assign == LRARational(8, 0)
 
 
 def test_backtracking_single_variable():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". --> 
Fixes partially: https://github.com/sympy/sympy/issues/29505
#### Brief description of what is fixed or changed
This PR adds a simplification process for the matrix `A` from "A Fast Linear-Arithmetic Solver for DPLL(T)"  that was not implemented here i.e the Gaussian elimination
The new function removes every non-atom variable from the matrix `A`.
#### Other comments
I might have confused some definitions and terms as I  started to learn about lra or SAT in general from a couple of uni slides and papers a couple days ago.
Benchmark I ran:
`failed` means timed out or 60s+
```
| Change   | Before [7e43f98d] <master>   | After [cb73c0a5] <lra>   | Ratio   | Benchmark (Parameter)                        |
|----------|------------------------------|--------------------------|---------|----------------------------------------------|
|          | 1.05±0s                      | 1.02±0s                  | 0.97    | logic.LogicSuite.time_dpll                   |
|          | 34.2±0.3ms                   | 32.6±0.1ms               | 0.95    | logic.LogicSuite.time_dpll2                  |
|          | 1.03±0.02ms                  | 1.01±0.01ms              | 0.98    | logic.LogicSuite.time_load_file              |
| +        | 114±1ms                      | 426±4ms                  | 3.73    | lra.LRASuite.time_from_encoded_cnf('large')  |
| +        | 47.5±0.5ms                   | 109±1ms                  | 2.29    | lra.LRASuite.time_from_encoded_cnf('medium') |
| +        | 11.7±0.7ms                   | 21.8±0.5ms               | 1.87    | lra.LRASuite.time_from_encoded_cnf('small')  |
| *        | failed                       | 29.0±0.1s                | n/a     | lra.LRASuite.time_satisfiable('large')       |
|          | 11.4±0.09s                   | 3.91±0.04s               | ~0.34   | lra.LRASuite.time_satisfiable('medium')      |
| -        | 1.88±0.01s                   | 215±2ms                  | 0.11    | lra.LRASuite.time_satisfiable('small')       |
```
This test from the linked issue now runs OK for me
```Python
# test written by Gemini CLI (but modified by me)
def test_satisfiable_lra_redundancy_crash():
    x, y = symbols("x y", real=True)

    # We want a SAT formula that might crash or return False wrongly.
    # True assignment: x >= 1 (p_true_1 is True).
    # But a conflict is forced on another branch.

    a = Q.eq(y, 0)  # branch variable
    p_true_1 = Q.ge(x, 1)

    # Conflict branch:
    p_conf_1 = Q.ge(2 * x, 2)
    p_conf_2 = Q.lt(2 * x, 2)

    phi = (a | p_true_1) & (~a | p_conf_1) & (~a | p_conf_2)

    # for i in range(3, 30):
    for i in range(3, 16):
        p_ge = Q.ge(i * x, i)
        p_lt = Q.lt(i * x, i)
        phi = phi & (p_ge | ~p_ge) & (p_lt | ~p_lt)

    res = satisfiable(phi, use_lra_theory=True)
    assert res is not False
```
#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
The above benchmark was mostly written by Claude.
The function was partially written by Claude at first. I cleaned it up through the commits.
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
