### PR TITLE
printing: keep integer-valued args integer in Fortran function calls (#20435)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -571,6 +571,7 @@ David T <derDavidT@users.noreply.github.com>
 Davide Sandonà <sandona.davide@gmail.com>
 Davy Mao <e_equals_mass_speed_light_squared@hotmail.com>
 Dean Price <dean1357price1357@gmail.com>
+Deeksha Manjunath <deekshaNVIDIA@users.noreply.github.com> <dmanjunath@nvidia.com>
 Demian Wassermann <demian@bwh.harvard.edu>
 Denis Ivanenko <ivanenko@ucu.edu.ua> Jack <ivanenko@ucu.edu.ua>
 Denis Ivanenko <ivanenko@ucu.edu.ua> LilJohny <ivanenko@ucu.edu.ua>

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -297,9 +297,14 @@ class FCodePrinter(CodePrinter):
             return CodePrinter._print_Add(self, expr)
 
     def _print_Function(self, expr):
-        # All constant function args are evaluated as floats
+        # Function args are evaluated as floats so that e.g. constants and
+        # real-valued expressions are passed as reals. Integer-valued symbolic
+        # expressions (e.g. ``n + 1`` for an integer symbol ``n``) are left
+        # untouched, since promoting them to reals produces invalid input for
+        # integer-argument intrinsics (see issue #20435).
         prec =  self._settings['precision']
-        args = [N(a, prec) for a in expr.args]
+        args = [a if (a.is_integer and not a.is_number) else N(a, prec)
+                for a in expr.args]
         eval_expr = expr.func(*args)
         if not isinstance(eval_expr, Function):
             return self._print(eval_expr)

--- a/sympy/printing/fortran.py
+++ b/sympy/printing/fortran.py
@@ -297,11 +297,8 @@ class FCodePrinter(CodePrinter):
             return CodePrinter._print_Add(self, expr)
 
     def _print_Function(self, expr):
-        # Function args are evaluated as floats so that e.g. constants and
-        # real-valued expressions are passed as reals. Integer-valued symbolic
-        # expressions (e.g. ``n + 1`` for an integer symbol ``n``) are left
-        # untouched, since promoting them to reals produces invalid input for
-        # integer-argument intrinsics (see issue #20435).
+        # Args are folded to floats unless they are integer-valued symbolic
+        # expressions, which stay integers for integer-argument intrinsics.
         prec =  self._settings['precision']
         args = [a if (a.is_integer and not a.is_number) else N(a, prec)
                 for a in expr.args]

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -158,6 +158,22 @@ def test_fcode_functions_with_integers():
     assert fcode(x * log(log(S(10)))) == "      x*%s" % loglog10_17
 
 
+def test_fcode_functions_with_integer_symbol_args():
+    # https://github.com/sympy/sympy/issues/20435
+    # Integer-valued arguments must not be promoted to reals inside a
+    # function call, otherwise integer-argument intrinsics get invalid input.
+    from sympy.functions.special.bessel import besselj
+    x = symbols('x')
+    n = symbols('n', integer=True)
+    assert fcode(besselj(n + 1, x**2), user_functions={'besselj': 'BESJN'},
+                 strict=False) == "      BESJN(n + 1, x**2)"
+    assert fcode(besselj(2*n, x), user_functions={'besselj': 'BESJN'},
+                 strict=False) == "      BESJN(2*n, x)"
+    # Purely numeric arguments are still evaluated as floats.
+    assert fcode(besselj(1, x), user_functions={'besselj': 'BESJN'},
+                 strict=False) == "      BESJN(1.0d0, x)"
+
+
 def test_fcode_NumberSymbol():
     prec = 17
     p = FCodePrinter()

--- a/sympy/printing/tests/test_fortran.py
+++ b/sympy/printing/tests/test_fortran.py
@@ -159,9 +159,8 @@ def test_fcode_functions_with_integers():
 
 
 def test_fcode_functions_with_integer_symbol_args():
-    # https://github.com/sympy/sympy/issues/20435
-    # Integer-valued arguments must not be promoted to reals inside a
-    # function call, otherwise integer-argument intrinsics get invalid input.
+    # Integer-valued arguments must not be promoted to reals inside a function
+    # call, otherwise integer-argument intrinsics get invalid input.
     from sympy.functions.special.bessel import besselj
     x = symbols('x')
     n = symbols('n', integer=True)
@@ -169,7 +168,7 @@ def test_fcode_functions_with_integer_symbol_args():
                  strict=False) == "      BESJN(n + 1, x**2)"
     assert fcode(besselj(2*n, x), user_functions={'besselj': 'BESJN'},
                  strict=False) == "      BESJN(2*n, x)"
-    # Purely numeric arguments are still evaluated as floats.
+    # Constant (purely numeric) arguments are still evaluated as floats.
     assert fcode(besselj(1, x), user_functions={'besselj': 'BESJN'},
                  strict=False) == "      BESJN(1.0d0, x)"
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #20435

#### Brief description of what is fixed or changed

`FCodePrinter._print_Function` evaluated **every** function argument with `N(...)`, which promoted integer-valued symbolic expressions to reals. For an integer symbol `n`:

```python
>>> from sympy import symbols, besselj, fcode
>>> n, x = symbols('n', integer=True), symbols('x')
>>> fcode(besselj(n + 1, x**2), user_functions={'besselj': 'BESJN'}, strict=False)
'      BESJN(n + 1.0d0, x**2)'
```

The `n + 1.0d0` argument is invalid input for Fortran intrinsics that expect an integer (e.g. the order of a Bessel function), as reported in #20435.

After this change, an argument is only evaluated as a float when it is **not** an integer-valued symbolic expression:

```python
>>> fcode(besselj(n + 1, x**2), user_functions={'besselj': 'BESJN'}, strict=False)
'      BESJN(n + 1, x**2)'
```

Purely numeric arguments and real-valued expressions are still passed as reals, so existing behaviour is preserved:

```python
>>> fcode(besselj(1, x), user_functions={'besselj': 'BESJN'}, strict=False)
'      BESJN(1.0d0, x)'
>>> fcode(erf(-2*x))            # coefficient still forced to real
'      erf(2.0d0*x)'
```

A regression test was added and the existing `printing` and `codegen` test suites pass.

#### Other comments

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed the Fortran code printer (`fcode`) promoting integer-valued symbolic function arguments to reals.
<!-- END RELEASE NOTES -->
