### PR TITLE
[GsOC] Added helper functions for zippel's algorithm to zippel.py, with tests in test_zippel.py

### DIFF
--- a/doc/src/modules/polys/internals.rst
+++ b/doc/src/modules/polys/internals.rst
@@ -751,6 +751,15 @@ Modular GCD
 .. autofunction:: _modgcd_multivariate_p
 .. autofunction:: func_field_modgcd
 
+Zippel algorithm
+****************
+
+.. currentmodule:: sympy.polys.zippel
+
+.. autofunction:: from_newt_to_poly
+.. autofunction:: incremental_newton_interp
+.. autofunction:: skeleton_sorter
+
 Undocumented
 ============
 

--- a/sympy/polys/tests/test_zippel.py
+++ b/sympy/polys/tests/test_zippel.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 from sympy.polys.rings import ring
 from sympy.polys.domains import ZZ
 from sympy.polys.zippel import (_LC, _chinese_remainder_reconstruction_multivariate, _deg,
-    _gf_gcd, _trivial_gcd, _primitive)
+    _gf_gcd, _trivial_gcd, _primitive, skeleton_sorter, from_newt_to_poly,
+    incremental_newton_interp)
 
 
 def test_gf_gcd():
@@ -103,3 +104,50 @@ def test_chinese_remainder_reconstruction_multivariate():
 
     assert hpq.trunc_ground(p) == hp
     assert hpq.trunc_ground(q) == hq
+
+
+def test_incremental_newton_interp():
+    # Polynomial to interpolate: P(x) = 3x^3 - 2x^2 + 17x - 5
+    x = ZZ.map([0, 1, 2])
+    v = ZZ.map([96, 18, 7])
+    xk = ZZ(3)
+    uk = ZZ(8)
+    p = ZZ(101)
+
+    assert incremental_newton_interp(x, v, xk, uk, p) == 3
+
+
+def test_from_newt_to_poly():
+    x = ZZ.map([0, 1, 2, 3])
+    v = ZZ.map([96, 18, 7, 3])
+    p = ZZ(101)
+
+    assert from_newt_to_poly(x, v, p) == [96, 17, 99, 3]
+
+
+def test_skeleton_sorter():
+    R, x, y, z, w = ring("x, y, z, w", ZZ)
+    G = 4*x**3*y**2*w - 2*x**3*z**5*w**2 + 7*x*y*z*w
+    S, h, monic, pseudomonic = skeleton_sorter(dict(G))
+
+    assert S == {
+        1: [[(1, 1, 1, 1), (0, 1), (1, 1), (2, 1)]],
+        3: [
+            [(3, 2, 0, 1), (0, 2), (2, 1)],
+            [(3, 0, 5, 2), (1, 5), (2, 2)]
+        ]
+    }
+    assert h == [[7], [4], [-2]]
+    assert monic == pseudomonic == False
+
+    R, x, y, z = ring("x, y, z", ZZ)
+    G = 5*x**2*y**2 + 7*x*y**5*z**3 + 8*x*z**4
+    S, h, monic, pseudomonic = skeleton_sorter(G)
+
+    assert S == {
+        2: [[(2, 2, 0), (0, 2)]],
+        1: [[(1, 5, 3), (0, 5), (1, 3)], [(1, 0, 4), (1, 4)]]
+    }
+    assert list(S.keys()) == [2, 1]
+    assert h == [[5], [7], [8]]
+    assert monic == pseudomonic == True

--- a/sympy/polys/tests/test_zippel.py
+++ b/sympy/polys/tests/test_zippel.py
@@ -122,31 +122,28 @@ def test_from_newt_to_poly():
     v = ZZ.map([96, 18, 7, 3])
     p = ZZ(101)
 
-    assert from_newt_to_poly(x, v, p) == [96, 17, 99, 3]
+    assert from_newt_to_poly(x, v, p) == [3, 99, 17, 96]
 
 
 def test_skeleton_sorter():
     R, x, y, z, w = ring("x, y, z, w", ZZ)
-    G = 4*x**3*y**2*w - 2*x**3*z**5*w**2 + 7*x*y*z*w
+    G = 4 * x**3 * y**2 * w - 2 * x**3 * z**5 * w**2 + 7 * x * y * z * w
     S, h, monic, pseudomonic = skeleton_sorter(dict(G))
 
     assert S == {
         1: [[(1, 1, 1, 1), (0, 1), (1, 1), (2, 1)]],
-        3: [
-            [(3, 2, 0, 1), (0, 2), (2, 1)],
-            [(3, 0, 5, 2), (1, 5), (2, 2)]
-        ]
+        3: [[(3, 2, 0, 1), (0, 2), (2, 1)], [(3, 0, 5, 2), (1, 5), (2, 2)]],
     }
     assert h == [[7], [4], [-2]]
     assert monic == pseudomonic == False
 
     R, x, y, z = ring("x, y, z", ZZ)
