### PR TITLE
solvers: fix solve_linear to accept plain Python ints

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1287,6 +1287,7 @@ Pierre Haessig <pierre.haessig@crans.org>
 Pieter Eendebak <pieter.eendebak@gmail.com>
 Pieter Gijsbers <p.gijsbers@tue.nl>
 Piotr Korgul <p.korgul@gmail.com>
+Piyush Bhakuni <bhakunipiyush23@gmail.com>
 Pontus von Brömssen <pontus.vonbromssen+github@gmail.com> <118356995+Pontus-vB@users.noreply.github.com>
 Poom Chiarawongse <eight1911@gmail.com> <15707729+Eight1911@users.noreply.github.com>
 Poom Chiarawongse <eight1911@gmail.com> <Eight1911@users.noreply.github.com>

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -2135,6 +2135,7 @@ def solve_linear(lhs, rhs=0, symbols=[], exclude=[]):
     solution.)
 
     """
+    lhs, rhs = _sympify(lhs), _sympify(rhs)
     if isinstance(lhs, Eq):
         if rhs:
             raise ValueError(filldedent('''

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -767,6 +767,8 @@ def test_solve_linear():
     assert solve_linear(eq) == (0, 1)
     eq = cos(x)**2 + sin(x)**2  # = 1
     assert solve_linear(eq) == (0, 1)
+    assert solve_linear(5) == (0, 1)
+    assert solve_linear(0) == (0, 1)
     raises(ValueError, lambda: solve_linear(Eq(x, 3), 3))
 
 


### PR DESCRIPTION
solve_linear raised AttributeError when passed a plain Python int because int does not have as_numer_denom(). Fix by sympifying lhs and rhs at the start of the function.

Fixes #29989

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #29989 

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
solve_linear(5) was giving attiributeerror because python int does not have as_numer_denom() method.  so i added  _sympify at the start of  function to convert inputs.  and also added two regression tests.


#### Other comments
_sympify was already  imported in the file.


#### AI Generation Disclosure
NO AI USE

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
*  solvers
  * Fixed attribute error when calling solve_linear with a plain python int. 

<!-- END RELEASE NOTES -->
