### PR TITLE
Fix lambdify dropping NumPy array shape for constant/partial expressions

### DIFF
--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -930,6 +930,9 @@ or tuple for the function arguments.
     funcname = '_lambdifygenerated'
     if _module_present('tensorflow', namespaces):
         funcprinter = _TensorflowEvaluatorPrinter(printer, dummify)
+    elif (_module_present('numpy', namespaces)
+          or _module_present('scipy', namespaces)):
+        funcprinter = _NumPyEvaluatorPrinter(printer, dummify)
     else:
         funcprinter = _EvaluatorPrinter(printer, dummify)
 
@@ -959,7 +962,8 @@ or tuple for the function arguments.
                 imp_mod_lines.append(ln)
 
     # Provide lambda expression with builtins, and compatible implementation of range
-    namespace.update({'builtins':builtins, 'range':range})
+    namespace.update({'builtins':builtins, 'range':range,
+                      '_numpy_broadcast_result': _numpy_broadcast_result})
 
     funclocals = {}
     global _lambdify_generated_counter
@@ -1224,6 +1228,18 @@ class _EvaluatorPrinter:
             else:
                 funcargs.append(argstr)
 
+        from sympy.core.symbol import Symbol
+        from sympy.core.expr import Expr as _Expr
+        broadcast_argstrs = []
+        if isinstance(expr, _Expr):
+            symbol_argstrs = [astr for a, astr in zip(args, argstrs)
+                              if isinstance(a, Symbol) and not iterable(astr)]
+            free = expr.free_symbols
+            missing = any(a not in free for a, astr in zip(args, argstrs)
+                          if isinstance(a, Symbol) and not iterable(astr))
+            if missing and symbol_argstrs:
+                broadcast_argstrs = symbol_argstrs
+
         funcsig = 'def {}({}):'.format(funcname, ', '.join(funcargs))
 
         # Wrap input arguments before unpacking
@@ -1247,7 +1263,7 @@ class _EvaluatorPrinter:
 
         if '\n' in str_expr:
             str_expr = '({})'.format(str_expr)
-        funcbody.append('return {}'.format(str_expr))
+        funcbody.append(self._print_return(broadcast_argstrs, expr, str_expr))
 
         funclines = [funcsig]
         funclines.extend(['    ' + line for line in funcbody])
@@ -1344,6 +1360,9 @@ class _EvaluatorPrinter:
         """
         return []
 
+    def _print_return(self, funcargs, expr, str_expr):
+        return 'return {}'.format(str_expr)
+
     def _print_unpacking(self, unpackto, arg):
         """Generate argument unpacking code.
 
@@ -1398,6 +1417,28 @@ class _TensorflowEvaluatorPrinter(_EvaluatorPrinter):
                                 for ind in flat_indexes(lvalues))
 
         return ['[{}] = [{}]'.format(', '.join(flatten(lvalues)), indexed)]
