### PR TITLE
ENH: Add the curry method to the Lambda.

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2101,6 +2101,45 @@ class Lambda(Expr):
 
         return symargmap
 
+    def curry(self):
+        """
+        Return a curried Lambda: any multi-variable Lambda becomes a
+        nest of single-argument Lambdas.
+
+        Examples
+        ========
+
+        >>> from sympy import Lambda, symbols
+        >>> x, y = symbols('x y')
+        >>> Lambda((x, y), x + y).curry()
+        Lambda(x, Lambda(y, x + y))
+        >>> Lambda(x, x ** 2).curry()
+        Lambda(x, x**2)
+        >>> from sympy import Tuple
+        >>> Lambda((x, Tuple(y,)), x*y).curry()
+        Lambda(x, Lambda(y, x*y))
+        >>> Lambda((x, (y,)), x*y).curry()
+        Lambda(x, Lambda(y, x*y))
+
+        Currying means every Lambda in the expression binds exactly one variable.
+        If already curried, returns self.
+        """
+        def _flatten_vars(sig):
+            if isinstance(sig, Tuple):
+                return sum([_flatten_vars(a) for a in sig], [])
+            else:
+                return [sig]
+        vars = _flatten_vars(self.signature)
+        e = self.expr
+        # If already curried (one variable per nested lambda), return as is
+        if len(vars) == 1 and isinstance(self.expr, Lambda):
+        # Already Lambda(x, Lambda(y, ...)), so nothing to do
+            return self
+        # Nest from the innermost outward
+        for v in reversed(vars):
+            e = Lambda(v, e)
+        return e
+
     @property
     def is_identity(self):
         """Return ``True`` if this ``Lambda`` is an identity function. """

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2109,7 +2109,8 @@ class Lambda(Expr):
     def curry(self):
         """
         Return a curried Lambda: any multi-variable Lambda becomes a
-        nest of single-argument Lambdas.
+        nest of single-argument Lambdas, e.g ``f(x,y)`` is rewritten as ``f(x)(y)``.
+
 
         Examples
         ========

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2101,6 +2101,11 @@ class Lambda(Expr):
 
         return symargmap
 
+    @property
+    def is_identity(self):
+        """Return ``True`` if this ``Lambda`` is an identity function. """
+        return self.signature == self.expr
+
     def curry(self):
         """
         Return a curried Lambda: any multi-variable Lambda becomes a
@@ -2109,41 +2114,33 @@ class Lambda(Expr):
         Examples
         ========
 
-        >>> from sympy import Lambda, symbols
-        >>> x, y = symbols('x y')
+        >>> from sympy import Lambda
+        >>> from sympy.abc import x, y, z
         >>> Lambda((x, y), x + y).curry()
         Lambda(x, Lambda(y, x + y))
-        >>> Lambda(x, x ** 2).curry()
+        >>> Lambda((x, y, z), x*y + z).curry()
+        Lambda(x, Lambda(y, Lambda(z, x*y + z)))
+        >>> Lambda(x, x**2).curry()
         Lambda(x, x**2)
-        >>> from sympy import Tuple
-        >>> Lambda((x, Tuple(y,)), x*y).curry()
-        Lambda(x, Lambda(y, x*y))
-        >>> Lambda((x, (y,)), x*y).curry()
-        Lambda(x, Lambda(y, x*y))
 
-        Currying means every Lambda in the expression binds exactly one variable.
-        If already curried, returns self.
+        Nested tuples in the signature are flattened into their component
+        variables:
+
+        >>> Lambda(((x, y), z), x + y + z).curry()
+        Lambda(x, Lambda(y, Lambda(z, x + y + z)))
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Currying
         """
-        def _flatten_vars(sig):
-            if isinstance(sig, Tuple):
-                return sum([_flatten_vars(a) for a in sig], [])
-            else:
-                return [sig]
-        vars = _flatten_vars(self.signature)
-        e = self.expr
-        # If already curried (one variable per nested lambda), return as is
-        if len(vars) == 1 and isinstance(self.expr, Lambda):
-        # Already Lambda(x, Lambda(y, ...)), so nothing to do
+        variables = self.variables
+        if not variables:
             return self
-        # Nest from the innermost outward
-        for v in reversed(vars):
-            e = Lambda(v, e)
-        return e
-
-    @property
-    def is_identity(self):
-        """Return ``True`` if this ``Lambda`` is an identity function. """
-        return self.signature == self.expr
+        expr = self.expr
+        for v in reversed(variables):
+            expr = Lambda(v, expr)
+        return expr
 
     def _eval_evalf(self, prec):
         return self.func(self.args[0], self.args[1].evalf(n=prec_to_dps(prec)))

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -2136,7 +2136,7 @@ class Lambda(Expr):
         .. [1] https://en.wikipedia.org/wiki/Currying
         """
         variables = self.variables
