### PR TITLE
[GsOC] adding vandermonde systems solvers to zippel.py

### DIFF
--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -751,6 +751,14 @@ Modular GCD
 .. autofunction:: _modgcd_multivariate_p
 .. autofunction:: func_field_modgcd
 
+Zippel algorithm
+****************
+
+.. currentmodule:: sympy.polys.zippel
+
+.. autofunction:: lag_basis
+.. autofunction:: vandermonde_interp
+
 Undocumented
 ============
 

--- a/doc/src/modules/polys/literature.rst
+++ b/doc/src/modules/polys/literature.rst
@@ -157,3 +157,6 @@ a theoretical foundation for implementing polynomials manipulation module.
 .. [Abbott13] John Abbott. "Bounds on factors in Z[x]".
     Journal of Symbolic Computation 50 (2013), pp. 532-563
     https://doi.org/10.1016/j.jsc.2012.09.004
+
+.. [Yang09] S. Yang, Computing the Greatest Common Divisor of
+    Multivariate Polynomials over Finite Fields, Simon Fraser University, 2009.

--- a/sympy/polys/tests/test_zippel.py
+++ b/sympy/polys/tests/test_zippel.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 from sympy.polys.rings import ring
 from sympy.polys.domains import ZZ
 from sympy.polys.zippel import (_LC, _chinese_remainder_reconstruction_multivariate, _deg,
-    _gf_gcd, _trivial_gcd, _primitive)
+    _gf_gcd, _trivial_gcd, _primitive, lag_basis, vandermonde_interp)
+from sympy.matrices import Matrix
 
 
 def test_gf_gcd():
@@ -103,3 +104,19 @@ def test_chinese_remainder_reconstruction_multivariate():
 
     assert hpq.trunc_ground(p) == hp
     assert hpq.trunc_ground(q) == hq
+
+
+def test_vandermonde_interpolate():
+    p = ZZ(100003)
+    k = ZZ.map([3, 6, 12, 33])
+    A = Matrix([[el**j for j in range(len(k))] for el in k])
+    x_list = [12, 2, 1, 27]
+    x = Matrix(x_list)
+    v = [ZZ(int(el)) for el in A * x]
+    v_t = [ZZ(int(el)) for el in A.T * x]
+
+    bas = lag_basis(k, p)
+    sol_t = vandermonde_interp(bas, v_t, p)
+    sol = vandermonde_interp(bas, v, p, trans = False)
+
+    assert sol == sol_t == x_list

--- a/sympy/polys/tests/test_zippel.py
+++ b/sympy/polys/tests/test_zippel.py
@@ -117,6 +117,6 @@ def test_vandermonde_interpolate():
 
     bas = lag_basis(k, p)
     sol_t = vandermonde_interp(bas, v_t, p)
-    sol = vandermonde_interp(bas, v, p, trans = False)
+    sol = vandermonde_interp(bas, v, p, trans=False)
 
     assert sol == sol_t == x_list

--- a/sympy/polys/zippel.py
+++ b/sympy/polys/zippel.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
-from sympy.polys.galoistools import gf_gcd, gf_quo, gf_from_dict
+from sympy.polys.galoistools import gf_div, gf_eval, gf_gcd, gf_mul, gf_quo, gf_from_dict
 from sympy.ntheory.modular import crt
 from sympy.polys.domains import PolynomialRing
 
