### PR TITLE
[GSoC] manualintegrate: improve u substitution to handle linear substitutions

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -40,8 +40,7 @@ from sympy.core.singleton import S
 from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol, Wild
 from sympy.core.exprtools import factor_terms
-from sympy.core.function import WildFunction
-from sympy.core.function import count_ops
+from sympy.core.function import WildFunction, count_ops
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction, csch,
@@ -1311,6 +1310,7 @@ def find_substitutions(integrand, symbol, u_var):
             if substitution not in results:
                 results.append(substitution)
 
+    results.sort(key=lambda sub: count_ops(sub[2]))
     return results
 
 def rewriter(condition, rewrite):
@@ -2531,10 +2531,7 @@ def substitution_rule(integral):
                         pieces.append((subrule, True))
                         subrule = PiecewiseRule(substituted, symbol, pieces)
 
-            ways.append((substituted, URule(integrand, symbol, u_var, u_func, subrule)))
-
-        ways.sort(key=lambda w: count_ops(w[0]))
-        ways = [w[1] for w in ways]
+            ways.append(URule(integrand, symbol, u_var, u_func, subrule))
 
         if len(ways) > 1:
             return AlternativeRule(integrand, symbol, ways)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1224,6 +1224,8 @@ def find_substitutions(integrand, symbol, u_var):
         # where u = x + 1 and u_var = u
         if (
             substituted.has_free(symbol) and
+            # avoid redundant rational function shift
+            not integrand.is_rational_function(symbol) and
             u.is_polynomial(symbol) and degree(u, symbol) == 1
         ):
             a = u.coeff(symbol)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2780,6 +2780,7 @@ def manualintegrate(f, var):
             result = result.func(
                 (result.args[1][0], Ne(*cond.args)),
                 (result.args[0][0], True))
+
     # Factor terms like erf(x)*sin(x) that may have been expanded
     def _has_erf_trig_mul(expr):
         for sub in expr.find(Mul):
@@ -2788,8 +2789,21 @@ def manualintegrate(f, var):
         return False
     if _has_erf_trig_mul(f) and _has_erf_trig_mul(result):
         result = factor_terms(result)
+
     def _remove_additive_constants(expr, var):
-        _, dependent = expr.as_independent(var, as_Add=True)
-        return dependent
-    result = _remove_additive_constants(result, var)
+        if not expr.has(var):
+            return S.Zero
+        if expr.is_Add:
+            args = [_remove_additive_constants(arg, var) for arg in expr.args]
+            return Add(*args)
+        if expr.is_Mul:
+            indep, dep = expr.as_independent(var)
+            if dep.is_Add:
+                return indep * _remove_additive_constants(dep, var)
+            return expr
+        return expr
+    # Avoid removing additive constants if the integrand contains a derivative
+    if not f.has(Derivative):
+        result = _remove_additive_constants(result, var)
+
     return result

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -41,6 +41,7 @@ from sympy.core.sorting import ordered
 from sympy.core.symbol import Dummy, Symbol, Wild
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import WildFunction
+from sympy.core.function import count_ops
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction, csch,
@@ -2526,7 +2527,10 @@ def substitution_rule(integral):
                         pieces.append((subrule, True))
                         subrule = PiecewiseRule(substituted, symbol, pieces)
 
-            ways.append(URule(integrand, symbol, u_var, u_func, subrule))
+            ways.append((substituted, URule(integrand, symbol, u_var, u_func, subrule)))
+
+        ways.sort(key=lambda w: count_ops(w[0]))
+        ways = [w[1] for w in ways]
 
         if len(ways) > 1:
             return AlternativeRule(integrand, symbol, ways)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -44,7 +44,7 @@ from sympy.core.function import WildFunction
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction, csch,
-    cosh, coth, sech, sinh, tanh, asinh, acosh, atanh)
+    cosh, coth, sech, sinh, tanh, asinh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
@@ -1206,9 +1206,6 @@ def manual_subs(expr, *args):
 # Stormy Decade"
 
 inverse_trig_functions = (atan, asin, acos, acot, acsc, asec)
