### PR TITLE
fix: make old assumptions cache publication thread-safe

### DIFF
--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -488,7 +488,10 @@ class StdFactKB(FactKB):
             self.deduce_all_facts(facts)
 
     def copy(self):
-        return self.__class__(self)
+        copied = self.__class__()
+        copied.update(self)
+        copied._generator = self.generator
+        return copied
 
     @property
     def generator(self):
@@ -504,18 +507,17 @@ def make_property(fact):
     """Create the automagic property corresponding to a fact."""
 
     def getit(self):
+        assumptions = self._assumptions
         try:
-            return self._assumptions[fact]
+            return assumptions[fact]
         except KeyError:
-            if self._assumptions is self.default_assumptions:
-                self._assumptions = self.default_assumptions.copy()
-            return _ask(fact, self)
+            return _ask(fact, self, assumptions)
 
     getit.func_name = as_property(fact)
     return property(getit)
 
 
-def _ask(fact, obj):
+def _ask(fact, obj, base):
     """
     Find the truth value for a property of an object.
 
@@ -540,7 +542,7 @@ def _ask(fact, obj):
     deduced, and the result is cached in ._assumptions.
     """
     # FactKB which is dict-like and maps facts to their known values:
-    assumptions = obj._assumptions
+    assumptions = base.copy()
 
     # A dict that maps facts to their handlers:
     handler_map = obj._prop_handler
@@ -552,12 +554,8 @@ def _ask(fact, obj):
     # Loop over the queue as it extends
     for fact_i in facts_to_check:
 
-        # If fact_i has already been determined then we don't need to rerun the
-        # handler. There is a potential race condition for multithreaded code
-        # though because it's possible that fact_i was checked in another
-        # thread. The main logic of the loop below would potentially skip
-        # checking assumptions[fact] in this case so we check it once after the
-        # loop to be sure.
+        # Published snapshots contain complete implication closures, so a
+        # known fact does not need its handler to be run again.
         if fact_i in assumptions:
             continue
 
@@ -574,16 +572,10 @@ def _ask(fact, obj):
         if fact_i_value is not None:
             assumptions.deduce_all_facts(((fact_i, fact_i_value),))
 
-        # Usually if assumptions[fact] is now not None then that is because of
-        # the call to deduce_all_facts above. The handler for fact_i returned
-        # True or False and knowing fact_i (which is equal to fact in the first
-        # iteration) implies knowing a value for fact. It is also possible
-        # though that independent code e.g. called indirectly by the handler or
-        # called in another thread in a multithreaded context might have
-        # resulted in assumptions[fact] being set. Either way we return it.
+        # Stop once deduction determines the requested fact.
         fact_value = assumptions.get(fact)
         if fact_value is not None:
-            return fact_value
+            break
 
         # Extend the queue with other facts that might determine fact_i. Here
         # we randomise the order of the facts that are checked. This should not
@@ -597,27 +589,11 @@ def _ask(fact, obj):
         facts_to_check.extend(new_facts_to_check)
         facts_queued.update(new_facts_to_check)
 
-    # The above loop should be able to handle everything fine in a
-    # single-threaded context but in multithreaded code it is possible that
-    # this thread skipped computing a particular fact that was computed in
-    # another thread (due to the continue). In that case it is possible that
-    # fact was inferred and is now stored in the assumptions dict but it wasn't
-    # checked for in the body of the loop. This is an obscure case but to make
-    # sure we catch it we check once here at the end of the loop.
-    if fact in assumptions:
-        return assumptions[fact]
-
-    # This query can not be answered. It's possible that e.g. another thread
-    # has already stored None for fact but assumptions._tell does not mind if
-    # we call _tell twice setting the same value. If this raises
-    # InconsistentAssumptions then it probably means that another thread
-    # attempted to compute this and got a value of True or False rather than
-    # None. In that case there must be a bug in at least one of the handlers.
-    # If the handlers are all deterministic and are consistent with the
-    # inference rules then the same value should be computed for fact in all
-    # threads.
-    assumptions._tell(fact, None)
-    return None
+    assumptions.setdefault(fact, None)
+    # Publish the complete snapshot atomically. Concurrent publications use
+    # last-writer-wins semantics and can only discard cached facts.
+    obj._assumptions = assumptions
+    return assumptions[fact]
 
 
 def _prepare_class_assumptions(cls):

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-import threading
-
 from sympy.core.mod import Mod
 from sympy.core.numbers import (I, oo, pi)
 from sympy.functions.combinatorial.factorials import factorial
@@ -8,7 +6,7 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (asin, sin)
 from sympy.simplify.simplify import simplify
-from sympy.core import Basic, Symbol, S, Rational, Integer, Dummy, Wild, Pow
+from sympy.core import Symbol, S, Rational, Integer, Dummy, Wild, Pow
 from sympy.core.assumptions import (assumptions, check_assumptions,
     failing_assumptions, common_assumptions, _generate_assumption_rules,
     _load_pre_generated_assumption_rules)
@@ -17,7 +15,7 @@ from sympy.core.random import seed
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.perm_groups import PermutationGroup
 
-from sympy.testing.pytest import raises, XFAIL, skip_under_pyodide
+from sympy.testing.pytest import raises, XFAIL
 
 
 def test_symbol_unset():
@@ -1267,57 +1265,6 @@ def test_assumptions_copy():
         'real': False,
         'transcendental': False,
         'zero': False}
