### PR TITLE
perf(matrices): use SCC decomposition for inverse

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -583,6 +583,7 @@ Devansh <be19b002@smail.iitm.ac.in> prototypevito <96943731+prototypevito@users.
 Devesh Sawant <devesh47cool@gmail.com> dsaw <devesh47cool@gmail.com>
 Devesh Sawant <devesh47cool@gmail.com> dsaw <devsaw115@gmail.com>
 Devyani Kota <devyanikota@gmail.com> <divs.passion.18@gmail.com>
+Dex Hunter <i@dex.moe> Dex <i@dex.moe>
 Dhia Kennouche <kendhia@gmail.com>
 Dhia Kennouche <kendhia@gmail.com> <algheart@live.fr>
 Dhruv Bhanushali <dhruv_b@live.com>

--- a/sympy/matrices/inverse.py
+++ b/sympy/matrices/inverse.py
@@ -336,6 +336,23 @@ def _inv_DM(dM, cancel=True):
     else:
         dom_exact = None
 
+    if cancel and len(dM.scc()) > 1:
+        try:
+            dMi = dM.to_field().inv()
+        except DMNonInvertibleMatrixError:
+            raise NonInvertibleMatrixError("Matrix det == 0; not invertible.")
+        if dom_exact is not None:
+            dom_field = dom if dom.is_Field else dom.get_field()
+            dMi = dMi.convert_to(dom_field)
+        Mi = dMi.to_Matrix()
+        dMi_ground = dMi.domain.domain if dMi.domain.is_FractionField else dMi.domain
+        if (dom_exact is not None
+                or dMi_ground.is_AlgebraicField
+                or dMi_ground.is_GaussianField):
+            from sympy.polys.polytools import cancel as cancel_expr
+            Mi = Mi.applyfunc(cancel_expr)
+        return Mi
+
     try:
         dMi, den = dM.inv_den()
     except DMNonInvertibleMatrixError:

