### PR TITLE
typing: Add overloads for evaluate=False

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Literal, overload
 from collections import defaultdict
 from functools import reduce
 from operator import attrgetter
@@ -187,7 +187,21 @@ class Add(Expr, AssocOp):
 
     if TYPE_CHECKING:
 
-        def __new__(cls, *args: Expr | complex, evaluate: bool=True) -> Expr: # type: ignore
+        @overload
+        def __new__(
+            cls,
+            arg1: Expr | complex,
+            arg2: Expr | complex,
+            *args: Expr | complex,
+            evaluate: Literal[False],
+        ) -> Add:  # type: ignore
+            ...
+
+        @overload
+        def __new__(cls, *args: Expr | complex, evaluate: bool = True) -> Expr:  # type: ignore
+            ...
+
+        def __new__(cls, *args: Expr | complex, evaluate: bool = True) -> Expr:  # type: ignore
             ...
 
         @property

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 from .basic import Atom, Basic
 from .coreerrors import LazyExceptionMessage
@@ -794,6 +794,14 @@ class Unequality(Relational):
     rel_op = '!='
 
     __slots__ = ()
+
+    @overload
+    def __new__(cls, lhs, rhs, *, evaluate: Literal[False], **options) -> Unequality:
+        ...
+
+    @overload
+    def __new__(cls, lhs, rhs, **options) -> Unequality | BooleanFalse | BooleanTrue: # type: ignore
+        ...
 
     def __new__(cls, lhs, rhs, **options) -> Unequality | BooleanFalse | BooleanTrue: # type: ignore
         lhs = _sympify(lhs)

--- a/sympy/printing/smtlib.py
+++ b/sympy/printing/smtlib.py
@@ -185,7 +185,7 @@ class SMTLibPrinter(Printer):
 
     def _print_AppliedBinaryRelation(self, e: AppliedPredicate):
         if e.function == Q.ne:
-            return self._print_Unequality(Unequality(*e.arguments))
+            return self._print_Unequality(Unequality(*e.arguments, evaluate=False))
         else:
             return self._print_Function(e)
 

--- a/sympy/printing/tests/test_smtlib.py
+++ b/sympy/printing/tests/test_smtlib.py
@@ -84,6 +84,12 @@ def test_AppliedBinaryRelation():
         assert smtlib_code(Q.gt(x, y), auto_declare=False, log_warn=w) == "(assert (> x y))"
         assert smtlib_code(Q.ge(x, y), auto_declare=False, log_warn=w) == "(assert (>= x y))"
 
+    with _check_warns([]) as w:
+        assert smtlib_code(Q.ne(1, 1), auto_declare=False, log_warn=w) == \
+            "(assert (not (= 1 1)))"
+        assert smtlib_code(Q.ne(1, 2), auto_declare=False, log_warn=w) == \
+            "(assert (not (= 1 2)))"
+
     raises(ValueError, lambda: smtlib_code(Q.complex(x), log_warn=w))
 
 


### PR DESCRIPTION
Closes https://github.com/sympy/sympy/pull/30039

Fixes check errors seen with mypy 2.2.0.

Previously mypy checks in CI failed with
```
sympy/core/evalf.py:997: error: Argument 1 to "evalf_add" has incompatible type "Expr"; expected "Add"  [arg-type]
sympy/printing/smtlib.py:188: error: Argument 1 to "_print_Unequality" of "SMTLibPrinter" has incompatible type "Unequality | BooleanFalse | BooleanTrue"; expected "Unequality"  [arg-type]
```
This is because mypy cannot infer the types correctly in these places. This PR adds overloads so that `Unequality.__new__` and `Add.__new__` are better understood by type checkers.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
