### PR TITLE
Fix substitution returning non-empty solutions for inconsistent systems

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3274,7 +3274,9 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
 
     for i, e in enumerate(system):
         if isinstance(e, Eq):
-            system[i] = e.lhs - e.rhs
+            system[i] = sympify(e.lhs - e.rhs)
+        else:
+            system[i] = sympify(e)
 
     if not symbols:
         msg = ('Symbols must be given, for which solution of the '
@@ -3444,7 +3446,12 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
         u = Dummy('u')
         if n:
             eq = eq.subs(n, 0)
-        satisfy = eq if eq in (True, False) else checksol(u, u, eq, minimal=True)
+        if eq is True or eq is S.true:
+            satisfy = True
+        elif eq is False or eq is S.false:
+            satisfy = False
+        else:
+            satisfy = checksol(u, u, eq, minimal=True)
         if satisfy is False:
             delete_soln = True
             res = {}
@@ -3500,7 +3507,8 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
         elif satisfy_exclude:
             delete_soln = True
             rnew = {}
-        _restore_imgset(rnew, original_imageset, newresult)
+        if not delete_soln:
+            _restore_imgset(rnew, original_imageset, newresult)
         return newresult, delete_soln
 
     def _new_order_result(result, eq):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3615,3 +3615,11 @@ def test_issue_26077():
         Complement(S.Reals, excluded_points)
     )
     assert solution.as_dummy() == critical_points.as_dummy()
+
+
+def test_substitution_inconsistent():
+    from sympy.solvers.solveset import substitution
+    from sympy import symbols, EmptySet
+    x, y = symbols('x y')
+    # System: x + y - 1 = 0, x + y - 2 = 0
+    assert substitution([x + y - 1, x + y - 2], [x, y]) == EmptySet


### PR DESCRIPTION
## Summary

This PR fixes a correctness issue in `sympy.solvers.solveset.substitution` where inconsistent systems could incorrectly return non-empty solution sets instead of `EmptySet`.

During substitution, equations that simplify to boolean values or constant residuals indicating an inconsistency were not always handled correctly. As a result, contradictory systems such as:

```python
from sympy import symbols
from sympy.solvers.solveset import substitution

a = symbols("a")

substitution(
    [
        a - 1,
        a - 2,
    ],
    [a],
)
```

incorrectly returned

```python
{(2,)}
```

instead of

```python
EmptySet
```

The same behavior also appeared in more complex systems containing contradictory assignments, where inconsistent solution branches were retained instead of being discarded.

## Changes

* Updated the contradiction handling in `substitution` so that inconsistent solution branches are correctly identified and removed.
* Replaced boolean equality checks with explicit identity checks for Python and SymPy boolean singletons, preventing integer constants such as `1` and `0` from being treated as boolean values during contradiction detection.
* Added a regression test covering inconsistent systems to prevent this behavior from recurring.

## Testing

The fix was verified locally by reproducing the reported bug and confirming that inconsistent systems now correctly return `EmptySet`.

The relevant solver test suite was also executed successfully, including the newly added regression test.

<!-- BEGIN RELEASE NOTES -->

* solvers

  * Fixed `solveset.substitution` incorrectly returning non-empty solutions for inconsistent systems instead of `EmptySet`.

<!-- END RELEASE NOTES -->

---

## AI Disclosure

I used AI during the investigation to discuss the code paths, explore possible root causes, and help draft the issue and PR descriptions.

The investigation, implementation, testing, and validation of the fix were performed manually before submitting this PR.
