### PR TITLE
Fix typos in isympy man page

### DIFF
--- a/doc/man/isympy.1
+++ b/doc/man/isympy.1
@@ -84,7 +84,7 @@ choose python ground types even if gmpy is installed (e.g., for testing purposes
 Note that sympy ground types are not supported, and should be used
 only for experimental purposes.
 
-Note that the gmpy1 ground type is primarily intended for testing; it the
+Note that the gmpy1 ground type is primarily intended for testing; it forces the
 use of gmpy even if gmpy2 is available.
 
 This is the same as setting the environment variable
@@ -109,7 +109,7 @@ Note that for very large expressions, ORDER='none' may speed up
 printing considerably, with the tradeoff that the order of the terms
 in the printed expression will have no canonical order
 
-Example: isympy -o rev-lax
+Example: isympy -o rev-lex
 
 \fIORDER\fR must be one of 'lex', 'rev-lex', 'grlex',
 \&'rev-grlex', 'grevlex', 'rev-grevlex', 'old', or 'none'.


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->

## Summary

This PR fixes a couple of documentation typos in the `isympy` man page:

- Corrected `rev-lax` to `rev-lex` in the ordering example.
- Fixed the sentence describing the `gmpy1` ground type by adding the missing word `forces`.

These are documentation-only changes and do not affect functionality.