### PR TITLE
add support for Star operator in Mathematica parser

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -641,7 +641,7 @@ class MathematicaParser:
         (POSTFIX, None, {";": lambda x: x + ["Null"] if isinstance(x, list) and x and x[0] == "CompoundExpression" else ["CompoundExpression", x, "Null"]}),
         (INFIX, FLAT, {";": "CompoundExpression"}),
         (INFIX, RIGHT, {"=": "Set", ":=": "SetDelayed", "+=": "AddTo", "-=": "SubtractFrom", "*=": "TimesBy", "/=": "DivideBy"}),
-        (INFIX, FLAT, {"\N{THEREFORE}": "Therefore"}),
+        (INFIX, RIGHT, {"\N{THEREFORE}": "Therefore"}),
         (INFIX, LEFT, {"//": lambda x, y: [x, y]}),
         (POSTFIX, None, {"&": "Function"}),
         (INFIX, LEFT, {"/.": "ReplaceAll"}),

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -83,6 +83,33 @@ def parse_mathematica(s):
     return parser.parse(s)
 
 
+def parse_mathematica_to_fullformlist(s):
+    """
+    Translate a string containing a Wolfram Mathematica expression to its
+    ``FullForm`` represented as nested Python lists.
+
+    This is the intermediate representation produced by
+    :func:`parse_mathematica` before it is turned into a SymPy expression:
+    each node is a list whose first element is the head (as a string) followed
+    by its arguments, and atoms are left as strings. It is useful when the SymPy
+    conversion is undesired, for example to inspect the parsed syntax tree or to
+    perform a custom conversion.
+
+    Examples
+    ========
+
+    >>> from sympy.parsing.mathematica import parse_mathematica_to_fullformlist
+    >>> parse_mathematica_to_fullformlist("Sin[x]^2 Tan[y]")
+    ['Times', ['Power', ['Sin', 'x'], '2'], ['Tan', 'y']]
+    >>> parse_mathematica_to_fullformlist("x*(a + b)")
+    ['Times', 'x', ['Plus', 'a', 'b']]
+    >>> parse_mathematica_to_fullformlist("F[7, 5, 3]")
+    ['F', '7', '5', '3']
+    """
+    parser = MathematicaParser()
+    return parser.parse_fullformlist(s)
+
+
 def _parse_Function(*args):
     if len(args) == 1:
         arg = args[0]
@@ -593,11 +620,15 @@ class MathematicaParser:
         return s
 
     def parse(self, s):
+        s4 = self.parse_fullformlist(s)
+        s5 = self._from_fullformlist_to_sympy(s4)
+        return s5
+
+    def parse_fullformlist(self, s):
         s2 = named_characters_to_unicode(s)
         s3 = self._from_mathematica_to_tokens(s2)
         s4 = self._from_tokens_to_fullformlist(s3)
-        s5 = self._from_fullformlist_to_sympy(s4)
-        return s5
+        return s4
 
     INFIX = "Infix"
     PREFIX = "Prefix"
@@ -610,10 +641,12 @@ class MathematicaParser:
         (POSTFIX, None, {";": lambda x: x + ["Null"] if isinstance(x, list) and x and x[0] == "CompoundExpression" else ["CompoundExpression", x, "Null"]}),
         (INFIX, FLAT, {";": "CompoundExpression"}),
         (INFIX, RIGHT, {"=": "Set", ":=": "SetDelayed", "+=": "AddTo", "-=": "SubtractFrom", "*=": "TimesBy", "/=": "DivideBy"}),
+        (INFIX, FLAT, {"\N{THEREFORE}": "Therefore"}),
         (INFIX, LEFT, {"//": lambda x, y: [x, y]}),
         (POSTFIX, None, {"&": "Function"}),
         (INFIX, LEFT, {"/.": "ReplaceAll"}),
         (INFIX, RIGHT, {"->": "Rule", ":>": "RuleDelayed"}),
+        (INFIX, FLAT, {"\N{LEFT RIGHT ARROW}": "LeftRightArrow"}),
         (INFIX, LEFT, {"/;": "Condition"}),
         (INFIX, FLAT, {"|": "Alternatives"}),
         (POSTFIX, None, {"..": "Repeated", "...": "RepeatedNull"}),
