### PR TITLE
Fix construct_domain crash on a non-finite complex value (e.g. oo*I)

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -37,8 +37,12 @@ def _construct_simple(coeffs, opt):
         else:
             is_complex = pure_complex(coeff)
             if is_complex:
-                complexes = True
                 x, y = is_complex
+                if not (x.is_finite and y.is_finite):
+                    # A non-finite value such as oo*I cannot be an RR/CC
+                    # coefficient; fall back to EX, matching a bare oo.
+                    return None
+                complexes = True
                 if x.is_Rational and y.is_Rational:
                     if not (x.is_Integer and y.is_Integer):
                         rationals = True

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from sympy.testing.pytest import tooslow
 
+from sympy.core.cache import clear_cache
 from sympy.polys.constructor import construct_domain
 from sympy.polys.domains import ZZ, QQ, ZZ_I, QQ_I, RR, CC, EX
 from sympy.polys.domains.realfield import RealField
@@ -172,6 +173,17 @@ def test_complex_exponential():
          alg.convert(w),
          alg.convert(1)]
     )
+
+
+def test_construct_domain_non_finite():
+    # A non-finite complex value such as oo*I cannot be an RR/CC coefficient
+    # and must fall back to EX instead of raising, matching a bare oo
+    # (issue #30061). clear_cache() ensures the cold state where the bug
+    # manifests, independent of other tests.
+    clear_cache()
+    assert construct_domain([S.Infinity * I]) == (EX, [EX.convert(S.Infinity * I)])
+    assert construct_domain([-S.Infinity * I]) == (EX, [EX.convert(-S.Infinity * I)])
+    assert construct_domain([S.Infinity * I, S.One])[0] == EX
 
 
 def test_rootof():


### PR DESCRIPTION
Fixes #30061

#### References to other Issues or PRs

Analogous to the EX fallback for `construct_domain([x + oo])`.

#### Brief description of what is fixed or changed

`construct_domain([oo*I])` raised `TypeError: cannot create mpf from oo` instead of falling back to `EX` the way `construct_domain([oo])` already does:

```python
>>> from sympy import construct_domain, oo, I
>>> construct_domain([oo])      # EX
>>> construct_domain([oo*I])    # TypeError  <-- before this PR
```

In `_construct_simple`, `pure_complex(oo*I)` returns `(0, oo)`, so the value was classified as a `CC` coefficient; `ComplexField.from_sympy` then tried to build an `mpc` from a non-finite imaginary part and crashed.

This rejects a non-finite real/imaginary part in the `pure_complex` branch and returns `None`, so the value is routed through the composite/`EX` path — matching a bare `oo`. Finite complex values are unaffected:

```python
>>> construct_domain([oo*I])          # (EX, [EX.convert(oo*I)])
>>> construct_domain([I])             # ZZ_I
>>> construct_domain([1.5 + 2*I])     # CC
>>> construct_domain([I/2])           # QQ_I
```

#### Other comments

Added `test_construct_domain_non_finite` (calls `clear_cache()` so the cold state where the bug manifests is reproduced deterministically). It fails on `master` and passes with this change; `test_constructor.py` and `sympy/polys/domains/tests/` pass (66 passed).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a `TypeError` crash in `construct_domain` when given a non-finite complex value such as `oo*I`; it now falls back to `EX`.
<!-- END RELEASE NOTES -->