### PR TITLE
[GSoC 2026] Implements conjugate and adjoint for DDM, SDM, DFM, DomainMatrix and RepMatrix

### DIFF
--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -15,7 +15,7 @@ from sympy.core.sympify import _sympify, SympifyError
 from sympy.core.singleton import S
 from sympy.polys.domains import ZZ, QQ, GF, EXRAW
 from sympy.polys.matrices import DomainMatrix
-from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError, DMDomainError
+from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError
 from sympy.polys.polyerrors import CoercionFailed, NotInvertible
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import is_sequence
@@ -399,12 +399,7 @@ class RepMatrix(MatrixBase):
         return self._fromrep(self._rep.applyfunc(abs))
 
     def _eval_conjugate(self):
-        rep = self._rep
-        try:
-            return self._fromrep(rep.conjugate())
-        except DMDomainError:
-            pass
-        return self._fromrep(rep.convert_to(EXRAW).conjugate())
+        return self._fromrep(self._rep.conjugate())
 
     def _eval_adjoint(self):
         return self._fromrep(self._rep.adjoint())

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -407,12 +407,7 @@ class RepMatrix(MatrixBase):
         return self._fromrep(rep.convert_to(EXRAW).conjugate())
 
     def _eval_adjoint(self):
-        rep = self._rep
-        try:
-            return self._fromrep(rep.adjoint())
-        except DMDomainError:
-            pass
-        return self._fromrep(rep.convert_to(EXRAW).adjoint())
+        return self._fromrep(self._rep.adjoint())
 
     def equals(self, other, failing_expression=False):
         """Applies ``equals`` to corresponding elements of the matrices,

--- a/sympy/matrices/repmatrix.py
+++ b/sympy/matrices/repmatrix.py
@@ -15,7 +15,7 @@ from sympy.core.sympify import _sympify, SympifyError
 from sympy.core.singleton import S
 from sympy.polys.domains import ZZ, QQ, GF, EXRAW
 from sympy.polys.matrices import DomainMatrix
-from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError
+from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError, DMDomainError
 from sympy.polys.polyerrors import CoercionFailed, NotInvertible
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import is_sequence
@@ -400,11 +400,19 @@ class RepMatrix(MatrixBase):
 
     def _eval_conjugate(self):
         rep = self._rep
-        domain = rep.domain
-        if domain in (ZZ, QQ):
-            return self.copy()
-        else:
-            return self._fromrep(rep.applyfunc(lambda e: e.conjugate()))
+        try:
+            return self._fromrep(rep.conjugate())
+        except DMDomainError:
+            pass
+        return self._fromrep(rep.convert_to(EXRAW).conjugate())
+
+    def _eval_adjoint(self):
+        rep = self._rep
+        try:
+            return self._fromrep(rep.adjoint())
+        except DMDomainError:
+            pass
+        return self._fromrep(rep.convert_to(EXRAW).adjoint())
 
     def equals(self, other, failing_expression=False):
         """Applies ``equals`` to corresponding elements of the matrices,

--- a/sympy/matrices/tests/test_repmatrix.py
+++ b/sympy/matrices/tests/test_repmatrix.py
@@ -89,7 +89,7 @@ def test_repmatrix_conjugate():
     assert A.conjugate() == B
 
 
-def test_repmatrix_adjoint():    
+def test_repmatrix_adjoint():
     A = Matrix([[1, 2 + 3*I], [0, (4 - 5*I)/6]])
     B = Matrix([[1, 0], [2 - 3*I, (4 + 5*I)/6]])
     A = A._fromrep(A._rep.convert_to(QQ_I))

--- a/sympy/matrices/tests/test_repmatrix.py
+++ b/sympy/matrices/tests/test_repmatrix.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 from sympy.testing.pytest import raises
 from sympy.matrices.exceptions import NonSquareMatrixError, NonInvertibleMatrixError
+from sympy.polys.domains import QQ, QQ_I
 
-from sympy import Matrix, Rational
-
+from sympy import Matrix, Rational, sqrt, I
+from sympy.abc import x
 
 def test_lll():
     A = Matrix([[1, 0, 0, 0, -20160],
@@ -61,3 +62,53 @@ def test_matrix_inv_mod():
         [14, 1, 15, 1],
         [25, 23, 3, 12],
     ])
