### PR TITLE
printing: support inv_trig_style in Presentation MathML

### DIFF
--- a/sympy/printing/mathml.py
+++ b/sympy/printing/mathml.py
@@ -1,5 +1,6 @@
 """
 A MathML printer.
+
 """
 
 from __future__ import annotations
@@ -15,6 +16,14 @@ from sympy.printing.precedence import \
     precedence_traditional, PRECEDENCE, PRECEDENCE_TRADITIONAL
 from sympy.printing.pretty.pretty_symbology import greek_unicode
 from sympy.printing.printer import Printer, print_function
+
+
+_inverse_trigonometric_functions = (
+    "asin", "acos", "atan",
+    "acsc", "asec", "acot",
+    "asinh", "acosh", "atanh",
+    "acsch", "asech", "acoth",
+)
 
 
 class MathMLPrinterBase(Printer):
@@ -550,6 +559,13 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
     """
     printmethod = "_mathml_presentation"
 
+    def __init__(self, settings=None):
+        super().__init__(settings)
+        self._inv_trig_style_default = (
+            (settings is None or "inv_trig_style" not in settings) and
+            "inv_trig_style" not in self._global_settings
+        )
+
     def mathml_tag(self, e):
         """Returns the MathML tag for an expression."""
         translate = {
@@ -626,6 +642,32 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
             return mul_symbol_selection()
         n = e.__class__.__name__
         return n.lower()
+
+    def _print_inv_trig_function(self, e):
+        func_name = e.func.__name__
+        style = self._settings["inv_trig_style"]
+
+        if self._inv_trig_style_default:
+            text = self.mathml_tag(e)
+        elif style == "abbreviated":
+            text = func_name
+        elif style == "power":
+            msup = self.dom.createElement('msup')
+            mi = self.dom.createElement('mi')
+            mi.appendChild(self.dom.createTextNode(func_name[1:]))
+            mn = self.dom.createElement('mn')
+            mn.appendChild(self.dom.createTextNode('-1'))
+            msup.appendChild(mi)
+            msup.appendChild(mn)
+            return msup
+        elif style == "full":
+            text = "arc" + func_name[1:]
+        else:
+            text = func_name
+
+        mi = self.dom.createElement('mi')
+        mi.appendChild(self.dom.createTextNode(text))
+        return mi
 
     def _l_paren(self):
         mo = self.dom.createElement('mo')
@@ -1190,11 +1232,14 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
         return mrow
 
     def _print_Function(self, e):
-        x = self.dom.createElement('mi')
-        if self.mathml_tag(e) == 'log' and self._settings["ln_notation"]:
-            x.appendChild(self.dom.createTextNode('ln'))
+        if e.func.__name__ in _inverse_trigonometric_functions:
+            x = self._print_inv_trig_function(e)
         else:
-            x.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
+            x = self.dom.createElement('mi')
+            if self.mathml_tag(e) == 'log' and self._settings["ln_notation"]:
+                x.appendChild(self.dom.createTextNode('ln'))
+            else:
+                x.appendChild(self.dom.createTextNode(self.mathml_tag(e)))
         mrow = self.dom.createElement('mrow')
         mrow.appendChild(x)
         mrow.appendChild(self._paren_comma_separated(*e.args))
@@ -2110,6 +2155,11 @@ class MathMLPresentationPrinter(MathMLPrinterBase):
 def mathml(expr, printer='content', **settings):
     """Returns the MathML representation of expr. If printer is presentation
     then prints Presentation MathML else prints content MathML.
+
+    For Presentation MathML, omitting ``inv_trig_style`` preserves existing
+    inverse-trig function names. Pass ``inv_trig_style='full'``,
+    ``'abbreviated'``, or ``'power'`` explicitly to select a style for all
+    supported inverse trigonometric functions.
     """
     if printer == 'presentation':
         return MathMLPresentationPrinter(settings).doprint(expr)
@@ -2121,6 +2171,11 @@ def print_mathml(expr, printer='content', **settings):
     """
     Prints a pretty representation of the MathML code for expr. If printer is
     presentation then prints Presentation MathML else prints content MathML.
+
+    For Presentation MathML, omitting ``inv_trig_style`` preserves existing
+    inverse-trig function names. Pass ``inv_trig_style='full'``,
+    ``'abbreviated'``, or ``'power'`` explicitly to select a style for all
+    supported inverse trigonometric functions.
 
     Examples
     ========

