### PR TITLE
assumptions: add refine handler for tan

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -534,6 +534,45 @@ def refine_sin_cos(expr, assumptions):
         return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
 
 
+def refine_tan(expr, assumptions):
+    """
+    Handler for the tan function.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_tan
+    >>> from sympy import Symbol, Q, tan, pi
+    >>> from sympy.abc import x
+    >>> n = Symbol('n')
+    >>> refine_tan(tan(n*pi), Q.integer(n))
+    0
+    >>> refine_tan(tan(x + n*pi), Q.integer(n))
+    tan(x)
+
+    """
+    from sympy.functions.elementary.trigonometric import tan
+
+    arg = expr.args[0]
+
+    integer_pi_terms = []
+    remaining_terms = []
+
+    terms = arg.args if arg.is_Add else (arg,)
+    for term in terms:
+        coeff_of_pi = term.coeff(S.Pi)
+        if coeff_of_pi and ask(Q.integer(coeff_of_pi), assumptions):
+            integer_pi_terms.append(term)
+        else:
+            remaining_terms.append(term)
+
+    if not integer_pi_terms:
+        return expr
+
+    rem = Add(*remaining_terms) if remaining_terms else S.Zero
+    return tan(rem) if rem != S.Zero else S.Zero
+
+
 def refine_Heaviside(expr, assumptions):
     """
     Handler for the Heaviside step function.
@@ -613,6 +652,7 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
+    'tan': refine_tan,
     'exp': refine_exp,
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -538,6 +538,11 @@ def refine_tan(expr, assumptions):
     """
     Handler for the tan function.
 
+    ``tan`` has period ``pi``, so integer multiples of ``pi`` in the argument
+    drop out.  An *odd* multiple of ``pi/2`` additionally turns ``tan`` into
+    ``-cot`` (``tan(x + pi/2) == -cot(x)``), while an *even* multiple leaves a
+    plain ``tan``.
+
     Examples
     ========
 
@@ -549,28 +554,62 @@ def refine_tan(expr, assumptions):
     0
     >>> refine_tan(tan(x + n*pi), Q.integer(n))
     tan(x)