@@ -622,17 +655,23 @@ class MathematicaParser:
         (PREFIX, None, {"!": "Not"}),
         (INFIX, FLAT, {"===": "SameQ", "=!=": "UnsameQ"}),
         (INFIX, FLAT, {"==": "Equal", "!=": "Unequal", "<=": "LessEqual", "<": "Less", ">=": "GreaterEqual", ">": "Greater"}),
+        (INFIX, FLAT, {"\N{ALMOST EQUAL TO}": "TildeTilde"}),
         (INFIX, None, {";;": "Span"}),
         (INFIX, FLAT, {"+": "Plus", "-": "Plus"}),
+        (INFIX, FLAT, {"\N{CIRCLED PLUS}": "CirclePlus"}),
+        (INFIX, FLAT, {"\N{STAR OPERATOR}": "Star"}),
         (INFIX, FLAT, {"*": "Times", "/": "Times"}),
+        (INFIX, FLAT, {"\N{CIRCLED TIMES}": "CircleTimes"}),
         (INFIX, FLAT, {".": "Dot"}),
         (PREFIX, None, {"-": lambda x: MathematicaParser._get_neg(x),
                         "+": lambda x: x}),
+        (PREFIX, None, {"\N{NABLA}": "Del", "\N{WHITE SQUARE}": "Square"}),
         (INFIX, RIGHT, {"^": "Power"}),
         (INFIX, RIGHT, {"@@": "Apply", "/@": "Map", "//@": "MapAll", "@@@": lambda x, y: ["Apply", x, y, ["List", "1"]]}),
         (POSTFIX, None, {"'": "Derivative", "!": "Factorial", "!!": "Factorial2", "--": "Decrement"}),
         (INFIX, None, {"[": lambda x, y: [x, *y], "[[": lambda x, y: ["Part", x, *y]}),
