### PR TITLE
Set timeout_func_only=true and add faulthandler_timeout backstop

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -179,7 +179,7 @@ jobs:
           python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n auto --timeout 10 --durations=50 --durations-min=5
+      - run: pytest -n auto --timeout 10 --faulthandler-timeout 30 --durations=50 --durations-min=5
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -179,7 +179,7 @@ jobs:
           python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n auto --timeout 10 --faulthandler-timeout 30 --durations=50 --durations-min=5
+      - run: pytest -n auto --timeout 10 -o faulthandler_timeout=30 --durations=50 --durations-min=5
 
   # -------------------- Optional dependency tests ----------------- #
 
@@ -378,7 +378,7 @@ jobs:
           python-version: '3.13'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -m slow --timeout 595 --faulthandler-timeout 620 -n auto -v --durations=0
+      - run: pytest -m slow --timeout 595 -o faulthandler_timeout=620 -n auto -v --durations=0
 
   # -------------------- Test older (and newer) Python --------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -378,7 +378,7 @@ jobs:
           python-version: '3.13'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -m slow --timeout 595 -n auto -v --durations=0
+      - run: pytest -m slow --timeout 595 --faulthandler-timeout 620 -n auto -v --durations=0
 
   # -------------------- Test older (and newer) Python --------------- #
 

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ sample.tex
 .hypothesis
 
 sympy-env/
+venv-linux/

--- a/.mailmap
+++ b/.mailmap
@@ -1213,6 +1213,7 @@ Nimish Telang <ntelang@gmail.com>
 Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
 Nirmal Sarswat <nirmalsarswat400@gmail.com>
 Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
+Nisha Muthurajan <deltadelta5382@gmail.com>
 Nishant Nikhil <nishantiam@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
 Nitin Chaudhary <nitinmax1000@gmail.com>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [tool.pytest.ini_options]
+timeout_func_only = true
+faulthandler_timeout = 30
 # Don't run the tests marked as slow by default.
 addopts = "-m 'not slow and not tooslow'"
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.pytest.ini_options]
 timeout_func_only = true
-faulthandler_timeout = 30
 # Don't run the tests marked as slow by default.
 addopts = "-m 'not slow and not tooslow'"
 filterwarnings = [


### PR DESCRIPTION
Fixes #30038

pytest-timeout's default (timeout_func_only=False) arms SIGALRM around setup+call+teardown/report-formatting, not just the test body. If the alarm fires during report formatting instead of the test itself, pytest.fail() gets raised from inside pytest's internals rather than from the test's CallInfo, which crashes the xdist worker with an uncatchable INTERNALERROR and no useful sympy traceback.

Setting timeout_func_only=true confines the timer to the test call phase only, so timeouts always surface as a normal Failed: Timeout report with a real traceback.

faulthandler_timeout is added as a complementary backstop for tests stuck in long C-level calls (e.g. gmpy2/flint) where SIGALRM can't interrupt cleanly. The slow-test CI job gets its own --faulthandler-timeout override since it runs with a much longer --timeout (595s) than the default job (10s).

Also ignore the local venv-linux/ directory used for WSL testing.


#### References to other Issues or PRs

Fixes #30038


#### Brief description of what is fixed or changed

pytest-timeout's default setting (timeout_func_only=False) arms the
SIGALRM timer around the entire test protocol - setup, call, and
teardown/report-formatting - not just the test body. When the alarm
fires during report formatting instead of during the actual test, the
resulting exception isn't caught properly and crashes the xdist worker
with an uninformative INTERNALERROR instead of a normal timeout
failure with a traceback.

This PR sets timeout_func_only=true so the timer only covers the test
call itself, meaning timeouts now always produce a normal
"Failed: Timeout" report with a real traceback.

Also added faulthandler_timeout=30 as a backstop for tests stuck in
long C-level calls (e.g. gmpy2/flint) where SIGALRM can't interrupt
cleanly, since Python only handles the signal when it regains control.
The slow-test CI job gets its own --faulthandler-timeout=620 override
since it already runs with a longer --timeout (595s) than the default
job.

Tested locally on Linux (WSL2) with a synthetic infinite-loop test to
confirm the clean traceback, and ran test_wester.py (which contains
test_W19 from the original report) under xdist to confirm no
regressions - 243 passed, 2 skipped, 136 xfailed, no INTERNALERRORs.

#### Other comments

I haven't yet investigated whether sympy's printing code contributes
to slowness in cases like test_W19 (raised in the issue discussion) -
open to following up on that separately if it seems useful.

#### AI Generation Disclosure

I used Claude (Anthropic) to help me understand the root cause of this
issue (the SIGALRM/report-formatting interaction) and to walk through
the debugging, testing, and git/PR process, since I was new to this
codebase and workflow. The diagnosis of the root cause originated from
Claude's analysis (quoted by asmeurer in the issue thread) and I used
Claude to help verify it locally and to help me understand and write
this description. The actual code change (the two config lines in
pyproject.toml and the CI workflow line) is a small, verified config
change - I ran and interpreted the tests myself. Happy to answer any
questions about the change in review.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
