### PR TITLE
ENH: assumptions: `lra_theory`: rename slack/nonslack to basic/nonbasic

### DIFF
--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -176,6 +176,8 @@ class LRASolver():
 
         self.atom_id_to_boundaries = atom_id_to_boundaries
         self.A = A
+        # initially slack/basic and nonslack/nonbasic mean the same thing.
+        # however, basic/nonbasic can be modified in process meanwhile slack/nonslack stays constant.
         self.basic = slack_variables
         self.nonbasic = nonslack_variables
         self.basic_set = set(slack_variables)
@@ -351,7 +353,7 @@ class LRASolver():
 
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
         # matrix A is guaranteed to able to be simplified
-        # by removing the non-basic (e.g original) non-atom variables from it
+        # by removing the non-basic (e.g original or nonslack) non-atom variables from it
         # these removed variables will be replaced by linear equation of existing variables.
         nonatom_vars = {i for i in nonbasic if i not in atom_vars}
         A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode)
@@ -431,8 +433,10 @@ class LRASolver():
         more limiting. The assignment of variable xi is adjusted to be
         within the new bound if needed.
 
-        Also calls `self._update` to update the assignment for slack variables
+        Also calls `self._update` to update the assignment for basic variables
         to keep all equalities satisfied.
+
+        This method is the combination of AssertUpper and AssertLower in [1]
         """
         if self.result:
             assert self.result[0] != False
@@ -481,8 +485,8 @@ class LRASolver():
 
     def _update(self, xi, v):
         """
-        Updates all slack variables that have equations that contain
-        variable xi so that they stay satisfied given xi is equal to v.
+        Updates all basic variables that have equations that contain
+        nonbasic variable xi so that they stay satisfied given xi is equal to v.
         """
         i = xi.col_idx
         assert i is not None

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -179,8 +179,7 @@ class LRASolver():
         # initially slack/basic and nonslack/nonbasic mean the same thing.
         # however, basic/nonbasic can be modified in process meanwhile slack/nonslack stays constant.
         self.basic = slack_variables
-        self.nonbasic = nonslack_variables
-        self.basic_set = set(slack_variables)
+        self.nonbasic = set(nonslack_variables)
 
         self.all_var = nonslack_variables + slack_variables
 
@@ -420,7 +419,7 @@ class LRASolver():
             if res and res[0] is False:
                 break
 
-        if self.is_sat and all(b.var not in self.basic_set for b in boundaries):
+        if self.is_sat and all(b.var in self.nonbasic for b in boundaries):
             self.is_sat = res is None
         else:
             self.is_sat = False

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -176,11 +176,11 @@ class LRASolver():
 
         self.atom_id_to_boundaries = atom_id_to_boundaries
         self.A = A
-        self.slack = slack_variables
-        self.nonslack = nonslack_variables
-        self.all_var = nonslack_variables + slack_variables
+        self.basic = slack_variables
+        self.nonbasic = nonslack_variables
+        self.basic_set = set(slack_variables)
 
-        self.slack_set = set(slack_variables)
+        self.all_var = nonslack_variables + slack_variables
 
         self.is_sat = True  # While True, all constraints asserted so far are satisfiable
         self.result = None  # always one of: (True, assignment), (False, conflict clause), None
@@ -418,7 +418,7 @@ class LRASolver():
             if res and res[0] is False:
                 break
 
-        if self.is_sat and all(b.var not in self.slack_set for b in boundaries):
+        if self.is_sat and all(b.var not in self.basic_set for b in boundaries):
             self.is_sat = res is None
         else:
             self.is_sat = False
@@ -468,7 +468,7 @@ class LRASolver():
 
         xi.set_bound(boundary, literal)
 
-        if xi in self.nonslack and xi.assign * s > c_norm:
+        if xi in self.nonbasic and xi.assign * s > c_norm:
             self._update(xi, ci)
 
         if self.run_checks and all(not math.isinf(v.assign.q)
@@ -486,7 +486,7 @@ class LRASolver():
         """
         i = xi.col_idx
         assert i is not None
-        for j, b in enumerate(self.slack):
+        for j, b in enumerate(self.basic):
             aji = self.A[j, i]
             b.assign = b.assign + (v - xi.assign)*aji
         xi.assign = v
@@ -517,8 +517,8 @@ class LRASolver():
 
         from sympy.matrices.dense import Matrix
         M = self.A.copy()
-        basic = {s: i for i, s in enumerate(self.slack)}  # contains the row index associated with each basic variable
-        nonbasic = set(self.nonslack)
+        basic = {s: i for i, s in enumerate(self.basic)}  # contains the row index associated with each basic variable
+        nonbasic = set(self.nonbasic)
         while True:
             if self.run_checks:
                 # nonbasic variables must always be within bounds

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -113,8 +113,8 @@ def test_from_encoded_cnf():
     enc = boolean_formula_to_encoded_cnf(phi)
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
     assert lra.A.shape == (0, 3)
-    assert str(lra.slack) == '[]'
-    assert str(lra.nonslack) == '[x, _s1, _s2]'
+    assert str(lra.basic) == '[]'
+    assert str(lra.nonbasic) == '[x, _s1, _s2]'
     assert lra.A == Matrix(0,3, [])
     actual = {tuple(sorted((str(b.var), b.bound, b.upper, b.strict) for b in bs)) for bs in lra.atom_id_to_boundaries.values()}
     expected = {

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -114,7 +114,7 @@ def test_from_encoded_cnf():
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
     assert lra.A.shape == (0, 3)
     assert str(lra.basic) == '[]'
-    assert str(lra.nonbasic) == '[x, _s1, _s2]'
+    assert {str(v) for v in lra.nonbasic} == {'x', '_s1', '_s2'}
     assert lra.A == Matrix(0,3, [])
     actual = {tuple(sorted((str(b.var), b.bound, b.upper, b.strict) for b in bs)) for bs in lra.atom_id_to_boundaries.values()}
     expected = {

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -514,8 +514,8 @@ def test_example_from_paper():
     # Extracts the variables stored in the solver
     var_x = next(v for v in lra.all_var if str(v.var) == 'x')
     # var_y has been removed from A after the simplification
-    # var_s1 is a slack variable which corresponds for -x + y <= 1
-    # var_s2 is a slack variable which corresponds for -x - y <= 3
+    # var_s1 is a basic variable which corresponds for -x + y <= 1
+    # var_s2 is a basic variable which corresponds for -x - y <= 3
     _s1 = lra.s_subs[-x + y]
     _s2 = lra.s_subs[-x - y]
     var_s1 = next(v for v in lra.all_var if v.var == _s1)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

none

#### Brief description of what is fixed or changed
In general slack and nonslack terms are constant through the process, but basic and nonbasic are not. These terms are wrong both compared to the papers (they use basic/nonbasic through the pseucode) and after the introduction of `_reduce_matrix` the variable names would imply we were changing slack and nonslack variables, which is wrong of course. 

I also changed nonbasic to the set and basic as a list as the ordering on basic will matter in the continuation of the work, although not the nonbasic.
#### Other comments
This PR will be basis for other PRs I will open. I believe `check()` also need changes too. I am trying to implement backtracking/propagation which is sort of related to EUF solver, I was trying to make lra and euf solvers communicate,I will explain this in later PRs.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO ENTRY
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
