### PR TITLE
Fix mypy 2.2.0 type errors breaking CI

### DIFF
--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -3,7 +3,7 @@ Adaptive numerical evaluation of SymPy expressions, using mpmath
 for mathematical functions.
 """
 from __future__ import annotations
-from typing import Callable, TYPE_CHECKING, Any, overload
+from typing import Callable, TYPE_CHECKING, Any, cast, overload
 
 import math
 
@@ -993,7 +993,9 @@ def evalf_log(expr: 'log', prec: int, options: OPT_DICT) -> TMP_RES:
     if prec - size > workprec:
         from .add import Add
         # We actually need to compute x-1 accurately, not x
-        add = Add(S.NegativeOne, arg, evaluate=False)
+        # (evaluate=False guarantees an Add, but Add.__new__ is typed to
+        # return Expr, so narrow it back for evalf_add)
+        add = cast(Add, Add(S.NegativeOne, arg, evaluate=False))
         xre, xim, xre_acc, _ = evalf_add(add, prec, options)
         if xre != fzero and (xre_acc is None or xre_acc > 1):
             prec2 = workprec - fastlog(xre)

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -185,7 +185,10 @@ class SMTLibPrinter(Printer):
 
     def _print_AppliedBinaryRelation(self, e: AppliedPredicate):
         if e.function == Q.ne:
-            return self._print_Unequality(Unequality(*e.arguments))
+            # Q.ne always maps to an Unequality, but Unequality.__new__ is
+            # typed to return Unequality | BooleanTrue | BooleanFalse.
+            rel = typing.cast(Unequality, Unequality(*e.arguments))
+            return self._print_Unequality(rel)
         else:
             return self._print_Function(e)
 


### PR DESCRIPTION
#### References to other Issues or PRs


#### Brief description of what is fixed or changed

mypy 2.2.0 enforces the declared return types of `__new__` more strictly than
previous releases. This surfaced two `arg-type` errors that made the `mypy` (and
`mypy-flint`) CI jobs fail on every open PR:

```
sympy/core/evalf.py:997: error: Argument 1 to "evalf_add" has incompatible type "Expr"; expected "Add"  [arg-type]
sympy/printing/smtlib.py:188: error: Argument 1 to "_print_Unequality" of "SMTLibPrinter" has incompatible type "Unequality | BooleanFalse | BooleanTrue"; expected "Unequality"  [arg-type]
```

In both cases the value is genuinely narrower than the annotated `__new__`
return type:

- `Add(S.NegativeOne, arg, evaluate=False)` always produces an `Add`, but
  `Add.__new__` is annotated to return `Expr`.
- For `Q.ne`, `Unequality(*e.arguments)` produces an `Unequality`, but
  `Unequality.__new__` is annotated to return
  `Unequality | BooleanTrue | BooleanFalse`.

Both are narrowed with `typing.cast`, with a comment explaining why the
narrowing is safe. There are no runtime behavior changes. Verified with
`mypy sympy` (mypy 2.2.0), both with and without python-flint installed.

#### Other comments


#### AI Generation Disclosure

This PR was generated with Claude Code (Claude Opus 4.8). The AI diagnosed the
mypy failures and wrote the two-line `typing.cast` fixes in
`sympy/core/evalf.py` (line ~997) and `sympy/printing/smtlib.py` (line ~188),
including the surrounding explanatory comments, plus the `cast` import in
`evalf.py`.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