-    G = 5*x**2*y**2 + 7*x*y**5*z**3 + 8*x*z**4
+    G = 5 * x**2 * y**2 + 7 * x * y**5 * z**3 + 8 * x * z**4
     S, h, monic, pseudomonic = skeleton_sorter(G)
 
     assert S == {
         2: [[(2, 2, 0), (0, 2)]],
-        1: [[(1, 5, 3), (0, 5), (1, 3)], [(1, 0, 4), (1, 4)]]
+        1: [[(1, 5, 3), (0, 5), (1, 3)], [(1, 0, 4), (1, 4)]],
     }
     assert list(S.keys()) == [2, 1]
     assert h == [[5], [7], [8]]

--- a/sympy/polys/zippel.py
+++ b/sympy/polys/zippel.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
-from sympy.polys.galoistools import gf_gcd, gf_quo, gf_from_dict
+from typing import TYPE_CHECKING
+from collections import defaultdict
+from sympy.polys.domains.integerring import ZZ
+from sympy.polys.galoistools import gf_add, gf_gcd, gf_mul, gf_quo, gf_from_dict
 from sympy.ntheory.modular import crt
 from sympy.polys.domains import PolynomialRing
 
+if TYPE_CHECKING:
+    from sympy.external.gmpy import MPZ
+
+Monom = tuple[int, ...]
 
 def _gf_gcd(fp, gp, p):
     r"""
@@ -382,3 +389,130 @@ def _chinese_remainder_reconstruction_multivariate(hp, hq, p, q):
         hpq[monom] = crt_(zero, hq[monom], p, q)
 
     return hpq
+
+
+def incremental_newton_interp(x: list[MPZ], v: list[MPZ], xk: MPZ, uk: MPZ, p: MPZ
+    ) -> MPZ:
+    """
+    Computes the next Newton interpolation coefficient v_k over Z_p.
+
+    Given a list of k evaluation points x = [x_0, ..., x_{k-1}] and the
+    corresponding coefficients v = [v_0, ..., v_{k-1}] of the Newton
+    interpolation polynomial P_{k-1}(x), this function calculates the new
+    coefficient v_k required to interpolate a new point (x_k, u_k).
+
+    References
+    ==========
+
+    1. [Geddes92] p. 186.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.zippel import incremental_newton_interp
+    >>> x = [0, 1]
+    >>> v = [67, 47]
+    >>> xk = 2
+    >>> uk = 66
+    >>> p = 97
+    >>> v2 = incremental_newton_interp(x, v, xk, uk, p)
+    >>> v2
+    1
+
+    """
+    s = v[0]
+    c = ZZ.one
+    for i, el in enumerate(v[1:]):
+        c = (c * (xk - x[i])) % p
+        s = (s + el * c) % p
+    inv = ZZ.invert(c * (xk - x[len(v) - 1]), p)
+    return ((uk - s) * inv) % p
+
+
+def from_newt_to_poly(x: list[MPZ], v: list[MPZ], p: MPZ
+    ) -> list[MPZ]:
+    """
+    Given k evaluation points x = [x_0, ..., x_{k-1}] and the
+    corresponding coefficients v = [v_0, ..., v_{k-1}] of the Newton
+    interpolation polynomial P_{k-1}(x), this function calculates explicitly
+    and returns the interpolation polynomial P_{k-1}(x) over Z_p.
+
+    References
+    ==========
+
+    1. [Geddes92] p. 186.
+
+    Examples
+    ========
+
+    >>> from sympy.polys.zippel import from_newt_to_poly
+    >>> x = [0, 1, 2]
+    >>> v = [67, 47, 1]
+    >>> p = 97
+    >>> from_newt_to_poly(x, v, p)
+    [67, 46, 1]
+
+    """
+    pol = [v[-1]]
+    for i in range(len(v) - 2, -1, -1):
+        binomial = [ZZ.one, -x[i]]
+        pol = gf_mul(pol, binomial, p, ZZ)
+        pol = gf_add(pol, [v[i]], p, ZZ)
+
+    return pol[::-1]
+
+
+def skeleton_sorter(G: dict[Monom, MPZ]
+) -> tuple[dict[int, list[list[Monom]]], list[list[MPZ]], bool, bool]:
+    """
+    Reorganizes the skeleton of a sparse polynomial for multivariate interpolation.
+
+    This function extracts the monomials of a sparse polynomial.
+    It groups the monomials by the degree of the first variable,
+    sorts these groups by the number of monomials they contain
+    (in ascending order), and builds a compact representation of the non-zero
+    degrees for the remaining variables, useful to evaluate quickly the monomials.
+
+    It also saves the coefficients of each monomial in a list of lists, and
+    2 booleans needed by the function zippel_interp() to choose the right routine.
+
+    Examples
+    ========
+
+    If we take the sparse polynomial G = 5*x**2*y**2 + 7*x*y**5*z**3 + 8*x*z**4
+    in ZZ[x, y, z], skeleton_sorter(G) returns the following outputs:
+
+    S = {
+        2: [[(2, 2, 0), (0, 2)]],
+        1: [[(1, 5, 3), (0, 5), (1, 3)], [(1, 0, 4), (1, 4)]]
+    }
+
+    h = [[5], [7], [8]]
+
+    monic = True
+    pseudomonic = True
+
+    """
+    S_ = defaultdict(list)
+    for mon, _ in G.items():
+        S_[mon[0]].append([mon])
+    S = {deg: S_[deg] for deg in sorted(S_.keys(), key = lambda x: len(S_[x]))}
+    h = []
+    lc = S[max(S.keys())]
+
+    monic = False
+    pseudomonic = False
+    if len(lc) == 1:
+        monic = True
+        for el in lc[0][0][1:]:
+            if el != 0:
+                pseudomonic = True
+
+    for _, mons in S.items():
+        for mon_list in mons:
+            h.append([G[mon_list[0]]])
+            for i, el in enumerate(mon_list[0][1:]):
+                if el != 0:
+                    mon_list.append((i, el))
+
+    return S, h, monic, pseudomonic

--- a/sympy/polys/zippel.py
+++ b/sympy/polys/zippel.py
@@ -8,8 +8,9 @@ from sympy.polys.domains import PolynomialRing
 
 if TYPE_CHECKING:
     from sympy.external.gmpy import MPZ
+    from sympy.polys.densebasic import dup
+    from sympy.polys.monomials import monom
 
-Monom = tuple[int, ...]
 
 def _gf_gcd(fp, gp, p):
     r"""
