### PR TITLE
Fix sign-wrong antiderivative in meijerint_indefinite for negative x …

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1438,6 +1438,7 @@ S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
+SANJAY.S <sanjaycdsureshkumar@gmail.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1733,8 +1733,9 @@ def _meijerint_indefinite_1(f, x):
             place = 0  # Assume we can expand at zero
         else:
             place = None
-        r = hyperexpand(r.subs(t, a*x**b), place=place)
-
+        xd = Dummy('x')
+        r = hyperexpand(r.subs(t, a*xd**b), place=place)
+        r = r.subs(xd, x)
         # now substitute back
         # Note: we really do want the powers of x to combine.
         res += powdenest(fac_*r, polar=True)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1729,6 +1729,17 @@ def test_issue_17473():
     assert integrate(sin(_x**n), _x) == ans.xreplace(reps).expand()
 
 
+
+def test_issue_29900():
+    # integrate(f(x**n), x) used to return a sign-wrong antiderivative
+    # when x carried a negative=True assumption, because hyperexpand()
+    # resolved sqrt(x**6)-type radicals using x's sign at one internal
+    # step while the rest of the derivation did not account for it.
+    x = Symbol('x', negative=True)
+    F = integrate(sin(x**3), x)
+    for xv in (-0.5, -1.0, -1.7, -2.0):
+        assert abs((diff(F, x) - sin(x**3)).subs(x, xv).evalf()) < 1e-9
+
 def test_issue_17671():
     assert integrate(log(log(x)) / x**2, [x, 1, oo]) == -EulerGamma
     assert integrate(log(log(x)) / x**3, [x, 1, oo]) == -log(2)/2 - EulerGamma/2


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #29900

#### Brief description of what is fixed or changed
`integrate(f(x**n), x)` returned a sign-wrong antiderivative when the
integration variable had a `negative=True` assumption, for odd `n`
(e.g. `integrate(sin(x**3), x)` with `x = Symbol('x', negative=True)`).

The bug was in `_meijerint_indefinite_1` in `sympy/integrals/meijerint.py`.
The call `hyperexpand(r.subs(t, a*x**b), place=place)` let `hyperexpand`
resolve radicals like `sqrt(x**6)` using `x`'s sign assumption (e.g. as
`-x**3` instead of `x**3` for negative `x`). This branch decision was made
only at that one step, while the rest of the derivation (in particular the
`fac_` term computed earlier in the same loop) did not account for it,
producing an internally inconsistent, sign-flipped result whenever `x`
carried a sign assumption.

The fix performs that step with an assumption-free `Dummy` symbol instead
of the real `x`, then substitutes the real `x` back in afterward, so no
assumption-based branch decision leaks into a single intermediate step.

Added a regression test (`test_issue_29900`) reproducing the issue's
numeric check. Full `test_meijerint.py` and `test_integrals.py` suites
pass with no regressions.

#### Other comments
An earlier version of this fix wrapped the entire `meijerint_indefinite`
function with a fresh `Dummy` from the start. That also fixed the bug but
changed `default_sort_key` ordering used when picking among multiple valid
candidate antiderivatives, breaking `test_limit_bug` and `test_issue_17473`
(different, still-correct, but differently-simplified forms were selected).
The current fix is scoped to just the one `hyperexpand` call to avoid that.

#### AI Generation Disclosure
This PR was developed with the assistance of Claude (Anthropic). Claude
was used to: reproduce and diagnose the bug, trace it to the specific line
in `meijerint.py`, draft the code fix and the regression test, and run the
test suites to check for regressions. All AI-suggested code and text was
reviewed, tested, and verified locally before inclusion. The changed lines
in `sympy/integrals/meijerint.py` (the `Dummy`-based fix) and the added
test `test_issue_29900` in `sympy/integrals/tests/test_integrals.py` were
AI-drafted and human-reviewed.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* integrals
  * Fixed `integrate(f(x**n), x)` returning a sign-wrong antiderivative
    when the integration variable was assumed negative.
<!-- END RELEASE NOTES -->