### PR TITLE
Fix compatibility with llvmlite 0.48

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -430,6 +430,7 @@ Ben Oostendorp <oostben@umich.edu> oostben <oostben@umich.edu>
 Ben Payne <ben.is.located@gmail.com> Ben <ben.is.located@gmail.com>
 Bendik Samseth <b.samseth@gmail.com>
 Benedikt Placke <benedikt.placke@outlook.com>
+Benjamin A. Beasley <code@musicinmybrain.net>
 Benjamin Dolata <bendolata2@gmail.com> MajesticSlacks <bendolata2@gmail.com>
 Benjamin Fishbein <fishbeinb@gmail.com>
 Benjamin Gudehus <hastebrot@gmail.com>

--- a/sympy/printing/llvmjitcode.py
+++ b/sympy/printing/llvmjitcode.py
@@ -285,8 +285,7 @@ class LLVMJitCode:
             pmb.populate(pass_manager)
             pass_manager.run(llmod)
         else:
-            pto = llvm.create_pipeline_tuning_options(speed_level=2,
-                                                      size_level=0)
+            pto = llvm.create_pipeline_tuning_options(speed_level=2)
             pto.loop_vectorization = True
             pass_builder = llvm.create_pass_builder(target_machine, pto)
             pass_manager = pass_builder.getModulePassManager()


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
N/A

#### Brief description of what is fixed or changed

In `llvmlite` 0.48, size optimization is now expressed through per-function attributes rather than a pipeline-level option, and the `size_level` keyword argument to `llvm.create_pipeline_tuning_options` has been removed: therefore, we must stop supplying it. This should be backward-compatible with previous `llvmlite` releases because we were just explicitly passing the default value anyway.

#### Other comments

For more details, see the `llvmlite ` source diff https://github.com/numba/llvmlite/compare/v0.47.0...v0.48.0.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed compatibility with llvmlite version 0.48
<!-- END RELEASE NOTES -->
