### PR TITLE
[GSoC 2026] Implement domainmatrix.ground_eigenvals and ground_eigenvects

### DIFF
--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -3762,6 +3762,60 @@ class DomainMatrix:
         """
         return self.rep.charpoly()
 
+    def ground_eigenvals(self):
+        """
+        Return the eigenvalues in the ground domain together with their
+        algebraic multiplicities.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DM
+        >>> from sympy import QQ
+        >>> M = DM([[6, -1, 0, 0],
+        ...         [9, 12, 0, 0],
+        ...         [0,  0, 1, 2],
+        ...         [0,  0, 5, 6]], QQ)
+        >>> M.ground_eigenvals()
+        {9: 2}
+        """
+        p = self.charpoly()
+        _, factors = dup_factor_list(p, self.domain)
+        eigs = {}
+        for base, exp in factors:
+            if len(base) == 2:
+                v = -base[1]/base[0]
+                eigs[v] = exp
+        return eigs
+
+    def ground_eigenvects(self):
+        """
+        Return the eigenvalues in the ground domain together with
+        their eigenvectors.
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices import DM
+        >>> from sympy import QQ
+        >>> M = DM([[6, -1, 0, 0],
+        ...         [9, 12, 0, 0],
+        ...         [0,  0, 1, 2],
+        ...         [0,  0, 5, 6]], QQ)
+        >>> M.ground_eigenvects()
+        {9: DomainMatrix([[-1/3], [1], [0], [0]], (4, 1), QQ)}
+        """
+        p = self.charpoly()
+        _, factors = dup_factor_list(p, self.domain)
+        eigs = {}
+        divide_last = self.domain.is_Field
+        for base, _ in factors:
+            if len(base) == 2:
+                v = -base[1]/base[0]
+                B = self - self.diag([v]*self.shape[0], self.domain)
+                eigs[v] = B.nullspace(divide_last=divide_last).transpose()
+        return eigs
+
     @classmethod
     def eye(cls, shape, domain):
         r"""

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -3791,7 +3791,7 @@ class DomainMatrix:
     def ground_eigenvects(self):
         """
         Return the eigenvalues in the ground domain together with
-        their eigenvectors.
+        their algebraic multiplicites and eigenvectors.
 
         Examples
         ========
@@ -3803,18 +3803,14 @@ class DomainMatrix:
         ...         [0,  0, 1, 2],
         ...         [0,  0, 5, 6]], QQ)
         >>> M.ground_eigenvects()
-        {9: DomainMatrix([[-1/3], [1], [0], [0]], (4, 1), QQ)}
+        [(9, 2, DomainMatrix([[-1/3], [1], [0], [0]], (4, 1), QQ))]
         """
-        p = self.charpoly()
-        _, factors = dup_factor_list(p, self.domain)
-        eigs = {}
-        divide_last = self.domain.is_Field
-        for base, _ in factors:
-            if len(base) == 2:
-                v = -base[1]/base[0]
-                B = self - self.diag([v]*self.shape[0], self.domain)
-                eigs[v] = B.nullspace(divide_last=divide_last).transpose()
-        return eigs
+        eigs = self.ground_eigenvals()
+        result = []
+        for v, m in eigs.items():
+            B = self - self.diag([v]*self.shape[0], self.domain)
+            result.append((v, m, B.nullspace(divide_last=False).transpose()))
+        return result
 
     @classmethod
     def eye(cls, shape, domain):

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -1214,11 +1214,14 @@ def test_DomainMatrix_ground_eigenvects():
     assert A.ground_eigenvects() == [(QQ(0), 3, DomainMatrix.eye(3, QQ))]
 
     A = DM([[0, 1], [1, 0]], ZZ)
-    for B in (A, A.to_sparse()):
-        for l, m, V in B.ground_eigenvects():
-            assert l == ZZ(-1) or l == ZZ(1)
-            assert m == 1 and V.shape == (2, m)
-            assert B * V == l * V
+    assert A.ground_eigenvects() == [
+        (1, 1, DM([[1], [1]], ZZ)),
+        (-1, 1, DM([[-1], [1]], ZZ)),
+    ]
+    assert A.to_sparse().ground_eigenvects() == [
+        (1, 1, DM([[1], [1]], ZZ).to_sparse()),
+        (-1, 1, DM([[-1], [1]], ZZ).to_sparse()),
+    ]
 
     A = DM([[0, 1], [-1, 0]], QQ)
     assert A.ground_eigenvects() == []
