### PR TITLE
Clarify docstring distinction between is_number and Number class (#29…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1209,6 +1209,7 @@ Nimish Telang <ntelang@gmail.com>
 Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
 Nirmal Sarswat <nirmalsarswat400@gmail.com>
 Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
+Nisha Muthurajan <deltadelta5382@gmail.com>
 Nishant Nikhil <nishantiam@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
 Nitin Chaudhary <nitinmax1000@gmail.com>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -477,10 +477,8 @@ class Expr(Basic, EvalfMixin):
         >>> pi.is_number, pi.is_Number
         (True, False)
 
-        >>> from sympy import AlgebraicNumber, sqrt
-        >>> a = AlgebraicNumber(sqrt(2))
-        >>> a.is_number, a.is_Number
-        (True, False)
+        See :ref:`assumptions-guide-other-is-properties` for more on
+        this distinction.
 
         If something is a number it should evaluate to a number with
         real and imaginary parts that are Numbers; the result may not

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -477,6 +477,11 @@ class Expr(Basic, EvalfMixin):
         >>> pi.is_number, pi.is_Number
         (True, False)
 
+        >>> from sympy import AlgebraicNumber, sqrt
+        >>> a = AlgebraicNumber(sqrt(2))
+        >>> a.is_number, a.is_Number
+        (True, False)
+
         If something is a number it should evaluate to a number with
         real and imaginary parts that are Numbers; the result may not
         be comparable, however, since the real and/or imaginary part

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -334,10 +334,8 @@ class Number(AtomicExpr):
     they are not atomic.
 
     Being an instance of this class is unrelated to the ``is_number``
-    property, which is True for any expression that can be evaluated to
-    a floating point complex number, whether or not it is a ``Number``
-    instance (e.g. ``pi.is_number`` is True but ``pi.is_Number`` is
-    False).
+    property; see :ref:`assumptions-guide-other-is-properties` for the
+    distinction.
 
     See Also
     ========

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -333,6 +333,12 @@ class Number(AtomicExpr):
     complex numbers ``3 + 4*I``, are not instances of Number class as
     they are not atomic.
 
+    Being an instance of this class is unrelated to the ``is_number``
+    property, which is True for any expression that can be evaluated to
+    a floating point complex number, whether or not it is a ``Number``
+    instance (e.g. ``pi.is_number`` is True but ``pi.is_Number`` is
+    False).
+
     See Also
     ========
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #29749


#### Brief description of what is fixed or changed

The issue reported confusion about why AlgebraicNumber (which has is_number=True) isn't a subclass of Number, and why NaN is.
A maintainer clarified that is_number and Number are unrelated concepts: Number = atomic numeric literal types (Integer, Rational, Float, plus a few singletons like NaN/Infinity), while is_number = "can be evaluated to a numeric value."
This distinction was already documented in doc/src/guides/assumptions.rst but wasn't cross-referenced from the Number class docstring or the is_number property docstring, which is what caused the confusion.
This PR adds a short clarifying note to both docstrings, plus an AlgebraicNumber example in is_number's docstring alongside the existing pi example.
No behavior changes -  verified test_numbers.py, test_assumptions.py, test_expr.py all still pass.

#### Other comments
This is a documentation-only change. No source logic, class hierarchy, or assumption values were modified. All existing tests in test_numbers.py, test_assumptions.py, and test_expr.py pass unchanged.

#### AI Generation Disclosure

Used Claude (Anthropic) to help investigate the issue, identify the
relevant code locations. All commands were run and verified by me.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
