### PR TITLE
polys: fix `rs_cosh_sinh` so that `rs_cosh_sinh(R(0), x, 5)` returns `(1, 0)`

### DIFF
--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -1707,8 +1707,6 @@ def rs_cosh(p, x, prec):
     if rs_is_puiseux(p, x):
         return rs_puiseux(rs_cosh, p, x, prec)
     R = p.ring
-    if not p:
-        return R(1)
     c = _get_constant_term(p, x)
     if c:
         try:
@@ -1757,7 +1755,7 @@ def rs_cosh_sinh(p, x, prec):
         return rs_puiseux(rs_cosh_sinh, p, x, prec)
     R = p.ring
     if not p:
-        return R(0), R(0)
+        return R(1), R(0)
     c = _get_constant_term(p, x)
     if c:
         try:

--- a/sympy/polys/tests/test_ring_series.py
+++ b/sympy/polys/tests/test_ring_series.py
@@ -506,6 +506,9 @@ def test_sinh():
         2)*x**4*y + EX(sinh(a)/24)*x**4 + EX(sinh(a))*x**3*y + EX(cosh(a)/6)*x**3 \
         + EX(cosh(a))*x**2*y + EX(sinh(a)/2)*x**2 + EX(cosh(a))*x + EX(sinh(a))
 
+    R, x = ring('x', EX)
+    assert rs_sinh(R(a), x, 5) == R(EX(sinh(a)))
+
 
 def test_cosh():
     R, x, y = ring('x, y', QQ)
@@ -515,6 +518,7 @@ def test_cosh():
         x**8*y**10/48 + x**8*y**8/40320 + x**7*y**10/6 + \
         x**7*y**8/120 + x**6*y**8/4 + x**6*y**6/720 + x**5*y**6/6 + \
         x**4*y**6/2 + x**4*y**4/24 + x**3*y**4 + x**2*y**2/2 + 1
+    assert rs_cosh(R(0), x, 5) == R(1)
 
     # constant term in series
     a = symbols('a')
@@ -531,9 +535,15 @@ def test_cosh():
         2)*x**4*y + EX(cosh(a)/24)*x**4 + EX(cosh(a))*x**3*y + EX(sinh(a)/6)*x**3 \
         + EX(sinh(a))*x**2*y + EX(cosh(a)/2)*x**2 + EX(sinh(a))*x + EX(cosh(a))
 
+    R, x = ring('x', EX)
+    assert rs_cosh(R(a), x, 5) == R(EX(cosh(a)))
+
 
 def test_cosh_sinh():
     R, x, y = ring('x, y', QQ)
+    ch, sh = rs_cosh_sinh(R(0), x, 5)
+    assert ch == R(1)
+    assert sh == R(0)
     ch, sh = rs_cosh_sinh(x, x, 9)
     assert ch == rs_cosh(x, x, 9)
     assert sh == rs_sinh(x, x, 9)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Related issue: gh-28282 

#### Brief description of what is fixed or changed
Before the fix:

```python
In [1]: from sympy.polys.ring_series import rs_cosh_sinh, rs_cosh, rs_sinh

In [2]: R, x = ring('x', QQ)

In [3]: rs_cosh_sinh(R(0), x, 5)
Out[3]: (0, 0)
expected result = (1, 0)

In [4]: rs_cosh(R(0), x, 5)
Out[4]: 0
expected result = 1

In [5]: a = symbols('a')

In [6]: R, x = ring('x', EX)

In [7]: rs_cosh(R(a), x, 5)
Out[7]: EX(0)
expected result = EX(cosh(a))

In [8]: rs_sinh(R(a), x, 5)
Out[8]: EX(0)
expected result = EX(sinh(a))
```

After the fix, all the code snippets above produce the expected results.

#### Other comments
I added regression tests for all the cases above.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
All code was written manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed `rs_cosh_sinh` so that `rs_cosh_sinh(R(0), x, 5)` returns `(1, 0)`.
<!-- END RELEASE NOTES -->