### PR TITLE
fix substitution() returning non-empty solutions for inconsistent systems

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1196,6 +1196,7 @@ Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <47920034+NikhilSDate@users.no
 Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <nikhil.s.date@gmail.com>
 Nikhil Gopalam <gopalamn@umich.edu> gopalamn <gopalamn@umich.edu>
 Nikhil Maan <nikhilmaan22@gmail.com> Nikhil Maan <nikhilman22@gmail.com>
+Nikhil Nair <nikhil2005nair@gmail.com>
 Nikhil Pappu <nkhlpappu@gmail.com>
 Nikhil Sarda <diff.operator@gmail.com>
 Nikita <nikita.student.cse19@itbhu.ac.in>

--- a/.mailmap
+++ b/.mailmap
@@ -1196,6 +1196,7 @@ Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <47920034+NikhilSDate@users.no
 Nikhil Date <nikhil.s.date@gmail.com> NikhilSDate <nikhil.s.date@gmail.com>
 Nikhil Gopalam <gopalamn@umich.edu> gopalamn <gopalamn@umich.edu>
 Nikhil Maan <nikhilmaan22@gmail.com> Nikhil Maan <nikhilman22@gmail.com>
+Nikhil Nair <107941991+NikhilRN18@users.noreply.github.com>
 Nikhil Nair <nikhil2005nair@gmail.com>
 Nikhil Pappu <nkhlpappu@gmail.com>
 Nikhil Sarda <diff.operator@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,4 +1457,3 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
-Nikhil Nair <nikhil2005nair@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,3 +1457,4 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
+Nikhil Nair <nikhil2005nair@gmail.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -3444,7 +3444,10 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
         u = Dummy('u')
         if n:
             eq = eq.subs(n, 0)
-        satisfy = eq if eq in (True, False) else checksol(u, u, eq, minimal=True)
+        if isinstance(eq, bool) or eq is S.true or eq is S.false:
+            satisfy = bool(eq)
+        else:
+            satisfy = checksol(u, u, eq, minimal=True)
         if satisfy is False:
             delete_soln = True
             res = {}
@@ -3500,7 +3503,8 @@ def substitution(system, symbols, result=[{}], known_symbols=[],
         elif satisfy_exclude:
             delete_soln = True
             rnew = {}
-        _restore_imgset(rnew, original_imageset, newresult)
+        if not delete_soln:
+            _restore_imgset(rnew, original_imageset, newresult)
         return newresult, delete_soln
 
     def _new_order_result(result, eq):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -304,7 +304,7 @@ def test_issue_17479():
     # solution set. The next test checks the result for correctness.
 
 
-@XFAIL
+
 def test_issue_18449():
     x, y, z = symbols("x, y, z")
     f = (x**2 + y**2)**2 + (x**2 + z**2)**2 - 2*(2*x**2 + y**2 + z**2)
@@ -2437,14 +2437,25 @@ def test_substitution_basic():
     assert substitution(
         [x + y], [x], [{y: 1}], [y],
         {x + 1}, [y, x]) == S.EmptySet
+    
+def test_substitution_inconsistent():
+    # substitution should return EmptySet for inconsistent systems
+    # rather than a non-empty solution that ignores the contradictions.
+    assert substitution([a - 1, a - 2], [a]) == S.EmptySet
+    assert substitution([h - 1, k - 1, f - 2, f - 4, -2*k],
+                        [h, k, f]) == S.EmptySet
+    # a single contradictory constant residual (==1) used to slip through
+    assert substitution([a, a - 1], [a]) == S.EmptySet
+    assert substitution([a - 1, a], [a]) == S.EmptySet
+    # consistent systems are still solved
+    assert substitution([a - 1, a - 1], [a]) == {(1,)}
+    assert substitution([h - 1, k - 1, f - 2], [h, k, f]) == {(1, 1, 2)}
 
 
 @slow
 def test_substitution_incorrect():
     # the solutions in the following two tests are incorrect. The
-    # correct result is EmptySet in both cases.
-    assert substitution([h - 1, k - 1, f - 2, f - 4, -2 * k],
-                        [h, k, f]) == {(1, 1, f)}
+    # correct result is EmptySet.
     assert substitution([x + y + z, S.One, S.One, S.One], [x, y, z]) == \
                         {(-y - z, y, z)}
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2437,7 +2437,7 @@ def test_substitution_basic():
     assert substitution(
         [x + y], [x], [{y: 1}], [y],
         {x + 1}, [y, x]) == S.EmptySet
-    
+
 def test_substitution_inconsistent():
     # substitution should return EmptySet for inconsistent systems
     # rather than a non-empty solution that ignores the contradictions.


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29969
#### Brief description of what is fixed or changed
When a solution was deleted or excluded, _append_eq set it back to an empty dict, which _append_new_soln would then append back via _restore_imgset. The empty dict basically provided a branch that was constraint-free, which could re-solve remaining equations and led to near-random soutions.

This process is now skipped, when the solution is being deleted.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Claude code was used at certain points (lines 3447–3457 in _append_eq and lines 3513-3519 in _append_new_soln).



#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* solvers
  * Fixed substitution() and nonlinsolve() returning incorrect solutions for inconsistent systems of equations.

<!-- END RELEASE NOTES -->