### PR TITLE
Make symbolic MatrixSlice agree with Python/explicit slicing

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1300,6 +1300,8 @@ Prafullkumar P. Tale <hector1618@gmail.com> <Hector1618@gmail.com>
 Pragyan Mehrotra <pragyan18168@iiitd.ac.in>
 Prajwal Pathade <prajwalpathade7@gmail.com> Prajwal <prajwalpathade7@gmail.com>
 Pramod Ch <pramodch14@gmail.com>
+Pranav Achar <achar.pranav@gmail.com> Pranav Achar <73564284+PranavAchar01@users.noreply.github.com>
+Pranav Achar <achar.pranav@gmail.com> PranavAchar01 <achar.pranav@gmail.com>
 Pranjal Tale <pranjaltale16@gmail.com>
 Prashant Tandon <102211549+PT-10@users.noreply.github.com>\
 Prashant Tandon <tandonprashant101@gmail.com>

--- a/sympy/matrices/expressions/slice.py
+++ b/sympy/matrices/expressions/slice.py
@@ -2,19 +2,48 @@ from __future__ import annotations
 from sympy.matrices.expressions.matexpr import MatrixExpr
 from sympy.core.basic import Basic
 from sympy.core.containers import Tuple
-from sympy.functions.elementary.integers import floor
+from sympy.core.numbers import Integer
+from sympy.functions.elementary.integers import ceiling
+
+
+def _is_concrete_index(x):
+    return isinstance(x, int) or (isinstance(x, Basic) and x.is_Integer)
+
+
+def _slice_length(sl):
+    start, stop, step = sl
+    if all(_is_concrete_index(x) for x in (start, stop, step)):
+        return Integer(len(range(int(start), int(stop), int(step))))
+    length = stop - start
+    return length if step == 1 else ceiling(length / step)
+
 
 def normalize(i, parentsize):
     if isinstance(i, slice):
         i = (i.start, i.stop, i.step)
     if not isinstance(i, (tuple, list, Tuple)):
+        # A single index is not clamped: an out-of-range index is an error,
+        # just like indexing into a Python sequence.
         if (i < 0) == True:
             i += parentsize
-        i = (i, i+1, 1)
+        return (i, i + 1, 1)
     i = list(i)
     if len(i) == 2:
         i.append(1)
     start, stop, step = i
+    # When the slice bounds and the parent dimension are concrete integers,
+    # reuse Python's slice semantics (``slice.indices``) so that slicing a
+    # symbolic matrix agrees with slicing an explicit one, including negative
+    # steps and out-of-range bounds which are clamped rather than raising
+    # (see issue #18411).
+    if _is_concrete_index(parentsize) and all(
+        x is None or _is_concrete_index(x) for x in (start, stop, step)
+    ):
+        return slice(
+            None if start is None else int(start),
+            None if stop is None else int(stop),
+            None if step is None else int(step),
+        ).indices(int(parentsize))
     start = start or 0
     if stop is None:
         stop = parentsize
@@ -70,11 +99,7 @@ class MatrixSlice(MatrixExpr):
 
     @property
     def shape(self):
