### PR TITLE
polys: fix `rs_cos_sin` so that `rs_cos_sin(R(0), x, 5)` returns `(1, 0)`

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1501,7 +1501,7 @@ def rs_cos_sin(p, x, prec):
         return rs_puiseux(rs_cos_sin, p, x, prec)
     R = p.ring
     if not p:
-        return R(0), R(0)
+        return R(1), R(0)
     c = _get_constant_term(p, x)
     if c:
         try:

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -367,6 +367,9 @@ def test_sin():
         EX(cos(a)/6)*x**3 + EX(cos(a))*x**2*y - EX(sin(a)/2)*x**2 + \
         EX(cos(a))*x + EX(sin(a))
 
+    R, x = ring('x', EX)
+    assert rs_sin(R(a), x, 5) == R(EX(sin(a)))
+
 
 def test_cos():
     R, x, y = ring('x, y', QQ)
@@ -393,9 +396,15 @@ def test_cos():
         EX(sin(a)/6)*x**3 - EX(sin(a))*x**2*y - EX(cos(a)/2)*x**2 - \
         EX(sin(a))*x + EX(cos(a))
 
+    R, x = ring('x', EX)
+    assert rs_cos(R(a), x, 5) == R(EX(cos(a)))
+
 
 def test_cos_sin():
     R, x, y = ring('x, y', QQ)
+    c, s = rs_cos_sin(R(0), x, 5)
+    assert c == R(1)
+    assert s == R(0)
     c, s = rs_cos_sin(x, x, 9)
     assert c == rs_cos(x, x, 9)
     assert s == rs_sin(x, x, 9)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related issue: gh-28282 

#### Brief description of what is fixed or changed
Before the fix:

```python
In [1]: from sympy.polys.ring_series import rs_cos_sin, rs_cos, rs_sin

In [2]: R, x = ring('x', QQ)

In [3]: rs_cos_sin(R(0), x, 5)
Out[3]: (0, 0)
expected result = (1, 0)

In [4]: a = symbols('a')

In [5]: R, x = ring('x', EX)

In [6]: rs_cos(R(a), x, 5)
Out[6]: EX(0)
expected result = EX(cos(a))

In [7]: rs_sin(R(a), x, 5)
Out[7]: EX(0)
expected result = EX(sin(a))
```

After the fix, all the code snippets above produce the expected results.

#### Other comments
I added regression tests for all the cases above.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
All code was written manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed `rs_cos_sin` so that `rs_cos_sin(R(0), x, 5)` returns `(1, 0)`.
<!-- END RELEASE NOTES -->