### PR TITLE
Fix typo for CodeBlock (two left_hand_sides, instead of left and right)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1324,6 +1324,7 @@ Qijia Liu <liumeo@pku.edu.cn> Liumeo <liumeo@pku.edu.cn>
 Qijia Liu <liumeo@pku.edu.cn> eagleoflqj <liumeo@pku.edu.cn>
 Qingsha Shi <googol.sqs@gmail.com> sqs <googol.sqs@gmail.com>
 QuaBoo <kisonchristian@gmail.com>
+Quag <quaggy@gmail.com>
 Quek Zi Yao <ziyaoqzy2001@gmail.com> ZiYao <151983618+ZiYao54@users.noreply.github.com>
 Quek Zi Yao <ziyaoqzy2001@gmail.com> ZiYao54 <ziyaoqzy2001@gmail.com>
 Raffaele De Feo <alberthilbert@gmail.com>

--- a/sympy/codegen/ast.py
+++ b/sympy/codegen/ast.py
@@ -604,7 +604,7 @@ class CodeBlock(CodegenAST):
 
     ``left_hand_sides``:
         Tuple of left-hand sides of assignments, in order.
-    ``left_hand_sides``:
+    ``right_hand_sides``:
         Tuple of right-hand sides of assignments, in order.
     ``free_symbols``: Free symbols of the expressions in the right-hand sides
         which do not appear in the left-hand side of an assignment.


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
The docstring for https://docs.sympy.org/latest/modules/codegen.html#sympy.codegen.ast.CodeBlock has two left_hand_sides attributes instead of a left_hand_sides and right_hand_sides attributes.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