-
-
-@skip_under_pyodide("Cannot create threads under pyodide.")
-def test_assumptions_copy_on_write():
-    barrier = threading.Barrier(2)
-
-    class ConcurrentFacts(Basic):
-        def _eval_is_odd(self):
-            barrier.wait()
-            return True
-
-        def _eval_is_positive(self):
-            barrier.wait()
-            return True
-
-    obj = ConcurrentFacts()
-    initial = obj._assumptions
-    results = {}
-    errors = []
-
-    def query(fact):
-        try:
-            results[fact] = getattr(obj, f"is_{fact}")
-        except BaseException as exc:
-            errors.append(exc)
-
-    threads = [
-        threading.Thread(target=query, args=(fact,))
-        for fact in ("odd", "positive")
-    ]
-    for thread in threads:
-        thread.start()
-    for thread in threads:
-        thread.join()
-
-    assert not errors
-    assert results == {"odd": True, "positive": True}
-    assert "odd" not in initial
-    assert "positive" not in initial
-
-    # Both threads started from the same snapshot, so the last publication
-    # wins. Either result is valid, but its full implication closure must be
-    # visible rather than a partially updated knowledge base.
-    assumptions = obj._assumptions
-    assert ("odd" in assumptions) != ("positive" in assumptions)
-    if "odd" in assumptions:
-        assert assumptions["odd"] is True
-        assert assumptions["even"] is False
-    else:
-        assert assumptions["positive"] is True
-        assert assumptions["nonzero"] is True
 
 
 def test_check_assumptions():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import threading
+
 from sympy.core.mod import Mod
 from sympy.core.numbers import (I, oo, pi)
 from sympy.functions.combinatorial.factorials import factorial
@@ -6,7 +8,7 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (asin, sin)
 from sympy.simplify.simplify import simplify
-from sympy.core import Symbol, S, Rational, Integer, Dummy, Wild, Pow
+from sympy.core import Basic, Symbol, S, Rational, Integer, Dummy, Wild, Pow
 from sympy.core.assumptions import (assumptions, check_assumptions,
     failing_assumptions, common_assumptions, _generate_assumption_rules,
     _load_pre_generated_assumption_rules)
@@ -15,7 +17,7 @@ from sympy.core.random import seed
 from sympy.combinatorics import Permutation
 from sympy.combinatorics.perm_groups import PermutationGroup
 
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises, XFAIL, skip_under_pyodide
 
 
 def test_symbol_unset():
@@ -1265,6 +1267,57 @@ def test_assumptions_copy():
         'real': False,
         'transcendental': False,
         'zero': False}
+
+
+@skip_under_pyodide("Cannot create threads under pyodide.")
+def test_assumptions_copy_on_write():
+    barrier = threading.Barrier(2)
+
+    class ConcurrentFacts(Basic):
+        def _eval_is_odd(self):
+            barrier.wait()
+            return True
+
+        def _eval_is_positive(self):
+            barrier.wait()
+            return True
+
+    obj = ConcurrentFacts()
+    initial = obj._assumptions
+    results = {}
+    errors = []
+
+    def query(fact):
+        try:
+            results[fact] = getattr(obj, f"is_{fact}")
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=query, args=(fact,))
+        for fact in ("odd", "positive")
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert results == {"odd": True, "positive": True}
+    assert "odd" not in initial
+    assert "positive" not in initial
+
+    # Both threads started from the same snapshot, so the last publication
+    # wins. Either result is valid, but its full implication closure must be
+    # visible rather than a partially updated knowledge base.
+    assumptions = obj._assumptions
+    assert ("odd" in assumptions) != ("positive" in assumptions)
+    if "odd" in assumptions:
+        assert assumptions["odd"] is True
+        assert assumptions["even"] is False
+    else:
+        assert assumptions["positive"] is True
+        assert assumptions["nonzero"] is True
 
 
 def test_check_assumptions():

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -677,8 +677,12 @@ class Idx(Expr):
             args = label,
 
         obj = Expr.__new__(cls, *args, **kw_args)
-        obj._assumptions["finite"] = True
-        obj._assumptions["real"] = True
+        assumptions = obj._assumptions.copy()
+        assumptions.deduce_all_facts((
+            ("finite", True),
+            ("real", True),
+        ))
+        obj._assumptions = assumptions
         return obj
 
     @property


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

See gh-28239

#### Brief description of what is fixed or changed

Queries in the core (old) assumptions system update a dict _assumptions attached to any Basic instance. Updates to this dictionary were not thread-safe so that if two different threads simultaneously run queries there would be bugs resulting in different threads seeing inconsistent answers to the same queries and sometimes resulting in
InconsistentAssumptions exceptions.
    
This commit makes it so that whenever one thread is giong to mutate _assumptions it will start by making a copy of the dict and then will mutate that copy. Updating obj._assumptions then happens as a single atomic update that replaces the whole dict with the updated copy. This ensures thread-safety but incurs some runtime overhead from needing to copy the dict.

#### Other comments

I don't have a specific test case for the failure here but in general if you install pytest-run-parallel and run tests like
```
pytest sympy/core --parallel-threads=4
```
then there are a lot of test failures. The particular fix here is a cause of test failures seen all over the test suite so this is fixing the biggest broad thread-safety issue in SymPy that affects all of Expr/Basic.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Written by codex after much discussion.

EDIT: I was working on a branch for a while (using codex) to improve multithreaded correctness of sympy usage and I accumulated a bunch of differnet changes. What happened in this PR is that I asked codex to pull out one particularly important change as a separate ### PR.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
   * A significant bug is fixed in the old assumptions making many SymPy operations thread-safe in highly concurrent usage. Previously assumptions queries could give incorrect results or fail with exceptions and this could affect most multithreaded use of SymPy expressions.
<!-- END RELEASE NOTES -->
