### PR TITLE
fix(polys): prevent infinite recursion in FracField.field_new for EX/EXRAW coefficients

### DIFF
--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -265,6 +265,8 @@ class FracField(DefaultPrinting, Generic[Er]):
         elif isinstance(element, str):
             raise NotImplementedError("parsing")
         elif isinstance(element, Expr):
+            if not any(sym in element.free_symbols for sym in self.symbols):
+                return self.ground_new(element)
             return self.from_expr(element)
         else:
             return self.ground_new(element)

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -352,3 +352,13 @@ def test_FracField_index():
     raises(ValueError, lambda: F.index(1))
     raises(ValueError, lambda: F.index(a))
     pass
+
+
+def test_FracField_from_sympy_EXRAW():
+    from sympy import EXRAW, symbols, sympify
+    s = symbols("s")
+    field = EXRAW.frac_field(s)
+    expr = sympify(1)
+    frac_elem = field.from_sympy(expr)
+    assert frac_elem == field(1)
+


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29761

#### Brief description of what is fixed or changed

Checks if the incoming `Expr` contains any of the generator symbols in `FracField.field_new`. If it does not, it is treated as a ground coefficient element and converted using `ground_new(element)`. This prevents infinite recursion on constant expressions for domains like `EX` and `EXRAW`.

#### Other comments



#### AI Generation Disclosure

This pull request includes code generated with the assistance of Google Gemini. The implementation in `fields.py` and the test files were generated with AI assistance.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * Prevented infinite recursion in `FracField.field_new` for constant expressions in `EX`/`EXRAW` domains.
<!-- END RELEASE NOTES -->