### PR TITLE
ENH: assumptions: Improve positive handler of pow.

### DIFF
--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -318,9 +318,7 @@ def _(expr, assumptions):
     if expr.base == E:
         if _ask_recursive(Q.real(expr.exp), assumptions):
             return True
-        if _ask_recursive(Q.imaginary(expr.exp), assumptions):
-            return _ask_recursive(Q.even(expr.exp/(I*pi)), assumptions)
-        return
+        return _ask_recursive(Q.even(expr.exp/(I*pi)), assumptions)
 
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
@@ -341,8 +339,7 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     if _ask_recursive(Q.real(expr.exp), assumptions):
         return True
-    if _ask_recursive(Q.imaginary(expr.exp), assumptions):
-        return _ask_recursive(Q.even(expr.exp/(I*pi)), assumptions)
+    return _ask_recursive(Q.even(expr.exp/(I*pi)), assumptions)
 
 @PositivePredicate.register(log)
 def _(expr, assumptions):

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2000,8 +2000,8 @@ def test_positive():
     assert _ask_recursive(Q.positive(x**y),Q.zero(x)) is None
     assert _ask_recursive(Q.positive(x**y), Q.zero(x) & Q.negative(y)) is None
     assert _ask_recursive(Q.positive(x**y), Q.zero(x) & Q.even(y)) is None
-    assert ask(Q.positive(exp(1 + I))) is False
-    assert ask(Q.positive(Pow(E, 1 + I, evaluate=False))) is False
+    assert _ask_recursive(Q.positive(exp(1 + I))) is False
+    assert _ask_recursive(Q.positive(Pow(E, 1 + I, evaluate=False))) is False
 
     # logarithm
     assert _ask_recursive(Q.positive(log(x)), Q.imaginary(x)) is False

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -10,7 +10,7 @@ from sympy.assumptions.ask_generated import (get_all_known_facts,
     get_known_facts_dict)
 from sympy.core.add import Add
 from sympy.core.mul import Mul
-from sympy.core.numbers import (I, Integer, Rational, oo, zoo, pi)
+from sympy.core.numbers import (E, I, Integer, Rational, oo, zoo, pi)
 from sympy.core.singleton import S
 from sympy.core.power import Pow
 from sympy.core.symbol import Str, symbols, Symbol
@@ -2000,6 +2000,8 @@ def test_positive():
     assert _ask_recursive(Q.positive(x**y),Q.zero(x)) is None
     assert _ask_recursive(Q.positive(x**y), Q.zero(x) & Q.negative(y)) is None
     assert _ask_recursive(Q.positive(x**y), Q.zero(x) & Q.even(y)) is None
+    assert ask(Q.positive(exp(1 + I))) is False
+    assert ask(Q.positive(Pow(E, 1 + I, evaluate=False))) is False
 
     # logarithm
     assert _ask_recursive(Q.positive(log(x)), Q.imaginary(x)) is False


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

This change is required for https://github.com/sympy/sympy/pull/29965 to be merged
#### Brief description of what is fixed or changed
This change is only because `Q.imaginary` should not give `Q.imaginary(x*I*pi, Q.even(x))` as  `True` since `x` can be `0`.  As a consequence, if we fix the bug on `Q.imaginary`, some tests break for the edge value case `0`.
Also, it should be faster too.

I want to emphasize that this PR does not fix any issues by itself
#### Other comments
I believe not using `Q.imaginary` is fine here. Fable did not find any edge cases/problems with it too. I initially kept the `Q.imaginary` call, but I think it is unnecessary?

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
