### PR TITLE
fix: vendor mpmath's old repr_dps

### DIFF
--- a/sympy/external/mpmath.py
+++ b/sympy/external/mpmath.py
@@ -92,7 +92,6 @@ from mpmath.libmp import (
     normalize,
     phi_fixed,
     prec_to_dps,
-    repr_dps,
     round_nearest,
     sqrtrem,
     to_float,
@@ -108,6 +107,16 @@ except ImportError:
 
 from mpmath.libmp.libintmath import giant_steps
 from mpmath.matrices.matrices import _matrix
+
+
+def repr_dps(n: int) -> int:
+    # This is how mpmath's repr_dps was implemented in mpmath <= 1.4.0.
+    # Keep a stable version here that is not affected by the mpmath version.
+    dps = prec_to_dps(n)
+    if dps == 15:
+        return 17
+    return dps + 3
+
 
 __all__ = [
     "MPContext",

--- a/sympy/external/mpmath.py
+++ b/sympy/external/mpmath.py
@@ -110,7 +110,7 @@ from mpmath.matrices.matrices import _matrix
 
 
 def repr_dps(n: int) -> int:
-    # This is how mpmath's repr_dps was implemented in mpmath <= 1.4.0.
+    # This is how mpmath's repr_dps was implemented in mpmath < 1.5
     # Keep a stable version here that is not affected by the mpmath version.
     dps = prec_to_dps(n)
     if dps == 15:

--- a/sympy/external/tests/test_mpmath.py
+++ b/sympy/external/tests/test_mpmath.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from sympy.external.mpmath import repr_dps
 
 

--- a/sympy/external/tests/test_mpmath.py
+++ b/sympy/external/tests/test_mpmath.py
@@ -1,0 +1,8 @@
+from sympy.external.mpmath import repr_dps
+
+
+def test_repr_dps_is_stable():
+    assert repr_dps(13) == 6
+    assert repr_dps(33) == 12
+    assert repr_dps(53) == 17
+    assert repr_dps(66) == 22


### PR DESCRIPTION
In mpmath's master branch (future 1.5.0) the repr_dps function was changed. This commit adds the old version of this function in sympy so that there is a stable version independent of the mpmath version.

Fixes a couple of tests involving srepr with Floats that are otherwise failing with mpmath's master branch (showing as failures on recent PRs).

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

NO AI USE

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
