### PR TITLE
Add type annotations to matrix factorizations module (#28806)

### DIFF
--- a/sympy/matrices/expressions/factorizations.py
+++ b/sympy/matrices/expressions/factorizations.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 from sympy.matrices.expressions import MatrixExpr
-from sympy.assumptions.assume import Predicate
 from sympy.assumptions.ask import Q
+
+if TYPE_CHECKING:
+    from sympy.assumptions.assume import Predicate
 
 class Factorization(MatrixExpr):
     arg = property(lambda self: self.args[0])

--- a/sympy/matrices/expressions/factorizations.py
+++ b/sympy/matrices/expressions/factorizations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from sympy.matrices.expressions import MatrixExpr
+from sympy.assumptions.assume import Predicate
 from sympy.assumptions.ask import Q
 
 class Factorization(MatrixExpr):
@@ -8,11 +9,11 @@ class Factorization(MatrixExpr):
 
 class LofLU(Factorization):
     @property
-    def predicates(self):
+    def predicates(self) -> tuple[Predicate, ...]:
         return (Q.lower_triangular,)
 class UofLU(Factorization):
     @property
-    def predicates(self):
+    def predicates(self) -> tuple[Predicate, ...]:
         return (Q.upper_triangular,)
 
 class LofCholesky(LofLU): pass
@@ -20,44 +21,44 @@ class UofCholesky(UofLU): pass
 
 class QofQR(Factorization):
     @property
-    def predicates(self):
+    def predicates(self) -> tuple[Predicate, ...]:
         return (Q.orthogonal,)
 class RofQR(Factorization):
     @property
-    def predicates(self):
+    def predicates(self) -> tuple[Predicate, ...]:
         return (Q.upper_triangular,)
 
 class EigenVectors(Factorization):
     @property
-    def predicates(self):
+    def predicates(self) -> tuple[Predicate, ...]:
         return (Q.orthogonal,)
 class EigenValues(Factorization):
     @property
-    def predicates(self):
+    def predicates(self) -> tuple[Predicate, ...]:
         return (Q.diagonal,)
 
 class UofSVD(Factorization):
     @property
-    def predicates(self):
+    def predicates(self) -> tuple[Predicate, ...]:
         return (Q.orthogonal,)
 class SofSVD(Factorization):
     @property
-    def predicates(self):
+    def predicates(self) -> tuple[Predicate, ...]:
         return (Q.diagonal,)
 class VofSVD(Factorization):
     @property
-    def predicates(self):
+    def predicates(self) -> tuple[Predicate, ...]:
         return (Q.orthogonal,)
 
 
-def lu(expr):
+def lu(expr: MatrixExpr) -> tuple[LofLU, UofLU]:
     return LofLU(expr), UofLU(expr)
 
-def qr(expr):
+def qr(expr: MatrixExpr) -> tuple[QofQR, RofQR]:
     return QofQR(expr), RofQR(expr)
 
-def eig(expr):
+def eig(expr: MatrixExpr) -> tuple[EigenValues, EigenVectors]:
     return EigenValues(expr), EigenVectors(expr)
 
-def svd(expr):
+def svd(expr: MatrixExpr) -> tuple[UofSVD, SofSVD, VofSVD]:
     return UofSVD(expr), SofSVD(expr), VofSVD(expr)


### PR DESCRIPTION
Part of #28806 (incrementally adding type annotations).

Annotates `sympy/matrices/expressions/factorizations.py`:

- the public factory functions `lu`, `qr`, `eig`, `svd` now declare their `MatrixExpr` input and their factorization-tuple return types (e.g. `lu(expr: MatrixExpr) -> tuple[LofLU, UofLU]`);
- the `predicates` properties on the `Factorization` subclasses are annotated as `tuple[Predicate, ...]` (with `Predicate` imported under `TYPE_CHECKING`).

The module already had `from __future__ import annotations`, so this is runtime-neutral.

Verified locally:
- `mypy sympy --no-incremental` → `Success: no issues found in 1538 source files`
- `ruff check sympy/matrices/expressions/factorizations.py` → clean
- `pytest sympy/matrices/expressions/tests/test_factorizations.py` → 4 passed

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
