### PR TITLE
test: make the sympy/core tests compatible with pytest-run-parallel

### DIFF
--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -20,7 +20,7 @@ from sympy.utilities.misc import filldedent
 import string
 import re as _re
 import random
-from itertools import product
+from itertools import count, product
 
 
 if TYPE_CHECKING:
@@ -502,7 +502,7 @@ class Dummy(Symbol):
     # If a new session is started between `srepr` and `eval`, there is a very
     # small chance that `d2` will be equal to a previously-created Dummy.
 
-    _count = 0
+    _count = count()
     _prng = random.Random()
     _base_dummy_index = _prng.randint(10**6, 9*10**6)
 
@@ -516,12 +516,11 @@ class Dummy(Symbol):
         if dummy_index is not None:
             assert name is not None, "If you specify a dummy_index, you must also provide a name"
 
-        if name is None:
-            name = "Dummy_" + str(Dummy._count)
-
         if dummy_index is None:
-            dummy_index = Dummy._base_dummy_index + Dummy._count
-            Dummy._count += 1
+            count_value = next(Dummy._count)
+            dummy_index = Dummy._base_dummy_index + count_value
+            if name is None:
+                name = "Dummy_" + str(count_value)
 
         cls._sanitize(assumptions, cls)
         obj = Symbol.__xnew__(cls, name, **assumptions)

--- a/sympy/core/tests/test_operations.py
+++ b/sympy/core/tests/test_operations.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+import pytest
+
 from sympy.core.expr import Expr
 from sympy.core.numbers import Integer
 from sympy.core.singleton import S
@@ -71,6 +74,9 @@ def test_AssocOp_flatten():
     assert MyAssoc(a, v).args == (a, b, c, d)
 
 
+@pytest.mark.thread_unsafe(
+    reason="registers handlers in the process-global add dispatcher"
+)
 def test_add_dispatcher():
 
     class NewBase(Expr):
@@ -91,6 +97,9 @@ def test_add_dispatcher():
     assert add(a,b,a) == NewAdd(2*a, b)
 
 
+@pytest.mark.thread_unsafe(
+    reason="registers handlers in the process-global multiply dispatcher"
+)
 def test_mul_dispatcher():
 
     class NewBase(Expr):

--- a/sympy/core/tests/test_power.py
+++ b/sympy/core/tests/test_power.py
@@ -624,6 +624,9 @@ def test_rational_powers_larger_than_one():
     assert Rational(3, 7)**Rational(7, 3) == 9*3**Rational(1, 3)*7**Rational(2, 3)/343
 
 
+@pytest.mark.thread_unsafe(
+    reason="registers handlers in the process-global power dispatcher"
+)
 def test_power_dispatcher():
 
     class NewBase(Expr):

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -47,6 +47,30 @@ def test_Dummy():
     assert Dummy() != Dummy()
 
 
