### PR TITLE
assumptions: add refine handler for conjugate real arguments

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -602,6 +602,23 @@ def refine_floor_ceiling(expr, assumptions):
     return expr
 
 
+def refine_conjugate(expr, assumptions):
+    """
+    Simplify conjugate(x) given assumptions about x.
+
+    conjugation is a unary operation that reverses the sign of the imaginary part.
+    For conjugate to simplify, we need to know whether the argument is real
+    (in which case conjugate(x) = x) or purely imaginary (where it becomes -x).
+
+    This handler covers the real case which is the most common and useful
+    simplification.
+    """
+    arg = expr.args[0] if expr.args else expr
+    if ask(Q.real(arg), assumptions):
+        return arg
+    return expr
+
+
 handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Abs': refine_abs,
     'Pow': refine_Pow,
@@ -616,5 +633,6 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'exp': refine_exp,
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
-    'ceiling' : refine_floor_ceiling,
+    'ceiling': refine_floor_ceiling,
+    'conjugate': refine_conjugate,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -6,7 +6,7 @@ from sympy.core.expr import Expr
 from sympy.core.numbers import (I, Rational, nan, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
-from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
+from sympy.functions.elementary.complexes import (Abs, arg, conjugate, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin, tan)
@@ -354,3 +354,16 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+
+def test_conjugate():
+    from sympy import I
+
+    assert refine(conjugate(x), Q.real(x)) == x
+    assert refine(conjugate(x), Q.positive(x)) == x
+    assert refine(conjugate(x), Q.negative(x)) == x
+    assert refine(conjugate(x)) == conjugate(x)
+
+    # Literal values
+    assert refine(conjugate(3 + I)) == 3 - I
+    assert refine(conjugate(I)) == -I


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

See gh-27888 (Refine is not able to make many simplifications).


#### Brief description of what is fixed or changed

Add a new `refine` handler for `conjugate()` that simplifies `conjugate(x)` to `x` when `x` is known to be real. This is one of the enhancements requested in gh-27888 to make the refine function handle more cases.

The complex conjugate of a real number equals itself, so `conjugate(x) = x` for real `x`.


#### Other comments

Tests added: `test_conjugate` in `sympy/assumptions/tests/test_refine.py` with 6 assertions.


#### AI Generation Disclosure

NO AI USE

- This PR has no AI-generated content