### PR TITLE
Fixing wrong sign when using `polytope_integrate`

### DIFF
--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -93,12 +93,7 @@ def polytope_integrate(poly, expr=None, *, clockwise=False, max_degree=None):
         facets = poly[1:]
         hp_params = hyperplane_parameters(facets, vertices)
 
-        # main_integrate3d requires the facets' vertices to be wound so
-        # that their normals point outward. If they are all wound the
-        # other way instead, the computed volume comes out negated. Detect
-        # this via the sign of the volume and, if needed, reverse every
-        # facet so the orientation is consistent with the outward
-        # convention assumed elsewhere.
+        
         if main_integrate3d(1, facets, vertices, hp_params).is_negative:
             facets = [facet[::-1] for facet in facets]
             hp_params = hyperplane_parameters(facets, vertices)

--- a/sympy/integrals/intpoly.py
+++ b/sympy/integrals/intpoly.py
@@ -93,6 +93,16 @@ def polytope_integrate(poly, expr=None, *, clockwise=False, max_degree=None):
         facets = poly[1:]
         hp_params = hyperplane_parameters(facets, vertices)
 
+        # main_integrate3d requires the facets' vertices to be wound so
+        # that their normals point outward. If they are all wound the
+        # other way instead, the computed volume comes out negated. Detect
+        # this via the sign of the volume and, if needed, reverse every
+        # facet so the orientation is consistent with the outward
+        # convention assumed elsewhere.
+        if main_integrate3d(1, facets, vertices, hp_params).is_negative:
+            facets = [facet[::-1] for facet in facets]
+            hp_params = hyperplane_parameters(facets, vertices)
+
         if max_degree is None:
             if expr is None:
                 raise TypeError('Input expression must be a valid SymPy expression')


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->


#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #30008 
#### Brief description of what is fixed or changed
The fix computes the volume with a correction for negative values. Every vertex order is reversed before the requested expression is integrated. This corrects the sign for polytopes with inward-wound facets while leaving properly oriented ones unchanged.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Claude was used on lines 97-99 in intpoly.py
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed `polytope_integrate` returning the negated result for 3D polytopes whose facets are wound with inward-pointing normals.

<!-- END RELEASE NOTES -->