-trig_functions = (sin, cos, tan, sec, csc, cot)
-hyperbolic_functions = (sinh, cosh, tanh)
-inverse_hyperbolic_functions = (asinh, acosh, atanh)
 
 
 def find_substitutions(integrand, symbol, u_var):
@@ -1221,19 +1218,17 @@ def find_substitutions(integrand, symbol, u_var):
         debug("substituted: {}, u: {}, u_var: {}".format(substituted, u, u_var))
         substituted = manual_subs(substituted, u, u_var).cancel()
 
-        # if the term is linear, then we can solve for u in terms of the symbol and substitute that in
-        # this is useful for cases like 1/(x**2 + 1) where u = x**2 + 1 and
-        # u_var = u, we can substitute u = x**2 + 1 into the integrand to get
-        # 1/u
+        # if the term is linear, then we can solve for u in terms of the symbol
+        # and substitute that in this is useful for cases like exp(x)/(x+1)
+        # where u = x + 1 and u_var = u
         if (
-            substituted.has_free(symbol) and not
-            substituted.has((*inverse_trig_functions, *trig_functions,
-                             *hyperbolic_functions,
-                             *inverse_hyperbolic_functions)) and
-            u.is_polynomial(symbol) and degree(u, symbol) >= 1
+            substituted.has_free(symbol) and
+            u.is_polynomial(symbol) and degree(u, symbol) == 1
         ):
-            symbol_of_u = solve(Eq(u_var, u), symbol)
-            substituted = manual_subs(substituted, symbol, symbol_of_u[0]).cancel()
+            a = u.coeff(symbol)
+            b = u.subs(symbol, 0)
+            symbol_of_u = (u_var - b)/a
+            substituted = manual_subs(substituted, symbol, symbol_of_u).cancel()
 
         if substituted.has_free(symbol):
             return False

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -44,7 +44,7 @@ from sympy.core.function import WildFunction
 from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction, csch,