-        rows = self.rowslice[1] - self.rowslice[0]
-        rows = rows if self.rowslice[2] == 1 else floor(rows/self.rowslice[2])
-        cols = self.colslice[1] - self.colslice[0]
-        cols = cols if self.colslice[2] == 1 else floor(cols/self.colslice[2])
-        return rows, cols
+        return _slice_length(self.rowslice), _slice_length(self.colslice)
 
     def _entry(self, i, j, **kwargs):
         return self.parent._entry(i*self.rowslice[2] + self.rowslice[0],

--- a/sympy/matrices/expressions/tests/test_slice.py
+++ b/sympy/matrices/expressions/tests/test_slice.py
@@ -3,7 +3,7 @@ from sympy.matrices.expressions.slice import MatrixSlice
 from sympy.matrices.expressions import MatrixSymbol
 from sympy.abc import a, b, c, d, k, l, m, n
 from sympy.testing.pytest import raises, XFAIL
-from sympy.functions.elementary.integers import floor
+from sympy.functions.elementary.integers import ceiling
 from sympy.assumptions import assuming, Q
 
 
@@ -37,15 +37,38 @@ def test_slicing():
     assert X[1:5, :].shape == (4, X.shape[1])
     assert X[:, 1:5].shape == (X.shape[0], 4)
 
-    assert X[::2, ::2].shape == (floor(n/2), floor(m/2))
+    assert X[::2, ::2].shape == (ceiling(n/2), ceiling(m/2))
     assert X[2, :] == MatrixSlice(X, 2, (0, m))
     assert X[k, :] == MatrixSlice(X, k, (0, m))
 
 def test_exceptions():
     X = MatrixSymbol('x', 10, 20)
-    raises(IndexError, lambda: X[0:12, 2])
+    # Out-of-range single indices raise, like indexing a Python sequence.
+    raises(IndexError, lambda: X[12, 2])
     raises(IndexError, lambda: X[0:9, 22])
-    raises(IndexError, lambda: X[-1:5, 2])
+    # Out-of-range slice bounds are clamped to match Python slicing (#18411).
+    assert X[0:12, 2] == X[0:10, 2]
+    assert X[-1:5, 2].shape == (0, 1)
+
+
+def test_slice_matches_explicit():
+    # A symbolic slice must agree with slicing the explicit matrix, including
+    # stepped, negative-step and out-of-range slices. Non-regression test for
+    # https://github.com/sympy/sympy/issues/18411
+    A = MatrixSymbol('A', 4, 5)
+    explicit = A.as_explicit()
+    slices = [
+        slice(1, 4, 2), slice(5, 0, -1), slice(6, None, -1), slice(0, 5, -1),
+        slice(None, None, -1), slice(0, 10), slice(0, 4, 3), slice(3, None, -2),
+    ]
+    for rs in slices:
+        for cs in slices:
+            expected = explicit[rs, cs]
+            if 0 in expected.shape:
+                # empty result: just check the shape agrees
+                assert A[rs, cs].shape == expected.shape
+            else:
+                assert A[rs, cs].as_explicit() == expected
 
 @XFAIL
 def test_symmetry():

--- a/sympy/utilities/tests/test_codegen_julia.py
+++ b/sympy/utilities/tests/test_codegen_julia.py
@@ -436,7 +436,7 @@ def test_jl_matrixsymbol_slice2():
 def test_jl_matrixsymbol_slice3():
     A = MatrixSymbol('A', 8, 7)
     B = MatrixSymbol('B', 2, 2)
-    C = MatrixSymbol('C', 4, 2)
+    C = MatrixSymbol('C', 4, 3)
     name_expr = ("test", [Equality(B, A[6:, 1::3]),
                           Equality(C, A[::2, ::3])])
     result, = codegen(name_expr, "Julia", header=False, empty=False)

--- a/sympy/utilities/tests/test_codegen_octave.py
+++ b/sympy/utilities/tests/test_codegen_octave.py
@@ -413,7 +413,7 @@ def test_m_matrixsymbol_slice2():
 def test_m_matrixsymbol_slice3():
     A = MatrixSymbol('A', 8, 7)
     B = MatrixSymbol('B', 2, 2)
-    C = MatrixSymbol('C', 4, 2)
+    C = MatrixSymbol('C', 4, 3)
     name_expr = ("test", [Equality(B, A[6:, 1::3]),
                           Equality(C, A[::2, ::3])])
     result, = codegen(name_expr, "Octave", header=False, empty=False)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #18411

#### Brief description of what is fixed or changed

`MatrixSlice` of a `MatrixSymbol` did not agree with slicing an explicit matrix.
`normalize()` now defers to Python's `slice.indices` for concrete integer
slices, so negative steps and out-of-range bounds are handled the same way as
NumPy/Python slicing: out-of-range slice bounds are clamped, and an out-of-range
single index still raises. The slice length is computed as the true range length
(`len(range(start, stop, step))`) instead of `floor((stop - start) / step)`,
which fixes the shape of stepped slices (e.g. an `8x7` matrix sliced with
`[::2, ::3]` now has shape `(4, 3)` rather than `(4, 2)`).

#### Other comments

The Julia and Octave codegen slice tests were updated to reflect the corrected
stepped-slice shape.

#### AI Generation Disclosure

This PR was prepared with the assistance of Claude Code (AI). The changes to
`sympy/matrices/expressions/slice.py` and the accompanying test updates were
AI-generated and then reviewed and tested by the submitter.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed `MatrixSlice` of a `MatrixSymbol` to match Python/NumPy slicing for
    stepped, negative-step, and out-of-range slices.
<!-- END RELEASE NOTES -->