--- a/sympy/matrices/inverse.py
+++ b/sympy/matrices/inverse.py
@@ -536,7 +536,7 @@ def _inv(M: Tmat,
             method = 'GE'
 
     if dM is not None:
-        rv = _inv_DM(dM)
+        rv = _inv_DM(dM, cancel=method != "DMNC")
     elif method == "DMNC":
         rv = _inv_DM(dM, cancel=False)
     elif method == "GE":

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -2296,6 +2296,13 @@ def test_sparse_diagonal_inv():
     assert result[1000, 1000] == 1/(x + 1001)
 
 
+def test_sparse_diagonal_inv_DMNC():
+    M = SparseMatrix.diag(x**2 + x, x)
+    den = x**3 + x**2
+    assert M.inv(method="DMNC") == SparseMatrix.diag(
+        x/den, (x**2 + x)/den)
+
+
 def test_creation_args():
     """
     Check that matrix dimensions can be specified using any reasonable type

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -18,7 +18,7 @@ from sympy.abc import a, b, c, d, t, x, y, z
 from sympy.core.kind import NumberKind, UndefinedKind
 from sympy.matrices.determinant import _find_reasonable_pivot_naive
 from sympy.matrices.exceptions import (
-    MatrixError, NonSquareMatrixError, ShapeError)
+    MatrixError, NonInvertibleMatrixError, NonSquareMatrixError, ShapeError)
 from sympy.matrices.kind import MatrixKind
 from sympy.matrices.utilities import _dotprodsimp_state, _simplify, dotprodsimp
 from sympy.tensor.array.array_derivatives import ArrayDerivative
@@ -2265,6 +2265,35 @@ def test_inv_block():
     assert A.inv(try_block_diag=True, method="ADJ") == diag(
         a.inv(method="ADJ"), a.inv(method="ADJ"), b.inv(method="ADJ"),
         a.inv(method="ADJ"), c.inv(method="ADJ"), a.inv(method="ADJ"))
+
+
+def test_sparse_diagonal_inv():
+    for cls in SparseMatrix, ImmutableSparseMatrix:
+        for values in ((), (2,), (2, Rational(-3, 5)),
+                       (x + 1, 2 - I, Rational(7, 3), -5)):
+            M = cls(len(values), len(values), {(i, i): value
+                                                for i, value in enumerate(values)})
+            result = M.inv()
+            assert type(result) is cls
+            assert result == cls(len(values), len(values),
+                                 {(i, i): simplify(S.One/value) for i, value in enumerate(values)})
+            assert (result - M.to_DM().to_field().inv().to_Matrix()).applyfunc(
+                simplify) == zeros(len(values))
+
+        singular = cls(3, 3, {(0, 0): 1, (1, 1): 0, (2, 2): x + 1})
+        raises(NonInvertibleMatrixError, lambda: singular.inv())
+        M = cls(2, 2, {(0, 0): x, (1, 1): y})
+        calls = []
+        result = M.inv(method="GE", iszerofunc=lambda value: calls.append(value) or value.is_zero)
+        assert calls and result == diag(1/x, 1/y)
+        assert M.inv(method="DM") == diag(1/x, 1/y)
+        assert M.inv(try_block_diag=True) == diag(1/x, 1/y)
+
+    large = SparseMatrix(1001, 1001, {(i, i): x + i + 1 for i in range(1001)})
+    result = large.inv()
+    assert type(result) is SparseMatrix
+    assert result[0, 0] == 1/(x + 1)
+    assert result[1000, 1000] == 1/(x + 1001)
 
 
 def test_creation_args():

--- a/sympy/polys/matrices/domainmatrix.py
+++ b/sympy/polys/matrices/domainmatrix.py
@@ -2588,6 +2588,11 @@ class DomainMatrix:
         m, n = self.shape
         if m != n:
             raise DMNonSquareMatrixError
+
+        components = self.scc()
+        if len(components) > 1:
+            return _dm_inv_scc(self, components)
+
         inv = self.rep.inv()
         return self.from_rep(inv)
 
@@ -4052,3 +4057,63 @@ def _collect_factors(factors_list):
     factors_list = [(list(f), e) for f, e in factors.items()]
 
     return _sort_factors(factors_list)
+
+
+def _dm_inv_scc(A, components):
+    """Invert a field matrix using its strongly connected components."""
+    indices = [index for component in components for index in component]
+    block_sizes = [len(component) for component in components]
+    A_scc = A.extract(indices, indices)
+    Ainv_scc = _dm_inv_scc_blocks(A_scc, block_sizes)
+
+    inverse_indices = sorted(range(len(indices)), key=indices.__getitem__)
+    return Ainv_scc.extract(inverse_indices, inverse_indices)
+
+
+def _dm_inv_scc_blocks(A, block_sizes):
+    """Invert a lower block triangular matrix over a field."""
+    if len(block_sizes) == 1:
+        return A.from_rep(A.rep.inv())
+
+    blocks = []
+    offset = 0
+    diagonal_nnz = 0
+    for size in block_sizes:
+        block = A[offset:offset + size, offset:offset + size]
+        blocks.append((offset, block))
+        diagonal_nnz += block.nnz()
+        offset += size
+
+    if diagonal_nnz == A.nnz():
+        entries = {}
+        for offset, block in blocks:
+            block_inv = block.from_rep(block.rep.inv())
+            for (i, j), value in block_inv.to_dok().items():
+                entries[offset + i, offset + j] = value
+        Ainv = A.from_dok(entries, A.shape, A.domain)
+        if A.rep.fmt == 'dense':
+            Ainv = Ainv.to_dense()
+        return Ainv
+
+    split = len(block_sizes) // 2
+    split_row = sum(block_sizes[:split])
+    A11 = A[:split_row, :split_row]
+    A21 = A[split_row:, :split_row]
+    A22 = A[split_row:, split_row:]
+
+    # Invert [[A11, 0], [A21, A22]] using its lower triangular
+    # two-by-two block structure.
+    A11inv = _dm_inv_scc_blocks(A11, block_sizes[:split])
+    A22inv = _dm_inv_scc_blocks(A22, block_sizes[split:])
+    A21inv = -A22inv * A21 * A11inv
+
+    entries = A11inv.to_dok()
+    for (i, j), value in A21inv.to_dok().items():
+        entries[split_row + i, j] = value
+    for (i, j), value in A22inv.to_dok().items():
+        entries[split_row + i, split_row + j] = value
+
+    Ainv = A.from_dok(entries, A.shape, A.domain)
+    if A.rep.fmt == 'dense':
+        Ainv = Ainv.to_dense()
+    return Ainv

--- a/sympy/polys/matrices/tests/test_inverse.py
+++ b/sympy/polys/matrices/tests/test_inverse.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from sympy import ZZ, Matrix
+from sympy import QQ, ZZ, Matrix
 from sympy.polys.matrices import DM, DomainMatrix
 from sympy.polys.matrices.dense import ddm_iinv
 from sympy.polys.matrices.exceptions import DMNonInvertibleMatrixError
@@ -98,6 +98,23 @@ def test_dm_inv_den(name, A, A_inv, den):
         assert A_inv_f.cancel_denom(den_f) == A_inv.cancel_denom(den)
     else:
         raises(DMNonInvertibleMatrixError, lambda: A.inv_den())
+
+
+def test_dm_inv_scc():
+    A = DM([
+        [2, 1, 0, 0, 0],
+        [1, 3, 0, 0, 0],
+        [4, 0, 5, 1, 0],
+        [0, 2, 1, 7, 0],
+        [3, 0, 2, 0, 11],
+    ], QQ)
+    Ainv = A.from_rep(A.rep.inv())
+    assert A.scc() == [[0, 1], [2, 3], [4]]
+
+    for A_format in (A, A.to_sparse()):
+        Ainv_scc = A_format.inv()
+        assert Ainv_scc.rep.fmt == A_format.rep.fmt
+        assert Ainv_scc.to_dense() == Ainv
 
 
 @pytest.mark.parametrize('name, A, A_inv, den', INVERSE_EXAMPLES)


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #29698

#### Brief description of what is fixed or changed

The default `inv()` path for sparse matrices is extremely slow for symbolic diagonal matrices. For the 10x10 diagonal matrix in #29698 it routes through `_inv_DM`, whose fraction-free elimination performs gcd computations that
blow up on these entries.

The `DomainMatrix.inv()` method now computes the matrix's strongly connected components. When it finds more than one SCC, it permutes the matrix into lower block-triangular form and recursively inverts the resulting block structure. Diagonal matrices are handled naturally because every matrix index forms a singleton SCC. The same code also handles non-diagonal block-triangular matrices, so no separate diagonal fast path is needed. Dense and sparse representations are preserved, and explicitly selected inversion methods continue to use their existing paths.

Timing for the reproduction from #29698:

  | A.inv() | Runs
-- | -- | --
master | 8213.878 ms | 3
this PR | 14.984 ms | 7

#### Other comments

This implements the SCC decomposition suggested in #29698. The other suggestion in that issue, adding algorithm-selection heuristics for `RREF` and `inv()`, is left for follow-up.
New tests cover round-trip correctness for both sparse matrix classes, `NonInvertibleMatrixError` for a singular diagonal matrix, the existing behavior of explicit `method` arguments, and inversion of a 1001 × 1001 diagonal matrix without converting it to a dense representation. The full `sympy/matrices/tests/test_matrixbase.py` and `sympy/matrices/tests/test_sparse.py` test suites pass.

#### AI Generation Disclosure


<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Disclosure: This PR is co-authored by @aiden-weco. Full agent trajectory:
https://dashboard.weco.ai/share/mQoHSJaVVzh4NUzE7E_1I1XZnyUqmuYa
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* matrices
    * Fixed severe slowdown when inverting sparse diagonal matrices with symbolic entries. 

<!-- END RELEASE NOTES -->