-    cosh, coth, sech, sinh, tanh, asinh)
+    cosh, coth, sech, sinh, tanh, asinh, acosh, atanh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (TrigonometricFunction,
@@ -1206,6 +1206,9 @@ def manual_subs(expr, *args):
 # Stormy Decade"
 
 inverse_trig_functions = (atan, asin, acos, acot, acsc, asec)
+trig_functions = (sin, cos, tan, sec, csc, cot)
+hyperbolic_functions = (sinh, cosh, tanh)
+inverse_hyperbolic_functions = (asinh, acosh, atanh)
 
 
 def find_substitutions(integrand, symbol, u_var):
@@ -1217,6 +1220,20 @@ def find_substitutions(integrand, symbol, u_var):
         substituted = integrand / u_diff
         debug("substituted: {}, u: {}, u_var: {}".format(substituted, u, u_var))
         substituted = manual_subs(substituted, u, u_var).cancel()
+
+        # if the term is linear, then we can solve for u in terms of the symbol and substitute that in
+        # this is useful for cases like 1/(x**2 + 1) where u = x**2 + 1 and
+        # u_var = u, we can substitute u = x**2 + 1 into the integrand to get
+        # 1/u
+        if (
+            substituted.has_free(symbol) and not
+            substituted.has((*inverse_trig_functions, *trig_functions,
+                             *hyperbolic_functions,
+                             *inverse_hyperbolic_functions)) and
+            u.is_polynomial(symbol) and degree(u, symbol) >= 1
+        ):
+            symbol_of_u = solve(Eq(u_var, u), symbol)
+            substituted = manual_subs(substituted, symbol, symbol_of_u[0]).cancel()
 
         if substituted.has_free(symbol):
             return False

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1228,7 +1228,8 @@ def find_substitutions(integrand, symbol, u_var):
             a = u.coeff(symbol)
             b = u.subs(symbol, 0)
             symbol_of_u = (u_var - b)/a
-            substituted = manual_subs(substituted, symbol, symbol_of_u).cancel()
+            if b != 0:
+                substituted = manual_subs(substituted, symbol, symbol_of_u).cancel()
 
         if substituted.has_free(symbol):
             return False

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1231,7 +1231,9 @@ def find_substitutions(integrand, symbol, u_var):
             a = u.coeff(symbol)
             b = u.subs(symbol, 0)
             symbol_of_u = (u_var - b)/a
-            if b != 0:
+            # avoid infinite recursion when b = 0, and avoid division by zero
+            # when a = 0
+            if b != 0 and a != 0:
                 substituted = manual_subs(substituted, symbol, symbol_of_u).cancel()
 
         if substituted.has_free(symbol):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2787,4 +2787,8 @@ def manualintegrate(f, var):
         return False
     if _has_erf_trig_mul(f) and _has_erf_trig_mul(result):
         result = factor_terms(result)
+    def _remove_additive_constants(expr, var):
+        _, dependent = expr.as_independent(var, as_Add=True)
+        return dependent
+    result = _remove_additive_constants(result, var)
     return result

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -39,7 +39,7 @@ from sympy.functions.elementary.integers import floor
 from sympy.integrals.integrals import Integral
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.physics import units
-from sympy.testing.pytest import raises, slow, warns_deprecated_sympy, warns
+from sympy.testing.pytest import raises, slow, tooslow, warns_deprecated_sympy, warns
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.random import verify_numerically
 
@@ -1433,7 +1433,7 @@ def test_issue_8945():
     assert integrate(cos(x)**2/x**2, x) == -Si(2*x) - cos(2*x)/(2*x) - 1/(2*x)
 
 
-@slow
+@tooslow
 def test_issue_7130():
     i, L, a, b = symbols('i L a b')
     integrand = (cos(pi*i*x/L)**2 / (a + b*x)).rewrite(exp)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -18,7 +18,7 @@ from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, asin, atan, cos, sin, sinc, tan, sec)
 from sympy.functions.special.delta_functions import DiracDelta, Heaviside
-from sympy.functions.special.error_functions import (Ci, Ei, Si, erf, erfc, erfi, fresnelc, li)
+from sympy.functions.special.error_functions import (Ci, Ei, Si, erf, erfc, erfi, fresnelc, li, expint)
 from sympy.functions.special.gamma_functions import (gamma, polygamma)
 from sympy.functions.special.hyper import (hyper, meijerg)
 from sympy.functions.special.singularity_functions import SingularityFunction
@@ -434,7 +434,7 @@ def test_issue_13749():
 
 
 def test_issue_18133():
-    assert integrate(exp(x)/(1 + x)**2, x) == NonElementaryIntegral(exp(x)/(x + 1)**2, x)
+    assert integrate(exp(x)/(1 + x)**2, x) == -exp(-1)*expint(2, -x - 1)/(x + 1)
 
 
 def test_issue_21741():

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -720,6 +720,12 @@ def test_issue_25093():
         + cos(b)*fresnelc(sqrt(2)*sqrt(a)*x/sqrt(pi)))/(2*sqrt(a)))
 
 
+def test_issue_29999():
+    f = exp(x) / (3 * x + 2)
+    F = exp(-Rational(2, 3)) * Ei(x + Rational(2, 3)) * S.One / 3
+    assert_is_integral_of(f, F)
+
+
 def test_nested_pow():
     assert_is_integral_of(sqrt(x**2), x*sqrt(x**2)/2)
     assert_is_integral_of(sqrt(x**(S(5)/3)), 6*x*sqrt(x**(S(5)/3))/11)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -462,7 +462,7 @@ def test_issue_6799():
     integrand = (cos(n*(x-phi))*cos(n*x))
     limits = (x, -pi, pi)
     assert manualintegrate(integrand, x) == \
