### PR TITLE
Mark process-global state tests as thread-unsafe

### DIFF
--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -9,6 +9,8 @@ import os
 import re
 from pathlib import Path
 
+import pytest
+
 from sympy.assumptions.ask import Q
 from sympy.core.basic import Basic
 from sympy.core.function import (Function, Lambda)
@@ -30,6 +32,9 @@ whitelist = [
      "sympy.assumptions.relation.equality",    # tested by test_predicates()
 ]
 
+@pytest.mark.thread_unsafe(
+    reason="performs a package-wide import scan that cannot run concurrently"
+)
 def test_all_classes_are_tested():
     this = os.path.split(__file__)[0]
     path = os.path.join(this, os.pardir, os.pardir)

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+import pytest
+
 from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.mod import Mod
@@ -1693,6 +1696,9 @@ def test_AssocOp_doit():
     assert d.doit().args == (4*S.One, Pow(x,2))
 
 
+@pytest.mark.thread_unsafe(
+    reason="expects warning side effects from cached constructors"
+)
 def test_Add_Mul_Expr_args():
     nonexpr = [Basic(), Poly(x, x), FiniteSet(x)]
     for typ in [Add, Mul]:

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+import pytest
+
 from sympy.core.mod import Mod
 from sympy.core.numbers import (I, oo, pi)
 from sympy.functions.combinatorial.factorials import factorial
@@ -1320,6 +1323,9 @@ def test_pre_generated_assumption_rules_are_valid():
     assert pre_generated_assumptions._to_python() == generated_assumptions._to_python(), "pre-generated assumptions are invalid, see sympy.core.assumptions._generate_assumption_rules"
 
 
+@pytest.mark.thread_unsafe(
+    reason="resets and consumes process-global RNG state"
+)
 def test_ask_shuffle():
     grp = PermutationGroup(Permutation(1, 0, 2), Permutation(2, 1, 3))
 

--- a/sympy/core/tests/test_compatibility.py
+++ b/sympy/core/tests/test_compatibility.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
+
+import pytest
+
 from sympy.testing.pytest import warns_deprecated_sympy
 
+
+@pytest.mark.thread_unsafe(
+    reason="expects a warning side effect from a one-time module import"
+)
 def test_compatibility_submodule():
     # Test the sympy.core.compatibility deprecation warning
     with warns_deprecated_sympy():

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 import numbers as nums
 import decimal
+
+import pytest
+
 from sympy.concrete.summations import Sum
 from sympy.core import (EulerGamma, Catalan, TribonacciConstant,
     GoldenRatio)
@@ -50,6 +53,7 @@ def same_and_same_prec(a, b):
     return a == b and a._prec == b._prec
 
 
+@pytest.mark.thread_unsafe(reason="mutates process-global division error state")
 def test_seterr():
     seterr(divide=True)
     raises(ValueError, lambda: S.Zero/S.Zero)
@@ -323,6 +327,9 @@ def test_Integer_new():
     assert Integer(Rational('1.' + '9'*20)) == 1
 
 
+@pytest.mark.thread_unsafe(
+    reason="expects warning side effects from cached constructors"
+)
 def test_Rational_new():
     """"
     Test for Rational constructor

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+import pytest
+
 from sympy.core import (
     Basic, Rational, Symbol, S, Float, Integer, Mul, Number, Pow,
     Expr, I, nan, pi, symbols, oo, zoo, N)
@@ -195,6 +198,9 @@ def test_issue_4362():
     assert ((1 + x/y)**i).as_numer_denom() == ((x + y)**i, y**i)
 
 
+@pytest.mark.thread_unsafe(
+    reason="expects warning side effects from cached constructors"
+)
 def test_Pow_Expr_args():
     bases = [Basic(), Poly(x, x), FiniteSet(x)]
     for base in bases:

--- a/sympy/core/tests/test_random.py
+++ b/sympy/core/tests/test_random.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 import random
+
+import pytest
+
 from sympy.core.random import random as rand, seed, shuffle, _assumptions_shuffle
 from sympy.core.symbol import Symbol, symbols
 from sympy.functions.elementary.trigonometric import sin, acos
 from sympy.abc import x
 
 
+@pytest.mark.thread_unsafe(reason="resets and consumes process-global RNG state")
 def test_random():
     random.seed(42)
     a = random.random()
@@ -33,6 +37,7 @@ def test_random():
     assert y == z
 
 
+@pytest.mark.thread_unsafe(reason="resets and consumes process-global RNG state")
 def test_seed():
     assert rand() < 1
     seed(1)

--- a/sympy/core/tests/test_singleton.py
+++ b/sympy/core/tests/test_singleton.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
+
+import pytest
+
 from sympy.core.basic import Basic
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S, Singleton
 
+@pytest.mark.thread_unsafe(
+    reason="registers temporary classes in the process-global singleton registry"
+)
 def test_Singleton():
 
     class MySingleton(Basic, metaclass=Singleton):
@@ -20,6 +26,9 @@ def test_Singleton():
     assert MySingleton_sub() is not MySingleton()
     assert MySingleton_sub() is MySingleton_sub()
 
+@pytest.mark.thread_unsafe(
+    reason="registers temporary classes in the process-global singleton registry"
+)
 def test_singleton_redefinition():
     class TestSingleton(Basic, metaclass=Singleton):
         pass


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

See gh-28239

#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Used codex to write these

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
