### PR TITLE
Raise ValueError for a*b == 1 in kid_rsa_public_key / kid_rsa_private_key

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -492,6 +492,7 @@ Charalampos Tsiagkalis <ctsiagkalis@uth.gr> ctsiagkalis <49073139+ctsiagkalis@us
 Charles Harris <erdos4d@gmail.com> Charles Harris <72926946+erdos4d@users.noreply.github.com>
 Charles Harris <erdos4d@gmail.com> cbh <cbharris@andeswebdesign.com>
 Charles Weiss <charles.weiss@augie.edu> Charles Weiss <69219836+weisscharlesj@users.noreply.github.com>
+CharlesCNorton <machineelv@gmail.com>
 Charlie Lam <888lamcharlie@gmail.com>
 Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>

--- a/sympy/crypto/crypto.py
+++ b/sympy/crypto/crypto.py
@@ -2106,6 +2106,8 @@ def kid_rsa_public_key(a, b, A, B):
 
     """
     M = a*b - 1
+    if M == 0:
+        raise ValueError("a*b must not equal 1")
     e = A*M + a
     d = B*M + b
     n = (e*d - 1)//M
@@ -2128,6 +2130,8 @@ def kid_rsa_private_key(a, b, A, B):
 
     """
     M = a*b - 1
+    if M == 0:
+        raise ValueError("a*b must not equal 1")
     e = A*M + a
     d = B*M + b
     n = (e*d - 1)//M

--- a/sympy/crypto/tests/test_crypto.py
+++ b/sympy/crypto/tests/test_crypto.py
@@ -385,6 +385,13 @@ def test_kid_rsa_private_key():
     assert kid_rsa_private_key(1, 2, 1, 2) == (7, 4)
 
 
+def test_kid_rsa_degenerate():
+    # a*b == 1 makes M = a*b - 1 == 0; reject it with ValueError instead of
+    # raising a bare ZeroDivisionError from the (e*d - 1)//M division.
+    raises(ValueError, lambda: kid_rsa_public_key(1, 1, 5, 6))
+    raises(ValueError, lambda: kid_rsa_private_key(1, 1, 5, 6))
+
+
 def test_encipher_kid_rsa():
     assert encipher_kid_rsa(1, (5, 2)) == 2
     assert encipher_kid_rsa(1, (8, 3)) == 3


### PR DESCRIPTION
#### References to other Issues or PRs

None.

#### Brief description of what is fixed or changed

`kid_rsa_public_key(a, b, A, B)` and `kid_rsa_private_key(a, b, A, B)` compute `M = a*b - 1` and then `n = (e*d - 1)//M`. The docstrings instruct the user to "select positive integers `a, b, A, B` at random", but `a = b = 1` (both positive integers) gives `M = 0`, so the floor division raised a bare `ZeroDivisionError`:

```python
>>> from sympy.crypto.crypto import kid_rsa_public_key
>>> kid_rsa_public_key(1, 1, 5, 6)
Traceback (most recent call last):
  ...
ZeroDivisionError: integer division or modulo by zero
```

This guards `M == 0` in both functions and raises a clear `ValueError` instead. Valid keys are unaffected.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* crypto
  * `kid_rsa_public_key` and `kid_rsa_private_key` now raise `ValueError` instead of `ZeroDivisionError` when `a*b == 1`.
<!-- END RELEASE NOTES -->