@@ -391,20 +392,23 @@ def _chinese_remainder_reconstruction_multivariate(hp, hq, p, q):
     return hpq
 
 
-def incremental_newton_interp(x: list[MPZ], v: list[MPZ], xk: MPZ, uk: MPZ, p: MPZ
-    ) -> MPZ:
-    """
-    Computes the next Newton interpolation coefficient v_k over Z_p.
+def incremental_newton_interp(
+    x: list[MPZ], v: list[MPZ], xk: MPZ, uk: MPZ, p: MPZ
+) -> MPZ:
+    r"""
+    Computes the next Newton interpolation coefficient `v_k` over
+    `\mathbb{Z}_p`.
 
-    Given a list of k evaluation points x = [x_0, ..., x_{k-1}] and the
-    corresponding coefficients v = [v_0, ..., v_{k-1}] of the Newton
-    interpolation polynomial P_{k-1}(x), this function calculates the new
-    coefficient v_k required to interpolate a new point (x_k, u_k).
+    Given a list of `k` evaluation points
+    `x = [x_0, \ldots, x_{k-1}]` and the corresponding coefficients
+    `v = [v_0, \ldots, v_{k-1}]` of the Newton interpolation polynomial
+    `P_{k-1}(x)`, this function calculates the new coefficient `v_k` required
+    to interpolate a new point `(x_k, u_k)`.
 
     References
     ==========
 
-    1. [Geddes92] p. 186.
+    .. [1] [Geddes92]_ p. 186.
 
     Examples
     ========