-        ((-n*phi/2 + n*x/2 - sin(2*n*phi - 2*n*x)/4)*cos(n*phi) + sin(n*phi)*cos(n*phi - n*x)**2/2)/n
+        ((n*x/2 - sin(2*n*phi - 2*n*x)/4)*cos(n*phi) + sin(n*phi)*cos(n*phi - n*x)**2/2)/n
     assert r * integrate(integrand, limits).trigsimp() / pi == r * cos(n * phi)
     assert not integrate(integrand, limits).has(Dummy)
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -462,7 +462,7 @@ def test_issue_6799():
     integrand = (cos(n*(x-phi))*cos(n*x))
     limits = (x, -pi, pi)
     assert manualintegrate(integrand, x) == \
-        ((n*x/2 + sin(2*n*x)/4)*cos(n*phi) - sin(n*phi)*cos(n*x)**2/2)/n
+        ((-n*phi/2 + n*x/2 - sin(2*n*phi - 2*n*x)/4)*cos(n*phi) + sin(n*phi)*cos(n*phi - n*x)**2/2)/n
     assert r * integrate(integrand, limits).trigsimp() / pi == r * cos(n * phi)
     assert not integrate(integrand, limits).has(Dummy)
 

--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -364,9 +364,9 @@ def test_variable_moment():
     b.bc_deflection = [(0, 0)]
     b.bc_slope = [(0, 0)]
     b.solve_for_reaction_loads(R, M)
-    assert b.slope().expand() == ((-80*(-log(-E) + log(-E + x))*SingularityFunction(x, 0, 0)
-        + 80*(-log(-E + 4) + log(-E + x))*SingularityFunction(x, 4, 0) + 20*(-E*log(-E)
-        + E*log(-E + x) + x)*SingularityFunction(x, 0, 0) - 20*(-E*log(-E + 4) + E*log(-E + x)
+    assert b.slope().expand() == ((-80*(-log(E) + log(E - x))*SingularityFunction(x, 0, 0)
+        + 80*(-log(E - 4) + log(E - x))*SingularityFunction(x, 4, 0) + 20*(-E*log(E)
+        + E*log(E - x) + x)*SingularityFunction(x, 0, 0) - 20*(-E*log(E - 4) + E*log(E - x)
         + x - 4)*SingularityFunction(x, 4, 0))/I).expand()
 
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #29999 

#### Brief description of what is fixed or changed

The issue with the current u-substitution implementation is that it only matches identical expressions e.g. `exp(x+1)/(x+1)` -> `exp(_u)/_u`, but if it is `exp(x)/(x+1)` then it would not be able to solve it as the result is `exp(x)/_u`, even though it should be `exp(_u-1)/_u`, which is easily solvable.

Now, it tries to solve for x in terms of u, then does the substitution and checks whether it is a solvable expression or not. e.g. `exp(x)/(x+1)` -> `_u=x+1` -> `exp(x)/_u` -> `x=_u-1` -> `exp(_u-1)/_u`.

Example:

```python

In [1]: from sympy.integrals.manualintegrate import manualintegrate, integral_steps

In [2]: manualintegrate(exp(x)/(x-1), x)
Out[2]: ℯ⋅Ei(x - 1)

In [3]: manualintegrate(exp(x)/(x+1), x)
Out[3]: 
 -1          
ℯ  ⋅Ei(x + 1)

In [4]: 
```

The following guards are put in order to avoid overly complicated expressions that almost never help in solving the integral

```python
            substituted.has_free(symbol) and not
            substituted.has((*inverse_trig_functions, *trig_functions,
                             *hyperbolic_functions,
                             *inverse_hyperbolic_functions)) and
            u.is_polynomial(symbol) and degree(u, symbol) >= 1

```

#### Other comments

Many tests fail, some because the new changes results in a different form for some integrals (e.g. an added extra constant), and for some others I could not figure out what is the reason.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
    * Recognize additional u-substitution opportunities of linear expressions.
<!-- END RELEASE NOTES -->