@@ -1228,14 +1231,14 @@ def test_DomainMatrix_ground_eigenvects():
             [-3, QQ(1, 2), 0, 0],
             [0, 0, 2, QQ(3, 2)],
             [0, 0, 0, 2]], QQ)
-    for B in (A, A.to_sparse()):
-        for l, m, V in B.ground_eigenvects():
-            assert l == QQ(2) or l == QQ(5, 2)
-            assert B * V == l * V
-            if l == QQ(2):
-                assert m == 3 and V.shape == (4, 2) and V.rank() == 2
-            elif l == QQ(5, 2):
-                assert m == 1 and V.shape == (4, 1) and V.rank() == 1
+    assert A.ground_eigenvects() == [
+        (QQ(5, 2), 1, DM([[-QQ(2, 3)], [1], [0], [0]], QQ)),
+        (QQ(2), 3, DM([[-QQ(1, 2), 0], [1, 0], [0, 1], [0, 0]], QQ)),
+    ]
+    assert A.to_sparse().ground_eigenvects() == [
+        (QQ(5, 2), 1, DM([[-QQ(2, 3)], [1], [0], [0]], QQ).to_sparse()),
+        (QQ(2), 3, DM([[-QQ(1, 2), 0], [1, 0], [0, 1], [0, 0]], QQ).to_sparse()),
+    ]
 
     A = DM([[1, 2]], QQ)
     raises(DMNonSquareMatrixError, lambda: A.ground_eigenvects())

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -1207,34 +1207,35 @@ def test_DomainMatrix_ground_eigenvals():
 
 def test_DomainMatrix_ground_eigenvects():
     A = DomainMatrix([], (0, 0), ZZ)
-    assert A.ground_eigenvects() == {}
-    assert A.to_sparse().ground_eigenvects() == {}
+    assert A.ground_eigenvects() == []
+    assert A.to_sparse().ground_eigenvects() == []
 
     A = DomainMatrix.zeros((3, 3), QQ)
-    assert A.ground_eigenvects() == {QQ(0): DomainMatrix.eye(3, QQ)}
+    assert A.ground_eigenvects() == [(QQ(0), 3, DomainMatrix.eye(3, QQ))]
 
     A = DM([[0, 1], [1, 0]], ZZ)
     for B in (A, A.to_sparse()):
-        V = B.ground_eigenvects()
-        assert set(V) == {ZZ(1), ZZ(-1)}
-        for l, m in ((ZZ(1), 1), (ZZ(-1), 1)):
-            assert V[l].shape == (2, m)
-            assert B * V[l] == l * V[l]
+        for l, m, V in B.ground_eigenvects():
+            assert l == ZZ(-1) or l == ZZ(1)
+            assert m == 1 and V.shape == (2, m)
+            assert B * V == l * V
 
     A = DM([[0, 1], [-1, 0]], QQ)
-    assert A.ground_eigenvects() == {}
-    assert A.to_sparse().ground_eigenvects() == {}
+    assert A.ground_eigenvects() == []
+    assert A.to_sparse().ground_eigenvects() == []
 
     A = DM([[4, 1, 0, 0],
             [-3, QQ(1, 2), 0, 0],
             [0, 0, 2, QQ(3, 2)],
             [0, 0, 0, 2]], QQ)
     for B in (A, A.to_sparse()):
-        V = B.ground_eigenvects()
-        assert set(V) == {QQ(2), QQ(5, 2)}
-        for l, m in ((QQ(2), 2), (QQ(5, 2), 1)):
-            assert V[l].shape == (4, m) and V[l].rank() == m
-            assert B * V[l] == l * V[l]
+        for l, m, V in B.ground_eigenvects():
+            assert l == QQ(2) or l == QQ(5, 2)
+            assert B * V == l * V
+            if l == QQ(2):
+                assert m == 3 and V.shape == (4, 2) and V.rank() == 2
+            elif l == QQ(5, 2):
+                assert m == 1 and V.shape == (4, 1) and V.rank() == 1
 
     A = DM([[1, 2]], QQ)
     raises(DMNonSquareMatrixError, lambda: A.ground_eigenvects())

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -1175,6 +1175,71 @@ def test_DomainMatrix_charpoly_factor_list():
     ]
 
 
