### PR TITLE
[GSoC] manualintegrate: set dv = 1 and u to be a special error function

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1763,10 +1763,10 @@ def parts_rule(integral):
                 return
             _parts_u_cache[cachekey] += 1
 
-        priori_steps = [result]
-
         # Try cyclic integration by parts a few times
         for _ in range(4):
+            if dv == 1:
+                break
             debug("Cyclic integration {} with v: {}, du: {}, integrand: {}".format(_, v, du, integrand))
             coefficient = ((v * du) / integrand).cancel()
             if coefficient == 1:
@@ -1801,10 +1801,6 @@ def parts_rule(integral):
     if steps:
         u, dv, v, du, v_step = steps[0]
         second_step = make_second_step(steps[1:], v * du)
-        if second_step.contains_dont_know() and (priori_steps != steps):
-            debug("Repeated integration by parts failed because the second step contains a DontKnowRule")
-            debug("Use the first step instead")
-            second_step = make_second_step(priori_steps[1:], v * du)
         rule = PartsRule(integrand, symbol, u, dv, v_step, second_step)
         if (constant != 1) and rule:
             rule = ConstantTimesRule(constant * integrand, symbol, constant, integrand, rule)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1763,6 +1763,8 @@ def parts_rule(integral):
                 return
             _parts_u_cache[cachekey] += 1
 
+        priori_steps = [result]
+
         # Try cyclic integration by parts a few times
         for _ in range(4):
             debug("Cyclic integration {} with v: {}, du: {}, integrand: {}".format(_, v, du, integrand))
@@ -1798,7 +1800,12 @@ def parts_rule(integral):
 
     if steps:
         u, dv, v, du, v_step = steps[0]
-        rule = PartsRule(integrand, symbol, u, dv, v_step, make_second_step(steps[1:], v * du))
+        second_step = make_second_step(steps[1:], v * du)
+        if second_step.contains_dont_know() and (priori_steps != steps):
+            debug("Repeated integration by parts failed because the second step contains a DontKnowRule")
+            debug("Use the first step instead")
+            second_step = make_second_step(priori_steps[1:], v * du)
+        rule = PartsRule(integrand, symbol, u, dv, v_step, second_step)
         if (constant != 1) and rule:
             rule = ConstantTimesRule(constant * integrand, symbol, constant, integrand, rule)
         return rule

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1677,8 +1677,9 @@ def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None
 
 
     dummy = Dummy("temporary")
-    # we can integrate log(x) and atan(x) by setting dv = 1
-    if isinstance(integrand, (log, *inverse_trig_functions)):
+    # we can integrate log(x), atan(x), and erf by setting dv = 1
+    if isinstance(integrand, (log, *inverse_trig_functions,
+                              *special_error_functions)):
         integrand = dummy * integrand
 
     for index, rule in enumerate(liate_rules):
@@ -2687,7 +2688,8 @@ def integral_steps(integrand, symbol, **options):
                     cancel_rule),
                 condition(
                     integral_is_subclass(Mul, log,
-                    *inverse_trig_functions),
+                                         *inverse_trig_functions,
+                                         *special_error_functions),
                     parts_rule),
                 condition(
                     integral_is_subclass(Mul, Pow),

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -304,6 +304,28 @@ def test_manualintegrate_special():
     F = sqrt(pi)*log(x)*erf(x)/2 - sqrt(pi)*Integral(erf(x)/x, x)/2
     assert_is_integral_of(f, F)
 
+    f, F = erf(x), x*erf(x) + exp(-x**2)/sqrt(pi)
+    assert_is_integral_of(f, F)
+    f, F = erfc(x), x*erfc(x) - exp(-x**2)/sqrt(pi)
+    assert_is_integral_of(f, F)
+    f, F = erfi(x), x*erfi(x) - exp(x**2)/sqrt(pi)
+    assert_is_integral_of(f, F)
+    f, F = fresnelc(x), x*fresnelc(x) - sin(pi*x**2/2)/pi
+    assert_is_integral_of(f, F)
+    f, F = fresnels(x), x*fresnels(x) + cos(pi*x**2/2)/pi
+    assert_is_integral_of(f, F)
+    f, F = Ci(x), x*Ci(x) - sin(x)
+    assert_is_integral_of(f, F)
+    f, F = Chi(x), x*Chi(x) - sinh(x)
+    assert_is_integral_of(f, F)
+    f, F = Si(x), x*Si(x) + cos(x)
+    assert_is_integral_of(f, F)
+    f, F = Shi(x), x*Shi(x) - cosh(x)
+    assert_is_integral_of(f, F)
+    f, F = Ei(x), x*Ei(x) - exp(x)
+    assert_is_integral_of(f, F)
+    f, F = li(x), x*li(x) - Ei(2*log(x))
+    assert_is_integral_of(f, F)
 
 
 @slow


### PR DESCRIPTION
#### References to other Issues or PRs

N/A

#### Brief description of what is fixed or changed

This PR extends the integration by parts heuristic in `manualintegrate` to handle the special error functions (`erf`, `erfc`, `erfi`, `fresnelc`, `fresnels`, `Ci`, `Chi`, `Si`, `Shi`, `Ei`, and `li`) in the same way as logarithmic and inverse trigonometric functions by selecting `dv = 1` when they appear as the integrand.

It also improves repeated integration by parts. If the repeated integration by parts strategy produces a `DontKnowRule` in the continuation, the additional integration by parts steps are discarded and the solver falls back to using only the initial integration by parts step. This allows the remaining integral to be handled by the normal rule dispatcher, avoiding unnecessary failures on integrals where a different technique (such as substitution) is more appropriate.

For example,

```python
In [2]: manualintegrate(fresnelc(x), x)
Out[2]: 
            ⎛   2⎞
            ⎜π⋅x ⎟
         sin⎜────⎟
            ⎝ 2  ⎠
x⋅C(x) - ─────────
             π    

In [3]: 

```

instead of producing a `DontKnowRule` in the second integration step.

#### Other comments

The fallback only affects repeated integration by parts. Existing cyclic integration by parts behavior is preserved for cases where it is applicable. However, the current solution is suboptimal because it could possibly return the original integral back again after doing IBP enough times. Such integrals was not discovered yet, because such cases usually involves logs and special error functions, which already have guards put in place to stop. I was trying to add a `posteriori_steps`, but could not figure out exactly how.

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* integrals
  * Improved `manualintegrate` to apply integration by parts directly to the special error functions by treating them analogously to logarithmic and inverse trigonometric functions.
  * Fixed a case where repeated integration by parts could end in a `DontKnowRule` even though the remaining integral was solvable by another integration technique.

<!-- END RELEASE NOTES -->