-        if not variables:
+        if len(variables) <= 1 and self.signature == variables:
             return self
         expr = self.expr
         for v in reversed(variables):

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -340,6 +340,8 @@ def test_Lambda_curry():
     assert Lambda((x, y, z), x*y + z).curry() == \
         Lambda(x, Lambda(y, Lambda(z, x*y + z)))
     assert Lambda(x, x**2).curry() == Lambda(x, x**2)
+    assert Lambda(((x,),), x**2).curry() == Lambda(x, x**2)
+    assert Lambda((x,), x**2).curry() == Lambda(x, x**2)
     assert Lambda(x, Lambda(y, x + y)).curry() == Lambda(x, Lambda(y, x + y))
     assert Lambda((x, (y, z)), x*y*z).curry() == \
         Lambda(x, Lambda(y, Lambda(z, x*y*z)))

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -335,6 +335,31 @@ def test_Lambda_equality():
     assert Lambda(x, 2*x) != Lambda(y, 2*y)
 
 
+def test_Lambda_curry():
+    """
+    Lambda((x, y), x + y) -> Lambda(x, Lambda(y, x + y))
+    Lambda(x, Lambda(y, x + y)) is already curried.
+    Lambda(x, x**2) should return itself.
+    Lambda((x, (y, z)), x*y*z) -> Lambda(x, Lambda(y, Lambda(z, x*y*z)))
+    Lambda((x, y, z), x*y + z) ==> Lambda(x, Lambda(y, Lambda(z, x*y+z)))
+    """
+    f = Lambda((x, y), x + y)
+    fc = f.curry()
+    assert fc == Lambda(x, Lambda(y, x + y))
+    c = Lambda(x, Lambda(y, x + y))
+    out = c.curry()
+    assert out == c
+    f = Lambda(x, x**2)
+    out = f.curry()
+    assert out == f
+    f = Lambda((x, (y, z)), x*y*z)
+    fc = f.curry()
+    assert fc == Lambda(x, Lambda(y, Lambda(z, x*y*z)))
+    f = Lambda((x, y, z), x*y+z)
+    fc = f.curry()
+    assert fc == Lambda(x, Lambda(y, Lambda(z, x*y+z)))
+
+
 def test_Subs():
     assert Subs(1, (), ()) is S.One
     # check null subs influence on hashing

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -336,28 +336,19 @@ def test_Lambda_equality():
 
 
 def test_Lambda_curry():
-    """
-    Lambda((x, y), x + y) -> Lambda(x, Lambda(y, x + y))
-    Lambda(x, Lambda(y, x + y)) is already curried.
-    Lambda(x, x**2) should return itself.
-    Lambda((x, (y, z)), x*y*z) -> Lambda(x, Lambda(y, Lambda(z, x*y*z)))
-    Lambda((x, y, z), x*y + z) ==> Lambda(x, Lambda(y, Lambda(z, x*y+z)))
-    """
-    f = Lambda((x, y), x + y)
-    fc = f.curry()
-    assert fc == Lambda(x, Lambda(y, x + y))
-    c = Lambda(x, Lambda(y, x + y))
-    out = c.curry()
-    assert out == c
-    f = Lambda(x, x**2)
-    out = f.curry()
-    assert out == f
-    f = Lambda((x, (y, z)), x*y*z)
-    fc = f.curry()
-    assert fc == Lambda(x, Lambda(y, Lambda(z, x*y*z)))
-    f = Lambda((x, y, z), x*y+z)
-    fc = f.curry()
-    assert fc == Lambda(x, Lambda(y, Lambda(z, x*y+z)))
+    assert Lambda((x, y), x + y).curry() == Lambda(x, Lambda(y, x + y))
+    assert Lambda((x, y, z), x*y + z).curry() == \
+        Lambda(x, Lambda(y, Lambda(z, x*y + z)))
+    assert Lambda(x, x**2).curry() == Lambda(x, x**2)
+    assert Lambda(x, Lambda(y, x + y)).curry() == Lambda(x, Lambda(y, x + y))
+    assert Lambda((x, (y, z)), x*y*z).curry() == \
+        Lambda(x, Lambda(y, Lambda(z, x*y*z)))
+    assert Lambda(((x, y), z), x + y + z).curry() == \
+        Lambda(x, Lambda(y, Lambda(z, x + y + z)))
+    assert Lambda((x), 1).curry() == Lambda(x, 1)
+    assert Lambda((x, (y, (z, t))), 1).curry() == \
+        Lambda(x, Lambda(y, Lambda(z, Lambda(t, 1))))
+    assert Lambda((), 1).curry() == Lambda((), 1)
 
 
 def test_Subs():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
See: https://github.com/sympy/sympy/pull/28242  https://github.com/sympy/sympy/pull/28423  and the comment https://github.com/sympy/sympy/pull/28242#issuecomment-3070548655

I might attempt revive these PRs so I am dividing the work between PRs if possible

#### Brief description of what is fixed or changed
Adds `curry()` method to Lambda. My understanding is that `curry` also should flatten the variables like this.

#### Other comments
I did coauthor the original author, although I did change the code a little bit

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Claude was used in the docs
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Added curry() method to Lambda
<!-- END RELEASE NOTES -->