+from typing import TYPE_CHECKING
+
+from sympy.polys.domains.integerring import ZZ
+
+if TYPE_CHECKING:
+    from sympy.external.gmpy import MPZ
 
 def _gf_gcd(fp, gp, p):
     r"""
@@ -382,3 +388,80 @@ def _chinese_remainder_reconstruction_multivariate(hp, hq, p, q):
         hpq[monom] = crt_(zero, hq[monom], p, q)
 
     return hpq
+
+
+def lag_basis(evalpoints: list[MPZ], p: MPZ) -> list[list[MPZ]]:
+    """
+    Computes the Lagrange basis associated to the given
+    list of evaluation points over Z_p.
+
+    Example
+    =======
+
+    >>> from sympy.polys.zippel import lag_basis
+    >>> evalpoints = [1, 2, 5]
+    >>> p = 11
+    >>> lag_basis(evalpoints, p)
+    [[3, 1, 8], [7, 2, 2], [1, 8, 2]]
+
+    """
+    master_pol = [ZZ.one]
+    for k in evalpoints:
+        master_pol = gf_mul(master_pol, [ZZ.one, -k], p, ZZ)
+
+    v = [gf_div(master_pol, [ZZ.one, -k], p, ZZ)[0] for k in evalpoints]
+    for i, poly in enumerate(v):
+        c = gf_eval(poly, evalpoints[i], p, ZZ)
+        c = ZZ.invert(c, p)
+        v[i] = [(c*el) % p for el in v[i]]
+    return v
+
+
+def vandermonde_interp(basis: list[list[MPZ]], values: list[MPZ],
+    p: MPZ, trans: bool = True) -> list[MPZ]:
+    """
+    Solves for x the linear system A^T * x = values in Z_p,
+    where A is the Vandermonde matrix such that a_{i,j} = k[i]^j.
+    If trans = False, it solves the linear system A*x = values.
+    Both systems are solved in O(n^2) time.
+
+    The parameter basis can be computed using lag_basis(k, p).
+
+    Note that solving a linear system with associated Vandermonde matrix is
+    equivalent to interpolating an univariate polynomial.
+    Note also that the interpolation of a multivariate polynomial in
+    Z_p[x1,...,xn], can be made equivalent to the resolution of a linear system
+    with the transposed of a Vandermonde matrix as the associated matrix.
+    It is sufficient to choose a random tuple (t1,...,tn),
+    and to use (t1^j,...,tn^j) for j in {0,1,...} as evaluation points.
+
+    Example
+    =======
+
+    >>> from sympy.polys.zippel import vandermonde_interp, lag_basis
+    >>> from sympy import Matrix
+
+    >>> k = [1, 2, 5]
+    >>> p = 9973
+    >>> values = [4, 9, 36]
+    >>> A = Matrix([[1, 1, 1], [1, 2, 4], [1, 5, 25]])
+
+    >>> bas = lag_basis(k, p)
+
+    >>> x = vandermonde_interp(bas, values, p, trans = False)
+
+    >>> A * Matrix(x) == Matrix(values)
+    True
+
+    """
+    deg = len(values)-1
+    if trans:
+        sol = []
+        for poly in basis:
+            sol.append(sum(val * poly[deg-i] for i, val in enumerate(values)) % p)
+    else:
+        sol = []
+        for i in range(len(values)):
+            sol.append(sum(values[j] * basis[j][deg-i] for j in range(len(values))) % p)
+
+    return sol

--- a/sympy/polys/zippel.py
+++ b/sympy/polys/zippel.py
@@ -9,6 +9,7 @@ from sympy.polys.domains.integerring import ZZ
 
 if TYPE_CHECKING:
     from sympy.external.gmpy import MPZ
+    from sympy.polys.densebasic import dup
 
 def _gf_gcd(fp, gp, p):
     r"""
@@ -390,10 +391,10 @@ def _chinese_remainder_reconstruction_multivariate(hp, hq, p, q):
     return hpq
 
 
-def lag_basis(evalpoints: list[MPZ], p: MPZ) -> list[list[MPZ]]:
-    """
+def lag_basis(evalpoints: list[MPZ], p: MPZ) -> list[dup[MPZ]]:
+    r"""
     Computes the Lagrange basis associated to the given
-    list of evaluation points over Z_p.
+    list of evaluation points over `\mathbb{Z}_p`.
 
     Example
     =======
@@ -404,6 +405,11 @@ def lag_basis(evalpoints: list[MPZ], p: MPZ) -> list[list[MPZ]]:
     >>> lag_basis(evalpoints, p)
     [[3, 1, 8], [7, 2, 2], [1, 8, 2]]
 