--- a/sympy/printing/tests/test_mathml.py
+++ b/sympy/printing/tests/test_mathml.py
@@ -22,7 +22,7 @@ from sympy.functions.elementary.hyperbolic import (tanh, acoth, atanh,
 from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.functions.elementary.trigonometric import (csc, sec, tan,
-    atan, sin, asec, cot, cos, acot, acsc, asin, acos)
+    atan, atan2, sin, asec, cot, cos, acot, acsc, asin, acos)
 from sympy.functions.special.delta_functions import Heaviside
 from sympy.functions.special.elliptic_integrals import (elliptic_pi,
     elliptic_f, elliptic_k, elliptic_e)
@@ -62,6 +62,42 @@ from sympy.testing.pytest import raises, XFAIL
 x, y, z, a, b, c, d, e, n = symbols('x:z a:e n')
 mp = MathMLContentPrinter()
 mpp = MathMLPresentationPrinter()
+
+
+_inverse_trig_functions = (
+    asin, acos, atan,
+    acsc, asec, acot,
+    asinh, acosh, atanh,
+    acsch, asech, acoth,
+)
+
+_inverse_trig_default_names = {
+    asin: 'arcsin',
+    acos: 'arccos',
+    atan: 'arctan',
+    acsc: 'acsc',
+    asec: 'asec',
+    acot: 'arccot',
+    asinh: 'arcsinh',
+    acosh: 'arccosh',
+    atanh: 'arctanh',
+    acsch: 'acsch',
+    asech: 'asech',
+    acoth: 'acoth',
+}
+
+
+def _presentation_function(name, *args):
+    inner = '<mo>,</mo>'.join(args)
+    return f'<mrow><mi>{name}</mi><mrow><mo>(</mo>{inner}<mo>)</mo></mrow></mrow>'
+
+
+def _presentation_inverse_power_function(name, *args):
+    inner = '<mo>,</mo>'.join(args)
+    return (
+        f'<mrow><msup><mi>{name}</mi><mn>-1</mn></msup>'
+        f'<mrow><mo>(</mo>{inner}<mo>)</mo></mrow></mrow>'
+    )
 
 
 def test_mathml_printer():
@@ -924,15 +960,6 @@ def test_presentation_mathml_trig():
     mml = mpp._print(tan(x))
     assert mml.childNodes[0].childNodes[0].nodeValue == 'tan'
 
-    mml = mpp._print(asin(x))
-    assert mml.childNodes[0].childNodes[0].nodeValue == 'arcsin'
-
-    mml = mpp._print(acos(x))
-    assert mml.childNodes[0].childNodes[0].nodeValue == 'arccos'
-
-    mml = mpp._print(atan(x))
-    assert mml.childNodes[0].childNodes[0].nodeValue == 'arctan'
-
     mml = mpp._print(sinh(x))
     assert mml.childNodes[0].childNodes[0].nodeValue == 'sinh'
 
@@ -942,14 +969,76 @@ def test_presentation_mathml_trig():
     mml = mpp._print(tanh(x))
     assert mml.childNodes[0].childNodes[0].nodeValue == 'tanh'
 
-    mml = mpp._print(asinh(x))
-    assert mml.childNodes[0].childNodes[0].nodeValue == 'arcsinh'
+    for func in _inverse_trig_functions:
+        assert mathml(func(x), printer='presentation') == \
+            _presentation_function(_inverse_trig_default_names[func],
+                                   '<mi>x</mi>')
 
-    mml = mpp._print(atanh(x))
-    assert mml.childNodes[0].childNodes[0].nodeValue == 'arctanh'
 
