### PR TITLE
fix(core): Exclude evaluation-parameter tests from concurrent execution

### DIFF
--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+import pytest
+
 from sympy.concrete.summations import Sum
 from sympy.core.basic import Basic, _aresame
 from sympy.core.cache import clear_cache
@@ -1179,6 +1182,11 @@ def test_Derivative_as_finite_difference():
     assert (d2fdxdy.as_finite_difference() - ref2).simplify() == 0
 
 
+# XXX: The expression cache is shared between threads but does not include the
+# thread-local exp_is_pow setting in its cache keys.
+@pytest.mark.thread_unsafe(
+    reason="changes exp_is_pow while using the shared expression cache"
+)
 def test_issue_11159():
     # Tests Application._eval_subs
     with _exp_is_pow(False):

--- a/sympy/core/tests/test_parameters.py
+++ b/sympy/core/tests/test_parameters.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
+
+import pytest
+
 from sympy.abc import x, y
 from sympy.core.parameters import evaluate
 from sympy.core import Mul, Add, Pow, S
 from sympy.core.numbers import oo
 from sympy.functions.elementary.miscellaneous import sqrt
+
+
+pytestmark = pytest.mark.thread_unsafe(
+    reason="changes thread-local evaluation modes while using the shared expression cache"
+)
 
 def test_add():
     with evaluate(False):


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

gh-28239

#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Used codex.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
