### PR TITLE
Fix outdated parameter in init_session docstring

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1823,6 +1823,7 @@ dps7ud <dps7ud@virginia.edu>
 dranknight09 <cbhaavan@gmail.com>
 dustyrockpyle <dustyrockpyle@gmail.com>
 eeshsaxena <eeshsaxena@gmail.com>
+eeshsaxena <eeshsaxena@gmail.com> eeshsaxena <139802361+eeshsaxena@users.noreply.github.com>
 elvis-sik <e.sikora@grad.ufsc.br>
 erdOne <36414270+erdOne@users.noreply.github.com>
 extraymond <extraymond@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1822,6 +1822,7 @@ dodo <palumbododo@gmail.com> Dodopalu <87149525+Dodopalu@users.noreply.github.co
 dps7ud <dps7ud@virginia.edu>
 dranknight09 <cbhaavan@gmail.com>
 dustyrockpyle <dustyrockpyle@gmail.com>
+eeshsaxena <eeshsaxena@gmail.com>
 elvis-sik <e.sikora@grad.ufsc.br>
 erdOne <36414270+erdOne@users.noreply.github.com>
 extraymond <extraymond@gmail.com>

--- a/sympy/interactive/session.py
+++ b/sympy/interactive/session.py
@@ -379,11 +379,11 @@ def init_session(console_backend=None, pretty_print=True, order=None,
         that things like 1/2 give Rational(1, 2).
         If False, it will not.
         The default is False.
-    ipython: boolean or None
-        If True, printing will initialize for an IPython console;
-        if False, printing will initialize for a normal console;
-        The default is None, which automatically determines whether we are in
-        an ipython instance or not.
+    console_backend: str or None
+        The interactive console backend to initialize, one of ``'python'``,
+        ``'ipython'`` or ``'bpython'``. The default is None, which
+        automatically selects an IPython console when one is available and a
+        Python console otherwise.
     str_printer: function, optional, default=None
         A custom string printer function. This should mimic
         sympy.printing.sstrrepr().


### PR DESCRIPTION
#### References to other Issues or PRs
None.

#### Brief description of what is fixed or changed

`init_session` (`sympy/interactive/session.py`) accepts a `console_backend` argument, but its docstring still documented a removed `ipython` boolean parameter and did not document `console_backend` at all. This replaces the stale `ipython` entry with an accurate `console_backend` description (one of `'python'`, `'ipython'`, `'bpython'`, or `None` to auto-select).

Documentation-only change.

#### Other comments

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