-        (PREFIX, None, {"{": lambda x: ["List", *x], "(": lambda x: x[0]}),
+        (PREFIX, None, {"{": lambda x: ["List", *x], "(": lambda x: x[0],
+                        "\N{LEFT-POINTING ANGLE BRACKET}": lambda x: ["AngleBracket", *x]}),
         (INFIX, None, {"?": "PatternTest"}),
         (POSTFIX, None, {
             "_": lambda x: ["Pattern", x, ["Blank"]],
@@ -666,8 +705,8 @@ class MathematicaParser:
 
     _number = r"(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)"
 
-    _enclosure_open = ["(", "[", "[[", "{"]
-    _enclosure_close = [")", "]", "]]", "}"]
+    _enclosure_open = ["(", "[", "[[", "{", "\N{LEFT-POINTING ANGLE BRACKET}"]
+    _enclosure_close = [")", "]", "]]", "}", "\N{RIGHT-POINTING ANGLE BRACKET}"]
 
     @classmethod
     def _get_neg(cls, x):

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from sympy import sin, Function, symbols, Dummy, Lambda, cos, Symbol, factorial, S
-from sympy.parsing.mathematica import parse_mathematica, MathematicaParser
+from sympy.parsing.mathematica import (
+    parse_mathematica, parse_mathematica_to_fullformlist, MathematicaParser)
 from sympy.core.sympify import sympify
 from sympy.abc import n, w, x, y, z
 from sympy.testing.pytest import raises
@@ -108,9 +109,10 @@ def test_mathematica():
 
 
 def test_parser_mathematica_tokenizer():
-    parser = MathematicaParser()
-
-    chain = lambda expr: parser._from_tokens_to_fullformlist(parser._from_mathematica_to_tokens(expr))
+    # ``parse_mathematica_to_fullformlist`` is the public entry point for the
+    # intermediate FullForm (as nested Python lists), i.e. the parse pipeline up
+    # to (but excluding) the conversion into SymPy objects.
+    chain = parse_mathematica_to_fullformlist
 
     # Basic patterns
     assert chain("x") == "x"
@@ -378,3 +380,101 @@ def test_mathematica_not_operator():
     # Factorial with implicit multiplication
     assert parse_mathematica("x!y") == y*factorial(x)
     assert parse_mathematica("x!y!") == factorial(x)*factorial(y)
+
+
+def test_mathematica_star_operator():
+    # \[Star], the literal ⋆ (U+22C6) and "Star[...]" are the same operator,
+    # which is distinct from Times.  Assertions are made on the FullForm list so
+    # they are not affected by any SymPy-level reordering.
+    fullform = parse_mathematica_to_fullformlist
+    assert fullform(r"a \[Star] b") == ["Star", "a", "b"]
+    assert fullform("a \N{STAR OPERATOR} b") == ["Star", "a", "b"]
+    assert fullform("Star[a, b]") == ["Star", "a", "b"]
+
+    # Star is flat: a ⋆ b ⋆ c -> Star[a, b, c]
+    assert fullform("a \N{STAR OPERATOR} b \N{STAR OPERATOR} c") == ["Star", "a", "b", "c"]
+
+    # Precedence: Star binds looser than Times but tighter than Plus.
+    assert fullform("a + b \N{STAR OPERATOR} c") == ["Plus", "a", ["Star", "b", "c"]]
+    assert fullform("a*b \N{STAR OPERATOR} c*d") == \
+        ["Star", ["Times", "a", "b"], ["Times", "c", "d"]]
+
+    # Times is unaffected.
+    assert fullform("a * b") == ["Times", "a", "b"]
+
+    # End-to-end: with no built-in meaning Star becomes an undefined Function.
+    a, b = symbols("a b")
+    assert parse_mathematica(r"a \[Star] b") == Function("Star")(a, b)
+
+
+def test_mathematica_operators_without_builtin_meaning():
+    # Operators listed under "Operators without built-in meanings" in
+    # https://reference.wolfram.com/language/tutorial/TextualInputAndOutput.html
+    # Each must produce its own head instead of being dropped/parsed as Times.
+    # Assertions are on the FullForm list (see parse_mathematica_to_fullformlist).
+    fullform = parse_mathematica_to_fullformlist
+
+    # Infix operators, both named-character and literal forms; all are flat.
+    assert fullform(r"x \[CirclePlus] y") == ["CirclePlus", "x", "y"]
+    assert fullform("x \N{CIRCLED PLUS} y \N{CIRCLED PLUS} z") == \
+        ["CirclePlus", "x", "y", "z"]
+    assert fullform(r"x \[CircleTimes] y") == ["CircleTimes", "x", "y"]
+    assert fullform("x \N{CIRCLED TIMES} y \N{CIRCLED TIMES} z") == \
+        ["CircleTimes", "x", "y", "z"]
+    assert fullform(r"x \[TildeTilde] y") == ["TildeTilde", "x", "y"]
+    assert fullform("x \N{ALMOST EQUAL TO} y \N{ALMOST EQUAL TO} z") == \
+        ["TildeTilde", "x", "y", "z"]
+    assert fullform(r"x \[Therefore] y") == ["Therefore", "x", "y"]
+    assert fullform(r"x \[LeftRightArrow] y") == ["LeftRightArrow", "x", "y"]
+    assert fullform("x \N{LEFT RIGHT ARROW} y \N{LEFT RIGHT ARROW} z") == \
+        ["LeftRightArrow", "x", "y", "z"]
+
+    # Prefix operators.
+    assert fullform(r"\[Del] x") == ["Del", "x"]
+    assert fullform("\N{NABLA}x") == ["Del", "x"]
+    assert fullform("\N{NABLA}(x + y)") == ["Del", ["Plus", "x", "y"]]
+    assert fullform(r"\[Square] x") == ["Square", "x"]
+    assert fullform("\N{WHITE SQUARE}x") == ["Square", "x"]
+
+    # Matchfix AngleBracket, with one or more comma-separated arguments.
+    assert fullform(r"\[LeftAngleBracket] x \[RightAngleBracket]") == \
+        ["AngleBracket", "x"]
+    assert fullform(r"\[LeftAngleBracket] a, b, c \[RightAngleBracket]") == \
+        ["AngleBracket", "a", "b", "c"]
+
+    # Precedence matches Wolfram: CirclePlus binds looser than Times but
+    # tighter than Plus; CircleTimes binds tighter than Times; Del (prefix)
+    # binds looser than Power.
+    assert fullform("a + b \N{CIRCLED PLUS} c") == ["Plus", "a", ["CirclePlus", "b", "c"]]
+    assert fullform("a \N{CIRCLED PLUS} b*c") == ["CirclePlus", "a", ["Times", "b", "c"]]
+    assert fullform("a*b \N{CIRCLED TIMES} c*d") == \
+        ["Times", "a", ["CircleTimes", "b", "c"], "d"]
+    assert fullform("\N{NABLA}x^2") == ["Del", ["Power", "x", "2"]]
+
+    # End-to-end: with no built-in meaning each head becomes an undefined
+    # Function once converted to SymPy.
+    x, y = symbols("x y")
+    assert parse_mathematica(r"x \[CirclePlus] y") == Function("CirclePlus")(x, y)
+    assert parse_mathematica(r"\[Del] x") == Function("Del")(x)
+    assert parse_mathematica(r"\[LeftAngleBracket] x, y \[RightAngleBracket]") == \
+        Function("AngleBracket")(x, y)
+
+
+def test_parse_mathematica_to_fullformlist():
+    # The function returns the intermediate FullForm as nested Python lists,
+    # with heads and atoms represented as strings.
+    assert parse_mathematica_to_fullformlist("Sin[x]^2 Tan[y]") == \
+        ['Times', ['Power', ['Sin', 'x'], '2'], ['Tan', 'y']]
+    assert parse_mathematica_to_fullformlist("x*(a + b)") == \
+        ['Times', 'x', ['Plus', 'a', 'b']]
+    assert parse_mathematica_to_fullformlist("F[7, 5, 3]") == ['F', '7', '5', '3']
+
+    # Named characters are resolved before tokenizing, unlike the raw tokenizer
+    # stages, so both the \[Name] form and the literal character are accepted.
+    assert parse_mathematica_to_fullformlist(r"a \[CirclePlus] b") == \
+        ['CirclePlus', 'a', 'b']
+    assert parse_mathematica_to_fullformlist("a \N{STAR OPERATOR} b \N{STAR OPERATOR} c") == \
+        ['Star', 'a', 'b', 'c']
+
+    # The method form on the parser class is equivalent.
+    assert MathematicaParser().parse_fullformlist("a + b") == ['Plus', 'a', 'b']

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -414,7 +414,9 @@ def test_mathematica_operators_without_builtin_meaning():
     # Assertions are on the FullForm list (see parse_mathematica_to_fullformlist).
     fullform = parse_mathematica_to_fullformlist
 
-    # Infix operators, both named-character and literal forms; all are flat.
+    # Infix operators, both named-character and literal forms. CirclePlus,
+    # CircleTimes, TildeTilde and LeftRightArrow are flat (x op y op z ->
+    # op[x, y, z]).
     assert fullform(r"x \[CirclePlus] y") == ["CirclePlus", "x", "y"]
     assert fullform("x \N{CIRCLED PLUS} y \N{CIRCLED PLUS} z") == \
         ["CirclePlus", "x", "y", "z"]
@@ -424,10 +426,15 @@ def test_mathematica_operators_without_builtin_meaning():
     assert fullform(r"x \[TildeTilde] y") == ["TildeTilde", "x", "y"]
     assert fullform("x \N{ALMOST EQUAL TO} y \N{ALMOST EQUAL TO} z") == \
         ["TildeTilde", "x", "y", "z"]
-    assert fullform(r"x \[Therefore] y") == ["Therefore", "x", "y"]
     assert fullform(r"x \[LeftRightArrow] y") == ["LeftRightArrow", "x", "y"]
     assert fullform("x \N{LEFT RIGHT ARROW} y \N{LEFT RIGHT ARROW} z") == \
         ["LeftRightArrow", "x", "y", "z"]
+
+    # Therefore is right-associative: x ∴ y ∴ z groups as x ∴ (y ∴ z).
+    # https://reference.wolfram.com/language/ref/Therefore.html
+    assert fullform(r"x \[Therefore] y") == ["Therefore", "x", "y"]
+    assert fullform("x \N{THEREFORE} y \N{THEREFORE} z") == \
+        ["Therefore", "x", ["Therefore", "y", "z"]]
 
     # Prefix operators.
     assert fullform(r"\[Del] x") == ["Del", "x"]


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Added operators without built-in meaning from Wolfram Mathematica to our mathematica parser:
https://reference.wolfram.com/language/tutorial/TextualInputAndOutput.html#41

RUBI ruleset uses one of them (Star), so I am updating the parser to allow SymPy to correctly import Mathematica code.

I've also added `parse_mathematica_to_fullformlist( )` which parses Wolfram Mathematica code without converting it to SymPy code (it's the parser without the converter to SymPy).


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Claude Opus, everything in this PR was vibe coded.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
