### PR TITLE
Mark test_W19 as slow to prevent CI timeout (#29842)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1438,6 +1438,7 @@ S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
+SANJAY.S <sanjaycdsureshkumar@gmail.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>

--- a/sympy/utilities/tests/test_wester.py
+++ b/sympy/utilities/tests/test_wester.py
@@ -2568,6 +2568,7 @@ def test_W18():
     assert integrate((besselj(1, x)/x)**2, (x, 0, oo)) == 4/(3*pi)
 
 
+@slow
 @XFAIL
 def test_W19():
     # Integral not calculated


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #29842

#### Brief description of what is fixed or changed
`test_W19` in `sympy/utilities/tests/test_wester.py` is an `@XFAIL`
test — it checks an integral that SymPy is not currently able to
evaluate. The test was timing out in the standard ("fast") CI test
run because the underlying (unsuccessful) integration attempt takes
longer than the fast job's time budget.

This PR marks `test_W19` with the existing `@slow` decorator (already
imported in this file from `sympy.testing.pytest`), which moves it
into SymPy's dedicated slow-test CI job instead of the fast job. The
test's behavior is unchanged — it still correctly `XFAIL`s.

#### Other comments
Verified locally:
- `pytest sympy/utilities/tests/test_wester.py -k test_W19` (no `-m slow`):
  test is now deselected, confirming it no longer runs in the fast suite.
- `pytest sympy/utilities/tests/test_wester.py -k test_W19 -m slow`:
  test runs and correctly `XFAIL`s in ~4 seconds.
- Full file suite via `sympy.testing.runtests.test(...)`: 243 passed,
  19 skipped, 135 expected to fail — no regressions.

#### AI Generation Disclosure
This PR was developed with the assistance of Claude (Anthropic), used
to help identify the root cause described in the issue, confirm the
correct fix pattern by inspecting SymPy's existing `@slow`/`@XFAIL`
usage in this file, and verify the fix locally. All code and test
output were reviewed and run locally before inclusion. The one-line
change (`@slow` decorator addition) in
`sympy/utilities/tests/test_wester.py` was AI-suggested and
human-reviewed.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->