-    mml = mpp._print(acosh(x))
-    assert mml.childNodes[0].childNodes[0].nodeValue == 'arccosh'
+def test_presentation_mathml_inv_trig_styles():
+    for func in _inverse_trig_functions:
+        assert mathml(func(x), printer='presentation',
+            inv_trig_style='abbreviated') == \
+                _presentation_function(func.__name__, '<mi>x</mi>')
+        assert mathml(func(x), printer='presentation',
+            inv_trig_style='full') == \
+                _presentation_function(f'arc{func.__name__[1:]}', '<mi>x</mi>')
+
+
+def test_presentation_mathml_inv_trig_power_style():
+    for func in _inverse_trig_functions:
+        assert mathml(func(x), printer='presentation',
+            inv_trig_style='power') == \
+                _presentation_inverse_power_function(
+                    func.__name__[1:], '<mi>x</mi>')
+
+    assert mathml(asin(x), printer='presentation', inv_trig_style='power') == \
+        '<mrow><msup><mi>sin</mi><mn>-1</mn></msup><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow>'
+    assert mathml(asinh(x), printer='presentation',
+        inv_trig_style='power') == \
+            '<mrow><msup><mi>sinh</mi><mn>-1</mn></msup><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow>'
+    assert mathml(asin(x)**2, printer='presentation',
+        inv_trig_style='power') == \
+            '<msup><mrow><msup><mi>sin</mi><mn>-1</mn></msup><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow><mn>2</mn></msup>'
+
+
+def test_presentation_mathml_inv_trig_global_setting():
+    had_global_setting = 'inv_trig_style' in MathMLPresentationPrinter._global_settings
+    old_global_setting = MathMLPresentationPrinter._global_settings.get(
+        'inv_trig_style')
+    MathMLPresentationPrinter.set_global_settings(inv_trig_style='power')
+    try:
+        assert mathml(asin(x), printer='presentation') == \
+            _presentation_inverse_power_function('sin', '<mi>x</mi>')
+        assert mathml(asin(x), printer='presentation',
+            inv_trig_style='abbreviated') == \
+                _presentation_function('asin', '<mi>x</mi>')
+    finally:
+        if had_global_setting:
+            MathMLPresentationPrinter._global_settings[
+                'inv_trig_style'] = old_global_setting
+        else:
+            del MathMLPresentationPrinter._global_settings['inv_trig_style']
+
+
+def test_presentation_mathml_atan2_inv_trig_style_regression():
+    expected = _presentation_function('arctan', '<mi>x</mi>', '<mi>y</mi>')
+    assert mathml(atan2(x, y), printer='presentation') == expected
+    assert mathml(atan2(x, y), printer='presentation',
+        inv_trig_style='abbreviated') == expected
+    assert mathml(atan2(x, y), printer='presentation',
+        inv_trig_style='full') == expected
+    assert mathml(atan2(x, y), printer='presentation',
+        inv_trig_style='power') == expected
+
+
+def test_content_mathml_inv_trig_style_regression():
+    expected = '<apply><arcsin/><ci>x</ci></apply>'
+    assert mathml(asin(x), printer='content') == expected
+    assert mathml(asin(x), printer='content',
+        inv_trig_style='abbreviated') == expected
+    assert mathml(asin(x), printer='content', inv_trig_style='full') == expected
+    assert mathml(asin(x), printer='content', inv_trig_style='power') == expected
 
 
 def test_presentation_mathml_relational():


### PR DESCRIPTION
#### References to other Issues or PRs

See #15877.

#### Brief description of what is fixed or changed

This adds support for the existing `inv_trig_style` MathML printer setting in the Presentation MathML printer.

`inv_trig_style` was already present in the MathML printer defaults, but inverse trigonometric functions in Presentation MathML did not use it. This change applies the setting to unary inverse trig functions such as `asin`, `acos`, `atan`, `acsc`, `asec`, `acot`, and their hyperbolic variants.

The supported explicit styles are:

- `inv_trig_style='abbreviated'`, which prints names such as `asin`
- `inv_trig_style='full'`, which prints names such as `arcsin`
- `inv_trig_style='power'`, which prints forms such as `sin^{-1}(x)`

For compatibility, omitting `inv_trig_style` preserves the existing Presentation MathML output. Explicit call-time settings override global printer settings.

This PR is intentionally scoped to Presentation MathML. Content MathML output is unchanged, and `atan2` is also unchanged because it is not a unary inverse trigonometric function.

#### Other comments

This addresses one remaining checklist item from #15877. It does not attempt to close the full umbrella issue, since other MathML printer configuration items are still outstanding.

The tests cover:

- default Presentation MathML behavior
- all explicit `inv_trig_style` values
- the full supported inverse trig function set
- global printer settings
- call-time override behavior
- `atan2` non-regression
- Content MathML non-regression

#### AI Generation Disclosure

Codex AI was used for validation and PR proof-reading. The code changes were designed and written by a human.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* printing
  * Added support for the `inv_trig_style` setting in Presentation MathML.

<!-- END RELEASE NOTES -->