+    >>> refine_tan(tan(x + n*pi/2), Q.even(n))
+    tan(x)
+    >>> refine_tan(tan(x + n*pi/2), Q.odd(n))
+    -cot(x)
 
     """
-    from sympy.functions.elementary.trigonometric import tan
+    from sympy.functions.elementary.trigonometric import tan, cot
+
+    if not isinstance(expr, tan):
+        raise TypeError("refine_tan expects a tan function.")
 
     arg = expr.args[0]
 
-    integer_pi_terms = []
+    if ask(Q.zero(arg), assumptions):
+        return S.Zero
+
+    # Collect the terms that are an integer multiple of pi/2 (recorded as that
+    # integer coefficient); everything else is left untouched in the argument.
+    integer_coeffs_of_pi_half = []
     remaining_terms = []
 
     terms = arg.args if arg.is_Add else (arg,)
     for term in terms:
         coeff_of_pi = term.coeff(S.Pi)
-        if coeff_of_pi and ask(Q.integer(coeff_of_pi), assumptions):
-            integer_pi_terms.append(term)
+        if coeff_of_pi and ask(Q.integer(2 * coeff_of_pi), assumptions):
+            integer_coeffs_of_pi_half.append(2 * coeff_of_pi)
         else:
             remaining_terms.append(term)
 
-    if not integer_pi_terms:
+    if not integer_coeffs_of_pi_half:
         return expr
 
-    rem = Add(*remaining_terms) if remaining_terms else S.Zero
-    return tan(rem) if rem != S.Zero else S.Zero
+    # Only the *parity* of the total pi/2 coefficient matters. Sum the
+    # coefficients whose parity is known (tracking the running parity), and
+    # leave any parity-unknown coefficients inside the refined argument.
+    sum_of_parity_known_coeffs = 0
+    sum_of_parity_unknown_coeffs = 0
+    sum_of_parity_known_coeffs_is_even = True
+    for coeff in integer_coeffs_of_pi_half:
+        coeff_is_even = ask(Q.even(coeff), assumptions)
+        if coeff_is_even is None:
+            sum_of_parity_unknown_coeffs += coeff
+        else:
+            sum_of_parity_known_coeffs += coeff
+            sum_of_parity_known_coeffs_is_even = (
+                sum_of_parity_known_coeffs_is_even == coeff_is_even
+            )
+
+    if sum_of_parity_known_coeffs == 0:
+        return expr
+
+    rem = Add(*remaining_terms) + sum_of_parity_unknown_coeffs * S.Pi / 2
+    # even multiple of pi/2 -> tan(rem); odd multiple -> -cot(rem)
+    if sum_of_parity_known_coeffs_is_even:
+        return tan(rem)
+    return -cot(rem)
 
 
 def refine_Heaviside(expr, assumptions):

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from sympy.assumptions.ask import Q
-from sympy.assumptions.refine import refine, refine_sin_cos
+from sympy.assumptions.refine import refine, refine_sin_cos, refine_tan
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.expr import Expr
 from sympy.core.numbers import (I, Rational, nan, pi)
@@ -9,7 +9,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
-from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin, tan)
+from sympy.functions.elementary.trigonometric import (atan, atan2, cos, cot, sin, tan)
 from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
@@ -359,8 +359,23 @@ def test_Heaviside():
 
 def test_tan():
     n = Symbol('n')
+    m = Symbol('m')
+    # Integer multiples of pi drop out (tan has period pi).
     assert refine(tan(n*pi), Q.integer(n)) == 0
     assert refine(tan(x + n*pi), Q.integer(n)) == tan(x)
     assert refine(tan(x + 2*n*pi), Q.integer(n)) == tan(x)
+    assert refine(tan(x + n*pi + m*pi), Q.integer(n) & Q.integer(m)) == tan(x)
+    # Even/odd multiples of pi/2: even -> tan, odd -> -cot.
+    assert refine(tan(n*pi/2), Q.even(n)) == 0
+    assert refine(tan(x + n*pi/2), Q.even(n)) == tan(x)
+    assert refine(tan(x + n*pi/2), Q.odd(n)) == -cot(x)
+    assert refine(tan(x + 3*n*pi/2), Q.odd(n)) == -cot(x)
+    # Zero argument.
+    assert refine(tan(n), Q.zero(n)) == 0
+    # Parity of the pi/2 coefficient unknown -> left unrefined.
+    assert refine(tan(x + n*pi/2), Q.integer(n)) == tan(x + n*pi/2)
+    # Nothing to do.
     assert refine(tan(x), Q.integer(n)) == tan(x)
     assert refine(tan(x), True) == tan(x)
+    # Wrong function type is rejected.
+    raises(TypeError, lambda: refine_tan(sin(x), Q.real(x)))

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -16,6 +16,7 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.special.delta_functions import Heaviside
+from sympy.functions.elementary.trigonometric import tan
 
 from sympy.testing.pytest import raises, slow
 
@@ -354,3 +355,12 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+
+def test_tan():
+    n = Symbol('n')
+    assert refine(tan(n*pi), Q.integer(n)) == 0
+    assert refine(tan(x + n*pi), Q.integer(n)) == tan(x)
+    assert refine(tan(x + 2*n*pi), Q.integer(n)) == tan(x)
+    assert refine(tan(x), Q.integer(n)) == tan(x)
+    assert refine(tan(x), True) == tan(x)


### PR DESCRIPTION
#### References to other Issues or PRs
See #27888

#### Brief description of what is fixed or changed
Adds a `refine_tan` handler so `refine` can simplify `tan` expressions when the argument contains integer multiples of `pi` or `pi/2`.

`tan` has period `pi`, so any integer multiple of `pi` in the argument drops out, and an *odd* multiple of `pi/2` turns `tan` into `-cot`:

```python
>>> refine(tan(n*pi), Q.integer(n))
0
>>> refine(tan(x + n*pi), Q.integer(n))
tan(x)
>>> refine(tan(x + n*pi/2), Q.even(n))
tan(x)
>>> refine(tan(x + n*pi/2), Q.odd(n))
-cot(x)
```

Without this handler, all of those returned unchanged.

The implementation follows the same pattern as `refine_sin_cos`: it splits the argument into terms that are integer multiples of `pi/2`, then tracks the parity of that coefficient, since `tan(x + k*pi/2)` is `tan(x)` for even `k` and `-cot(x)` for odd `k`. A zero argument refines to `0`, and non-`tan` input raises `TypeError`.

#### Other comments
Both the integer-`pi` case and the odd-`pi/2` (`-> -cot`) case are handled. Terms whose `pi/2` coefficient has unknown parity are left untouched in the refined argument, so nothing is simplified incorrectly.

#### AI Generation Disclosure
I used AI to check my code.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* assumptions
  * `refine(tan(...))` now simplifies integer multiples of `pi` and odd multiples of `pi/2` in the argument (to `tan` and `-cot` respectively).
<!-- END RELEASE NOTES -->