+    References
+    ==========
+
+    .. [1] [Yang09]_
+
     """
     master_pol = [ZZ.one]
     for k in evalpoints:
@@ -413,27 +419,33 @@ def lag_basis(evalpoints: list[MPZ], p: MPZ) -> list[list[MPZ]]:
     for i, poly in enumerate(v):
         c = gf_eval(poly, evalpoints[i], p, ZZ)
         c = ZZ.invert(c, p)
-        v[i] = [(c*el) % p for el in v[i]]
+        v[i] = [(c * el) % p for el in v[i]]
     return v
 
 
-def vandermonde_interp(basis: list[list[MPZ]], values: list[MPZ],
-    p: MPZ, trans: bool = True) -> list[MPZ]:
-    """
-    Solves for x the linear system A^T * x = values in Z_p,
-    where A is the Vandermonde matrix such that a_{i,j} = k[i]^j.
-    If trans = False, it solves the linear system A*x = values.
-    Both systems are solved in O(n^2) time.
+def vandermonde_interp(
+    basis: list[dup[MPZ]], values: list[MPZ], p: MPZ, trans: bool = True
+) -> list[MPZ]:
+    r"""
+    Solves for `x` the linear system `A^T x = \mathrm{values}` in
+    `\mathbb{Z}_p`, where `A` is the Vandermonde matrix such that
+    `a_{i,j} = k_i^j`.
+    If `\mathrm{trans} = \mathrm{False}`, it solves the linear system
+    `A x = \mathrm{values}`.
+    Both systems are solved in `O(n^2)` time.
 
-    The parameter basis can be computed using lag_basis(k, p).
+    The parameter basis can be computed using
+    `\operatorname{lag\_basis}(k, p)`.
 
     Note that solving a linear system with associated Vandermonde matrix is
     equivalent to interpolating an univariate polynomial.
     Note also that the interpolation of a multivariate polynomial in
-    Z_p[x1,...,xn], can be made equivalent to the resolution of a linear system
-    with the transposed of a Vandermonde matrix as the associated matrix.
-    It is sufficient to choose a random tuple (t1,...,tn),
-    and to use (t1^j,...,tn^j) for j in {0,1,...} as evaluation points.
+    `\mathbb{Z}_p[x_1, \ldots, x_n]`, can be made equivalent to the resolution
+    of a linear system with the transposed of a Vandermonde matrix as the
+    associated matrix.
+    It is sufficient to choose a random tuple `(t_1, \ldots, t_n)`,
+    and to use `(t_1^j, \ldots, t_n^j)` for
+    `j \in \{0, 1, \ldots\}` as evaluation points.
 
     Example
     =======
@@ -453,15 +465,22 @@ def vandermonde_interp(basis: list[list[MPZ]], values: list[MPZ],
     >>> A * Matrix(x) == Matrix(values)
     True
 
+    References
+    ==========
+
+    .. [1] [Yang09]_
+
     """
-    deg = len(values)-1
+    deg = len(values) - 1
     if trans:
         sol = []
         for poly in basis:
-            sol.append(sum(val * poly[deg-i] for i, val in enumerate(values)) % p)
+            sol.append(sum(val * poly[deg - i] for i, val in enumerate(values)) % p)
     else:
         sol = []
         for i in range(len(values)):
-            sol.append(sum(values[j] * basis[j][deg-i] for j in range(len(values))) % p)
+            sol.append(
+                sum(values[j] * basis[j][deg - i] for j in range(len(values))) % p
+            )
 
     return sol


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Implementation of the functions lag_basis() and vandermonde_interp(), that are useful during the stage of sparse interpolation in Zippel's algorithm, and adding type annotations to zippel.py, and adding type annotations to zippel.py.


#### Other comments
During the sparse interpolation stage of Zippel's algorithm, a multivariate polynomial has to be interpolated. 
This is done by evaluating the polynomial in random points, and setting up a system of linear equations.
If every evalution point is chosen randomly, then this has complexity of O(n^3) (the complexity of solving a generic linear system).
Instead a more efficient approach can be adopted:
the problem can be made equivalent to the resolution of a linear system with the transposed of a Vandermonde matrix as the associated matrix. It is sufficient to choose a random tuple (t1,...,tn), and to use (t1^j,...,tn^j) for j in {0,1,...} as evaluation points.
The two functions of this pr are implemented to solve this particular type of linear system over Z_p.
You can find a more detailed description of the math behind this approach in section 2.4 of the paper: 
[Computing the Greatest Common Divisor of Multivariate Polynomials over Finite Fields], by Suling Yang.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Code was written by myself, and I used the assistance of gemini for reviewing and ideas validation.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added two functions to solve systems with a Vandermonde matrix as the associated matrix, which is useful during the sparse interpolation stage in Zippel's algorithm to zippel.py
<!-- END RELEASE NOTES -->
