### PR TITLE
Improve derivative calculation for power expressions with constant exponent.

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -1222,6 +1222,9 @@ class Pow(Expr):
         dbase = self.base.diff(s)
         dexp = self.exp.diff(s)
 
+        if dexp == 0:
+            return dbase * self.exp * self.base**(self.exp - 1)
+
         return self * (dexp * log(self.base) + dbase * self.exp/self.base)
 
     def _eval_evalf(self, prec):

--- a/sympy/core/tests/test_diff.py
+++ b/sympy/core/tests/test_diff.py
@@ -15,6 +15,7 @@ from sympy.functions.elementary.trigonometric import (cos, cot, sin, tan)
 from sympy.tensor.array.ndim_array import NDimArray
 from sympy.testing.pytest import raises, slow
 from sympy.abc import a, b, c, x, y, z
+from sympy.tensor.indexed import Idx
 
 def test_diff():
     assert Rational(1, 3).diff(x) is S.Zero
@@ -84,6 +85,16 @@ def test_diff3():
     e = (Rational(2)**a/log(Rational(2)))
     assert e == 2**a*log(Rational(2))**(-1)
     assert e.diff(a) == 2**a
+
+
+def test_diff_pow_exponent_dependency():
+    f = Function("f")
+    n = Symbol("n")
+    i = Idx("i")
+
+    assert (x**n).diff(x) == n*x**(n - 1)
+    assert (x**i).diff(x) == i*x**(i - 1)
+    assert (x**f(x)).diff(x) == x**f(x)*(log(x)*f(x).diff(x) + f(x)/x)
 
 
 def test_diff_no_eval_derivative():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

" Fixes https://github.com/sympy/sympy/issues/30029 " (see https://github.com/sympy/sympy/issues/30029 for more information).

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Fixed differentiation of powers by selecting the derivative rule based on whether the exponent depends on the differentiation variable. When the exponent is independent of the variable, [Pow](vscode-file://vscode-app/c:/Users/santhosh/AppData/Local/Programs/Microsoft%20VS%20Code/fc3def6774/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now uses the constant-exponent rule. Otherwise, it falls back to the full [f(x)**g(x)](vscode-file://vscode-app/c:/Users/santhosh/AppData/Local/Programs/Microsoft%20VS%20Code/fc3def6774/resources/app/out/vs/code/electron-browser/workbench/workbench.html) derivative formula. Added regression tests covering [Symbol](vscode-file://vscode-app/c:/Users/santhosh/AppData/Local/Programs/Microsoft%20VS%20Code/fc3def6774/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [Idx](vscode-file://vscode-app/c:/Users/santhosh/AppData/Local/Programs/Microsoft%20VS%20Code/fc3def6774/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [Function](vscode-file://vscode-app/c:/Users/santhosh/AppData/Local/Programs/Microsoft%20VS%20Code/fc3def6774/resources/app/out/vs/code/electron-browser/workbench/workbench.html) exponents


#### Other comments

Added regression coverage for:

 * symbolic constant exponents,
 * indexed exponents,
 * function-valued exponents.

#### AI Generation Disclosure

GitHub Copilot was used to generate the code changes.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

 * core
   * Fixed differentiation of powers to use the constant-exponent rule when the exponent does not depend on the differentiation variable, while preserving the general [f(x)**g(x)](vscode-file://vscode-app/c:/Users/santhosh/AppData/Local/Programs/Microsoft%20VS%20Code/fc3def6774/resources/app/out/vs/code/electron-browser/workbench/workbench.html) rule otherwise.

<!-- END RELEASE NOTES -->