+@skip_under_pyodide("Cannot create threads under pyodide.")
+def test_Dummy_concurrent_creation():
+    thread_count = 8
+    dummies_per_thread = 2000
+    barrier = threading.Barrier(thread_count)
+    results = [None] * thread_count
+
+    def create_dummies(index):
+        barrier.wait()
+        results[index] = [Dummy('x') for _ in range(dummies_per_thread)]
+
+    threads = [
+        threading.Thread(target=create_dummies, args=(index,))
+        for index in range(thread_count)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    dummies = [dummy for result in results for dummy in result]
+    assert len({dummy.dummy_index for dummy in dummies}) == len(dummies)
+
+
 def test_Dummy_force_dummy_index():
     raises(AssertionError, lambda: Dummy(dummy_index=1))
     assert Dummy('d', dummy_index=2) == Dummy('d', dummy_index=2)
@@ -57,7 +81,6 @@ def test_Dummy_force_dummy_index():
     assert d1 != d2
     d3 = Dummy('d', dummy_index=3)
     assert d1 == d3
-    assert Dummy()._count == Dummy('d', dummy_index=3)._count
 
 
 def test_lt_gt():

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -28,11 +28,12 @@ from sympy.geometry import Point, Line
 from sympy.functions.combinatorial.factorials import factorial, factorial2
 from sympy.abc import _clash, _clash1, _clash2
 from sympy.external.gmpy import gmpy as _gmpy, flint as _flint
-from sympy.external.mpmath import conserve_mpmath_dps
+from sympy.external.mpmath import conserve_mpmath_dps, local_workdps
 from sympy.sets import FiniteSet, EmptySet
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
 
 import mpmath
+import pytest
 from collections import defaultdict, OrderedDict
 
 
@@ -122,6 +123,7 @@ def test_sympify_flint():
         assert value == Rational(101, 127) and type(value) is Rational
 
 
+@pytest.mark.thread_unsafe(reason="uses mpmath's process-global context")
 @conserve_mpmath_dps
 def test_sympify_mpmath():
     value = sympify(mpmath.mpf(1.0))
@@ -141,6 +143,26 @@ def test_sympify_mpmath():
 
     mpmath.mp.dps = 15
     assert sympify(mpmath.mpc(1.0 + 2.0j)) == Float(1.0) + Float(2.0)*I
+
+
+def test_sympify_mpmath_local():
+    with local_workdps(15) as ctx:
+        value = sympify(ctx.mpf(1.0))
+        assert value == Float(1.0) and type(value) is Float
+
+    with local_workdps(12) as ctx:
+        value = sympify(ctx.pi)
+        assert value.epsilon_eq(Float("3.14159265359"), Float("1e-12"))
+        assert not value.epsilon_eq(Float("3.14159265359"), Float("1e-13"))
+
+    with local_workdps(6) as ctx:
+        value = sympify(ctx.pi)
+        assert value.epsilon_eq(Float("3.14159"), Float("1e-5"))
+        assert not value.epsilon_eq(Float("3.14159"), Float("1e-6"))
+
+    with local_workdps(15) as ctx:
+        value = sympify(ctx.mpc(1.0 + 2.0j))
+        assert value == Float(1.0) + Float(2.0)*I
 
 
 def test_sympify2():
@@ -543,6 +565,9 @@ def test_issue_6540_6552():
     assert S('Matrix([2*(1)])') == Matrix([2])
 
 
+@pytest.mark.thread_unsafe(
+    reason="temporarily mutates process-global clash dictionaries"
+)
 def test_issue_6046():
     assert str(S("Q & C", locals=_clash1)) == 'C & Q'
     assert str(S('pi(x)', locals=_clash2)) == 'pi(x)'

--- a/sympy/polys/numberfields/galois_resolvents.py
+++ b/sympy/polys/numberfields/galois_resolvents.py
@@ -297,43 +297,38 @@ class Resolvent:
 
         """
         with local_workprec(53) as mp:
-            return self._approximate_roots_of_poly(T, target, mp)
+            # Because sympy.polys.polyroots._integer_basis() is called when a
+            # CRootOf is formed, we proactively extract the integer basis now.
+            # This means that when we call T.all_roots(), every root will be a
+            # CRootOf, not a Mul of Integer*CRootOf.
+            coeff, T = preprocess_roots(T)
+            coeff = mp.mpf(str(coeff))
 
-    def _approximate_roots_of_poly(self, T, target, mp):
-        """Internal implementation using the supplied mpmath context."""
+            scaled_roots = T.all_roots(radicals=False)
 
-        # Because sympy.polys.polyroots._integer_basis() is called when a
-        # CRootOf is formed, we proactively extract the integer basis now.
-        # This means that when we call T.all_roots(), every root will be a
-        # CRootOf, not a Mul of Integer*CRootOf.
-        coeff, T = preprocess_roots(T)
-        coeff = mp.mpf(str(coeff))
+            # Since we're going to be approximating the roots of T anyway, we
+            # can get a good upper bound on the magnitude of the roots by
+            # starting with a very low precision approx.
+            approx0 = [coeff * quad_to_mpmath(_evalf_with_bounded_error(r, m=0), mp) for r in scaled_roots]
+            # Here we add 1 to account for the possible error in our initial
+            # approximation.
+            M = mp.fadd(max(mp.fabs(b) for b in approx0), 1)
+            m = self.get_prec(M, target=target)
+            n = fastlog(M._mpf_) + 1
+            p = m + n + 1
+            mp.prec = p
+            d = prec_to_dps(p)
 
-        scaled_roots = T.all_roots(radicals=False)
+            approx1 = [
+                r.eval_approx(d, return_mpmath=True, context=mp)
+                for r in scaled_roots
+            ]
+            approx1 = [mp.fmul(coeff, mp.mpc(r)) for r in approx1]
 
-        # Since we're going to be approximating the roots of T anyway, we
-        # can get a good upper bound on the magnitude of the roots by
-        # starting with a very low precision approx.
-        approx0 = [coeff * quad_to_mpmath(_evalf_with_bounded_error(r, m=0), mp) for r in scaled_roots]
-        # Here we add 1 to account for the possible error in our initial
-        # approximation.
-        M = mp.fadd(max(mp.fabs(b) for b in approx0), 1)
-        m = self.get_prec(M, target=target)
-        n = fastlog(M._mpf_) + 1
-        p = m + n + 1
-        mp.prec = p
-        d = prec_to_dps(p)
-
-        approx1 = [
-            r.eval_approx(d, return_mpmath=True, context=mp)
-            for r in scaled_roots
-        ]
-        approx1 = [mp.fmul(coeff, mp.mpc(r)) for r in approx1]
-
-        return [
-            Float._new(root.real._mpf_, p) + I*Float._new(root.imag._mpf_, p)
-            for root in approx1
-        ]
+            return [
+                Float._new(root.real._mpf_, p) + I*Float._new(root.imag._mpf_, p)
+                for root in approx1
+            ]
 
     @staticmethod
     def round_mpf(a):

--- a/sympy/polys/numberfields/galois_resolvents.py
+++ b/sympy/polys/numberfields/galois_resolvents.py
@@ -340,7 +340,7 @@ class Resolvent:
         if isinstance(a, int):
             return a
         if not hasattr(a, 'context'):
-            return ZZ(a.round())
+            return ZZ(int(a.round()))
         # If we use python's built-in `round()`, we lose precision.
         # If we use `ZZ` directly, we may add or subtract 1.
         #

--- a/sympy/polys/numberfields/galois_resolvents.py
+++ b/sympy/polys/numberfields/galois_resolvents.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 from sympy.core.evalf import (
     evalf, fastlog, _evalf_with_bounded_error, quad_to_mpmath,
 )
+from sympy.core.numbers import Float, I
 from sympy.core.symbol import symbols, Dummy
-from sympy.external.mpmath import prec_to_dps, local_workprec
+from sympy.external.mpmath import local_workprec, prec_to_dps
 from sympy.polys.densetools import dup_eval
 from sympy.polys.domains import ZZ
 from sympy.polys.orderings import lex
@@ -296,43 +297,62 @@ class Resolvent:
 
         """
         with local_workprec(53) as mp:
-            # Because sympy.polys.polyroots._integer_basis() is called when a
-            # CRootOf is formed, we proactively extract the integer basis now.
-            # This means that when we call T.all_roots(), every root will be a
-            # CRootOf, not a Mul of Integer*CRootOf.
-            coeff, T = preprocess_roots(T)
-            coeff = mp.mpf(str(coeff))
+            return self._approximate_roots_of_poly(T, target, mp)
 
-            scaled_roots = T.all_roots(radicals=False)
+    def _approximate_roots_of_poly(self, T, target, mp):
+        """Internal implementation using the supplied mpmath context."""
 
-            # Since we're going to be approximating the roots of T anyway, we
-            # can get a good upper bound on the magnitude of the roots by
-            # starting with a very low precision approx.
-            approx0 = [coeff * quad_to_mpmath(_evalf_with_bounded_error(r, m=0), mp) for r in scaled_roots]
-            # Here we add 1 to account for the possible error in our initial
-            # approximation.
-            M = mp.fadd(max(mp.fabs(b) for b in approx0), 1)
-            m = self.get_prec(M, target=target)
-            n = fastlog(M._mpf_) + 1
-            p = m + n + 1
-            mp.prec = p
-            d = prec_to_dps(p)
+        # Because sympy.polys.polyroots._integer_basis() is called when a
+        # CRootOf is formed, we proactively extract the integer basis now.
+        # This means that when we call T.all_roots(), every root will be a
+        # CRootOf, not a Mul of Integer*CRootOf.
+        coeff, T = preprocess_roots(T)
+        coeff = mp.mpf(str(coeff))
 
-            approx1 = [r.eval_approx(d, return_mpmath=True) for r in scaled_roots]
-            approx1 = [mp.fmul(coeff, mp.mpc(r)) for r in approx1]
+        scaled_roots = T.all_roots(radicals=False)
 
-            return approx1
+        # Since we're going to be approximating the roots of T anyway, we
+        # can get a good upper bound on the magnitude of the roots by
+        # starting with a very low precision approx.
+        approx0 = [coeff * quad_to_mpmath(_evalf_with_bounded_error(r, m=0), mp) for r in scaled_roots]
+        # Here we add 1 to account for the possible error in our initial
+        # approximation.
+        M = mp.fadd(max(mp.fabs(b) for b in approx0), 1)
+        m = self.get_prec(M, target=target)
+        n = fastlog(M._mpf_) + 1
+        p = m + n + 1
+        mp.prec = p
+        d = prec_to_dps(p)
+
+        approx1 = [
+            r.eval_approx(d, return_mpmath=True, context=mp)
+            for r in scaled_roots
+        ]
+        approx1 = [mp.fmul(coeff, mp.mpc(r)) for r in approx1]
+
+        return [
+            Float._new(root.real._mpf_, p) + I*Float._new(root.imag._mpf_, p)
+            for root in approx1
+        ]
 
     @staticmethod
     def round_mpf(a):
         if isinstance(a, int):
             return a
+        if not hasattr(a, 'context'):
+            return ZZ(a.round())
         # If we use python's built-in `round()`, we lose precision.
         # If we use `ZZ` directly, we may add or subtract 1.
         #
         # XXX: We have to convert to int before converting to ZZ because
         # flint.fmpz cannot convert a mpmath mpf.
         return ZZ(int(a.context.nint(a)))
+
+    @staticmethod
+    def real_imag(a):
+        if isinstance(a, int):
+            return a, 0
+        return a.evalf().as_real_imag()
 
     def round_roots_to_integers_for_poly(self, T):
         """
@@ -369,9 +389,10 @@ class Resolvent:
         approx_roots_of_T = self.approximate_roots_of_poly(T, target='roots')
         approx_roots_of_self = [r(*approx_roots_of_T) for r in self.root_lambdas]
         return {
-            i: self.round_mpf(r.real)
+            i: self.round_mpf(re)
             for i, r in enumerate(approx_roots_of_self)
-            if self.round_mpf(r.imag) == 0
+            for re, im in [self.real_imag(r)]
+            if self.round_mpf(im) == 0
         }
 
     def eval_for_poly(self, T, find_integer_root=False):
@@ -409,18 +430,21 @@ class Resolvent:
 
         R = []
         for c in approx_coeffs_of_self:
-            if self.round_mpf(c.imag) != 0:
+            re, im = self.real_imag(c)
+            if self.round_mpf(im) != 0:
                 # If precision was enough, this should never happen.
-                raise ResolventException(f"Got non-integer coeff for resolvent: {c}")
-            R.append(self.round_mpf(c.real))
+                raise ResolventException(
+                    f"Got non-integer coeff for resolvent: {c}")
+            R.append(self.round_mpf(re))
 
         a0, i0 = None, None
 
         if find_integer_root:
             for i, r in enumerate(approx_roots_of_self):
-                if self.round_mpf(r.imag) != 0:
+                re, im = self.real_imag(r)
+                if self.round_mpf(im) != 0:
                     continue
-                if not dup_eval(R, (a := self.round_mpf(r.real)), ZZ):
+                if not dup_eval(R, (a := self.round_mpf(re)), ZZ):
                     a0, i0 = a, i
                     break
 

--- a/sympy/polys/numberfields/tests/test_galoisgroups.py
+++ b/sympy/polys/numberfields/tests/test_galoisgroups.py
@@ -1,6 +1,8 @@
 """Tests for computing Galois groups. """
 from __future__ import annotations
 
+import pytest
+
 from sympy.abc import x
 from sympy.combinatorics.galois import (
     S1TransitiveSubgroups, S2TransitiveSubgroups, S3TransitiveSubgroups,
@@ -18,6 +20,7 @@ from sympy.polys.polytools import Poly
 from sympy.testing.pytest import raises
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling with concurrent root analysis")
 def test_tschirnhausen_transformation():
     for T in [
         Poly(x**2 - 2),
@@ -129,6 +132,7 @@ def test__galois_group_degree_4_root_approx():
         assert _galois_group_degree_4_root_approx(Poly(T)) == (G, alt)
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling with concurrent root analysis")
 def test__galois_group_degree_5_hybrid():
     for T, G, alt in test_polys_by_deg[5]:
         assert _galois_group_degree_5_hybrid(Poly(T)) == (G, alt)

--- a/sympy/polys/numberfields/tests/test_subfield.py
+++ b/sympy/polys/numberfields/tests/test_subfield.py
@@ -1,6 +1,8 @@
 """Tests for the subfield problem and allied problems. """
 from __future__ import annotations
 
+import pytest
+
 from sympy.core.numbers import (AlgebraicNumber, I, pi, Rational)
 from sympy.core.singleton import S
 from sympy.functions.elementary.exponential import exp
@@ -306,6 +308,7 @@ def test_issue_22736():
     assert field_isomorphism(a, b) == [1, 0]
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling with concurrent root analysis")
 def test_issue_27798():
     # https://github.com/sympy/sympy/issues/27798
     a, b = CRootOf(49*x**3 - 49*x**2 + 14*x - 1, 2), CRootOf(49*x**3 - 49*x**2 + 14*x - 1, 0)

--- a/sympy/polys/rootisolation.py
+++ b/sympy/polys/rootisolation.py
@@ -1786,11 +1786,17 @@ class RealInterval:
     @property
     def b(self):
         """Return the position of the right end. """
-        was = self.neg
-        self.neg = not was
-        rv = -self.a
-        self.neg = was
-        return rv
+        field = self.dom.get_field()
+        a, b, c, d = self.mobius
+
+        if not self.neg:
+            if a*d > b*c:
+                return field(a, c)
+            return field(b, d)
+        else:
+            if a*d < b*c:
+                return -field(a, c)
+            return -field(b, d)
 
     @property
     def dx(self):

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -437,9 +437,9 @@ class ComplexRootOf(RootOf):
         if use_cache and currentfactor in _reals_cache:
             real_part = _reals_cache[currentfactor]
         else:
-            _reals_cache[currentfactor] = real_part = \
-                dup_isolate_real_roots_sqf(
-                    currentfactor.rep.to_list(), currentfactor.rep.dom, blackbox=True)
+            real_part = dup_isolate_real_roots_sqf(
+                currentfactor.rep.to_list(), currentfactor.rep.dom,
+                blackbox=True)
 
         return real_part
 
@@ -449,8 +449,7 @@ class ComplexRootOf(RootOf):
         if use_cache and currentfactor in _complexes_cache:
             complex_part = _complexes_cache[currentfactor]
         else:
-            _complexes_cache[currentfactor] = complex_part = \
-                dup_isolate_complex_roots_sqf(
+            complex_part = dup_isolate_complex_roots_sqf(
                 currentfactor.rep.to_list(), currentfactor.rep.dom, blackbox=True)
         return complex_part
 
@@ -471,6 +470,12 @@ class ComplexRootOf(RootOf):
                 reals.extend(new)
 
         reals = cls._reals_sorted(reals)
+
+        real_factors = {factor for _, factor, _ in reals}
+        for currentfactor, _ in factors:
+            if currentfactor not in real_factors:
+                _reals_cache[currentfactor] = []
+
         return reals
 
     @classmethod
@@ -490,6 +495,12 @@ class ComplexRootOf(RootOf):
                 complexes.extend(new)
 
         complexes = cls._complexes_sorted(complexes)
+
+        complex_factors = {factor for _, factor, _ in complexes}
+        for currentfactor, _ in factors:
+            if currentfactor not in complex_factors:
+                _complexes_cache[currentfactor] = []
+
         return complexes
 
     @classmethod

--- a/sympy/polys/rootoftools.py
+++ b/sympy/polys/rootoftools.py
@@ -1,7 +1,7 @@
 """Implementation of RootOf class and related tools. """
 from __future__ import annotations
 
-
+from contextlib import nullcontext
 
 from sympy.core.basic import Basic
 from sympy.core import (S, Expr, Integer, Float, I, oo, Add, Lambda,
@@ -914,16 +914,22 @@ class ComplexRootOf(RootOf):
         expr, i = self.args
         return self.func(expr, i + (1 if self._get_interval().conj else -1))
 
-    def eval_approx(self, n, return_mpmath=False):
+    def eval_approx(self, n, return_mpmath=False, context=None):
         """Evaluate this complex root to the given precision.
 
         This uses secant method and root bounds are used to both
         generate an initial guess and to check that the root
         returned is valid. If ever the method converges outside the
         root bounds, the bounds will be made smaller and updated.
+
+        If ``context`` is provided, it is used for the calculation instead
+        of borrowing a local mpmath context. This is required when returning
+        an mpmath value so that the caller owns the value's context for as
+        long as it is used.
         """
         prec = dps_to_prec(n)
-        with local_workprec(prec) as mp:
+        workprec = local_workprec(prec) if context is None else nullcontext(context)
+        with workprec as mp:
             g = self.poly.gen
             if not g.is_Symbol:
                 d = Dummy('x')

--- a/sympy/polys/series/tests/test_hypothesis.py
+++ b/sympy/polys/series/tests/test_hypothesis.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from hypothesis.strategies import composite
@@ -66,6 +68,7 @@ def dup_one_const(draw, min_size=3, max_size=25):
 
 @settings(max_examples=25)
 @given(f=dup_zero_const())
+@pytest.mark.thread_unsafe(reason="has pathological scaling under concurrent series expansion")
 def test_rs_series_zero(f):
     Rs, _ = power_series_ring("x", QQ, 25)
     Rp, x = ring("x", QQ)
@@ -89,6 +92,7 @@ def test_rs_series_zero(f):
 
 
 @given(f=dup_one_const())
+@pytest.mark.thread_unsafe(reason="has pathological scaling under concurrent series expansion")
 def test_rs_series_one(f):
     Rs, _ = power_series_ring("x", QQ, 25)
     Rp, x = ring("x", QQ)
@@ -122,6 +126,7 @@ def test_global_series_zero(f):
 
 
 @given(f=dup_one_const(max_size=5))
+@pytest.mark.thread_unsafe(reason="has pathological scaling under concurrent series expansion")
 def test_global_series_one(f):
     Rs, _ = power_series_ring("x", QQ, 5)
 

--- a/sympy/polys/tests/test_galoistools.py
+++ b/sympy/polys/tests/test_galoistools.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+import pytest
+
 from sympy.polys.galoistools import (
     gf_crt, gf_crt1, gf_crt2, gf_int,
     gf_degree, gf_strip, gf_trunc, gf_normal,
@@ -444,6 +447,7 @@ def test_gf_irreducible():
     assert gf_irreducible_p(gf_irreducible(7, 11, ZZ), 11, ZZ) is True
 
 
+@pytest.mark.thread_unsafe(reason="changes process-global polynomial configuration")
 def test_gf_irreducible_p():
     assert gf_irred_p_ben_or(ZZ.map([7]), 11, ZZ) is True
     assert gf_irred_p_ben_or(ZZ.map([7, 3]), 11, ZZ) is True

--- a/sympy/polys/tests/test_hypothesis.py
+++ b/sympy/polys/tests/test_hypothesis.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import pytest
 from hypothesis import given
 from hypothesis import settings, strategies as st
 from hypothesis.strategies import composite
@@ -191,6 +193,7 @@ def test_dup_series_mul_rational_karatsuba_boundary():
     pow=st.integers(min_value=0, max_value=10),
     n=st.integers(min_value=3, max_value=200),
 )
+@pytest.mark.thread_unsafe(reason="has pathological scaling under concurrent series expansion")
 def test_dup_series_pow_rational(f, pow, n):
     Dup_pow = dup_truncate(dup_pow(f, pow, QQ), n, QQ)
     series_pow = dup_series_pow(f, pow, n, QQ)

--- a/sympy/polys/tests/test_polyroots.py
+++ b/sympy/polys/tests/test_polyroots.py
@@ -1,6 +1,8 @@
 """Tests for algorithms for computing symbolic roots of polynomials. """
 from __future__ import annotations
 
+import pytest
+
 from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, Wild, symbols)
@@ -187,6 +189,7 @@ def test_roots_cubic():
         ]
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling with concurrent root analysis")
 def test_roots_quartic():
     assert roots_quartic(Poly(x**4, x)) == [0, 0, 0, 0]
     assert roots_quartic(Poly(x**4 + x**3, x)) in [
@@ -250,6 +253,7 @@ def test_issue_21287():
         Poly(x**4 - x**2*(3 + 5*I) + 2*x*(-1 + I) - 1 + 3*I, x)))
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling with concurrent root analysis")
 def test_roots_quintic():
     eqs = (x**5 - 2,
             (x/2 + 1)**5 - 5*(x/2 + 1) + 12,

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import pickle
 
+import pytest
+
 from sympy.polys.polytools import (
     Poly, PurePoly, poly,
     parallel_poly_from_expr,
@@ -304,6 +306,7 @@ def test_Poly_from_expr():
     assert Poly.from_expr(y + 5, x, y, domain=ZZ).rep == DMP([[ZZ(1), ZZ(5)]], ZZ)
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling with concurrent root analysis")
 def test_Poly_rootof_extension():
     r1 = rootof(x**3 + x + 3, 0)
     r2 = rootof(x**3 + x + 3, 1)
@@ -332,6 +335,7 @@ def test_Poly_rootof_same_symbol_issue_26808():
     assert Poly(r1, x, extension=True) == Poly(r1, x, domain=K1)
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling with concurrent root analysis")
 def test_Poly_rootof_extension_to_sympy():
     # Verify that when primitive elements and RootOf are used, the expression
     # is not exploded on the way back to sympy.
@@ -1208,6 +1212,7 @@ def test_Poly_lift():
     assert p.lift() == Poly(x**8 + x**2 - 34*x + 289, x, domain='QQ')
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling under concurrent polynomial lifting")
 def test_Poly_lift_multiple():
 
     r1 = rootof(y**3 + y**2 - 1, 0)
@@ -2708,6 +2713,7 @@ def test_sqf():
     ])
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling under concurrent factorization")
 def test_factor():
     f = x**5 - x**3 - x**2 + 1
 
@@ -4133,6 +4139,7 @@ def test_issue_28156():
     assert roots
 
 
+@pytest.mark.thread_unsafe(reason="has pathological scaling with concurrent root analysis")
 def test_hurwitz_conditions():
     raises(ValueError, lambda: Poly(0, x).hurwitz_conditions())
     raises(NotImplementedError, lambda: Poly(x**2 + (1+I)).hurwitz_conditions())

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -1,6 +1,8 @@
 """Tests for the implementation of RootOf class and related tools. """
 from __future__ import annotations
 
+import pytest
+
 from sympy.polys.polytools import Poly
 import sympy.polys.rootoftools as rootoftools
 from sympy.polys.rootoftools import (rootof, RootOf, CRootOf, RootSum,
@@ -391,6 +393,7 @@ def test_CRootOf_eval_rational():
              ]
 
 
+@pytest.mark.thread_unsafe(reason="clears and inspects process-global CRootOf caches")
 def test_CRootOf_lazy():
     # irreducible poly with both real and complex roots:
     f = Poly(x**3 + 2*x + 2)

--- a/sympy/polys/tests/test_rootoftools.py
+++ b/sympy/polys/tests/test_rootoftools.py
@@ -1,6 +1,9 @@
 """Tests for the implementation of RootOf class and related tools. """
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
 import pytest
 
 from sympy.polys.polytools import Poly
@@ -26,7 +29,7 @@ from sympy.polys.orthopolys import legendre_poly
 from sympy.solvers.solvers import solve
 
 
-from sympy.testing.pytest import raises, slow
+from sympy.testing.pytest import raises, skip_under_pyodide, slow
 from sympy.core.expr import unchanged
 
 from sympy.abc import a, b, x, y, z, r
@@ -622,6 +625,27 @@ def test_is_disjoint():
     ii = rootof(eq, 1)._get_interval()
     assert ir.is_disjoint(ii)
     assert ii.is_disjoint(ir)
+
+
+@skip_under_pyodide("Cannot create threads under pyodide.")
+def test_CRootOf_concurrent_cache():
+    poly = Poly((x**3 + x + 3)*(x**3 + 5*x + 1), x)
+    expected = [str(root.evalf(12)) for root in poly.all_roots()]
+    barrier = Barrier(4)
+
+    def get_roots(_):
+        results = []
+        for _ in range(10):
+            barrier.wait()
+            roots = poly.all_roots()
+            results.append([str(root.evalf(12)) for root in roots])
+        return results
+
+    CRootOf.clear_cache()
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = pool.map(get_roots, range(4))
+
+    assert all(roots == expected for result in results for roots in result)
 
 
 def test_pure_key_dict():


### PR DESCRIPTION
These tests mutate global state and don't work if the test suite is run concurrently with multithreading so they should be skipped.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

See https://github.com/sympy/sympy/issues/28239

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Used codex to fix some of the remaining failures when running the test suite with parallel threading using `pytest-run-parallel`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