+def test_DomainMatrix_ground_eigenvals():
+    A = DomainMatrix([], (0, 0), ZZ)
+    assert A.ground_eigenvals() == {}
+    assert A.to_sparse().ground_eigenvals() == {}
+
+    A = DomainMatrix.zeros((3, 3), QQ)
+    assert A.ground_eigenvals() == {QQ(0): 3}
+    assert A.to_sparse().ground_eigenvals() == {QQ(0): 3}
+
+    A = DM([[0, 1], [1, 0]], ZZ)
+    assert A.ground_eigenvals() == {ZZ(1): 1, ZZ(-1): 1}
+    assert A.to_sparse().ground_eigenvals() == {ZZ(1): 1, ZZ(-1): 1}
+
+    A = DM([[0, 1], [-1, 0]], QQ)
+    assert A.ground_eigenvals() == {}
+    assert A.to_sparse().ground_eigenvals() == {}
+
+    A = DM([[0, 1], [-1, 0]], QQ_I)
+    assert A.ground_eigenvals() == {QQ_I(0, 1): 1, QQ_I(0, -1): 1}
+
+    A = DM([[4, 1, 0, 0],
+            [-3, QQ(1, 2), 0, 0],
+            [0, 0, 2, QQ(3, 2)],
+            [0, 0, 0, 2]], QQ)
+    assert A.ground_eigenvals() == {QQ(2): 3, QQ(5, 2): 1}
+
+    A = DM([[1, 2]], QQ)
+    raises(DMNonSquareMatrixError, lambda: A.ground_eigenvals())
+
+
+def test_DomainMatrix_ground_eigenvects():
+    A = DomainMatrix([], (0, 0), ZZ)
+    assert A.ground_eigenvects() == {}
+    assert A.to_sparse().ground_eigenvects() == {}
+
+    A = DomainMatrix.zeros((3, 3), QQ)
+    assert A.ground_eigenvects() == {QQ(0): DomainMatrix.eye(3, QQ)}
+
+    A = DM([[0, 1], [1, 0]], ZZ)
+    for B in (A, A.to_sparse()):
+        V = B.ground_eigenvects()
+        assert set(V) == {ZZ(1), ZZ(-1)}
+        for l, m in ((ZZ(1), 1), (ZZ(-1), 1)):
+            assert V[l].shape == (2, m)
+            assert B * V[l] == l * V[l]
+
+    A = DM([[0, 1], [-1, 0]], QQ)
+    assert A.ground_eigenvects() == {}
+    assert A.to_sparse().ground_eigenvects() == {}
+
+    A = DM([[4, 1, 0, 0],
+            [-3, QQ(1, 2), 0, 0],
+            [0, 0, 2, QQ(3, 2)],
+            [0, 0, 0, 2]], QQ)    
+    for B in (A, A.to_sparse()):
+        V = B.ground_eigenvects()
+        assert set(V) == {QQ(2), QQ(5, 2)}
+        for l, m in ((QQ(2), 2), (QQ(5, 2), 1)):
+            assert V[l].shape == (4, m) and V[l].rank() == m
+            assert B * V[l] == l * V[l]
+
+    A = DM([[1, 2]], QQ)
+    raises(DMNonSquareMatrixError, lambda: A.ground_eigenvects())
+
+
 def test_DomainMatrix_eye():
     A = DomainMatrix.eye(3, QQ)
     assert A.rep == SDM.eye((3, 3), QQ)

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -1228,7 +1228,7 @@ def test_DomainMatrix_ground_eigenvects():
     A = DM([[4, 1, 0, 0],
             [-3, QQ(1, 2), 0, 0],
             [0, 0, 2, QQ(3, 2)],
-            [0, 0, 0, 2]], QQ)    
+            [0, 0, 0, 2]], QQ)
     for B in (A, A.to_sparse()):
         V = B.ground_eigenvects()
         assert set(V) == {QQ(2), QQ(5, 2)}


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

This PR implements the methods `ground_eigenvals` and `ground_eigenvects` for the class `DomainMatrix`, which allows computing eigenvalues and eigenvectors over the matrix domain.


#### Other comments

Due to python-flint issue 373 (an issue in `nmod.__hash__`, fixed by PR 374), dicts containing FiniteField elements from flint <=0.8.0 could exhibit undetermined behaviours. This may slightly affect downstream code that uses the dictionaries of eigenvalues or eigenvectors for matrices over finite fields.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Implemented `ground_eigenvals` and `ground_eigenvects` for `DomainMatrix` to compute the eigenvalues or eigenvectors over the matrix domain.
<!-- END RELEASE NOTES -->