@@ -429,18 +433,18 @@ def incremental_newton_interp(x: list[MPZ], v: list[MPZ], xk: MPZ, uk: MPZ, p: M
     return ((uk - s) * inv) % p
 
 
-def from_newt_to_poly(x: list[MPZ], v: list[MPZ], p: MPZ
-    ) -> list[MPZ]:
-    """
-    Given k evaluation points x = [x_0, ..., x_{k-1}] and the
-    corresponding coefficients v = [v_0, ..., v_{k-1}] of the Newton
-    interpolation polynomial P_{k-1}(x), this function calculates explicitly
-    and returns the interpolation polynomial P_{k-1}(x) over Z_p.
+def from_newt_to_poly(x: list[MPZ], v: list[MPZ], p: MPZ) -> dup[MPZ]:
+    r"""
+    Given `k` evaluation points `x = [x_0, \ldots, x_{k-1}]` and the
+    corresponding coefficients `v = [v_0, \ldots, v_{k-1}]` of the Newton
+    interpolation polynomial `P_{k-1}(x)`, this function calculates explicitly
+    and returns the interpolation polynomial `P_{k-1}(x)` over
+    `\mathbb{Z}_p`.
 
     References
     ==========
 
-    1. [Geddes92] p. 186.
+    .. [1] [Geddes92]_ p. 186.
 
     Examples
     ========
@@ -450,7 +454,7 @@ def from_newt_to_poly(x: list[MPZ], v: list[MPZ], p: MPZ
     >>> v = [67, 47, 1]
     >>> p = 97
     >>> from_newt_to_poly(x, v, p)
-    [67, 46, 1]
+    [1, 46, 67]
 
     """
     pol = [v[-1]]
@@ -459,12 +463,13 @@ def from_newt_to_poly(x: list[MPZ], v: list[MPZ], p: MPZ
         pol = gf_mul(pol, binomial, p, ZZ)
         pol = gf_add(pol, [v[i]], p, ZZ)
 
-    return pol[::-1]
+    return pol
 
 
-def skeleton_sorter(G: dict[Monom, MPZ]
-) -> tuple[dict[int, list[list[Monom]]], list[list[MPZ]], bool, bool]:
-    """
+def skeleton_sorter(
+    G: dict[monom, MPZ],
+) -> tuple[dict[int, list[list[monom]]], list[list[MPZ]], bool, bool]:
+    r"""
     Reorganizes the skeleton of a sparse polynomial for multivariate interpolation.
 
     This function extracts the monomials of a sparse polynomial.
@@ -474,29 +479,32 @@ def skeleton_sorter(G: dict[Monom, MPZ]
     degrees for the remaining variables, useful to evaluate quickly the monomials.
 
     It also saves the coefficients of each monomial in a list of lists, and
-    2 booleans needed by the function zippel_interp() to choose the right routine.
+    2 booleans needed by the function ``zippel_interp()`` to choose the right routine.
 
     Examples
     ========
 
-    If we take the sparse polynomial G = 5*x**2*y**2 + 7*x*y**5*z**3 + 8*x*z**4
-    in ZZ[x, y, z], skeleton_sorter(G) returns the following outputs:
+    If we take the sparse polynomial
+    `G = 5x^2y^2 + 7xy^5z^3 + 8xz^4` in `\mathbb{Z}[x, y, z]`,
+    ``skeleton_sorter(G)`` returns the following outputs:
 
-    S = {
-        2: [[(2, 2, 0), (0, 2)]],
-        1: [[(1, 5, 3), (0, 5), (1, 3)], [(1, 0, 4), (1, 4)]]
-    }
+    .. code-block:: python
 
-    h = [[5], [7], [8]]
+        S = {
+            2: [[(2, 2, 0), (0, 2)]],
+            1: [[(1, 5, 3), (0, 5), (1, 3)], [(1, 0, 4), (1, 4)]]
+        }
 
-    monic = True
-    pseudomonic = True
+        h = [[5], [7], [8]]
+
+        monic = True
+        pseudomonic = True
 
     """
     S_ = defaultdict(list)
     for mon, _ in G.items():
         S_[mon[0]].append([mon])
-    S = {deg: S_[deg] for deg in sorted(S_.keys(), key = lambda x: len(S_[x]))}
+    S = {deg: S_[deg] for deg in sorted(S_.keys(), key=lambda x: len(S_[x]))}
     h = []
     lc = S[max(S.keys())]
 


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Added newton interpolation functions, and a helper function for Zippel's algorithm.

#### Other comments
The functions `newton_interp` and `from_newt_to_poly` are functions needed to incrementally interpolate a polynomial:
`incremental_newton_interp` computes the next Newton coefficient when a new evaluation point is added, without recomputing the whole interpolation coefficients from scratch. `from_newt_to_poly` converts the Newton-form interpolation data into the usual dense polynomial representation over `Z_p`.

The function `skeleton_sorter` preprocesses a dictionary representing a sparse polynomial, and is a helper function for Zippel's algorithm.

I also added tests for the functions.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Functions written by myself, used AI to get reviews and write the tests, that I then manually verified.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * added helper functions (newton_interp, from_newt_to_poly, skeleton_sorter) for Zippel's algorithm.
<!-- END RELEASE NOTES -->