+
+
+def test_repmatrix_conjugate():
+    A = Matrix([[1, 2 + 3*I], [0, (4 - 5*I)/6]])
+    B = Matrix([[1, 2 - 3*I], [0, (4 + 5*I)/6]])
+    A = A._fromrep(A._rep.convert_to(QQ_I))
+    B = B._fromrep(B._rep.convert_to(QQ_I))
+    AC = A.conjugate()
+    assert AC == B and AC._rep.domain == A._rep.domain
+
+    K = QQ.algebraic_field((-1 + sqrt(-3))/2)
+    A = Matrix([[sqrt(-3) + 3, sqrt(-3)/4]])
+    B = Matrix([[-sqrt(-3) + 3, -sqrt(-3)/4]])
+    A = A._fromrep(A._rep.convert_to(K))
+    B = B._fromrep(B._rep.convert_to(K))
+    AC = A.conjugate()
+    assert AC == B and AC._rep.domain == A._rep.domain
+
+    r = (x**5 - x + 1).as_poly(x).all_roots()[-1]
+    z = r.conjugate()
+    K = QQ.algebraic_field(r)
+    A = Matrix([[1, r/3], [2*r + 5, -r], [0, 4]])
+    B = Matrix([[1, z/3], [2*z + 5, -z], [0, 4]])
+    A = A._fromrep(A._rep.convert_to(K))
+    assert A.conjugate() == B
+
+
+def test_repmatrix_adjoint():    
+    A = Matrix([[1, 2 + 3*I], [0, (4 - 5*I)/6]])
+    B = Matrix([[1, 0], [2 - 3*I, (4 + 5*I)/6]])
+    A = A._fromrep(A._rep.convert_to(QQ_I))
+    B = B._fromrep(B._rep.convert_to(QQ_I))
+    AH = A.adjoint()
+    assert AH == B and AH._rep.domain == A._rep.domain
+
+    K = QQ.algebraic_field((-1 + sqrt(-3))/2)
+    A = Matrix([[sqrt(-3) + 3, sqrt(-3)/4]])
+    B = Matrix([[-sqrt(-3) + 3], [-sqrt(-3)/4]])
+    A = A._fromrep(A._rep.convert_to(K))
+    B = B._fromrep(B._rep.convert_to(K))
+    AH = A.adjoint()
+    assert AH == B and AH._rep.domain == A._rep.domain
+
+    r = (x**5 - x + 1).as_poly(x).all_roots()[-1]
+    z = r.adjoint()
+    K = QQ.algebraic_field(r)
+    A = Matrix([[1, r/3], [2*r + 5, -r], [0, 4]])
+    B = Matrix([[1, 2*z + 5, 0], [z/3, -z, 4]])
+    A = A._fromrep(A._rep.convert_to(K))
+    assert A.adjoint() == B

--- a/sympy/matrices/tests/test_repmatrix.py
+++ b/sympy/matrices/tests/test_repmatrix.py
@@ -4,6 +4,7 @@ from sympy.matrices.exceptions import NonSquareMatrixError, NonInvertibleMatrixE
 
 from sympy import Matrix, Rational
 
