### PR TITLE
Use exact pi/180 for AutoLev Units degree conversion

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -671,6 +671,7 @@ Fredrik Johansson <fredrik.johansson@gmail.com> <fredrik@airy.(none)>
 Fredrik Johansson <fredrik.johansson@gmail.com> fredrik.johansson <devnull@localhost>
 Friedrich Hagedorn <friedrich_h@gmx.de>
 Frédéric Chapoton <fchapoton2@gmail.com> fchapoton <fchapoton2@gmail.com>
+Fstarnb <fstarnb@gmail.com>
 G. D. McBain <gdmcbain@protonmail.com>
 Gabriel Bernardino <gabriel.bernardino@upf.edu>
 Gabriel Orisaka <orisaka@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -672,6 +672,7 @@ Fredrik Johansson <fredrik.johansson@gmail.com> fredrik.johansson <devnull@local
 Friedrich Hagedorn <friedrich_h@gmx.de>
 Frédéric Chapoton <fchapoton2@gmail.com> fchapoton <fchapoton2@gmail.com>
 Fstarnb <fstarnb@gmail.com>
+Fstarnb <fstarnb@gmail.com> <78671757+Fstarnb@users.noreply.github.com>
 G. D. McBain <gdmcbain@protonmail.com>
 Gabriel Bernardino <gabriel.bernardino@upf.edu>
 Gabriel Orisaka <orisaka@gmail.com>

--- a/sympy/parsing/autolev/_listener_autolev_antlr.py
+++ b/sympy/parsing/autolev/_listener_autolev_antlr.py
@@ -1164,9 +1164,10 @@ if AutolevListener:
             # Units(deg, rad)
             elif func_name == "units":
                 if ch.expr(0).getText().lower() == "deg" and ch.expr(1).getText().lower() == "rad":
-                    factor = 0.0174533
+                    # Exact conversion via pi (issue #30063)
+                    factor = "_sm.pi/180"
                 elif ch.expr(0).getText().lower() == "rad" and ch.expr(1).getText().lower() == "deg":
-                    factor = 57.2958
+                    factor = "180/_sm.pi"
                 self.setValue(ctx, str(factor))
             # Mass(A)
             elif func_name == "mass":


### PR DESCRIPTION
## Summary

The AutoLev translator used truncated float factors `0.0174533` and `57.2958` for degree/radian conversion. Replace them with exact SymPy expressions `_sm.pi/180` and `180/_sm.pi`.

## Test plan

- [x] Source no longer contains truncated float factors
- [ ] Autolev parse tests when antlr4 is available in CI

Fixes #30063.

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Use exact `pi/180` for AutoLev `Units` degree/radian conversion instead of truncated floats
<!-- END RELEASE NOTES -->