### PR TITLE
polys: fix `construct_domain` so that `construct_domain([x + oo])` returns `(EX, [EX(x + oo)])`

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -9,7 +9,7 @@ from sympy.polys.domains import ZZ, QQ, ZZ_I, QQ_I, EX
 from sympy.polys.domains.complexfield import ComplexField
 from sympy.polys.domains.realfield import RealField
 from sympy.polys.polyoptions import build_options
-from sympy.polys.polyutils import parallel_dict_from_basic
+from sympy.polys.polyutils import parallel_dict_from_basic, _not_a_coeff
 from sympy.utilities import public
 
 
@@ -144,7 +144,7 @@ def _construct_composite(coeffs, opt):
         return None
 
     if opt.composite is None:
-        if any(gen.is_number and gen.is_algebraic for gen in gens):
+        if any(_not_a_coeff(gen) or gen.is_number and gen.is_algebraic for gen in gens):
             return None # generators are number-like so lets better use EX
 
         all_symbols = set()

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -11,6 +11,7 @@ from sympy.polys.domains.complexfield import ComplexField
 from sympy.core import (Catalan, GoldenRatio)
 from sympy.core.numbers import (E, Float, I, Rational, pi)
 from sympy.core.singleton import S
+from sympy.core.symbol import Symbol
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import sin
@@ -235,3 +236,19 @@ def test_issue_11538():
         assert construct_domain(x + n)[0] == ZZ[x, n]
     assert construct_domain(GoldenRatio)[0] == EX
     assert construct_domain(x + GoldenRatio)[0] == EX
+
+
+def test_issue_25337():
+    assert construct_domain([S.ComplexInfinity]) == (EX, [EX(S.ComplexInfinity)])
+    assert construct_domain([S.Infinity]) == (EX, [EX(S.Infinity)])
+    assert construct_domain([S.NegativeInfinity]) == (EX, [EX(S.NegativeInfinity)])
+    assert construct_domain([S.NaN]) == (EX, [EX(S.NaN)])
+
+    assert construct_domain([x + S.ComplexInfinity]) == (EX, [EX(x + S.ComplexInfinity)])
+    assert construct_domain([x + S.Infinity]) == (EX, [EX(x + S.Infinity)])
+
+    assert construct_domain(S.ComplexInfinity) == (EX, EX(S.ComplexInfinity))
+    assert construct_domain(S.NaN) == (EX, EX(S.NaN))
+
+    x_algebraic = Symbol('x', algebraic=True)
+    assert construct_domain(x_algebraic)[0] == ZZ[x_algebraic]


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #25337, #29734


#### Brief description of what is fixed or changed
Before the fix, `construct_domain` showed the following behavior.

```python
In [1]: construct_domain([S.ComplexInfinity]) 
Out[1]: (ZZ[zoo], [zoo])
expected result = (EX, [EX(zoo)])

In [2]: construct_domain([S.Infinity])
Out[2]: (ZZ[oo], [oo])
expected result = (EX, [EX(oo)])

In [3]: construct_domain([S.NegativeInfinity])
Out[3]: (ZZ[-oo], [(-oo)])
expected result = (EX, [EX(-oo)])

In [4]: construct_domain([S.NaN])
Out[4]: (ZZ[nan], [nan])
expected result = (EX, [EX(nan)])

In [5]: construct_domain([x + S.ComplexInfinity])
Out[5]: (ZZ[x,zoo], [x + zoo])
expected result = (EX, [EX(x + zoo)])

In [6]: construct_domain([x + S.Infinity])
Out[6]: (ZZ[x,oo], [x + oo])
expected result = (EX, [EX(x + oo)])

In [7]: construct_domain(S.ComplexInfinity)
Out[7]: (ZZ[zoo], zoo)
expected result = (EX, EX(zoo))

In [8]: construct_domain(S.NaN)
Out[8]: (ZZ[nan], nan)
expected result = (EX, EX(nan))

In [9]: x = Symbol('x', algebraic=True)

In [10]: construct_domain([x])
Out[10]: (ZZ[x], [x])
already correct
```

After the fix, all the code snippets above produce the expected results.

#### Other comments
I added regression tests for all the cases above.

And here is what `_not_a_coeff` does:
https://github.com/sympy/sympy/blob/06f6e3a8cf4a1a9a8323722c74fb38394f5aa8e4/sympy/polys/polyutils.py#L213-L219

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
DeepSeek assisted in finding the cause.
All code was written manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed `construct_domain` so that `construct_domain([x + oo])` returns `(EX, [EX(x + oo)])`.
<!-- END RELEASE NOTES -->