### PR TITLE
[GSoC] manualintegrate: remove alternatives from integral_steps

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2676,25 +2676,14 @@ def integral_steps(integrand, symbol, **options):
         do_one(
             null_safe(trig_rule),
             null_safe(hyperbolic_rule),
-            null_safe(alternatives(
-                rewrites_rule,
-                substitution_rule,
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    partial_fractions_rule),
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    cancel_rule),
-                condition(
-                    integral_is_subclass(Mul, log,
-                    *inverse_trig_functions),
-                    parts_rule),
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    distribute_expand_rule),
-                trig_powers_products_rule,
-                trig_expand_rule
-            )),
+            null_safe(rewrites_rule),
+            null_safe(substitution_rule),
+            null_safe(condition(integral_is_subclass(Mul, Pow), partial_fractions_rule)),
+            null_safe(condition(integral_is_subclass(Mul, Pow), cancel_rule)),
+            null_safe(condition(integral_is_subclass(Mul, log, *inverse_trig_functions), parts_rule)),
+            null_safe(condition(integral_is_subclass(Mul, Pow), distribute_expand_rule)),
+            null_safe(trig_powers_products_rule),
+            null_safe(trig_expand_rule),
             null_safe(condition(integral_is_subclass(Mul, Pow), nested_pow_rule)),
             null_safe(trig_substitution_rule)
         ),


### PR DESCRIPTION
#### References to other Issues or PRs

#29862

#### Brief description of what is fixed or changed

This change removes the `alternatives` combinator from the main `integral_steps` strategy and instead applies each rule sequentially through `do_one`.

Previously, `alternatives` evaluated all matching rules before selecting a result, which caused unnecessary work for expensive rules that would ultimately be discarded. Since `do_one` already stops after the first successful rule, applying the rules directly preserves the existing rule priority while avoiding the overhead of constructing alternative candidates.

This significantly improves the performance of `manualintegrate` without changing the integration strategy or the produced results.

Benchmarking using `hyperfine`,

Before:

```text
Benchmark 1: .venv/bin/python -m pytest -v sympy/integrals/tests/test_manual.py
  Time (mean ± σ):     39.876 s ±  1.997 s    [User: 35.392 s, System: 3.938 s]
  Range (min … max):   36.962 s … 42.401 s    10 runs
```

```text
Benchmark 1: .venv/bin/python -m pytest -m slow -v sympy/integrals/tests/test_manual.py
  Time (mean ± σ):     197.990 s ±  8.469 s    [User: 180.051 s, System: 15.665 s]
  Range (min … max):   186.796 s … 209.256 s    10 runs
```

After:

```text
Benchmark 1: .venv/bin/python -m pytest -v sympy/integrals/tests/test_manual.py
  Time (mean ± σ):     25.435 s ±  0.555 s    [User: 23.160 s, System: 1.991 s]
  Range (min … max):   24.735 s … 26.532 s    10 runs
```

```text
Benchmark 1: .venv/bin/python -m pytest -m slow -v sympy/integrals/tests/test_manual.py
  Time (mean ± σ):     60.243 s ±  1.826 s    [User: 54.507 s, System: 5.094 s]
  Range (min … max):   59.283 s … 65.407 s    10 runs
```

#### Other comments

More discussion regarding offering alternatives for when requested is further needed to keep support for interfaces like [sympy gamma](https://github.com/sympy/sympy_gamma) and [sympy beta](https://github.com/eagleoflqj/sympy_beta).

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* integrals
  * remove `alternatives` from `manualintegrate` to optimize performance

<!-- END RELEASE NOTES -->
