### PR TITLE
fix(matrices): allow noncommutative scalars in MatMul

### DIFF
--- a/sympy/matrices/expressions/matmul.py
+++ b/sympy/matrices/expressions/matmul.py
@@ -127,9 +127,6 @@ class MatMul(MatrixExpr, Mul):
         scalars = [x for x in self.args if not x.is_Matrix]
         matrices = [x for x in self.args if x.is_Matrix]
         coeff = Mul(*scalars)
-        if coeff.is_commutative is False:
-            raise NotImplementedError("noncommutative scalars in MatMul are not supported.")
-
         return coeff, matrices
 
     def as_coeff_mmul(self):

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -707,3 +707,10 @@ def test_matexpr_derivative_by_matrix_element():
 
     A = MatrixSymbol(a, a, a)
     assert A.diff(Y[a,a]) == ZeroMatrix(a, a)
+def test_exponentiated_matrix_derivative():
+    m, n, p = symbols('m n p')
+    A = MatrixSymbol('A', m, n)
+    B = MatrixSymbol('B', n, p)
+    C = exp(MatMul(A, B))
+    res = diff(C, A)
+    assert res == PermuteDims(ArrayTensorProduct(exp(A*B)*Identity(m), B), Permutation(3)(1, 2))

--- a/sympy/matrices/expressions/tests/test_matmul.py
+++ b/sympy/matrices/expressions/tests/test_matmul.py
@@ -147,7 +147,6 @@ def test_matmul_args_cnc():
     assert MatMul(n, A, A.T).args_cnc() == [[n], [A, A.T]]
     assert MatMul(A, A.T).args_cnc() == [[], [A, A.T]]
 
-@XFAIL
 def test_matmul_args_cnc_symbols():
     # Not currently supported
     a, b = symbols('a b', commutative=False)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #17972

#### Brief description of what is fixed or changed

Allows noncommutative scalars in MatMul by removing the restriction in `MatMul.as_coeff_matrices`. This resolves the `NotImplementedError` raised when differentiating exponentiated matrices (such as `diff(exp(A*B), A)`).

#### Other comments



#### AI Generation Disclosure

This pull request includes code generated with the assistance of Google Gemini. The implementation in `matmul.py` and the test files were generated with AI assistance.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Allowed noncommutative scalars in `MatMul` by removing the `is_commutative` restriction in `as_coeff_matrices`.
<!-- END RELEASE NOTES -->