### PR TITLE
manualintegrate: improved rational integration

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -80,10 +80,12 @@ def _if_zero_implies_zero(P, Q):
     Returns True if P is not zero or if substituting every irreducible
     factor of the numerator of P in the numerator of Q makes Q = 0.
     """
+    if P.is_zero is False:
+        return True
+    if P.is_zero is True:
+        return Q.is_zero
     num_p, _ = P.as_numer_denom()
     num_q, _ = Q.as_numer_denom()
-    if P.is_zero:
-        return Q.is_zero
     factors_P = {f for f, p in factor_list(num_p)[1]}
     # use factor() to help find substitutions (eg. (a**2 - 1) is zero if (a + 1) = 0)
     factored_num_q = num_q.factor()
@@ -1972,6 +1974,11 @@ def quadratic_denom_rule(integral):
             subexpr = (B/a**n) * u**(-2*n)
             substep = integral_steps(subexpr, u)
             rule = RewriteRule(integrand, symbol, rewritten, URule(rewritten, symbol, u, u_func, substep))
+            if discriminant.is_zero:
+                if pieces:
+                    pieces.append((rule, S.true))
+                    return PiecewiseRule(integrand, symbol, pieces)
+                return rule
             pieces.append((rule, Eq(discriminant, 0)))
         if n == 1:
             # base case, B / (a*x**2 + b*x + c), solve by substitution with _arctan_match

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1895,9 +1895,7 @@ def quadratic_denom_rule(integral):
     den_const, den_x = den.as_independent(symbol, as_Add=False)
     if den_const != 1:
         num = num / den_const
-        den = den_x
-    else:
-        den = den_x
+    den = den_x
     if den.is_Pow:
         q = den.base
         n = den.exp
@@ -1915,7 +1913,7 @@ def quadratic_denom_rule(integral):
     if deg_num >= deg_den:
         return None
 
-    def _arctan_match(B, a, c, symbol, degenerate = True):
+    def _arctan_match(B, a, c, symbol, degenerate=True):
         # integrates B / a*x**2 + c
         integrand = B / (a*symbol**2 + c)
         pieces = []
@@ -1955,13 +1953,13 @@ def quadratic_denom_rule(integral):
         return general_rule
 
 
-    def _complete_square(B, a, b, c, n, symbol, degenerate_a = True, degenerate_discriminant = True):
+    def _complete_square(B, a, b, c, n, symbol, degenerate_a=True, degenerate_discriminant=True):
         # integrates B / (a*x**2 + b*x + c)**n
         pieces = []
         discriminant = 4*a*c - b**2
         denominator = a*symbol**2 + b*symbol + c
         integrand = B / denominator**n
-        # degenerate flags avoid to recalculate Piecewise branches recursively
+        # degenerate flags avoid recalculating Piecewise branches recursively
         if degenerate_a and not _if_zero_implies_zero(a, denominator):
             substituted = integrand.subs(a, 0)
             substep = integral_steps(substituted, symbol)
@@ -1984,7 +1982,7 @@ def quadratic_denom_rule(integral):
             # base case, B / (a*x**2 + b*x + c), solve by substitution with _arctan_match
             u = Dummy("u")
             u_func = symbol + b/(2*a)
-            # we put degenrate = False since after substitution, the integrand becomes  B/(a*u**2 + discriminant/(4*a)),
+            # we put degenerate = False since after substitution, the integrand becomes B/(a*u**2 + discriminant/(4*a)),
             # then the _arctan_match conditions (a != 0 and discriminant !=0) are already computed
             substep = _arctan_match(B, a, discriminant/(4*a), u, degenerate=False)
             general_step = URule(integrand, symbol, u, u_func, substep)
@@ -2031,14 +2029,14 @@ def quadratic_denom_rule(integral):
         if const != 1:
             step1 = ConstantTimesRule(const*qprime_part, symbol, const, qprime_part, step1)
         if numer2.is_zero:
-            rewriten = const*qprime_part
-            general_step = RewriteRule(integrand, symbol, rewriten, step1)
+            rewritten = const*qprime_part
+            general_step = RewriteRule(integrand, symbol, rewritten, step1)
         else:
             # since degenerate a condition is already computed, degenerate_a = False
             step2 = _complete_square(numer2, a, b, c, n, symbol, degenerate_a=False)
-            rewriten = const*qprime_part + numer2/denominator**n
-            substeps = AddRule(rewriten, symbol, [step1, step2])
-            general_step = RewriteRule(integrand, symbol, rewriten, substeps)
+            rewritten = const*qprime_part + numer2/denominator**n
+            substeps = AddRule(rewritten, symbol, [step1, step2])
+            general_step = RewriteRule(integrand, symbol, rewritten, substeps)
         if pieces:
             pieces.append((general_step, S.true))
             return PiecewiseRule(integrand, symbol, pieces)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1884,29 +1884,53 @@ def trig_cmplx_exp_rule(integral: IntegralInfo):
 
 def quadratic_denom_rule(integral):
     integrand, symbol = integral
-    a = Wild('a', exclude=[symbol, 0])
-    b = Wild('b', exclude=[symbol, 0])
-    c = Wild('c', exclude=[symbol, 0])
+    if not integrand.is_rational_function(symbol):
+        return None
+    num, den = integrand.as_numer_denom()
+    if den == 1:
+        return None
+    # Prevents things like c*(c*x + d)**n from hiding the power
+    den_const, den_x = den.as_independent(symbol, as_Add=False)
+    if den_const != 1:
+        num = num / den_const
+        den = den_x
+    else:
+        den = den_x
+    if den.is_Pow:
+        q = den.base
+        n = den.exp
+    else:
+        q = den
+        n = S.One
+    den_poly = Poly(q, symbol)
+    num_poly = Poly(num, symbol)
+    deg_den = den_poly.degree()
+    deg_num = num_poly.degree()
+    # TODO: may add n = 1 here and do a general manual rational integration rule
+    # instead of letting general substitution rule find the pattern
+    if deg_den != 2:
+        return None
+    if deg_num >= deg_den:
+        return None
 
-    match = integrand.match(a / (b * symbol ** 2 + c))
-
-    if match:
-        a, b, c = match[a], match[b], match[c]
+    def _arctan_match(B, a, c, symbol, degenerate = True):
+        # integrates B / a*x**2 + c
+        integrand = B / (a*symbol**2 + c)
         pieces = []
-        # skips degenerate case if b != 0 or if b = 0 would cause null denominator
-        if not _if_zero_implies_zero(b, c):
-            substituted = integrand.subs(b, 0)
+        # skips degenerate case if a != 0 or if a = 0 would cause null denominator
+        if degenerate and not _if_zero_implies_zero(a, c):
+            substituted = B / c
             substep = integral_steps(substituted, symbol)
-            pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(b, 0)))
-        if not _if_zero_implies_zero(c, b):
-            substituted = integrand.subs(c, 0)
+            pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(a, 0)))
+        if degenerate and not _if_zero_implies_zero(c, a):
+            substituted = B / (a*symbol**2)
             substep = integral_steps(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(c, 0)))
-        if b.is_extended_real and c.is_extended_real:
-            positive_cond = c/b > 0
+        if a.is_extended_real and c.is_extended_real:
+            positive_cond = c/a > 0
             if positive_cond is not S.true:
-                coeff = a/(2*sqrt(-c)*sqrt(b))
-                constant = sqrt(-c/b)
+                coeff = B/(2*sqrt(-c)*sqrt(a))
+                constant = sqrt(-c/a)
                 r1 = 1/(symbol-constant)
                 r2 = 1/(symbol+constant)
                 log_steps = [ReciprocalRule(r1, symbol, symbol-constant),
@@ -1921,52 +1945,110 @@ def quadratic_denom_rule(integral):
                     pieces.append((negative_step, S.true))
                     return PiecewiseRule(integrand, symbol, pieces)
                 else:
-                    pieces.append((negative_step, c / b < 0))
-        general_rule = ArctanRule(integrand, symbol, a, b, c)
+                    pieces.append((negative_step, c / a < 0))
+        general_rule = ArctanRule(integrand, symbol, B, a, c)
         if pieces:
             pieces.append((general_rule, S.true))
             return PiecewiseRule(integrand, symbol, pieces)
         return general_rule
 
 
-    d = Wild('d', exclude=[symbol])
-    match2 = integrand.match(a / (b * symbol ** 2 + c * symbol + d))
-    if match2:
-        b, c =  match2[b], match2[c]
-        if b.is_zero:
-            return
-        u = Dummy('u')
-        u_func = symbol + c/(2*b)
-        integrand2 = integrand.subs(symbol, u - c / (2*b))
-        next_step = integral_steps(integrand2, u)
-        if next_step:
-            return URule(integrand2, symbol, u, u_func, next_step)
+    def _complete_square(B, a, b, c, n, symbol, degenerate_a = True, degenerate_discriminant = True):
+        # integrates B / (a*x**2 + b*x + c)**n
+        pieces = []
+        discriminant = 4*a*c - b**2
+        denominator = a*symbol**2 + b*symbol + c
+        integrand = B / denominator**n
+        # degenerate flags avoid to recalculate Piecewise branches recursively
+        if degenerate_a and not _if_zero_implies_zero(a, denominator):
+            substituted = B / (b*symbol + c)**n
+            substep = integral_steps(substituted, symbol)
+            pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(a, 0)))
+        if degenerate_discriminant and not _if_zero_implies_zero(discriminant, denominator):
+            u = Dummy("u")
+            # we divide by a, Piecewise condition above
+            u_func = symbol + b/(2*a)
+            rewritten = (B/a**n) * u_func**(-2*n)
+            subexpr = (B/a**n) * u**(-2*n)
+            substep = integral_steps(subexpr, u)
+            rule = RewriteRule(integrand, symbol, rewritten, URule(rewritten, symbol, u, u_func, substep))
+            pieces.append((rule, Eq(discriminant, 0)))
+        if n == 1:
+            # base case, B / (a*x**2 + b*x + c), solve by substitution with _arctan_match
+            u = Dummy("u")
+            u_func = symbol + b/(2*a)
+            # we put degenrate = False since after substitution, the integrand becomes  B/(a*u**2 + discriminant/(4*a)),
+            # then the _arctan_match conditions (a != 0 and discriminant !=0) are already computed
+            substep = _arctan_match(B, a, discriminant/(4*a), u, degenerate=False)
+            general_step = URule(integrand, symbol, u, u_func, substep)
         else:
-            return
-    e = Wild('e', exclude=[symbol])
-    match3 = integrand.match((a* symbol + b) / (c * symbol ** 2 + d * symbol + e))
-    if match3:
-        a, b, c, d, e = match3[a], match3[b], match3[c], match3[d], match3[e]
-        if c.is_zero:
-            return
-        denominator = c * symbol**2 + d * symbol + e
-        const =  a/(2*c)
-        numer1 =  (2*c*symbol+d)
-        numer2 = - const*d + b
-        u = Dummy('u')
-        step1 = URule(integrand, symbol,
-                      u, denominator, integral_steps(u**(-1), u))
-        if const != 1:
-            step1 = ConstantTimesRule(const*numer1/denominator, symbol,
-                                      const, numer1/denominator, step1)
-        if numer2.is_zero:
-            return step1
-        step2 = integral_steps(numer2/denominator, symbol)
-        substeps = AddRule(integrand, symbol, [step1, step2])
-        rewriten = const*numer1/denominator+numer2/denominator
-        return RewriteRule(integrand, symbol, rewriten, substeps)
+            # reduction step for B/q**n
+            # Differentiate B*T/((n - 1)*discriminant*q**(n - 1)), with T = q'(x), using T**2 = 4*a*q - discriminant,
+            # this derivative equals B/q**n - coeff*B/q**(n - 1), so the remaining integral has power n - 1
+            T = 2*a*symbol + b
+            # we divide by discriminant, Piecewise condition above
+            F = B*T / ((n - 1)*discriminant*denominator**(n - 1))
+            derivative = Derivative(F, symbol, evaluate=False)
+            coeff = 2*a*(2*n - 3) / ((n - 1)*discriminant)
+            remainder = B / denominator**(n - 1)
+            scaled_remainder = coeff * remainder
+            rewritten = derivative + scaled_remainder
+            derivative_step = DerivativeRule(derivative, symbol)
+            remainder_step = _complete_square(B, a, b, c, n - 1, symbol, degenerate_a=False, degenerate_discriminant=False)
+            scaled_step = ConstantTimesRule(scaled_remainder, symbol, coeff, remainder, remainder_step)
+            add_step = AddRule(rewritten, symbol, [derivative_step, scaled_step])
+            general_step = RewriteRule(integrand, symbol, rewritten, add_step)
+        if pieces:
+            pieces.append((general_step, S.true))
+            return PiecewiseRule(integrand, symbol, pieces)
+        return general_step
 
-    return
+    def _split_sum(A, B, a, b, c, n, symbol):
+        # integrates (A*x + B) / (a*x**2 + b*x + c)**n. Split A*x + B as alpha*q'(x) + beta,
+        # then integrate the two terms separately (first by substitution, second with _complete_square)
+        pieces = []
+        denominator = (a*symbol**2 + b*symbol + c)
+        integrand = (A*symbol + B) / denominator**n
+        if not _if_zero_implies_zero(a, denominator):
+            substituted = (A*symbol + B) / (b*symbol + c)**n
+            substep = integral_steps(substituted, symbol)
+            pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(a, 0)))
+        # we divide by a, Piecewise condition above
+        const =  A/(2*a)
+        numer1 =  (2*a*symbol + b)
+        numer2 = - const*b + B
+        qprime_part = numer1 / denominator**n
+        u = Dummy('u')
+        step1 = URule(qprime_part, symbol,
+                      u, denominator, integral_steps(u**(-n), u))
+        if const != 1:
+            step1 = ConstantTimesRule(const*qprime_part, symbol, const, qprime_part, step1)
+        if numer2.is_zero:
+            rewriten = const*qprime_part
+            general_step = RewriteRule(integrand, symbol, rewriten, step1)
+        else:
+            # since degenerate a condition is already computed, degenerate_a = False
+            step2 = _complete_square(numer2, a, b, c, n, symbol, degenerate_a=False)
+            rewriten = const*qprime_part + numer2/denominator**n
+            substeps = AddRule(rewriten, symbol, [step1, step2])
+            general_step = RewriteRule(integrand, symbol, rewriten, substeps)
+        if pieces:
+            pieces.append((general_step, S.true))
+            return PiecewiseRule(integrand, symbol, pieces)
+        return general_step
+
+    B = num_poly.nth(0)
+    a = den_poly.nth(2)
+    b = den_poly.nth(1)
+    c = den_poly.nth(0)
+
+    if b == 0 and deg_num == 0 and n == 1:
+        return _arctan_match(B, a, c, symbol)
+    if deg_num == 1:
+        A = num_poly.nth(1)
+        return _split_sum(A, B, a, b, c, n, symbol)
+
+    return _complete_square(B, a, b, c, n, symbol)
 
 
 def sqrt_fractional_linear_rule(integral : IntegralInfo):
@@ -2598,13 +2680,17 @@ partial_fractions_rule = rewriter(
 cancel_rule = rewriter(
     # lambda integrand, symbol: integrand.is_algebraic_expr(),
     # lambda integrand, symbol: isinstance(integrand, Mul),
-    lambda integrand, symbol: True,
+    lambda integrand, symbol: not integrand.is_rational_function(symbol),
     lambda integrand, symbol: integrand.cancel())
 
 distribute_expand_rule = rewriter(
     lambda integrand, symbol: (
-        isinstance(integrand, (Pow, Mul)) or all(arg.is_Pow or arg.is_polynomial(symbol) for arg in integrand.args)),
-    lambda integrand, symbol: integrand.expand())
+        (isinstance(integrand, (Pow, Mul))
+         or all(arg.is_Pow or arg.is_polynomial(symbol) for arg in integrand.args))
+        and not integrand.is_rational_function(symbol)
+    ),
+    lambda integrand, symbol: integrand.expand()
+)
 
 trig_expand_rule = rewriter(
     # If there are trig functions with different arguments, expand them

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1919,11 +1919,11 @@ def quadratic_denom_rule(integral):
         pieces = []
         # skips degenerate case if a != 0 or if a = 0 would cause null denominator
         if degenerate and not _if_zero_implies_zero(a, c):
-            substituted = B / c
+            substituted = integrand.subs(a, 0)
             substep = integral_steps(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(a, 0)))
         if degenerate and not _if_zero_implies_zero(c, a):
-            substituted = B / (a*symbol**2)
+            substituted = integrand.subs(c, 0)
             substep = integral_steps(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(c, 0)))
         if a.is_extended_real and c.is_extended_real:
@@ -1961,7 +1961,7 @@ def quadratic_denom_rule(integral):
         integrand = B / denominator**n
         # degenerate flags avoid to recalculate Piecewise branches recursively
         if degenerate_a and not _if_zero_implies_zero(a, denominator):
-            substituted = B / (b*symbol + c)**n
+            substituted = integrand.subs(a, 0)
             substep = integral_steps(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(a, 0)))
         if degenerate_discriminant and not _if_zero_implies_zero(discriminant, denominator):
@@ -2010,7 +2010,7 @@ def quadratic_denom_rule(integral):
         denominator = (a*symbol**2 + b*symbol + c)
         integrand = (A*symbol + B) / denominator**n
         if not _if_zero_implies_zero(a, denominator):
-            substituted = (A*symbol + B) / (b*symbol + c)**n
+            substituted = integrand.subs(a, 0)
             substep = integral_steps(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(a, 0)))
         # we divide by a, Piecewise condition above
@@ -2042,13 +2042,22 @@ def quadratic_denom_rule(integral):
     b = den_poly.nth(1)
     c = den_poly.nth(0)
 
-    if b == 0 and deg_num == 0 and n == 1:
-        return _arctan_match(B, a, c, symbol)
-    if deg_num == 1:
-        A = num_poly.nth(1)
-        return _split_sum(A, B, a, b, c, n, symbol)
+    normalized_num = num_poly.as_expr()
+    normalized_den = den_poly.as_expr()
+    normalized_integrand = normalized_num / normalized_den**n
 
-    return _complete_square(B, a, b, c, n, symbol)
+    if b == 0 and deg_num == 0 and n == 1:
+        step = _arctan_match(B, a, c, symbol)
+    elif deg_num == 1:
+        A = num_poly.nth(1)
+        step = _split_sum(A, B, a, b, c, n, symbol)
+    else:
+        step = _complete_square(B, a, b, c, n, symbol)
+
+    if normalized_integrand != integrand:
+        step = RewriteRule(integrand, symbol, normalized_integrand, step)
+
+    return step
 
 
 def sqrt_fractional_linear_rule(integral : IntegralInfo):

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -711,6 +711,31 @@ def test_quadratic_denom():
     assert manualintegrate(f, x) == 5*log(3*x**2 - 2*x + 8)/6 + 11*sqrt(23)*atan(3*sqrt(23)*(x - Rational(1, 3))/23)/69
     g = 3/(2*x**2 + 3*x + 1)
     assert manualintegrate(g, x) == 3*log(x + S.Half) - 3*log(x + 1)
+    f = 1/(x**2 + 4*x + 2)**3
+    F = manualintegrate(f, x)
+    assert (f - F.diff(x)).cancel() == 0
+    # perfect square
+    f = 1/(x**2 + 2*x + 1)**3
+    F = manualintegrate(f, x)
+    assert (f - F.diff(x)).cancel() == 0
+    f = (3*x + 2)/(x**2 + 4*x + 2)**3
+    F = manualintegrate(f, x)
+    assert (f - F.diff(x)).cancel() == 0
+    # Polys simplification
+    f = 1/(3*((x - 1)*(x + 1)))
+    F = manualintegrate(f, x)
+    assert (f - F.diff(x)).cancel() == 0
+    A = symbols('A')
+    B = symbols('B')
+    f = (3*A*x + 2*B)/(2*a*x**2 + 2*x + c)**3
+    F = (piecewise_fold(manualintegrate(f, x))).args
+    # when Eq(a, 0)
+    assert (f.subs(a, 0) - F[2][0].diff(x)).cancel() == 0
+    # when Ne(a, 0) & Eq(a*c, 1/2)
+    assert (f.subs(c, 1/(2*a)) - (F[0][0].subs(c, 1/(2*a)).diff(x))).cancel() == 0
+    # a != 0
+    assert (f - F[1][0].diff(x)).cancel() == 0
+
 
 def test_issue_22757():
     assert manualintegrate(sin(x), y) == y * sin(x)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -735,6 +735,11 @@ def test_quadratic_denom():
     assert (f.subs(c, 1/(2*a)) - (F[0][0].subs(c, 1/(2*a)).diff(x))).cancel() == 0
     # a != 0
     assert (f - F[1][0].diff(x)).cancel() == 0
+    # issue 30031: the Eq(b, 0) branch used to divide by b
+    h = a/(b*x**2 + c*x + d)
+    H = manualintegrate(h, x)
+    assert (h.subs({b: 0, c: 3}) - H.subs({b: 0, c: 3}).diff(x)).cancel() == 0
+    assert (h.subs({b: 0, c: 0}) - H.subs({b: 0, c: 0}).diff(x)).cancel() == 0
 
 
 def test_issue_22757():

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -561,8 +561,8 @@ def test_issue_9462():
     assert manualintegrate(sin(2*x)*exp(x), x) == exp(x)*sin(2*x)/5 - 2*exp(x)*cos(2*x)/5
     assert not integral_steps(sin(2*x)*exp(x), x).contains_dont_know()
     assert manualintegrate((x - 3) / (x**2 - 2*x + 2)**2, x) == \
-                           Integral(x/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x) \
-                           - 3*Integral(1/(x**4 - 4*x**3 + 8*x**2 - 8*x + 4), x)
+                           (4 - 4*x)/(4*x**2 - 8*x + 8) - atan(x - 1) \
+                           - S.Half/(x**2 - 2*x + 2)
 
 
 def test_cyclic_parts():
@@ -579,7 +579,7 @@ def test_cyclic_parts():
 def test_issue_10847_slow():
     assert manualintegrate((4*x**4 + 4*x**3 + 16*x**2 + 12*x + 8)
                            / (x**6 + 2*x**5 + 3*x**4 + 4*x**3 + 3*x**2 + 2*x + 1), x) == \
-                           2*x/(x**2 + 1) + 3*atan(x) - 1/(x**2 + 1) - 3/(x + 1)
+                           8*x/(4*x**2 + 4) + 3*atan(x) - 1/(x**2 + 1) - 3/(x + 1)
 
 
 @slow
@@ -636,7 +636,7 @@ def test_issue_10847():
     assert manualintegrate(x**Rational(3,2) * log(x), x) == 2*x**Rational(5,2)*log(x)/5 - 4*x**Rational(5,2)/25
     assert manualintegrate(x**(-3) * log(x), x) == -log(x)/(2*x**2) - 1/(4*x**2)
     assert manualintegrate(log(y)/(y**2*(1 - 1/y)), y) == \
-        log(y)*log(-1 + 1/y) - Integral(log(-1 + 1/y)/y, y)
+        (-log(y) + log(y - 1))*log(y) + log(y)**2/2 - Integral(log(y - 1)/y, y)
 
 
 def test_issue_12899():
@@ -710,7 +710,7 @@ def test_quadratic_denom():
     f = (5*x + 2)/(3*x**2 - 2*x + 8)
     assert manualintegrate(f, x) == 5*log(3*x**2 - 2*x + 8)/6 + 11*sqrt(23)*atan(3*sqrt(23)*(x - Rational(1, 3))/23)/69
     g = 3/(2*x**2 + 3*x + 1)
-    assert manualintegrate(g, x) == 3*log(4*x + 2) - 3*log(4*x + 4)
+    assert manualintegrate(g, x) == 3*log(x + S.Half) - 3*log(x + 1)
 
 def test_issue_22757():
     assert manualintegrate(sin(x), y) == y * sin(x)
@@ -786,7 +786,7 @@ def test_manualintegrate_sqrt_fractional_linear():
     assert F2.diff(x) == f.subs(a, 0)
     # linear dependent bases (2*x + 2)/(x - 1) and (x + 1)/(x - 1)
     f = ((2*x+2)/(x-1))**(S.One/4)*sqrt(((x+1)/(x-1)))
-    F = (-8*2**(S.One/4)*(-((x + 1)/(x - 1))**(S.One/4)*S(1)/8/(sqrt((x + 1)/(x - 1)) + 1)
+    F = (-8*2**(S.One/4)*(-((x + 1)/(x - 1))**(S.One/4)/2/(4*sqrt((x + 1)/(x - 1)) + 4)
          + 3*log(((x + 1)/(x - 1))**(S.One/4) - 1)/16 - 3*log(((x + 1)/(x - 1))**(S.One/4) + 1)/16
          + 3*atan(((x + 1)/(x - 1))**(S.One/4))/8 - S(1)/16/(((x + 1)/(x - 1))**(S.One/4) + 1)
          - S(1)/16/(((x + 1)/(x - 1))**(S.One/4) - 1)))


### PR DESCRIPTION

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #30031 
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This PR improves the capabilities of `manualintegrate`.

Previously, `manualintegrate` mainly supported integrals of the form

```python
(A*x + B) / (a*x**2 + b*x + c)
```

including, of course, the cases where `A` or `a` are zero.

This PR extends that support to integrals of the form

```python
(A*x + B) / (a*x**2 + b*x + c)**n
```

where `n` is a positive integer.

This improves `manualintegrate` in two ways:

- more rational integrals can now be solved directly
- some cases that were previously solved through expensive trigonometric substitutions are now handled much faster

The PR also avoids applying `expand` and `cancel` to rational functions. This is possible because `quadratic_denom_rule` now extracts the relevant coefficients directly, instead of relying on less precise pattern matching. As a result, `manualintegrate` avoids many unnecessary alternative paths and intermediate steps.

The approach used is described in the issue mentioned above.

#### Other comments

See in my comment below all the improvements of this PR

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

ChatGPT 5.5 helped to write small portions of code I asked for (I often changed the output). It helped for code review too.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Improved `manualintegrate` for rational functions with quadratic denominators

<!-- END RELEASE NOTES -->