+
+
+class _NumPyEvaluatorPrinter(_EvaluatorPrinter):
+
+    def _print_return(self, funcargs, expr, str_expr):
+        if not funcargs:
+            return 'return {}'.format(str_expr)
+        arg_shapes = ', '.join('numpy.shape({})'.format(a) for a in funcargs)
+        return 'return _numpy_broadcast_result(({}), ({},))'.format(
+            str_expr, arg_shapes)
+
+
+def _numpy_broadcast_result(result, arg_shapes):
+    import numpy
+    try:
+        shape = numpy.broadcast_shapes(numpy.shape(result), *arg_shapes)
+    except (ValueError, TypeError):
+        return result
+    if shape and numpy.shape(result) != shape:
+        return numpy.broadcast_to(result, shape).copy()
+    return result
+
 
 def _imp_namespace(expr, namespace=None):
     """ Return namespace dict with function implementations

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1430,6 +1430,25 @@ def test_numpy_array_arg():
     assert f(numpy.array([2.0, 1.0])) == 5
 
 
+def test_issue_5642():
+    if not numpy:
+        skip("numpy not installed")
+    u = numpy.linspace(-2, 2, 10)
+    g = lambdify(x, diff(x**2, x, 2), "numpy")
+    r = g(u)
+    assert isinstance(r, numpy.ndarray) and r.shape == (10,)
+    assert numpy.all(r == 2)
+    h = lambdify([x, y], S(5), "numpy")
+    assert h(u, u).shape == (10,)
+    p = lambdify([x, y], y - 4, "numpy")
+    assert p(numpy.zeros((4,)), numpy.ones((1,))).shape == (4,)
+    assert lambdify(x, x**2, "numpy")(u).shape == (10,)
+    assert numpy.ndim(lambdify(x, x**2, "numpy")(3.0)) == 0
+    assert numpy.ndim(lambdify(x, S(2), "numpy")(3.0)) == 0
+    assert lambdify(x, Matrix([1, 2]), "numpy")(u).shape == (2, 1)
+    assert numpy.ndim(lambdify(x, S(2), [])(u)) == 0
+
+
 def test_scipy_fns():
     if not scipy:
         skip("scipy not installed")


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #5642.

#### Brief description of what is fixed or changed

`lambdify(..., modules="numpy")` collapsed to a Python scalar whenever the
compiled expression did not reference every argument, discarding the shape
of array inputs:

```python
>>> import numpy, sympy
>>> x = sympy.Symbol("x")
>>> u = numpy.linspace(-2, 2, 10)
>>> g = sympy.lambdify(x, sympy.diff(x**2, x, 2), "numpy")   # d²/dx²(x²) = 2
>>> g(u)
2            # expected: array([2., 2., ..., 2.]) with shape (10,)
```

The generated source was `return 2`, so an argument absent from the
expression contributed nothing to the output shape — while the dependent
case (`return x**2`) gets shape broadcasting for free from NumPy.

This adds a NumPy-family evaluator printer that makes the generated
function shape-preserving: when a scalar expression omits at least one of
its scalar `Symbol` arguments, the result is broadcast to the common shape
of the arguments. After the change:

```python
>>> g(u).shape
(10,)
>>> sympy.lambdify([x, y], sympy.Integer(5), "numpy")(u, u).shape   # partial
(10,)
```

Design points that keep existing behaviour intact:

- **NumPy family only.** The printer is selected for the `numpy` and
  `scipy` modules. Other backends (`math`, `mpmath`, `jax`, `cupy`,
  `tensorflow`, `torch`, ...) are unchanged, since broadcasting there would
  need each backend's own array type.
- **Scalar expressions only.** Non-`Expr` returns (Matrices, tuples,
  lists, `Indexed` structures) already carry a shape or are not
  array-broadcastable and are returned unchanged.
- **Only when an argument is missing.** Fully-dependent expressions are not
  wrapped at all — their generated source and runtime cost are unchanged.
- **Scalar in, scalar out.** With all-scalar inputs the common shape is
  `()`, so the result stays a scalar.
- **Reductions and packed args are respected.** A scalar expression that
  reduces over an array-valued argument (e.g. `Sum` over an `IndexedBase`)
  and nested/packed arguments do not participate in the broadcast shape.

#### Other comments

- Scope: this fixes the scalar shape-collapse. Broadcasting the *entries*
  of a constant/partial `Matrix` against array arguments (e.g.
  `lambdify((x, y), Matrix([[y, x], [1, 2]]), "numpy")` on point batches)
  is a larger, separate change; let me know if you want me to fix it, too.
- Testing: the new `test_issue_5642` covers the constant case, the
  partial-dependence case (including a present array argument with a
  larger absent-argument shape), and the backward-compatibility cases
  (dependent expressions, scalar inputs, constant `Matrix`, non-NumPy
  modules). The full `test_lambdify.py` suite passes with no new failures.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* utilities
  * `lambdify` with `modules="numpy"` (or `"scipy"`) now preserves the
    shape of array arguments for constant and partially-dependent
    expressions, broadcasting the result instead of collapsing to a
    scalar.
<!-- END RELEASE NOTES -->