+
 def test_lll():
     A = Matrix([[1, 0, 0, 0, -20160],
                 [0, 1, 0, 0, 33768],

--- a/sympy/matrices/tests/test_repmatrix.py
+++ b/sympy/matrices/tests/test_repmatrix.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 from sympy.testing.pytest import raises
 from sympy.matrices.exceptions import NonSquareMatrixError, NonInvertibleMatrixError
-from sympy.polys.domains import QQ, QQ_I
 
-from sympy import Matrix, Rational, sqrt, I
-from sympy.abc import x
+from sympy import Matrix, Rational
 
 def test_lll():
     A = Matrix([[1, 0, 0, 0, -20160],
@@ -62,53 +60,3 @@ def test_matrix_inv_mod():
         [14, 1, 15, 1],
         [25, 23, 3, 12],
     ])
-
-
-def test_repmatrix_conjugate():
-    A = Matrix([[1, 2 + 3*I], [0, (4 - 5*I)/6]])
-    B = Matrix([[1, 2 - 3*I], [0, (4 + 5*I)/6]])
-    A = A._fromrep(A._rep.convert_to(QQ_I))
-    B = B._fromrep(B._rep.convert_to(QQ_I))
-    AC = A.conjugate()
-    assert AC == B and AC._rep.domain == A._rep.domain
-
-    K = QQ.algebraic_field((-1 + sqrt(-3))/2)
-    A = Matrix([[sqrt(-3) + 3, sqrt(-3)/4]])
-    B = Matrix([[-sqrt(-3) + 3, -sqrt(-3)/4]])
-    A = A._fromrep(A._rep.convert_to(K))
-    B = B._fromrep(B._rep.convert_to(K))
-    AC = A.conjugate()
-    assert AC == B and AC._rep.domain == A._rep.domain
-
-    r = (x**5 - x + 1).as_poly(x).all_roots()[-1]
-    z = r.conjugate()
-    K = QQ.algebraic_field(r)
-    A = Matrix([[1, r/3], [2*r + 5, -r], [0, 4]])
-    B = Matrix([[1, z/3], [2*z + 5, -z], [0, 4]])
-    A = A._fromrep(A._rep.convert_to(K))
-    assert A.conjugate() == B
-
-
-def test_repmatrix_adjoint():
-    A = Matrix([[1, 2 + 3*I], [0, (4 - 5*I)/6]])
-    B = Matrix([[1, 0], [2 - 3*I, (4 + 5*I)/6]])
-    A = A._fromrep(A._rep.convert_to(QQ_I))
-    B = B._fromrep(B._rep.convert_to(QQ_I))
-    AH = A.adjoint()
-    assert AH == B and AH._rep.domain == A._rep.domain
-
-    K = QQ.algebraic_field((-1 + sqrt(-3))/2)
-    A = Matrix([[sqrt(-3) + 3, sqrt(-3)/4]])
-    B = Matrix([[-sqrt(-3) + 3], [-sqrt(-3)/4]])
-    A = A._fromrep(A._rep.convert_to(K))
-    B = B._fromrep(B._rep.convert_to(K))
-    AH = A.adjoint()
-    assert AH == B and AH._rep.domain == A._rep.domain
-
-    r = (x**5 - x + 1).as_poly(x).all_roots()[-1]
-    z = r.adjoint()
-    K = QQ.algebraic_field(r)
-    A = Matrix([[1, r/3], [2*r + 5, -r], [0, 4]])
-    B = Matrix([[1, 2*z + 5, 0], [z/3, -z, 4]])
-    A = A._fromrep(A._rep.convert_to(K))
-    assert A.adjoint() == B

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -560,6 +560,14 @@ class AlgebraicField(
         return prime_decomp(p, ZK=ZK, dK=dK, radical=rad)
 
     @cached_property
+    def is_ConjugateDomain(self):
+        try:
+            _ = self.conjugate
+        except CoercionFailed:
+            return False
+        return True
+
+    @cached_property
     def conjugate(self):
         """Returns the complex conjugate of ``a``. """
         try:

--- a/sympy/polys/domains/algebraicfield.py
+++ b/sympy/polys/domains/algebraicfield.py
@@ -563,7 +563,7 @@ class AlgebraicField(
     def is_ConjugateDomain(self):
         try:
             _ = self.conjugate
-        except CoercionFailed:
+        except DomainError:
             return False
         return True
 
@@ -575,7 +575,7 @@ class AlgebraicField(
             z = self.ext.func((self.ext.minpoly, self.ext.conjugate()))
             conj = self.from_sympy(z)
         except CoercionFailed:
-            raise CoercionFailed("the algebraic field is not closed under conjugation")
+            raise DomainError("the algebraic field is not closed under conjugation")
 
         if conj.rep == [1, 0]:
             # conj == ext implies ext is real

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1483,7 +1483,7 @@ def test_Domain_conjugate():
     a = Poly(x**3 - x + 1, x, domain=ZZ).all_roots()[-1]
     K = QQ.algebraic_field(a)
     assert not K.is_ConjugateDomain
-    raises(CoercionFailed, lambda: K.conjugate(K.from_sympy(a)))
+    raises(DomainError, lambda: K.conjugate(K.from_sympy(a)))
 
     # cyclotomic fields
     K = QQ.cyclotomic_field(7)

--- a/sympy/polys/domains/tests/test_domains.py
+++ b/sympy/polys/domains/tests/test_domains.py
@@ -1482,6 +1482,7 @@ def test_Domain_conjugate():
 
     a = Poly(x**3 - x + 1, x, domain=ZZ).all_roots()[-1]
     K = QQ.algebraic_field(a)
+    assert not K.is_ConjugateDomain
     raises(CoercionFailed, lambda: K.conjugate(K.from_sympy(a)))
 
     # cyclotomic fields

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -472,12 +472,13 @@ class DFM:
     def conjugate(self):
         """Return the conjugate of a DFM matrix."""
         dom = self.domain
-        if dom.is_ConjugateDomain:
-            if dom.is_ZZ or dom.is_QQ or dom.is_RR:
-                return self.copy()
+        if not dom.is_ConjugateDomain:
+            raise DMDomainError("%s does not support conjugation" % dom)
 
+        if dom.is_ZZ or dom.is_QQ or dom.is_RR:
+            return self.copy()
+        else:
             return self.applyfunc(dom.conjugate, dom)
-        raise DMDomainError("%s does not support conjugation" % dom)
 
     def adjoint(self):
         """Return the adjoint of a DFM matrix."""

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -475,7 +475,7 @@ class DFM:
         dom = self.domain
         if dom.is_ConjugateDomain:
             if dom.is_ZZ or dom.is_QQ or dom.is_RR:
-                return self
+                return self.copy()
 
             try:
                 return self.applyfunc(dom.conjugate, dom)

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 
 from sympy.external.gmpy import GROUND_TYPES
 from sympy.external.importtools import import_module
-from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities.decorator import doctest_depends_on
 
 from sympy.polys.domains import ZZ, QQ
@@ -477,10 +476,7 @@ class DFM:
             if dom.is_ZZ or dom.is_QQ or dom.is_RR:
                 return self.copy()
 
-            try:
-                return self.applyfunc(dom.conjugate, dom)
-            except CoercionFailed:
-                pass
+            return self.applyfunc(dom.conjugate, dom)
         raise DMDomainError("%s does not support conjugation" % dom)
 
     def adjoint(self):

--- a/sympy/polys/matrices/_dfm.py
+++ b/sympy/polys/matrices/_dfm.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 from sympy.external.gmpy import GROUND_TYPES
 from sympy.external.importtools import import_module
+from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities.decorator import doctest_depends_on
 
 from sympy.polys.domains import ZZ, QQ
@@ -468,6 +469,23 @@ class DFM:
     def transpose(self):
         """Transpose a DFM matrix."""
         return self._new(self.rep.transpose(), (self.cols, self.rows), self.domain)
+
+    def conjugate(self):
+        """Return the conjugate of a DFM matrix."""
+        dom = self.domain
+        if dom.is_ConjugateDomain:
+            if dom.is_ZZ or dom.is_QQ or dom.is_RR:
+                return self
+
+            try:
+                return self.applyfunc(dom.conjugate, dom)
+            except CoercionFailed:
+                pass
+        raise DMDomainError("%s does not support conjugation" % dom)
+
+    def adjoint(self):
+        """Return the adjoint of a DFM matrix."""
+        return self.conjugate().transpose()
 
     def hstack(self, *others):
         """Horizontally stack matrices."""

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -65,7 +65,6 @@ from __future__ import annotations
 from itertools import chain
 
 from sympy.external.gmpy import GROUND_TYPES
-from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities.decorator import doctest_depends_on
 
 from .exceptions import (
@@ -632,10 +631,7 @@ class DDM(list):
             if dom.is_ZZ or dom.is_QQ or dom.is_RR:
                 return self.copy()
 
-            try:
-                return self.applyfunc(dom.conjugate, dom)
-            except CoercionFailed:
-                pass
+            return self.applyfunc(dom.conjugate, dom)
         raise DMDomainError("%s does not support conjugation" % dom)
 
     def adjoint(self):

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -639,7 +639,12 @@ class DDM(list):
         raise DMDomainError("%s does not support conjugation" % dom)
 
     def adjoint(self):
-        return self.conjugate().transpose()
+        dom = self.domain
+        if not dom.is_EXRAW:
+            return self.conjugate().transpose()
+
+        # handle noncommutative elements
+        return self.applyfunc(lambda x: x.adjoint(), dom).transpose()
 
     def __add__(a, b):
         if not isinstance(b, DDM):

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -627,12 +627,13 @@ class DDM(list):
 
     def conjugate(self):
         dom = self.domain
-        if dom.is_ConjugateDomain:
-            if dom.is_ZZ or dom.is_QQ or dom.is_RR:
-                return self.copy()
+        if not dom.is_ConjugateDomain:
+            raise DMDomainError("%s does not support conjugation" % dom)
 
+        if dom.is_ZZ or dom.is_QQ or dom.is_RR:
+            return self.copy()
+        else:
             return self.applyfunc(dom.conjugate, dom)
-        raise DMDomainError("%s does not support conjugation" % dom)
 
     def adjoint(self):
         dom = self.domain
@@ -641,8 +642,8 @@ class DDM(list):
         elif dom.is_EXRAW:
             # handle noncommutative elements
             return self.applyfunc(lambda x: x.adjoint(), dom).transpose()
-
-        return self.applyfunc(lambda x: dom.dtype(x.ex.adjoint()), dom).transpose()
+        else:
+            return self.applyfunc(lambda x: dom.dtype(x.ex.adjoint()), dom).transpose()
 
     def __add__(a, b):
         if not isinstance(b, DDM):

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 from itertools import chain
 
 from sympy.external.gmpy import GROUND_TYPES
+from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities.decorator import doctest_depends_on
 
 from .exceptions import (
@@ -624,6 +625,21 @@ class DDM(list):
         else:
             ddmT = [[]] * cols
         return DDM(ddmT, (cols, rows), self.domain)
+
+    def conjugate(self):
+        dom = self.domain
+        if dom.is_ConjugateDomain:
+            if dom.is_ZZ or dom.is_QQ or dom.is_RR:
+                return self
+
+            try:
+                return self.applyfunc(dom.conjugate, dom)
+            except CoercionFailed:
+                pass
+        raise DMDomainError("%s does not support conjugation" % dom)
+
+    def adjoint(self):
+        return self.conjugate().transpose()
 
     def __add__(a, b):
         if not isinstance(b, DDM):

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -630,7 +630,7 @@ class DDM(list):
         dom = self.domain
         if dom.is_ConjugateDomain:
             if dom.is_ZZ or dom.is_QQ or dom.is_RR:
-                return self
+                return self.copy()
 
             try:
                 return self.applyfunc(dom.conjugate, dom)

--- a/sympy/polys/matrices/ddm.py
+++ b/sympy/polys/matrices/ddm.py
@@ -636,11 +636,13 @@ class DDM(list):
 
     def adjoint(self):
         dom = self.domain
-        if not dom.is_EXRAW:
+        if not (dom.is_EXRAW or dom.is_EX):
             return self.conjugate().transpose()
+        elif dom.is_EXRAW:
+            # handle noncommutative elements
+            return self.applyfunc(lambda x: x.adjoint(), dom).transpose()
 
-        # handle noncommutative elements
-        return self.applyfunc(lambda x: x.adjoint(), dom).transpose()
+        return self.applyfunc(lambda x: dom.dtype(x.ex.adjoint()), dom).transpose()
 
     def __add__(a, b):
         if not isinstance(b, DDM):

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -1180,6 +1180,14 @@ class DomainMatrix:
         """Matrix transpose of ``self``"""
         return self.from_rep(self.rep.transpose())
 
+    def conjugate(self):
+        """Entrywise conjugate of ``self``"""
+        return self.from_rep(self.rep.conjugate())
+
+    def adjoint(self):
+        """Matrix adjoint of ``self``"""
+        return self.from_rep(self.rep.adjoint())
+
     def flat(self):
         rows, cols = self.shape
         return [self[i,j].element for i in range(rows) for j in range(cols)]

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -9,6 +9,7 @@ from operator import add, neg, pos, sub, mul
 from collections import defaultdict
 
 from sympy.external.gmpy import GROUND_TYPES
+from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import _strongly_connected_components
 
@@ -84,7 +85,7 @@ class SDM(dict):
         if not all(0 <= r < m for r in self):
             raise DMBadInputError("Row out of range")
         if not all(0 <= c < n for row in self.values() for c in row):
-            raise DMBadInputError("Column out of range")
+            raise DMBadInputError("alumn out of range")
 
     def getitem(self, i, j):
         try:
@@ -746,6 +747,45 @@ class SDM(dict):
         """
         MT = sdm_transpose(M)
         return M.new(MT, M.shape[::-1], M.domain)
+
+    def conjugate(M):
+        """
+        Returns the conjugate of a :py:class:`~.SDM` matrix
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ_I
+        >>> A = SDM({0:{1:QQ_I(2, -3)}, 1:{}}, (2, 2), QQ_I)
+        >>> A.conjugate()
+        {0: {1: (2 + 3*I)}, 1: {}}
+        """
+        dom = M.domain
+        if dom.is_ConjugateDomain:
+            if dom.is_ZZ or dom.is_QQ or dom.is_RR:
+                return M
+
+            try:
+                return M.applyfunc(dom.conjugate, dom)
+            except CoercionFailed:
+                pass
+        raise DMDomainError("%s does not support conjugation" % dom)
+
+    def adjoint(M):
+        """
+        Returns the adjoint of a :py:class:`~.SDM` matrix
+
+        Examples
+        ========
+
+        >>> from sympy.polys.matrices.sdm import SDM
+        >>> from sympy import QQ_I
+        >>> A = SDM({0:{1:QQ_I(2, -3)}, 1:{}}, (2, 2), QQ_I)
+        >>> A.adjoint()
+        {1: {0: (2 + 3*I)}}
+        """
+        return M.conjugate().transpose()
 
     def __add__(A, B):
         if not isinstance(B, SDM):

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -782,10 +782,13 @@ class SDM(dict):
         {1: {0: (2 + 3*I)}}
         """
         dom = M.domain
-        if not dom.is_EXRAW:
+        if not (dom.is_EXRAW or dom.is_EX):
             return M.conjugate().transpose()
+        elif dom.is_EXRAW:
+            # handle noncommutative elements
+            return M.applyfunc(lambda x: x.adjoint(), dom).transpose()
 
-        return M.applyfunc(lambda x: x.adjoint(), dom).transpose()
+        return M.applyfunc(lambda x: dom.dtype(x.ex.adjoint()), dom).transpose()
 
     def __add__(A, B):
         if not isinstance(B, SDM):

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -785,7 +785,11 @@ class SDM(dict):
         >>> A.adjoint()
         {1: {0: (2 + 3*I)}}
         """
-        return M.conjugate().transpose()
+        dom = M.domain
+        if not dom.is_EXRAW:
+            return M.conjugate().transpose()
+
+        return M.applyfunc(lambda x: x.adjoint(), dom).transpose()
 
     def __add__(A, B):
         if not isinstance(B, SDM):

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -761,12 +761,13 @@ class SDM(dict):
         {0: {1: (2 + 3*I)}, 1: {}}
         """
         dom = M.domain
-        if dom.is_ConjugateDomain:
-            if dom.is_ZZ or dom.is_QQ or dom.is_RR:
-                return M.copy()
+        if not dom.is_ConjugateDomain:
+            raise DMDomainError("%s does not support conjugation" % dom)
 
+        if dom.is_ZZ or dom.is_QQ or dom.is_RR:
+            return M.copy()
+        else:
             return M.applyfunc(dom.conjugate, dom)
-        raise DMDomainError("%s does not support conjugation" % dom)
 
     def adjoint(M):
         """
@@ -787,8 +788,8 @@ class SDM(dict):
         elif dom.is_EXRAW:
             # handle noncommutative elements
             return M.applyfunc(lambda x: x.adjoint(), dom).transpose()
-
-        return M.applyfunc(lambda x: dom.dtype(x.ex.adjoint()), dom).transpose()
+        else:
+            return M.applyfunc(lambda x: dom.dtype(x.ex.adjoint()), dom).transpose()
 
     def __add__(A, B):
         if not isinstance(B, SDM):

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -764,7 +764,7 @@ class SDM(dict):
         dom = M.domain
         if dom.is_ConjugateDomain:
             if dom.is_ZZ or dom.is_QQ or dom.is_RR:
-                return M
+                return M.copy()
 
             try:
                 return M.applyfunc(dom.conjugate, dom)

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -85,7 +85,7 @@ class SDM(dict):
         if not all(0 <= r < m for r in self):
             raise DMBadInputError("Row out of range")
         if not all(0 <= c < n for row in self.values() for c in row):
-            raise DMBadInputError("alumn out of range")
+            raise DMBadInputError("Column out of range")
 
     def getitem(self, i, j):
         try:

--- a/sympy/polys/matrices/sdm.py
+++ b/sympy/polys/matrices/sdm.py
@@ -9,7 +9,6 @@ from operator import add, neg, pos, sub, mul
 from collections import defaultdict
 
 from sympy.external.gmpy import GROUND_TYPES
-from sympy.polys.polyerrors import CoercionFailed
 from sympy.utilities.decorator import doctest_depends_on
 from sympy.utilities.iterables import _strongly_connected_components
 
@@ -766,10 +765,7 @@ class SDM(dict):
             if dom.is_ZZ or dom.is_QQ or dom.is_RR:
                 return M.copy()
 
-            try:
-                return M.applyfunc(dom.conjugate, dom)
-            except CoercionFailed:
-                pass
+            return M.applyfunc(dom.conjugate, dom)
         raise DMDomainError("%s does not support conjugation" % dom)
 
     def adjoint(M):

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -395,7 +395,7 @@ def test_DomainMatrix_conjugate():
     A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
     assert A.conjugate() == A
 
-    A = DomainMatrix([[QQ_I(2, 3)/4, QQ_I(-3, 1)]], (1, 2), QQ_I)    
+    A = DomainMatrix([[QQ_I(2, 3)/4, QQ_I(-3, 1)]], (1, 2), QQ_I)
     B = DomainMatrix([[QQ_I(2, -3)/4, QQ_I(-3, -1)]], (1, 2), QQ_I)
     assert A.conjugate() == B
     assert B.conjugate() == A

--- a/sympy/polys/matrices/tests/test_domainmatrix.py
+++ b/sympy/polys/matrices/tests/test_domainmatrix.py
@@ -391,6 +391,27 @@ def test_DomainMatrix_transpose():
     assert A.transpose() == AT
 
 
+def test_DomainMatrix_conjugate():
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    assert A.conjugate() == A
+
+    A = DomainMatrix([[QQ_I(2, 3)/4, QQ_I(-3, 1)]], (1, 2), QQ_I)    
+    B = DomainMatrix([[QQ_I(2, -3)/4, QQ_I(-3, -1)]], (1, 2), QQ_I)
+    assert A.conjugate() == B
+    assert B.conjugate() == A
+
+
+def test_DomainMatrix_adjoint():
+    A = DomainMatrix([[ZZ(1), ZZ(2)], [ZZ(3), ZZ(4)]], (2, 2), ZZ)
+    AT = DomainMatrix([[ZZ(1), ZZ(3)], [ZZ(2), ZZ(4)]], (2, 2), ZZ)
+    assert A.adjoint() == AT
+
+    A = DomainMatrix([[QQ_I(2, 3)/4, QQ_I(-3, 1)]], (1, 2), QQ_I)
+    B = DomainMatrix([[QQ_I(2, -3)/4], [QQ_I(-3, -1)]], (2, 1), QQ_I)
+    assert A.adjoint() == B
+    assert B.adjoint() == A
+
+
 def test_DomainMatrix_is_zero_matrix():
     A = DomainMatrix([[ZZ(1)]], (1, 1), ZZ)
     B = DomainMatrix([[ZZ(0)]], (1, 1), ZZ)

--- a/sympy/polys/matrices/tests/test_xxm.py
+++ b/sympy/polys/matrices/tests/test_xxm.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from sympy.external.gmpy import GROUND_TYPES
 
-from sympy import ZZ, QQ, GF, ZZ_I, symbols
+from sympy import ZZ, QQ, GF, ZZ_I, symbols, sqrt
 
 from sympy.polys.matrices.exceptions import (
     DMBadInputError,
@@ -655,6 +655,58 @@ def test_XXM_diag(DM):
 def test_XXM_transpose(DM):
     A = DM([[1, 2, 3], [4, 5, 6]])
     assert A.transpose() == DM([[1, 4], [2, 5], [3, 6]])
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_conjugate_real(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    assert A.conjugate() == A
+
+
+def test_XXM_conjugate_complex():
+    A = DDM([[ZZ_I(1, 2), ZZ_I(3, 4)], [ZZ_I(0, 0), ZZ_I(7, 8)]], (2, 2), ZZ_I)
+    B = DDM([[ZZ_I(1, -2), ZZ_I(3, -4)], [ZZ_I(0, 0), ZZ_I(7, -8)]], (2, 2), ZZ_I)
+    assert A.conjugate() == B
+    assert B.conjugate() == A
+    assert A.to_sdm().conjugate() == B.to_sdm()
+    assert B.to_sdm().conjugate() == A.to_sdm()
+
+    K = QQ.algebraic_field(4 + sqrt(-2))
+    A = DDM([[K.convert((-1 + sqrt(-2))/4)], [K.convert(3 + 5*sqrt(-2))]], (2, 1), K)
+    B = DDM([[K.convert((-1 - sqrt(-2))/4)], [K.convert(3 - 5*sqrt(-2))]], (2, 1), K)
+    assert A.conjugate() == B
+    assert B.conjugate() == A
+    assert A.to_sdm().conjugate() == B.to_sdm()
+    assert B.to_sdm().conjugate() == A.to_sdm()
+
+    A = DDM([[1, 2, 3], [4, 5, 6]], (2, 3), GF(7))
+    raises(DMDomainError, lambda: A.conjugate())
+
+
+@pytest.mark.parametrize('DM', DMZ_all)
+def test_XXM_adjoint_real(DM):
+    A = DM([[1, 2, 3], [4, 5, 6]])
+    assert A.adjoint() == DM([[1, 4], [2, 5], [3, 6]])
+
+
+def test_XXM_adjoint_complex():
+    A = DDM([[ZZ_I(1, 2), ZZ_I(3, 4)], [ZZ_I(0, 0), ZZ_I(7, 8)]], (2, 2), ZZ_I)
+    B = DDM([[ZZ_I(1, -2), ZZ_I(0, 0)], [ZZ_I(3, -4), ZZ_I(7, -8)]], (2, 2), ZZ_I)
+    assert A.adjoint() == B
+    assert B.adjoint() == A
+    assert A.to_sdm().adjoint() == B.to_sdm()
+    assert B.to_sdm().adjoint() == A.to_sdm()
+
+    K = QQ.algebraic_field(4 + sqrt(-2))
+    A = DDM([[K.convert((-1 + sqrt(-2))/4)], [K.convert(3 + 5*sqrt(-2))]], (2, 1), K)
+    B = DDM([[K.convert((-1 - sqrt(-2))/4), K.convert(3 - 5*sqrt(-2))]], (1, 2), K)
+    assert A.adjoint() == B
+    assert B.adjoint() == A
+    assert A.to_sdm().adjoint() == B.to_sdm()
+    assert B.to_sdm().adjoint() == A.to_sdm()
+
+    A = DDM([[1, 2, 3], [4, 5, 6]], (2, 3), GF(7))
+    raises(DMDomainError, lambda: A.adjoint())
 
 
 @pytest.mark.parametrize('DM', DMZ_all)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #27436 

The following code works with this PR.
```python
>>> import sympy
>>> sympy.Matrix([[1j]]).to_DM().adjoint()
DomainMatrix({0: {0: (0.0 - 1.0j)}}, (1, 1), CC)
```

However, not all domains support conjugate / adjoint as discussed in the linked issue.

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

This PR implements conjugate and adjoint for DDM, SDM, DFM, DomainMatrix and RepMatrix.

DDM, SDM, DFM and DomainMatrix call `Domain.conjugate` on each element for domains that supports conjugation, and raise a `DMDomainError` otherwise. The `conjugate` and `adjoint` methods keep the matrix domain unchanged.

~~For RepMatrix, it tries to convert the domain to EXRAW if the current domain does not support conjugation.~~

#### Other comments

When the domain is EXRAW, it uses `applyfunc(lambda x: x.adjoint())` to handle noncommutative elements correctly. This preserves the behaviors in #27422.
#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Implemented `conjugate` and `adjoint` for `DDM`, `SDM`, `DFM`, `DomainMatrix`.
 
<!-- END RELEASE NOTES -->
