### PR TITLE
Fix _collect_factor_and_dimension returning variable-length tuple for Functions

### DIFF
--- a/sympy/physics/units/tests/test_quantities.py
+++ b/sympy/physics/units/tests/test_quantities.py
@@ -557,6 +557,34 @@ def test_prefixed_property():
     assert kilogram.is_prefixed
     assert pebibyte.is_prefixed
 
+def test_issue_29032():
+    from sympy.functions.elementary.miscellaneous import cbrt
+    q1 = Quantity('q1')
+    SI.set_quantity_dimension(q1, length)
+    SI.set_quantity_scale_factor(q1, 1)
+    q2 = Quantity('q2')
+    SI.set_quantity_dimension(q2, time)
+    SI.set_quantity_scale_factor(q2, 1)
+
+    f = Function('f')
+
+    # _collect_factor_and_dimension must always return a 2-tuple
+    result = SI._collect_factor_and_dimension(f(q1, q2))
+    assert len(result) == 2
+
+    # sqrt/cbrt wrapping a Function with multiple dimensional args
+    # previously raised ValueError: too many values to unpack
+    result = SI._collect_factor_and_dimension(sqrt(f(q1, q2)))
+    assert len(result) == 2
+
+    result = SI._collect_factor_and_dimension(cbrt(f(q1, q2)))
+    assert len(result) == 2
+
+    # Single-arg functions still pass through dimension directly
+    assert SI._collect_factor_and_dimension(Abs(q1)) == (1, length)
+    assert SI._collect_factor_and_dimension(exp(q1/q2)) == (exp(1), Dimension(1))
+
+
 def test_physics_constant():
     from sympy.physics.units import definitions
 

--- a/sympy/physics/units/unitsystem.py
+++ b/sympy/physics/units/unitsystem.py
@@ -194,8 +194,15 @@ class UnitSystem(_QuantityMapper):
             return factor, dim
         elif isinstance(expr, Function):
             fds = [self._collect_factor_and_dimension(arg) for arg in expr.args]
-            dims = [Dimension(1) if self.get_dimension_system().is_dimensionless(d[1]) else d[1] for d in fds]
-            return (expr.func(*(f[0] for f in fds)), *dims)
+            factor = expr.func(*(f[0] for f in fds))
+            dims = [d[1] for d in fds]
+            if len(dims) == 1:
+                if self.get_dimension_system().is_dimensionless(dims[0]):
+                    return factor, Dimension(1)
+                return factor, dims[0]
+            if all(self.get_dimension_system().is_dimensionless(d) for d in dims):
+                return factor, Dimension(1)
+            return factor, Dimension(expr.func(*[d.name for d in dims]))
         elif isinstance(expr, Dimension):
             return S.One, expr
         else:


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The `Function` branch in `_collect_factor_and_dimension` returned a variable-length tuple `(factor, dim1, dim2, ...)` instead of a 2-tuple `(factor, dimension)`. When `sqrt` or `cbrt` (which are `Pow` instances) wrapped a `Function` with multiple dimensional arguments, the `Pow` branch failed with:

```
ValueError: too many values to unpack (expected 2, got 3)
```

**Reproduction:**
```python
from sympy import sqrt, cbrt, Function
from sympy.physics.units import meter, second
from sympy.physics.units.systems.si import SI
from sympy.physics.units import Quantity

q1 = Quantity("q1")
SI.set_quantity_dimension(q1, meter.dimension)
SI.set_quantity_scale_factor(q1, 1)

q2 = Quantity("q2")
SI.set_quantity_dimension(q2, second.dimension)
SI.set_quantity_scale_factor(q2, 1)

f = Function("f")

# This raised ValueError: too many values to unpack (expected 2, got 3)
SI._collect_factor_and_dimension(sqrt(f(q1, q2)))
```

**Fix:**
Always return a 2-tuple `(factor, dimension)`:
- **Single-arg functions** (`Abs`, `exp`, `log`, etc.): Pass through the argument's dimension directly (preserving existing behavior)
- **Multi-arg functions**: If all args are dimensionless, return `Dimension(1)`. Otherwise, wrap dimensions in the function call: `Dimension(expr.func(*[d.name for d in dims]))`, consistent with `get_dimensional_expr`'s `Function` branch.

#### Other comments

This bug was introduced in PR #23296 which added the `Function` branch. It went undetected because existing tests only cover single-argument functions (`exp`, `log`, `Abs`).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.units
  * Fixed `_collect_factor_and_dimension` returning a variable-length tuple for `Function` expressions, which caused `sqrt` and `cbrt` to fail with `ValueError` when applied to functions with multiple dimensional arguments.
<!-- END RELEASE NOTES -->