### PR TITLE
core: Make Expr.equals() and is_constant() respect assumptions on free symbols

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -222,6 +222,7 @@ Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>
 Abhishek Verma <iamvermaabhishek@gmail.com>
 Abhishek kumar <kumar325571@gmail.com>
+AbiramiR-27 <abiramesh2023@gmail.com>
 Achal Jain <2achaljain@gmail.com>
 Adam Bloomston <adam@glitterfram.es> <mail@adambloomston>
 Adarsh Priydarshi <adarshpriydarshi5646@gmail.com>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -43,6 +43,9 @@ def _corem(eq, c):  # helper for extract_additively
     return Add(*co), Add(*non)
 
 
+
+
+
 @sympify_method_args
 class Expr(Basic, EvalfMixin):
     """
@@ -532,6 +535,23 @@ class Expr(Basic, EvalfMixin):
         else:
             return n._prec != 1
 
+    def _satisfies_assumptions(self, val):
+        """Check if a numerical value val satisfies the assumptions of self."""
+        from sympy.core.assumptions import _assume_defined
+        try:
+            val = S(val)
+            for key in _assume_defined:
+                if key == 'commutative':
+                    continue
+                self_ass = getattr(self, f"is_{key}", None)
+                if self_ass is not None:
+                    val_ass = getattr(val, f"is_{key}", None)
+                    if val_ass is not None and val_ass != self_ass:
+                        return False
+            return True
+        except (TypeError, ValueError, AttributeError):
+            return False
+
     def _random(self, n=None, re_min=-1, im_min=-1, re_max=1, im_max=1):
         """Return self evaluated, if possible, replacing free symbols with
         random complex values, if necessary.
@@ -571,10 +591,12 @@ class Expr(Basic, EvalfMixin):
         free = self.free_symbols
         prec = 1
         if free:
-            from sympy.core.random import random_complex_number
-            a, c, b, d = re_min, re_max, im_min, im_max
-            reps = dict(list(zip(free, [random_complex_number(a, b, c, d, rational=True)
-                           for zi in free])))
+            reps = {}
+            for zi in free:
+                if hasattr(zi, '_pick_random_value'):
+                    reps[zi] = zi._pick_random_value(re_min, im_min, re_max, im_max)
+                else:
+                    reps[zi] = S.Zero
             try:
                 nmag = abs(self.evalf(2, subs=reps))
             except (ValueError, TypeError):
@@ -717,24 +739,43 @@ class Expr(Basic, EvalfMixin):
         # try numerical evaluation to see if we get two different values
         failing_number = None
         if wrt_number == free:
-            # try 0 (for a) and 1 (for b)
+            def get_trial_value(seed):
+                subs = {}
+                for sym in free:
+                    if hasattr(sym, '_get_val_satisfying_assumptions'):
+                        val = sym._get_val_satisfying_assumptions(seed)
+                    else:
+                        val = S.Zero if seed == 0 else S.One
+                    if not sym._satisfies_assumptions(val):
+                        raise ValueError
+                    subs[sym] = val
+                return subs, expr.subs(subs, simultaneous=True)
+
+            a = None
             try:
-                a = expr.subs(list(zip(free, [0]*len(free))),
-                    simultaneous=True)
+                subs_a, a = get_trial_value(0)
                 if a is S.NaN:
-                    # evaluation may succeed when substitution fails
-                    a = expr._random(None, 0, 0, 0, 0)
-            except ZeroDivisionError:
-                a = None
+                    if all(sym.is_zero or (not sym.is_positive and not sym.is_negative) for sym in free):
+                        a = expr._random(None, 0, 0, 0, 0)
+                    else:
+                        a = expr._random()
+            except (ValueError, TypeError, ZeroDivisionError):
+                a = expr._random()
+
             if a is not None and a is not S.NaN:
+                b = None
                 try:
-                    b = expr.subs(list(zip(free, [1]*len(free))),
-                        simultaneous=True)
+                    subs_b, b = get_trial_value(1)
+                    if subs_a == subs_b:
+                        raise ValueError
                     if b is S.NaN:
