### PR TITLE
fix(solvers): enforce constraints on unsolved variables in nonlinsolve instead of returning them as free

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1802,6 +1802,7 @@ alijosephine <alijosephine@gmail.com>
 amsuhane <ayushsuhane99@iitkgp.ac.in> amsuhane <“ayushsuhane99@iitkgp.ac.in”>
 anca-mc <anca-mc@users.noreply.github.com>
 andreo <andrey.torba@gmail.com>
+aoright <102943475+aoright@users.noreply.github.com>
 arooshiverma <av22@iitbbs.ac.in>
 asthapaikacse <paikaasthaatwork@gmail.com>
 atharvParlikar <atharvparlikar@gmail.com>
@@ -1912,3 +1913,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+辰言 <oncwnuIWp30GguOyJ615Fqj8H-yc@git.weixin.qq.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3726,7 +3726,6 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
                         subs_dict[k] = v
                 for eq in system:
                     eq_subs = eq.subs(subs_dict).expand()
-                    from sympy import Wild
                     W = Wild('W')
                     eq_subs = eq_subs.replace(exp(I*arg(W))*Abs(W), W).expand()
                     if eq_subs.has(unsolved_sym) and eq_subs != 0 and not eq_subs.is_zero:

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3716,7 +3716,29 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
             unsolved = list(filter(
                 lambda x: x not in solved_symbols, all_symbols))
             for unsolved_sym in unsolved:
-                res[unsolved_sym] = unsolved_sym
+                eqs_with_sym = []
+                subs_dict = {}
+                for k, v in res.items():
+                    if isinstance(v, ImageSet):
+                        vars = v.lamda.variables
+                        subs_dict[k] = v.lamda(*[0 for _ in vars])
+                    elif isinstance(v, Expr):
+                        subs_dict[k] = v
+                for eq in system:
+                    eq_subs = eq.subs(subs_dict).expand()
+                    from sympy import Wild
+                    W = Wild('W')
+                    eq_subs = eq_subs.replace(exp(I*arg(W))*Abs(W), W).expand()
+                    if eq_subs.has(unsolved_sym) and eq_subs != 0 and not eq_subs.is_zero:
+                        eqs_with_sym.append(eq_subs)
+                if eqs_with_sym:
+                    if len(eqs_with_sym) == 1:
+                        cond = Eq(eqs_with_sym[0], 0)
+                    else:
+                        cond = And(*[Eq(e, 0) for e in eqs_with_sym])
+                    res[unsolved_sym] = ConditionSet(unsolved_sym, cond, S.Complexes)
+                else:
+                    res[unsolved_sym] = unsolved_sym
             result_infinite.append(res)
         if res not in result_all_variables:
             result_all_variables.append(res)

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3712,18 +3712,19 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
         # Some or all the soln is dependent on 1 symbol.
         # eg. {x: y+2} then final soln {x: y+2, y: y}
         if len(res) < len(all_symbols):
-            solved_symbols = res.keys()
+            solved_symbols = set(res.keys())
             unsolved = list(filter(
                 lambda x: x not in solved_symbols, all_symbols))
-            for unsolved_sym in unsolved:
-                eqs_with_sym = []
-                subs_dict = {}
-                for k, v in res.items():
+            subs_dict = {}
+            for k, v in res.items():
+                if k in solved_symbols:
                     if isinstance(v, ImageSet):
                         vars = v.lamda.variables
                         subs_dict[k] = v.lamda(*[0 for _ in vars])
                     elif isinstance(v, Expr):
                         subs_dict[k] = v
+            for unsolved_sym in unsolved:
+                eqs_with_sym = []
                 for eq in system:
                     eq_subs = eq.subs(subs_dict).expand()
                     W = Wild('W')

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3472,8 +3472,8 @@ def test_issue_17580():
 
 def test_issue_17566_actual():
     sys = [2**x + 2**y - 3, 4**x + 9**y - 5]
-    # Not clear this is the correct result, but at least no recursion error
-    assert nonlinsolve(sys, x, y) == FiniteSet((log(3 - 2**y)/log(2), y))
+    # We now correctly return ConditionSet for the constrained unsolved variable
+    assert nonlinsolve(sys, x, y) == FiniteSet((log(3 - 2**y)/log(2), ConditionSet(y, Eq(4**(log(3 - 2**y)/log(2)) + 9**y - 5, 0), S.Complexes)))
 
 
 def test_issue_17565():
@@ -3540,8 +3540,11 @@ def test_issue_22413():
     res =  nonlinsolve((4*y*(2*x + 2*exp(y) + 1)*exp(2*x),
                          4*x*exp(2*x) + 4*y*exp(2*x + y) + 4*exp(2*x + y) + 1),
                         x, y)
-    # First solution is not correct, but the issue was an exception
-    sols = FiniteSet((x, S.Zero), (-exp(y) - S.Half, y))
+    # The solver now correctly returns ConditionSet for constrained unsolved variables instead of wrong free variables
+    sols = FiniteSet(
+        (-exp(y) - S.Half, ConditionSet(y, Eq(4*y*exp(-1)*exp(y)*exp(-2*exp(y)) + 1 - 2*exp(-1)*exp(-2*exp(y)), 0), S.Complexes)),
+        (ConditionSet(x, Eq(4*x*exp(2*x) + 4*exp(2*x) + 1, 0), S.Complexes), S.Zero)
+    )
     assert res == sols
 
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2444,14 +2444,14 @@ def test_substitution_incorrect():
     # the solutions in the following two tests are incorrect. The
     # correct result is EmptySet in both cases.
     assert substitution([h - 1, k - 1, f - 2, f - 4, -2 * k],
-                        [h, k, f]) == {(1, 1, f)}
+                        [h, k, f]) == {(1, 1, ConditionSet(f, Eq(f - 4, 0) & Eq(f - 2, 0), S.Complexes))}
     assert substitution([x + y + z, S.One, S.One, S.One], [x, y, z]) == \
                         {(-y - z, y, z)}
 
     # the correct result in the test below is {(-I, I, I, -I),
     # (I, -I, -I, I)}
     assert substitution([a - d, b + d, c + d, d**2 + 1], [a, b, c, d]) == \
-                        {(d, -d, -d, d)}
+                        {(d, -d, -d, ConditionSet(d, Eq(d**2 + 1, 0), S.Complexes))}
 
     # the result in the test below is incomplete. The complete result
     # is {(0, b), (log(2), 2)}


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29315

#### Brief description of what is fixed or changed

Enforces constraints on unsolved variables in `nonlinsolve` by returning them as `ConditionSet`s instead of incorrectly treating them as free variables.

#### Other comments



#### AI Generation Disclosure

This pull request includes code generated with the assistance of Google Gemini. The implementation in `solveset.py` and the test files were generated with AI assistance.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Enforced constraints on unsolved variables in `nonlinsolve` by returning them as `ConditionSet`s instead of incorrectly treating them as free variables.
<!-- END RELEASE NOTES -->