### PR TITLE
fix(integrals): correct domain restriction in trig_substitution_rule for secant substitution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1802,6 +1802,7 @@ alijosephine <alijosephine@gmail.com>
 amsuhane <ayushsuhane99@iitkgp.ac.in> amsuhane <“ayushsuhane99@iitkgp.ac.in”>
 anca-mc <anca-mc@users.noreply.github.com>
 andreo <andrey.torba@gmail.com>
+aoright <102943475+aoright@users.noreply.github.com>
 arooshiverma <av22@iitbbs.ac.in>
 asthapaikacse <paikaasthaatwork@gmail.com>
 atharvParlikar <atharvparlikar@gmail.com>
@@ -1912,3 +1913,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+辰言 <oncwnuIWp30GguOyJ615Fqj8H-yc@git.weixin.qq.com>

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -59,7 +59,7 @@ from sympy.functions.special.polynomials import (chebyshevt, chebyshevu,
     OrthogonalPolynomial)
 from sympy.functions.special.zeta_functions import polylog
 from .integrals import Integral
-from sympy.logic.boolalg import And, Boolean
+from sympy.logic.boolalg import And, Boolean, Or
 from sympy.ntheory.factor_ import primefactors
 from sympy.polys.polytools import degree, factor_list, lcm_list, gcd_list, Poly
 from sympy.simplify.radsimp import fraction
@@ -2411,7 +2411,7 @@ def trig_substitution_rule(integral):
             # b*x**2 - a**2. Assume sin(theta) > 0, 0 < theta < pi
             constant = sqrt(-a)/sqrt(b)
             x_func = constant * sec(theta)
-            restriction = And(symbol > -constant, symbol < constant)
+            restriction = Or(symbol < -constant, symbol > constant)
         if x_func:
             # Manually simplify sqrt(trig(theta)**2) to trig(theta)
             # Valid due to assumed domain restriction

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -16,7 +16,7 @@ from sympy.functions.special.gamma_functions import uppergamma
 from sympy.functions.special.polynomials import (assoc_laguerre, chebyshevt, chebyshevu, gegenbauer, hermite, jacobi, laguerre, legendre)
 from sympy.functions.special.zeta_functions import polylog
 from sympy.integrals.integrals import (Integral, integrate)
-from sympy.logic.boolalg import And
+from sympy.logic.boolalg import And, Or
 from sympy import factor
 from sympy.integrals.manualintegrate import (manualintegrate, find_substitutions,
     _parts_rule, integral_steps, manual_subs)
@@ -244,7 +244,7 @@ def test_manualintegrate_inversetrig():
 def test_manualintegrate_trig_substitution():
     assert manualintegrate(sqrt(16*x**2 - 9)/x, x) == \
         Piecewise((sqrt(16*x**2 - 9) - 3*acos(3/(4*x)),
-                   And(x < Rational(3, 4), x > Rational(-3, 4))))
+                   Or(x > Rational(3, 4), x < Rational(-3, 4))))
     assert manualintegrate(1/(x**4 * sqrt(25-x**2)), x) == \
         Piecewise((-sqrt(-x**2/25 + 1)/(125*x) -
                    (-x**2/25 + 1)**(3*S.Half)/(15*x**3), And(x < 5, x > -5)))


### PR DESCRIPTION
#### References to other Issues or PRs



#### Brief description of what is fixed or changed

Corrects the domain restriction for the secant trigonometric substitution rule in `manualintegrate`.

#### Other comments



#### AI Generation Disclosure

This pull request includes code generated with the assistance of Google Gemini. The implementation in `manualintegrate.py` and the test files were generated with AI assistance.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Corrected the domain restriction for the secant trigonometric substitution rule in `manualintegrate`.
<!-- END RELEASE NOTES -->