### PR TITLE
polys: add a regression test for gh-25341

### DIFF
--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3936,6 +3936,10 @@ def test_poly():
     expr2 = y*(y+1) + S(1)/3
     assert poly(expr2).as_expr() == expr2.expand()
 
+    # https://github.com/sympy/sympy/issues/25341
+    num = 2*x**2 - x*(x + 1) - (x + 1)**2/4
+    assert poly(num, x).as_expr() == num.expand()
+
 
 def test_keep_coeff():
     u = Mul(2, x + 1, evaluate=False)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
#25341

#### Brief description of what is fixed or changed
Add a regression test for gh-25341.

#### Other comments
gh-25341 was fixed by 9a61a90 from gh-26666.

Nevertheless, gh-25341 still doesn't have a regression test.  
After adding the regression test, I think gh-25341 can be closed.

Before 9a61a90 ,

```python
In [1]: num = 2*x**2 - x*(x + 1) - (x + 1)**2/4

In [2]: poly(num, x).as_expr()
```
raises `CoercionFailed`.

After 9a61a90 ,

```python
In [1]: num = 2*x**2 - x*(x + 1) - (x + 1)**2/4

In [2]: str(poly(num, x).as_expr())
Out[2]: '3*x**2/4 - 3*x/2 - 1/4'

In [3]: poly(num, x).as_expr() == num.expand()
Out[3]: True
```

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
All code was written manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
