### PR TITLE
Make more objects compare equal to themselves after pickling

### DIFF
--- a/sympy/core/multidimensional.py
+++ b/sympy/core/multidimensional.py
@@ -91,6 +91,14 @@ class vectorize:
                 raise TypeError("a is of invalid type")
         self.mdargs = mdargs
 
+    def __eq__(self, other):
+        if not isinstance(other, vectorize):
+            return NotImplemented
+        return self.mdargs == other.mdargs
+
+    def __hash__(self):
+        return hash((type(self), self.mdargs))
+
     def __call__(self, f):
         """
         Returns a wrapper for the one-dimensional function that can handle

--- a/sympy/core/singleton.py
+++ b/sympy/core/singleton.py
@@ -194,6 +194,11 @@ class SingletonRegistry(Registry):
     def __repr__(self):
         return "S"
 
+    def __reduce__(self):
+        # S is a singleton: pickling and copying should return the same
+        # instance so that it compares equal to itself after a round-trip.
+        return "S"
+
 S = SingletonRegistry()
 
 

--- a/sympy/ntheory/generate.py
+++ b/sympy/ntheory/generate.py
@@ -124,6 +124,18 @@ class Sieve:
         self.sieve_interval = sieve_interval
         assert all(len(i) == self._n for i in (self._list, self._tlist, self._mlist))
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Sieve):
+            return NotImplemented
+        return (self.sieve_interval == other.sieve_interval
+                and self._n == other._n
+                and self._list == other._list
+                and self._tlist == other._tlist
+                and self._mlist == other._mlist)
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.sieve_interval, self._n))
+
     def __repr__(self) -> str:
         return ("<%s sieve (%i): %i, %i, %i, ... %i, %i\n"
              "%s sieve (%i): %i, %i, %i, ... %i, %i\n"

--- a/sympy/polys/polyerrors.py
+++ b/sympy/polys/polyerrors.py
@@ -11,6 +11,14 @@ class BasePolynomialError(Exception):
     def new(self, *args):
         raise NotImplementedError("abstract base class")
 
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return NotImplemented
+        return self.args == other.args
+
+    def __hash__(self):
+        return hash((type(self), self.args))
+
 @public
 class ExactQuotientFailed(BasePolynomialError):
 

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -274,6 +274,18 @@ class Printer:
         # called. See StrPrinter._print_Float() for an example of usage
         self._print_level = 0
 
+    def __eq__(self, other):
+        # Two printers are equal if they are of the same type and configured
+        # with the same settings. ``_context`` and ``_print_level`` are
+        # transient printing state and are deliberately not compared, so that
+        # an idle printer compares equal to itself after a pickle round-trip.
+        if type(self) is not type(other):
+            return NotImplemented
+        return self._settings == other._settings
+
+    def __hash__(self):
+        return hash((type(self), frozenset(self._settings)))
+
     @classmethod
     def set_global_settings(cls, **settings):
         """Set system-wide printing settings. """

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -79,9 +79,7 @@ def check(a, exclude=[], check_attr=True, deprecated=()):
         assert set(d1) == set(d2)
 
         # Everything should compare equal to itself after a round-trip.
-        # Classes are pickled as themselves, so identity already holds.
-        if not isinstance(a, type):
-            assert a == b, "%r != %r, protocol: %s" % (a, b, protocol)
+        assert a == b, "%r != %r, protocol: %s" % (a, b, protocol)
 
         if not check_attr:
             continue

--- a/sympy/utilities/tests/test_pickling.py
+++ b/sympy/utilities/tests/test_pickling.py
@@ -78,6 +78,11 @@ def check(a, exclude=[], check_attr=True, deprecated=()):
         d2 = dir(b)
         assert set(d1) == set(d2)
 
+        # Everything should compare equal to itself after a round-trip.
+        # Classes are pickled as themselves, so identity already holds.
+        if not isinstance(a, type):
+            assert a == b, "%r != %r, protocol: %s" % (a, b, protocol)
+
         if not check_attr:
             continue
 


### PR DESCRIPTION
I've generated this PR as a consequence of the discussion https://github.com/sympy/sympy/pull/29702#discussion_r3593345787

This is an easy fix for AI.

#### References to other Issues or PRs

Addresses the review discussion in #29702:
https://github.com/sympy/sympy/pull/29702#discussion_r3593345787

#### Brief description of what is fixed or changed

Several objects relied on the default identity-based equality and therefore
compared as unequal to the original after a pickle/copy round-trip. The
following are fixed:

`test_pickling.check()` now asserts equality after every round-trip

#### Other comments


Disclosure: the code in this PR was written with the assistance of the Claude
Code coding agent (model Claude Opus 4.8), reviewed by me before submission.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