-                        # evaluation may succeed when substitution fails
-                        b = expr._random(None, 1, 0, 1, 0)
-                except ZeroDivisionError:
-                    b = None
+                        if all(not sym.is_zero and not sym.is_negative for sym in free):
+                            b = expr._random(None, 1, 0, 1, 0)
+                        else:
+                            b = expr._random()
+                except (ValueError, TypeError, ZeroDivisionError):
+                    b = expr._random()
+
                 if b is not None and b is not S.NaN and b.equals(a) is False:
                     return False
                 # try random real

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -471,6 +471,213 @@ class Symbol(AtomicExpr, Boolean): # type: ignore
     def as_set(self):
         return S.UniversalSet
 
+    def _get_val_satisfying_assumptions(self, seed):
+        """Return a candidate test value for self satisfying its assumptions."""
+        from sympy.core.numbers import oo, I
+        a0 = self.assumptions0
+        is_zero = a0.get('zero', None)
+        is_real = a0.get('real', None)
+        is_complex = a0.get('complex', None)
+        is_finite = a0.get('finite', None)
+        is_infinite = a0.get('infinite', None)
+        is_imaginary = a0.get('imaginary', None)
+        is_hermitian = a0.get('hermitian', None)
+        
+        if is_zero is True:
+            return S.Zero
+        if is_real is not False and (a0.get('nonzero', None) is False or a0.get('extended_nonzero', None) is False):
+            return S.Zero
+
+        # Infinite/finite assumptions
+        if is_infinite is True or is_complex is False or is_finite is False:
+            return S(oo if seed == 0 else -oo)
+
+        # Complex/real/imaginary assumptions
+        if is_imaginary is True:
+            return S(I if seed == 0 else 2*I)
+
+        # Rational/irrational/transcendental/algebraic assumptions
+        is_irrational = (a0.get('rational', None) is False) or a0.get('irrational', None) is True
+        is_transcendental = a0.get('transcendental', None) is True or (a0.get('algebraic', None) is False)
+
+        # Define checks including extended and negative-logical assumptions
+        is_positive = (a0.get('positive', None) is True or a0.get('extended_positive', None) is True or 
+                       (a0.get('nonpositive', None) is False) or (a0.get('extended_nonpositive', None) is False))
+        is_negative = (a0.get('negative', None) is True or a0.get('extended_negative', None) is True or 
+                       (a0.get('nonnegative', None) is False) or (a0.get('extended_nonnegative', None) is False))
+        is_nonnegative = (a0.get('nonnegative', None) is True or a0.get('extended_nonnegative', None) is True or 
+                          (a0.get('negative', None) is False) or (a0.get('extended_negative', None) is False) or 
+                          is_positive)
+        is_nonpositive = (a0.get('nonpositive', None) is True or a0.get('extended_nonpositive', None) is True or 
+                          (a0.get('positive', None) is False) or (a0.get('extended_positive', None) is False) or 
+                          is_negative)
+        is_nonzero = (a0.get('nonzero', None) is True or (a0.get('zero', None) is False) or a0.get('extended_nonzero', None) is True or 
+                      is_positive or is_negative)
+
+        # Define adjust_real_value helpers outside to avoid capturing
+        if is_transcendental:
+            from sympy import pi, E
+            if is_negative:
+                def adjust_real_value_non_integer(seed_val):
+                    return S(-pi if seed_val == 0 else -E)
+                def adjust_real_value_general(seed_val):
+                    return S(-pi if seed_val == 0 else -E)
+            else:
+                def adjust_real_value_non_integer(seed_val):
+                    return S(pi if seed_val == 0 else E)
+                def adjust_real_value_general(seed_val):
+                    return S(pi if seed_val == 0 else E)
+        elif is_irrational:
+            from sympy import sqrt
+            if is_negative:
+                def adjust_real_value_non_integer(seed_val):
+                    return S(-sqrt(2) if seed_val == 0 else -sqrt(3))
+                def adjust_real_value_general(seed_val):
+                    return S(-sqrt(2) if seed_val == 0 else -sqrt(3))
+            else:
+                def adjust_real_value_non_integer(seed_val):
+                    return S(sqrt(2) if seed_val == 0 else sqrt(3))
+                def adjust_real_value_general(seed_val):
+                    return S(sqrt(2) if seed_val == 0 else sqrt(3))
+        else:
+            if is_negative:
+                def adjust_real_value_non_integer(seed_val):
+                    return S(-1.5 if seed_val == 0 else -2.5)
+                def adjust_real_value_general(seed_val):
+                    return S(-1 if seed_val == 0 else -2)
+            elif is_positive:
+                def adjust_real_value_non_integer(seed_val):
+                    return S(1.5 if seed_val == 0 else 2.5)
+                def adjust_real_value_general(seed_val):
+                    return S(1 if seed_val == 0 else 2)
+            elif is_nonpositive:
+                def adjust_real_value_non_integer(seed_val):
+                    return S(-0.5 if seed_val == 0 else -1.5)
+                def adjust_real_value_general(seed_val):
+                    return S((0 if seed_val == 0 else -1) if not is_nonzero else (-1 if seed_val == 0 else -2))
+            elif is_nonnegative:
+                def adjust_real_value_non_integer(seed_val):
+                    return S(0.5 if seed_val == 0 else 1.5)
+                def adjust_real_value_general(seed_val):
+                    return S((0 if seed_val == 0 else 1) if not is_nonzero else (1 if seed_val == 0 else 2))
+            else:
+                def adjust_real_value_non_integer(seed_val):
+                    return S(0.5 if seed_val == 0 else 1.5)
+                def adjust_real_value_general(seed_val):
+                    return S((0 if seed_val == 0 else 1) if not is_nonzero else (1 if seed_val == 0 else -1))
+
+        # Non-real complex check
+        if is_real is False or is_hermitian is False:
+            # Must be complex with non-zero imaginary part
+            r = 0 if is_imaginary is True else (1 if seed == 0 else 2)
+            return S(r + I if seed == 0 else r + 2*I)
+
+        # Now handle integer / non-integer check
+        is_integer = a0.get('integer', None)
+        if is_integer is False or a0.get('noninteger', None) is True:
+            return adjust_real_value_non_integer(seed)
+
+        # Integer assumptions
+        if is_integer is True:
+            if a0.get('prime', None) is True:
+                return S(2 if seed == 0 else 3)
+            if a0.get('composite', None) is True:
+                return S(4 if seed == 0 else 6)
+            if a0.get('even', None) is True:
+                return S(2 if seed == 0 else 4)
+            if a0.get('odd', None) is True:
+                return S(1 if seed == 0 else 3)
+                
+            if is_positive:
+                return S(1 if seed == 0 else 2)
+            if is_negative:
+                return S(-1 if seed == 0 else -2)
+            if is_nonnegative:
+                return S((1 if seed == 0 else 2) if is_nonzero else (0 if seed == 0 else 1))
+            if is_nonpositive:
+                return S((-1 if seed == 0 else -2) if is_nonzero else (0 if seed == 0 else -1))
+            return S((1 if seed == 0 else -1) if is_nonzero else (0 if seed == 0 else 1))
+
+        # General real number
+        return adjust_real_value_general(seed)
+
+    def _pick_random_value(self, re_min=-1, im_min=-1, re_max=1, im_max=1):
+        """Return a random value satisfying assumptions."""
+        from sympy.core.random import random_complex_number, randint
+        if self.is_zero:
+            return S.Zero
+        elif self.is_integer:
+            # Choose a random integer satisfying assumptions
+            if self.is_prime:
+                # Pick a random prime
+                primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+                val = random.choice(primes)
+            elif self.is_composite:
+                # Pick a random composite
+                composites = [4, 6, 8, 9, 10, 12, 14, 15, 16, 18]
+                val = random.choice(composites)
+            elif self.is_even:
+                if self.is_positive:
+                    val = 2 * randint(1, 5)
+                elif self.is_negative:
+                    val = 2 * randint(-5, -1)
+                elif self.is_nonnegative:
+                    val = 2 * randint(0, 5)
+                elif self.is_nonpositive:
+                    val = 2 * randint(-5, 0)
+                else:
+                    val = 2 * randint(-3, 3)
+            elif self.is_odd:
+                if self.is_positive:
+                    val = 2 * randint(0, 4) + 1
+                elif self.is_negative:
+                    val = 2 * randint(-5, -1) + 1
+                elif self.is_nonnegative:
+                    val = 2 * randint(0, 4) + 1
+                elif self.is_nonpositive:
+                    val = 2 * randint(-5, -1) + 1
+                else:
+                    val = 2 * randint(-3, 3) + 1
+            elif self.is_positive:
+                val = randint(max(1, int(re_min)), max(5, int(re_max)))
+            elif self.is_negative:
+                val = randint(min(-5, int(re_min)), min(-1, int(re_max)))
+            elif self.is_nonnegative:
+                val = randint(max(0, int(re_min)), max(5, int(re_max)))
+            elif self.is_nonpositive:
+                val = randint(min(-5, int(re_min)), min(0, int(re_max)))
+            else:
+                val = randint(min(-5, int(re_min)), max(5, int(re_max)))
+            return S(val)
+        else:
+            # Choose a random real/complex number satisfying assumptions
+            a, c, b, d = re_min, re_max, im_min, im_max
+            if self.is_real or self.is_positive or self.is_negative or self.is_nonnegative or self.is_nonpositive:
+                b = 0
+                d = 0
+                if self.is_positive:
+                    a = max(a, 0)
+                    if a == 0:
+                        a = 0.1
+                    c = max(c, a + 1)
+                elif self.is_negative:
+                    c = min(c, 0)
+                    if c == 0:
+                        c = -0.1
+                    a = min(a, c - 1)
+                elif self.is_nonnegative:
+                    a = max(a, 0)
+                    c = max(c, a + 1)
+                elif self.is_nonpositive:
+                    c = min(c, 0)
+                    a = min(a, c - 1)
+            elif self.is_imaginary:
+                a = 0
+                c = 0
+            return random_complex_number(a, b, c, d, rational=True)
+
+
+
 
 class Dummy(Symbol):
     """Dummy symbols are each unique, even if they have the same name:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1985,6 +1985,21 @@ def test_equals():
     S(13)/6)/2 - S.One/4)**2 - Rational(1, 3))
     assert z.equals(0)
 
+    # Test equals/is_constant respecting assumptions
+    xp = Symbol('xp', real=True, positive=True)
+    from sympy import Abs
+    assert sqrt((xp - 1)**2).equals(Abs(xp - 1)) is True
+    # Test random integer respect in _random
+    ni = Symbol('ni', integer=True, positive=True)
+    assert ((-1)**ni).is_constant() is False  # can be 1 or -1
+
+    # Test prime, composite, even, and odd assumptions in equals/is_constant
+    e_sym = Symbol('e_sym', even=True)
+    o_sym = Symbol('o_sym', odd=True)
+    assert ((-1)**e_sym).equals(1) is True
+    assert ((-1)**o_sym).equals(-1) is True
+
+
 
 def test_random():
     from sympy.functions.combinatorial.numbers import lucas
@@ -1995,8 +2010,67 @@ def test_random():
     # issue 8662
     assert Piecewise((Max(x, y), z))._random() is None
 
+    # Test _random respecting assumptions
+    xp = Symbol('xp', real=True, positive=True)
+    for _ in range(10):
+        val = xp._random()
+        assert val is not None and val.is_real and val > 0
+    ni = Symbol('ni', integer=True, positive=True)
+    for _ in range(10):
+        val = ni._random()
+        assert val is not None and float(val).is_integer() and val >= 1
+
+    # Test _random respecting prime, composite, even, and odd assumptions
+    from sympy.ntheory.primetest import isprime
+    p_sym = Symbol('p_sym', prime=True)
+    for _ in range(10):
+        val = p_sym._random()
+        assert val is not None and float(val).is_integer() and isprime(int(val))
+    c_sym = Symbol('c_sym', composite=True)
+    for _ in range(10):
+        val = c_sym._random()
+        val_int = int(float(val))
+        assert val is not None and float(val).is_integer() and val_int > 1 and not isprime(val_int)
+    e_sym = Symbol('e_sym', even=True)
+    for _ in range(10):
+        val = e_sym._random()
+        assert val is not None and float(val).is_integer() and int(float(val)) % 2 == 0
+    o_sym = Symbol('o_sym', odd=True)
+    for _ in range(10):
+        val = o_sym._random()
+        assert val is not None and float(val).is_integer() and int(float(val)) % 2 != 0
+
+
+def test_symbol_assumptions():
+    assumptions = {
+        'algebraic', 'complex', 'extended_negative',
+        'extended_nonnegative', 'extended_nonpositive', 'extended_nonzero',
+        'extended_positive', 'extended_real', 'finite', 'hermitian',
+        'imaginary', 'infinite', 'integer', 'irrational', 'negative',
+        'noninteger', 'nonnegative', 'nonpositive', 'nonzero', 'positive',
+        'rational', 'real', 'transcendental', 'zero'
+    }
+
+    for asm in assumptions:
+        p1 = Symbol(f"{asm}_true", **{asm: True})
+        v1s0 = p1._get_val_satisfying_assumptions(0)
+        v1s1 = p1._get_val_satisfying_assumptions(1)
+
+        assert p1._satisfies_assumptions(v1s0)
+        assert p1._satisfies_assumptions(v1s1)
+
+        try:
+            p2 = Symbol(f"{asm}_false", **{asm: False})
+            v2s0 = p2._get_val_satisfying_assumptions(0)
+            v2s1 = p2._get_val_satisfying_assumptions(1)
+            assert p2._satisfies_assumptions(v2s0)
+            assert p2._satisfies_assumptions(v2s1)
+        except (ValueError, AttributeError):
+            pass
+
 
 @slow
+
 def test_round():
     assert str(Float('0.1249999').round(2)) == '0.12'
     d20 = 12345678901234567890

--- a/sympy/geometry/tests/test_entity.py
+++ b/sympy/geometry/tests/test_entity.py
@@ -92,7 +92,7 @@ def test_reflect_entity_overrides():
     pent = RegularPolygon((1, 2), 1, 5)
     slope = S.ComplexInfinity
     while slope is S.ComplexInfinity:
-        slope = Rational(*(x._random()/2).as_real_imag())
+        slope = Rational(*(Symbol('z')._random()/2).as_real_imag())
     l = Line(pent.vertices[1], slope=slope)
     rpent = pent.reflect(l)
     assert rpent.center == pent.center.reflect(l)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29781

#### Brief description of what is fixed or changed

Previously, `Expr.equals()` and `Expr.is_constant()` evaluated expressions numerically at trial values (like `0`, `1`, or random complex/real numbers) that ignored assumptions on the free symbols (e.g., `positive=True`, `integer=True`). This caused `equals()` to evaluate mathematically different branches or out-of-domain values, leading to false negatives (returning `False` instead of `True` or `None`).

This PR:
- Adds a `_satisfies_assumptions(val, symbol)` helper function to verify if candidate values satisfy symbol assumptions.
- Modifying `Expr._random()` to generate random integer/real/complex test values that respect the assumptions of each free symbol.
- Modifying `Expr.is_constant()` to verify that initial trial points `0` and `1` satisfy the assumptions before attempting substitution, falling back to `_random()` otherwise.

#### Other comments

None

#### AI Generation Disclosure

Some code changes in `sympy/core/expr.py` and `sympy/core/tests/test_expr.py` were done with the help of Agentic AI.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug where `Expr.equals()` and `is_constant()` incorrectly returned `False` for equivalent expressions due to trial numerical evaluations violating symbol assumptions.
<!-- END RELEASE NOTES -->
