### PR TITLE
Improve Basic.copy docstring

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,4 +1,4 @@
-y"""Base class for all the objects in SymPy"""
+"""Base class for all the objects in SymPy"""
 from __future__ import annotations
 
 from collections import Counter
@@ -1857,35 +1857,7 @@ class Basic(Printable):
         return dict(Counter(results))
 
     def count(self, query):
-        """
-        Count the number of matching subexpressions.
-
-        query : type, Basic, or callable
-            Same semantics as in ``find()``.
-
-        Examples
-        ========
-
-        >>> from sympy import sin, cos, Wild
-        >>> from sympy.abc import x, y
-
-        >>> expr = sin(x) + sin(x)*cos(x) + y*sin(y)
-        >>> expr.count(sin)
-        3
-
-        >>> w = Wild('w')
-        >>> expr.count(sin(w))
-        3
-
-        >>> expr.count(lambda e: e.is_Symbol)
-        5
-
-        See Also
-        ========
-
-        find : return matching subexpressions instead of a count
-        has : test whether any match exists
-        """
+        """Count the number of matching subexpressions."""
         query = _make_find_query(query)
         return sum(bool(query(sub)) for sub in _preorder_traversal(self))
 
@@ -2403,7 +2375,20 @@ def _atomic(e, recursive=False):
 
 
 def _make_find_query(query):
-    """Convert the argument of Basic.find() into a callable"""
+    """
+    Convert the argument of ``Basic.find()`` into a callable.
+
+    A type matches by ``isinstance``, a ``Basic`` expression is treated
+    as a pattern matched using ``.match()`` (with ``Wild`` symbols
+    acting as wildcards), and any other object is assumed to already be
+    callable.
+
+    See Also
+    ========
+
+    Basic.find
+    Basic.count
+    """
     try:
         query = _sympify(query)
     except SympifyError:

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,4 +1,4 @@
-"""Base class for all the objects in SymPy"""
+y"""Base class for all the objects in SymPy"""
 from __future__ import annotations
 
 from collections import Counter
@@ -1857,7 +1857,35 @@ class Basic(Printable):
         return dict(Counter(results))
 
     def count(self, query):
-        """Count the number of matching subexpressions."""
+        """
+        Count the number of matching subexpressions.
+
+        query : type, Basic, or callable
+            Same semantics as in ``find()``.
+
+        Examples
+        ========
+
+        >>> from sympy import sin, cos, Wild
+        >>> from sympy.abc import x, y
+
+        >>> expr = sin(x) + sin(x)*cos(x) + y*sin(y)
+        >>> expr.count(sin)
+        3
+
+        >>> w = Wild('w')
+        >>> expr.count(sin(w))
+        3
+
+        >>> expr.count(lambda e: e.is_Symbol)
+        5
+
+        See Also
+        ========
+
+        find : return matching subexpressions instead of a count
+        has : test whether any match exists
+        """
         query = _make_find_query(query)
         return sum(bool(query(sub)) for sub in _preorder_traversal(self))
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -313,6 +313,8 @@ class Basic(Printable):
         True
         >>> expr.copy() is expr
         False
+        >>> expr.copy().args[0] is expr.args[0]
+        True
 
         See Also
         ========

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -293,7 +293,7 @@ class Basic(Printable):
 
     def __new__(cls, *args):
         obj = object.__new__(cls)
-        obj._assumptions = cls.default_assumptionsf
+        obj._assumptions = cls.default_assumptions
         obj._mhash = None  # will be set by __hash__ method.
 
         obj._args = args  # all items in args must be Basic objects

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -293,13 +293,32 @@ class Basic(Printable):
 
     def __new__(cls, *args):
         obj = object.__new__(cls)
-        obj._assumptions = cls.default_assumptions
+        obj._assumptions = cls.default_assumptionsf
         obj._mhash = None  # will be set by __hash__ method.
 
         obj._args = args  # all items in args must be Basic objects
         return obj
 
     def copy(self):
+        """
+        Return a shallow copy of the expression.
+
+        Examples
+        ========
+
+        >>> from sympy import sin
+        >>> from sympy.abc import x
+        >>> expr = sin(x) + 1
+        >>> expr.copy() == expr
+        True
+        >>> expr.copy() is expr
+        False
+
+        See Also
+        ========
+
+        Basic.func
+        """
         return self.func(*self.args)
 
     def __getnewargs__(self) -> tuple[Basic, ...] | tuple[Hashable, ...]:
@@ -2375,20 +2394,7 @@ def _atomic(e, recursive=False):
 
 
 def _make_find_query(query):
-    """
-    Convert the argument of ``Basic.find()`` into a callable.
-
-    A type matches by ``isinstance``, a ``Basic`` expression is treated
-    as a pattern matched using ``.match()`` (with ``Wild`` symbols
-    acting as wildcards), and any other object is assumed to already be
-    callable.
-
-    See Also
-    ========
-
-    Basic.find
-    Basic.count
-    """
+    """Convert the argument of Basic.find() into a callable"""
     try:
         query = _sympify(query)
     except SympifyError:


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #30050

#### Brief description of what is fixed or changed
Improve the Basic.copy docstring by adding runnable examples demonstrating that the method returns a shallow copy of an expression, along with a See Also reference to the related Basic.func attribute.

#### Other comments
None

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
ChatGPT and Claude were used to help refine the docstring wording.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
