### PR TITLE
fix(core): dispatch to ArrayDerivative in Derivative.__new__ for array/matrix types

### DIFF
--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -1264,6 +1264,14 @@ class Derivative(Expr):
 
     def __new__(cls, expr, *variables, **kwargs):
         expr = sympify(expr)
+        if cls is Derivative:
+            from sympy.matrices.matrixbase import MatrixBase
+            from sympy.matrices.expressions.matexpr import MatrixExpr
+            from sympy.tensor.array import NDimArray
+            array_types = (MatrixBase, MatrixExpr, NDimArray, list, tuple, Tuple)
+            if isinstance(expr, array_types) or any(isinstance(i[0], array_types) if isinstance(i, (tuple, list, Tuple)) else isinstance(i, array_types) for i in variables):
+                from sympy.tensor.array.array_derivatives import ArrayDerivative
+                return ArrayDerivative(expr, *variables, **kwargs)
         if not isinstance(expr, Basic):
             raise TypeError(f"Cannot represent derivative of {type(expr)}")
         symbols_or_none = getattr(expr, "free_symbols", None)

--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -707,3 +707,18 @@ def test_matexpr_derivative_by_matrix_element():
 
     A = MatrixSymbol(a, a, a)
     assert A.diff(Y[a,a]) == ZeroMatrix(a, a)
+
+
+def test_transpose_derivative_by_matrix():
+    from sympy import Function, Derivative
+    from sympy.tensor.array.array_derivatives import ArrayDerivative
+    m = symbols('m')
+    u = MatrixSymbol('u', m, 1)
+    r_bar = u.applyfunc(Function('phi'))
+    W = MatrixSymbol('W', m, m)
+    expr = (u - W * r_bar).T
+    assert isinstance(Derivative(expr, u), ArrayDerivative)
+    res = Derivative(expr, u).doit()
+    assert res.dummy_eq(diff(expr, u))
+
+


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #21597

#### Brief description of what is fixed or changed

Dispatches to `ArrayDerivative` in `Derivative.__new__` when the expression or any variable of differentiation is an array/matrix type (e.g. `MatrixBase`, `MatrixExpr`, `NDimArray`, or list/tuple of them).

Previously, manually constructing `Derivative(expr, x)` (where `x` was a matrix/array type) and calling `.doit()` bypassed `_derivative_dispatch` and evaluated the derivative using scalar-like rules. This led to calling `_eval_derivative` on classes like `Transpose` which incorrectly assumed `x` was a scalar, eventually raising `TypeError: Mix of Matrix and Scalar symbols` when summing matrix and array-expression derivatives in `MatAdd`.

Dispatched `Derivative` calls to `ArrayDerivative` for array/matrix types correctly uses array derivative evaluation.

#### Other comments

None.

#### AI Generation Disclosure

This pull request includes code generated with the assistance of Google Gemini. The implementation in `function.py` and the test files were generated with AI assistance.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Dispatched `Derivative` to `ArrayDerivative` during construction when expression or variables contain array/matrix types, fixing `TypeError` when differentiating transposed matrix expressions.
<!-- END RELEASE NOTES -->