### PR TITLE
Fix Mathematica codegen for lerchphi (maps to HurwitzLerchPhi)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1575,6 +1575,7 @@ Sourav Goyal <souravgl0@gmail.com>
 Sourav Singh <souravsingh@users.noreply.github.com>
 Sparsh Bansal <itzzsparsh003@gmail.com>
 Srajan Garg <srajan.garg@gmail.com>
+Sreekant Baheti <60787859+Sreekant13@users.noreply.github.com>
 Srinivas Vasudevan <srvasude@gmail.com>
 Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> Arun Yeragudipati <ysarun1999@gmail.com>
 Srinivasa Arun Yeragudipati <ysarun1999@gmail.com> Srinivasa Arun Yeragudipati <38272686+arun-y99@users.noreply.github.com>

--- a/sympy/printing/mathematica.py
+++ b/sympy/printing/mathematica.py
@@ -106,7 +106,7 @@ known_functions = {
     "airyaiprime": [(lambda x: True, "AiryAiPrime")],
     "airybiprime": [(lambda x: True, "AiryBiPrime")],
     "polylog": [(lambda *x: True, "PolyLog")],
-    "lerchphi": [(lambda *x: True, "LerchPhi")],
+    "lerchphi": [(lambda *x: True, "HurwitzLerchPhi")],
     "gcd": [(lambda *x: True, "GCD")],
     "lcm": [(lambda *x: True, "LCM")],
     "jn": [(lambda *x: True, "SphericalBesselJ")],

--- a/sympy/printing/tests/test_mathematica.py
+++ b/sympy/printing/tests/test_mathematica.py
@@ -11,7 +11,7 @@ from sympy.functions import (exp, sin, cos, fresnelc, fresnels, conjugate, Max,
                              FallingFactorial, harmonic, atan2, sec, acsc,
                              hermite, laguerre, assoc_laguerre, jacobi,
                              gegenbauer, chebyshevt, chebyshevu, legendre,
-                             assoc_legendre, Li, LambertW)
+                             assoc_legendre, Li, LambertW, lerchphi)
 
 from sympy.printing.mathematica import mathematica_code as mcode
 
@@ -55,6 +55,7 @@ def test_Function():
     assert mcode(uppergamma(x, y)) == "Gamma[x, y]"
     assert mcode(polygamma(x, y)) == "PolyGamma[x, y]"
     assert mcode(loggamma(x)) == "LogGamma[x]"
+    assert mcode(lerchphi(x, y, z)) == "HurwitzLerchPhi[x, y, z]"
     assert mcode(erf(x)) == "Erf[x]"
     assert mcode(erfc(x)) == "Erfc[x]"
     assert mcode(erfi(x)) == "Erfi[x]"


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR description below or the PR will be closed. Follow the instructions in the template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #26707

<!-- If there is an issue related to this PR, include a link to the issue here. It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format, e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

#### Brief description of what is fixed or changed

SymPy's `lerchphi` corresponds to Mathematica's `HurwitzLerchPhi`, not `LerchPhi`. They are genuinely different functions in Mathematica. The Mathematica code printer was emitting `LerchPhi`. So the generated code was numerically wrong (confirmed against Mathematica 13.1 in the issue).

#### Other comments

#### AI Generation Disclosure

Claude (Claude Code) was used to identify the issue and write the change - the one-line mapping fix in sympy/printing/mathematica.py and the added test assertion. I reviewed the change and verified the output against HurwitzLerchPhi.

<!-- If this pull request includes AI-generated code or text, please disclose the tool used and specify which lines were generated. Disclosure is not required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area below.

DO NOT just delete this AI section of the PR template and do not leave this blank, or the PR will be closed. If you write "NO AI USE" and the code looks like it was generated by AI then the PR will be closed. -->

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END statements. The basic format is a bulleted list with the name of the subpackage and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information on how to write release notes. The bot will check your release notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed the Mathematica code printer to translate ``lerchphi`` to ``HurwitzLerchPhi`` instead of ``LerchPhi``.
<!-- END RELEASE NOTES -->