### PR TITLE
typing: add type annotation to DirectProduct

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -497,6 +497,7 @@ Charlie Lam <888lamcharlie@gmail.com>
 Chetan Choudhary <cc393653@gmail.com> Chetan Choudhary <134824444+amMistic@users.noreply.github.com>
 Chetan Choudhary <cc393653@gmail.com> ChetanChoudhary007 <cc393653@gmail.com>
 Chetna Gupta <cheta.gup@gmail.com>
+Chimwemwe Siyingwa <Chimwemwesiyingwa361@gmail.com> mwemmz <chimwemwesiyingwa361@gmail.com>
 Chiu-Hsiang Hsu <wdv4758h@gmail.com>
 Chris Cameron <chrisjamescameron1@gmail.com> ccam80 <63381855+ccam80@users.noreply.github.com>
 Chris Conley <chrisconley15@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,3 +1457,4 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
+mwemmz <chimwemwesiyingwa361@gmail.com> (@mwemmz)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1457,4 +1457,3 @@ Harsh Gupta <harsh2125gupta@gmail.com>
 Aman Kumar <133586536+Aman-Kumar2211@users.noreply.github.com>
 Mayank Singh <mayanksingh020607@gmail.com>
 Mohammed Umar <mdumr4@gmail.com>
-mwemmz <chimwemwesiyingwa361@gmail.com> (@mwemmz)

--- a/sympy/combinatorics/group_constructs.py
+++ b/sympy/combinatorics/group_constructs.py
@@ -6,7 +6,7 @@ from sympy.utilities.iterables import uniq
 _af_new = Permutation._af_new
 
 
-def DirectProduct(*groups):
+def DirectProduct(*groups: PermutationGroup) -> PermutationGroup:
     """
     Returns the direct product of several groups as a permutation group.
 


### PR DESCRIPTION
#### References to other Issues or PRs

See #28806

#### Brief description of what is fixed or changed

Added type annotations to `DirectProduct` in `sympy/combinatorics/group_constructs.py`.

Specifically:
- Annotated the `groups` parameter as `PermutationGroup`.
- Added `PermutationGroup` as the return type.

Validation performed:
- Ran `pytest sympy/combinatorics/tests`
- Ran `mypy sympy/combinatorics/group_constructs.py`

#### Other comments

This change is part of the ongoing effort to improve type annotations in SymPy.

#### AI Generation Disclosure

I used ChatGPT for guidance on the Git workflow and contribution process. The code change, testing, and final edits were completed and verified by me.

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Added type annotations to `DirectProduct` in `sympy.combinatorics.group_constructs`.
<!-- END RELEASE NOTES -->