### PR TITLE
[DON'T MERGE] integrals: move manualintegrate backtracking and pruning into the solver

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -26,6 +26,7 @@ from typing import NamedTuple, Callable, Sequence, TYPE_CHECKING
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Mapping
+from dataclasses import dataclass
 from functools import wraps
 from inspect import signature
 
@@ -69,7 +70,6 @@ from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
 from sympy.simplify.powsimp import powsimp
 from sympy.solvers.solvers import solve
-from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
 
@@ -1169,6 +1169,139 @@ class IntegralInfo(NamedTuple):
     symbol: Symbol
 
 
+# ---------------------------------------------------------------------------
+# Orchestrator / solver
+# ---------------------------------------------------------------------------
+#
+# Issue #30087: the individual integration *rules* below are stateless.  A rule
+# is a plain function ``rule(integral, solver, ...)`` whose output depends only
+# on the ``integral`` it is handed; it never reads or mutates module-global
+# state and it is unaware of what has been attempted before it.  When a rule
+# needs to integrate a sub-expression it asks the *solver* to do it through
+# ``solver.subsolve(...)`` -- it does not know (or care) how the solver routes
+# that request.
+#
+# All mutable state that used to live in module globals -- the loop-detection
+# cache, the integration-by-parts ``u`` counter, and any global options -- now
+# lives on a single :class:`IntegrationSolver` instance that owns the recursion
+# and records a trace of every routing attempt.  This is the "dedicated solver"
+# asked for in the issue: one place for loop detection, branch prioritisation,
+# state propagation and bookkeeping, instead of ad-hoc workarounds threaded
+# through recursive calls.
+
+
+@dataclass
+class RuleStep:
+    """One routing attempt recorded by :class:`IntegrationSolver`.
+
+    ``depth`` gives the position in the recursion tree (0 is the top-level
+    integral), ``rule`` is the name of the :class:`Rule` the solver settled on
+    for this sub-integral and ``outcome`` is one of ``'matched'`` (a real rule
+    applied), ``'fallback'`` (nothing applied, left as ``DontKnowRule``) or
+    ``'loop'`` (the solver detected a cycle and gave up on this branch).
+    """
+
+    integrand: Expr
+    variable: Symbol
+    depth: int
+    rule: str | None = None
+    outcome: str = 'pending'
+
+
+@dataclass
+class IntegrationResult:
+    """Return value of :func:`integral_steps_with_trace`.
+
+    Bundles the :class:`Rule` tree (exactly what :func:`integral_steps`
+    returns) together with the ordered ``trace`` of rule attempts recorded by
+    the solver while building it.  Inspired by the ``IntegrationResult`` /
+    ``ToolCallResult`` datatypes in the companion tool project.
+    """
+
+    rule: Rule
+    trace: list[RuleStep]
+
+    def eval(self) -> Expr:
+        return self.rule.eval()
+
+    def contains_dont_know(self) -> bool:
+        return self.rule.contains_dont_know()
+
+    def pretty_trace(self) -> str:
+        """A compact, indented outline of the rules the solver tried."""
+        lines = []
+        for step in self.trace:
+            indent = '  ' * step.depth
+            name = step.rule or '?'
+            suffix = '' if step.outcome == 'matched' else f'  [{step.outcome}]'
+            lines.append(
+                f'{indent}{name}: Integral({step.integrand}, {step.variable}){suffix}')
+        return '\n'.join(lines)
+
+
+class IntegrationSolver:
+    """Stateful orchestrator that drives the stateless integration rules.
+
+    A single solver instance is created for each top-level integration and is
+    threaded explicitly through every recursive call.  It owns:
+
+    * ``_active`` -- the set of sub-integrals currently on the recursion stack,
+      used for unified loop detection (replaces the old ``_integral_cache``
+      sentinel logic).
+    * ``_parts_u_cache`` -- how many times a given ``u`` has been chosen for
+      integration by parts, to stop cyclic parts from repeating forever.
+    * ``options`` -- global parameters/branching preferences that used to be
+      smuggled through recursion (e.g. via context variables); they now live in
+      one place and propagate automatically because the same solver is passed
+      down.
+    * ``trace`` -- the ordered list of :class:`RuleStep` describing every
+      routing decision, so callers can see exactly which rules were attempted.
+
+    The rules never touch this object's internals directly; they only call
+    :meth:`subsolve` to integrate sub-expressions.
+    """
+
+    def __init__(self, **options) -> None:
+        self.options = options
+        self._active: dict[Expr, None] = {}
+        self._parts_u_cache: dict[Expr, int] = defaultdict(int)
+        self.trace: list[RuleStep] = []
+        self._depth = 0
+
+    def subsolve(self, integrand: Expr, symbol: Symbol) -> Rule:
+        """Integrate ``integrand`` w.r.t. ``symbol``, returning a :class:`Rule`.
+
+        This is the single entry point the rules use for recursion.  It applies
+        loop detection, records the attempt in :attr:`trace` and dispatches to
+        the stateless rules.  The returned rule is never ``None`` -- an
+        unsolvable integral yields a :class:`DontKnowRule`.
+        """
+        cachekey = integrand.xreplace({symbol: _cache_dummy})
+        if cachekey in self._active:
+            # This exact sub-integral is already being solved higher up the
+            # stack: continuing would loop, so abandon this branch.
+            self.trace.append(
+                RuleStep(integrand, symbol, self._depth, 'DontKnowRule', 'loop'))
+            return DontKnowRule(integrand, symbol)
+
+        step = RuleStep(integrand, symbol, self._depth)
+        self.trace.append(step)
+
+        self._active[cachekey] = None
+        self._depth += 1
+        try:
+            result = _dispatch(IntegralInfo(integrand, symbol), self)
+        finally:
+            self._depth -= 1
+            del self._active[cachekey]
+
+        if result is None:
+            result = DontKnowRule(integrand, symbol)
+        step.rule = type(result).__name__
+        step.outcome = 'fallback' if isinstance(result, DontKnowRule) else 'matched'
+        return result
+
+
 def manual_diff(f, symbol):
     """Derivative of f in form expected by find_substitutions
 
@@ -1317,22 +1450,62 @@ def find_substitutions(integrand, symbol, u_var):
 
     return results
 
+
+# ---------------------------------------------------------------------------
+# Rule-combining strategies
+# ---------------------------------------------------------------------------
+#
+# The combinators below take stateless rules (functions of
+# ``(integral, solver)``) and build bigger stateless rules from them.  They
+# thread ``solver`` through unchanged; only the solver ever holds state.
+
+
+def _do_one(*rules):
+    """Return the result of the first rule that produces one (else ``None``)."""
+    def _do_one_rl(integral, solver):
+        for rule in rules:
+            result = rule(integral, solver)
+            if result is not None:
+                return result
+        return None
+    return _do_one_rl
+
+
+def _switch(key, mapping):
+    """Dispatch to ``mapping[key(integral)]`` when present."""
+    def _switch_rl(integral, solver):
+        rule = mapping.get(key(integral))
+        if rule is not None:
+            return rule(integral, solver)
+        return None
+    return _switch_rl
+
+
+def _condition(pred, rule):
+    """Apply ``rule`` only when ``pred(integral)`` holds."""
+    def _condition_rl(integral, solver):
+        if pred(integral):
+            return rule(integral, solver)
+        return None
+    return _condition_rl
+
+
 def rewriter(condition, rewrite):
     """Strategy that rewrites an integrand."""
-    def _rewriter(integral):
+    def _rewriter(integral, solver):
         integrand, symbol = integral
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewrite, symbol))
         if condition(*integral):
             rewritten = rewrite(*integral)
             if rewritten != integrand:
-                substep = integral_steps(rewritten, symbol)
+                substep = solver.subsolve(rewritten, symbol)
                 if not isinstance(substep, DontKnowRule) and substep:
                     return RewriteRule(integrand, symbol, rewritten, substep)
     return _rewriter
 
 def proxy_rewriter(condition, rewrite):
     """Strategy that rewrites an integrand based on some other criteria."""
-    def _proxy_rewriter(criteria):
+    def _proxy_rewriter(criteria, solver):
         criteria, integral = criteria
         integrand, symbol = integral
         debug("Integral: {} is rewritten with {} on symbol: {} and criteria: {}".format(integrand, rewrite, symbol, criteria))
@@ -1340,20 +1513,20 @@ def proxy_rewriter(condition, rewrite):
         if condition(*args):
             rewritten = rewrite(*args)
             if rewritten != integrand:
-                return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
+                return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
     return _proxy_rewriter
 
 def multiplexer(conditions):
     """Apply the rule that matches the condition, else None"""
-    def multiplexer_rl(expr):
+    def multiplexer_rl(expr, solver):
         for key, rule in conditions.items():
             if key(expr):
-                return rule(expr)
+                return rule(expr, solver)
     return multiplexer_rl
 
 def alternatives(*rules):
     """Strategy that makes an AlternativeRule out of multiple possible results."""
-    def _alternatives(integral):
+    def _alternatives(integral, solver):
         alts = []
         count = 0
         debug("List of Alternative Rules")
@@ -1361,7 +1534,7 @@ def alternatives(*rules):
             count = count + 1
             debug("Rule {}: {}".format(count, rule))
 
-            result = rule(integral)
+            result = rule(integral, solver)
             if (result and not isinstance(result, DontKnowRule) and
                 result != integral and result not in alts):
                 alts.append(result)
@@ -1375,10 +1548,10 @@ def alternatives(*rules):
                 return AlternativeRule(*integral, alts)
     return _alternatives
 
-def constant_rule(integral):
+def constant_rule(integral, solver):
     return ConstantRule(*integral)
 
-def power_rule(integral):
+def power_rule(integral, solver):
     integrand, symbol = integral
     base, expt = integrand.as_base_exp()
 
@@ -1399,13 +1572,13 @@ def power_rule(integral):
             (ConstantRule(1, symbol), True)
         ])
 
-def exp_rule(integral):
+def exp_rule(integral, solver):
     integrand, symbol = integral
     if isinstance(integrand.args[0], Symbol):
         return ExpRule(integrand, symbol, E, integrand.args[0])
 
 
-def combine_power_rule(integral):
+def combine_power_rule(integral, solver):
     """
     Strategy that simplifies the exponent of a power.
     exp(a*x**2) * exp(b*x) -> exp((a*x**2 + b*x))
@@ -1425,11 +1598,11 @@ def combine_power_rule(integral):
     simplified = powsimp(integrand, combine='exp')
 
     if simplified != integrand:
-        steps = integral_steps(simplified, symbol)
+        steps = solver.subsolve(simplified, symbol)
         return RewriteRule(integrand, symbol, simplified, steps)
 
 
-def orthogonal_poly_rule(integral):
+def orthogonal_poly_rule(integral, solver):
     orthogonal_poly_classes = {
         jacobi: JacobiRule,
         gegenbauer: GegenbauerRule,
@@ -1459,7 +1632,7 @@ _wilds: list[Wild] = []
 _symbol = Dummy('x')
 
 
-def special_function_rule(integral):
+def special_function_rule(integral, solver):
     integrand, symbol = integral
     if not _special_function_patterns:
         a = Wild('a', exclude=[_symbol], properties=[lambda x: not x.is_zero])
@@ -1517,7 +1690,7 @@ def _add_degenerate_step(generic_cond, generic_step: Rule, degenerate_step: Rule
     return PiecewiseRule(generic_step.integrand, generic_step.variable, subfunctions)
 
 
-def nested_pow_rule(integral: IntegralInfo):
+def nested_pow_rule(integral: IntegralInfo, solver=None):
     # nested (c*(a+b*x)**d)**e
     integrand, x = integral
 
@@ -1570,11 +1743,12 @@ def nested_pow_rule(integral: IntegralInfo):
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
-def inverse_trig_rule(integral: IntegralInfo, degenerate=True):
+def inverse_trig_rule(integral: IntegralInfo, solver=None, degenerate=True):
     """
     Set degenerate=False on recursive call where coefficient of quadratic term
     is assumed non-zero.
     """
+    solver = solver or IntegrationSolver()
     integrand, symbol = integral
     base, exp = integrand.as_base_exp()
     a = Wild('a', exclude=[symbol])
@@ -1611,7 +1785,7 @@ def inverse_trig_rule(integral: IntegralInfo, degenerate=True):
     elif b.is_zero:
         degenerate_step = ConstantRule(a ** exp, symbol)
     else:
-        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo((a + b * symbol) ** exp, symbol))
+        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo((a + b * symbol) ** exp, symbol), solver)
 
     if simplify(2*exp + 1) == 0:
         h, k = -b/(2*c), a - b**2/(4*c)  # rewrite base to k + c*(symbol-h)**2
@@ -1646,20 +1820,20 @@ def inverse_trig_rule(integral: IntegralInfo, degenerate=True):
         return _add_degenerate_step(generic_cond, step, degenerate_step)
 
 
-def add_rule(integral):
+def add_rule(integral, solver):
     integrand, symbol = integral
-    results = [integral_steps(g, symbol)
+    results = [solver.subsolve(g, symbol)
               for g in integrand.as_ordered_terms()]
     return None if None in results else AddRule(integrand, symbol, results)
 
 
-def mul_rule(integral: IntegralInfo):
+def mul_rule(integral: IntegralInfo, solver):
     integrand, symbol = integral
 
     # Constant times function case
     coeff, f = integrand.as_independent(symbol)
     if coeff != 1:
-        next_step = integral_steps(f, symbol)
+        next_step = solver.subsolve(f, symbol)
         if next_step is not None:
             return ConstantTimesRule(integrand, symbol, coeff, f, next_step)
 
@@ -1667,7 +1841,8 @@ def mul_rule(integral: IntegralInfo):
 special_error_functions = (erf, erfc, erfi, fresnelc, fresnels, Ci, Chi, Si, Shi, Ei, li)
 
 
-def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None:
+def _parts_rule(integrand, symbol, solver=None) -> tuple[Expr, Expr, Expr, Expr, Rule] | None:
+    solver = solver or IntegrationSolver()
     # LIATE rule:
     # log, inverse trig, algebraic, trigonometric, exponential
     def pull_out_algebraic(integrand):
@@ -1758,7 +1933,7 @@ def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None
             if rule == pull_out_algebraic:
                 if dv.is_Derivative or dv.has(TrigonometricFunction, HyperbolicFunction) or \
                         isinstance(dv, OrthogonalPolynomial):
-                    v_step = integral_steps(dv, symbol)
+                    v_step = solver.subsolve(dv, symbol)
                     if v_step.contains_dont_know():
                         return None
                     else:
@@ -1784,18 +1959,18 @@ def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None
 
             if accept:
                 du = u.diff(symbol)
-                v_step = integral_steps(simplify(dv), symbol)
+                v_step = solver.subsolve(simplify(dv), symbol)
                 if not v_step.contains_dont_know():
                     v = v_step.eval()
                     return u, dv, v, du, v_step
     return None
 
 
-def parts_rule(integral):
+def parts_rule(integral, solver):
     integrand, symbol = integral
     constant, integrand = integrand.as_coeff_Mul()
 
-    result = _parts_rule(integrand, symbol)
+    result = _parts_rule(integrand, symbol, solver)
 
     steps = []
     if result:
@@ -1809,9 +1984,9 @@ def parts_rule(integral):
         # Set a limit on the number of times u can be used
         if isinstance(u, (sin, cos, exp, sinh, cosh)):
             cachekey = u.xreplace({symbol: _cache_dummy})
-            if _parts_u_cache[cachekey] > 2:
+            if solver._parts_u_cache[cachekey] > 2:
                 return
-            _parts_u_cache[cachekey] += 1
+            solver._parts_u_cache[cachekey] += 1
 
         # Try cyclic integration by parts a few times
         for _ in range(4):
@@ -1832,7 +2007,7 @@ def parts_rule(integral):
 
             # _parts_rule is sensitive to constants, factor it out
             next_constant, next_integrand = (v * du).as_coeff_Mul()
-            result = _parts_rule(next_integrand, symbol)
+            result = _parts_rule(next_integrand, symbol, solver)
 
             if result:
                 u, dv, v, du, v_step = result
@@ -1846,7 +2021,7 @@ def parts_rule(integral):
         if steps:
             u, dv, v, du, v_step = steps[0]
             return PartsRule(integrand, symbol, u, dv, v_step, make_second_step(steps[1:], v * du))
-        return integral_steps(integrand, symbol)
+        return solver.subsolve(integrand, symbol)
 
     if steps:
         u, dv, v, du, v_step = steps[0]
@@ -1857,7 +2032,7 @@ def parts_rule(integral):
         return rule
 
 
-def trig_rule(integral):
+def trig_rule(integral, solver):
     integrand, symbol = integral
     if integrand == sin(symbol):
         return SinRule(integrand, symbol)
@@ -1883,9 +2058,9 @@ def trig_rule(integral):
     else:
         return
 
-    return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
+    return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
 
-def trig_product_rule(integral: IntegralInfo):
+def trig_product_rule(integral: IntegralInfo, solver):
     integrand, symbol = integral
     if integrand == sec(symbol) * tan(symbol):
         return SecTanRule(integrand, symbol)
@@ -1893,7 +2068,7 @@ def trig_product_rule(integral: IntegralInfo):
         return CscCotRule(integrand, symbol)
 
 
-def trig_cmplx_exp_rule(integral: IntegralInfo):
+def trig_cmplx_exp_rule(integral: IntegralInfo, solver):
     """
     Strategy that rewrites sin, cos, sinh, and cosh in terms of complex exponentials.
     Useful for integration techniques that handle exponentials better.
@@ -1928,11 +2103,11 @@ def trig_cmplx_exp_rule(integral: IntegralInfo):
 
     if rewritten != integrand:
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten, symbol))
-        steps = integral_steps(rewritten, symbol)
+        steps = solver.subsolve(rewritten, symbol)
         return RewriteRule(integrand, symbol, rewritten, steps)
 
 
-def quadratic_denom_rule(integral):
+def quadratic_denom_rule(integral, solver):
     integrand, symbol = integral
     a = Wild('a', exclude=[symbol, 0])
     b = Wild('b', exclude=[symbol, 0])
@@ -1946,11 +2121,11 @@ def quadratic_denom_rule(integral):
         # skips degenerate case if b != 0 or if b = 0 would cause null denominator
         if not _if_zero_implies_zero(b, c):
             substituted = integrand.subs(b, 0)
-            substep = integral_steps(substituted, symbol)
+            substep = solver.subsolve(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(b, 0)))
         if not _if_zero_implies_zero(c, b):
             substituted = integrand.subs(c, 0)
-            substep = integral_steps(substituted, symbol)
+            substep = solver.subsolve(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(c, 0)))
         if b.is_extended_real and c.is_extended_real:
             positive_cond = c/b > 0
@@ -1988,7 +2163,7 @@ def quadratic_denom_rule(integral):
         u = Dummy('u')
         u_func = symbol + c/(2*b)
         integrand2 = integrand.subs(symbol, u - c / (2*b))
-        next_step = integral_steps(integrand2, u)
+        next_step = solver.subsolve(integrand2, u)
         if next_step:
             return URule(integrand2, symbol, u, u_func, next_step)
         else:
@@ -2005,13 +2180,13 @@ def quadratic_denom_rule(integral):
         numer2 = - const*d + b
         u = Dummy('u')
         step1 = URule(integrand, symbol,
-                      u, denominator, integral_steps(u**(-1), u))
+                      u, denominator, solver.subsolve(u**(-1), u))
         if const != 1:
             step1 = ConstantTimesRule(const*numer1/denominator, symbol,
                                       const, numer1/denominator, step1)
         if numer2.is_zero:
             return step1
-        step2 = integral_steps(numer2/denominator, symbol)
+        step2 = solver.subsolve(numer2/denominator, symbol)
         substeps = AddRule(integrand, symbol, [step1, step2])
         rewriten = const*numer1/denominator+numer2/denominator
         return RewriteRule(integrand, symbol, rewriten, substeps)
@@ -2019,10 +2194,11 @@ def quadratic_denom_rule(integral):
     return
 
 
-def sqrt_fractional_linear_rule(integral : IntegralInfo):
+def sqrt_fractional_linear_rule(integral : IntegralInfo, solver=None):
     """
     Substitute common ((a*x + b)/(c*x + d))**(1/n)
     """
+    solver = solver or IntegrationSolver()
     integrand, x = integral
     a = Wild('a', exclude=[x])
     b = Wild('b', exclude=[x])
@@ -2070,7 +2246,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     if constant_bases_subs:
         integrand = integrand.subs(constant_bases_subs)
     if base0 is None:
-        substep = integral_steps(integrand, x)
+        substep = solver.subsolve(integrand, x)
         if not substep.contains_dont_know():
             debug("Integral: {} is rewritten with {} on symbol: {}".format(integral.integrand, integrand, x))
             return RewriteRule(integral.integrand, x, integrand, substep)
@@ -2085,7 +2261,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     for base_i, ratio_i, q_i in zip(bases, ratios, qs):
         subs_dict[base_i**(S.One/q_i)] = (ratio_i)**(S.One/q_i) * u**(q0/q_i)
     substituted = integrand.subs(subs_dict).subs(x, x_u) * dx_u
-    substep = integral_steps(substituted, u)
+    substep = solver.subsolve(substituted, u)
     if not substep.contains_dont_know():
         pieces: list[tuple[Rule, Boolean]] = []
         det = a0*d0 - b0*c0
@@ -2101,14 +2277,14 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
                 const_val = a0 / c0
                 subs_a = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
                 simplified_a = integrand.subs(subs_a)
-                degenerate_step_a = integral_steps(simplified_a, x)
+                degenerate_step_a = solver.subsolve(simplified_a, x)
                 pieces.append((degenerate_step_a, (And(Eq(det, 0), Ne(c0, 0)))))
             if not c0_implies_d0:
                 const_val = b0 / d0
                 subs_b = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
                 simplified_b = integrand.subs(subs_b)
                 simplified_b = simplified_b.subs({a0: 0, c0: 0}) # if det = 0, c = 0 and d != 0, a must be 0
-                degenerate_step_b = integral_steps(simplified_b, x)
+                degenerate_step_b = solver.subsolve(simplified_b, x)
                 pieces.append((degenerate_step_b, (And(Eq(det, 0), Eq(c0, 0)))))
         step: Rule = URule(integrand, x, u, u_x, substep)
         if pieces:
@@ -2121,7 +2297,8 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     return None
 
 
-def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
+def sqrt_quadratic_rule(integral: IntegralInfo, solver=None, degenerate=True):
+    solver = solver or IntegrationSolver()
     integrand, x = integral
     a = Wild('a', exclude=[x])
     b = Wild('b', exclude=[x])
@@ -2140,10 +2317,10 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
     if not degenerate or generic_cond is S.true:
         degenerate_step = None
     elif b.is_zero:
-        degenerate_step = integral_steps(f*sqrt(a)**n, x)
+        degenerate_step = solver.subsolve(f*sqrt(a)**n, x)
     else:
         degenerate_integrand = f*sqrt(a + b*x)**n
-        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo(degenerate_integrand, x))
+        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo(degenerate_integrand, x), solver)
         if degenerate_step is None:
             # since  sqrt_fractional_linear_rule does not guarantee a solution
             # we create a DontKnowRule so that _add_degenerate_step adds the degenerate condition
@@ -2168,7 +2345,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
                 if A != 1:
                     linear_step = ConstantTimesRule(A*pre_substitute, x, A, pre_substitute, linear_step)
             if B != 0:
-                constant_step = inverse_trig_rule(IntegralInfo(1/denom, x), degenerate=False)
+                constant_step = inverse_trig_rule(IntegralInfo(1/denom, x), solver, degenerate=False)
                 if B != 1:
                     constant_step = ConstantTimesRule(B/denom, x, B, 1/denom, constant_step)  # type: ignore
             if linear_step and constant_step:
@@ -2191,7 +2368,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
             square_base = sqrt(c)*x + b/(2*sqrt(c))
             nested = Pow(Pow(square_base, 2, evaluate=False), S(n)/2, evaluate=False)
             rewritten = const*nested
-            substep = nested_pow_rule(IntegralInfo(rewritten, x))
+            substep = nested_pow_rule(IntegralInfo(rewritten, x), solver)
             return RewriteRule(integrand, x, rewritten, substep)
 
         if delta.is_zero is True:
@@ -2205,12 +2382,12 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
 
         rewrite_expr = Derivative(constant_term, x) + coeff * expr
         derive_expr = Derivative(constant_term, x)
-        derive_step = integral_steps(derive_expr, x)
+        derive_step = solver.subsolve(derive_expr, x)
 
         if coeff == 0:
             substep = derive_step
         else:
-            next_step = integral_steps(expr, x)
+            next_step = solver.subsolve(expr, x)
             if not next_step:
                 next_step = DontKnowRule(expr, x)
 
@@ -2250,7 +2427,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
         if not quotient.is_zero:
             # n is increasing by 2 at each step, we will fall in one of the cases above
             quotient_integrand = quotient.as_expr() * sqrt(root_base)**(n + 2)
-            quotient_step = sqrt_quadratic_rule(IntegralInfo(quotient_integrand, x), degenerate=False)
+            quotient_step = sqrt_quadratic_rule(IntegralInfo(quotient_integrand, x), solver, degenerate=False)
             terms.append(quotient_integrand)
             steps.append(quotient_step)
         if not rest.is_zero:
@@ -2300,7 +2477,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
-def hyperbolic_rule(integral: tuple[Expr, Symbol]):
+def hyperbolic_rule(integral: tuple[Expr, Symbol], solver):
     integrand, symbol = integral
     if isinstance(integrand, HyperbolicFunction) and integrand.args[0] == symbol:
         if integrand.func == sinh:
@@ -2377,12 +2554,12 @@ def uncurry(func):
     return uncurry_rl
 
 def trig_rewriter(rewrite):
-    def trig_rewriter_rl(args):
+    def trig_rewriter_rl(args, solver):
         a, b, m, n, integrand, symbol = args
         rewritten = rewrite(a, b, m, n, integrand, symbol)
         if rewritten != integrand:
             debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewrite, symbol))
-            return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
+            return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
     return trig_rewriter_rl
 
 sincos_botheven_condition = uncurry(
@@ -2435,7 +2612,7 @@ cotcsc_cotodd = trig_rewriter(
                                     cot(a*symbol) *
                                     csc(b*symbol) ** n ))
 
-def trig_sincos_rule(integral):
+def trig_sincos_rule(integral, solver):
     integrand, symbol = integral
 
     if any(integrand.has(f) for f in (sin, cos)):
@@ -2450,9 +2627,9 @@ def trig_sincos_rule(integral):
             sincos_cosodd_condition: sincos_cosodd
         })(tuple(
             [match.get(i, S.Zero) for i in (a, b, m, n)] +
-            [integrand, symbol]))
+            [integrand, symbol]), solver)
 
-def trig_tansec_rule(integral):
+def trig_tansec_rule(integral, solver):
     integrand, symbol = integral
 
     integrand = integrand.subs({
@@ -2471,9 +2648,9 @@ def trig_tansec_rule(integral):
             tan_tansquared_condition: tan_tansquared
         })(tuple(
             [match.get(i, S.Zero) for i in (a, b, m, n)] +
-            [integrand, symbol]))
+            [integrand, symbol]), solver)
 
-def trig_cotcsc_rule(integral):
+def trig_cotcsc_rule(integral, solver):
     integrand, symbol = integral
     integrand = integrand.subs({
         1 / sin(symbol): csc(symbol),
@@ -2492,9 +2669,9 @@ def trig_cotcsc_rule(integral):
             cotcsc_csceven_condition: cotcsc_csceven
         })(tuple(
             [match.get(i, S.Zero) for i in (a, b, m, n)] +
-            [integrand, symbol]))
+            [integrand, symbol]), solver)
 
-def trig_sindouble_rule(integral):
+def trig_sindouble_rule(integral, solver):
     integrand, symbol = integral
     a = Wild('a', exclude=[sin(2*symbol)])
     match = integrand.match(sin(2*symbol)*a)
@@ -2502,16 +2679,16 @@ def trig_sindouble_rule(integral):
         sin_double = 2*sin(symbol)*cos(symbol)/sin(2*symbol)
         rewritten = integrand * sin_double
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, integrand * sin_double, symbol))
-        substeps = integral_steps(rewritten, symbol)
+        substeps = solver.subsolve(rewritten, symbol)
         return RewriteRule(integrand, symbol, rewritten, substeps)
 
-def trig_powers_products_rule(integral):
-    return do_one(null_safe(trig_sincos_rule),
-                  null_safe(trig_tansec_rule),
-                  null_safe(trig_cotcsc_rule),
-                  null_safe(trig_sindouble_rule))(integral)
+def trig_powers_products_rule(integral, solver):
+    return _do_one(trig_sincos_rule,
+                   trig_tansec_rule,
+                   trig_cotcsc_rule,
+                   trig_sindouble_rule)(integral, solver)
 
-def trig_substitution_rule(integral):
+def trig_substitution_rule(integral, solver):
     integrand, symbol = integral
     A = Wild('a', exclude=[0, symbol])
     B = Wild('b', exclude=[0, symbol])
@@ -2566,23 +2743,23 @@ def trig_substitution_rule(integral):
                         1/cos(theta): sec(theta)
                     })
 
-                substep = integral_steps(replaced, theta)
+                substep = solver.subsolve(replaced, theta)
                 if not substep.contains_dont_know():
                     return TrigSubstitutionRule(integrand, symbol,
                         theta, x_func, replaced, substep, restriction)
 
-def heaviside_rule(integral):
+def heaviside_rule(integral, solver):
     integrand, symbol = integral
     pattern, m, b, g = heaviside_pattern(symbol)
     match = integrand.match(pattern)
     if match and 0 != match[g]:
         # f = Heaviside(m*x + b)*g
-        substep = integral_steps(match[g], symbol)
+        substep = solver.subsolve(match[g], symbol)
         m, b = match[m], match[b]
         return HeavisideRule(integrand, symbol, m*symbol + b, -b/m, substep)
 
 
-def dirac_delta_rule(integral: IntegralInfo):
+def dirac_delta_rule(integral: IntegralInfo, solver):
     integrand, x = integral
     if len(integrand.args) == 1:
         n = S.Zero
@@ -2604,7 +2781,7 @@ def dirac_delta_rule(integral: IntegralInfo):
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
-def substitution_rule(integral):
+def substitution_rule(integral, solver):
     integrand, symbol = integral
 
     u_var = Dummy("u")
@@ -2616,7 +2793,7 @@ def substitution_rule(integral):
         factored_integrand = integrand.factor()
         _, denom_integrand = factored_integrand.as_numer_denom()
         for u_func, c, substituted in substitutions:
-            subrule = integral_steps(substituted, u_var)
+            subrule = solver.subsolve(substituted, u_var)
             count = count + 1
             debug("Rule {}: {}".format(count, subrule))
 
@@ -2636,7 +2813,7 @@ def substitution_rule(integral):
                         if not _if_zero_implies_zero(pole, denom_integrand):
                             rewritten_integral = manual_subs(factored_integrand, pole, 0)
                             debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten_integral, symbol))
-                            substep = integral_steps(rewritten_integral, symbol)
+                            substep = solver.subsolve(rewritten_integral, symbol)
 
                             if substep:
                                 substep = RewriteRule(integrand, symbol, rewritten_integral, substep)
@@ -2677,7 +2854,7 @@ trig_expand_rule = rewriter(
         len({a.args[0] for a in integrand.atoms(TrigonometricFunction)}) > 1),
     lambda integrand, symbol: integrand.expand(trig=True))
 
-def derivative_rule(integral):
+def derivative_rule(integral, solver):
     integrand = integral[0]
     diff_variables = integrand.variables
     undifferentiated_function = integrand.expr
@@ -2691,24 +2868,102 @@ def derivative_rule(integral):
     else:
         return ConstantRule(*integral)
 
-def rewrites_rule(integral):
+def rewrites_rule(integral, solver):
     integrand, symbol = integral
 
     if integrand.match(1/cos(symbol)):
         rewritten = integrand.subs(1/cos(symbol), sec(symbol))
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten, symbol))
-        return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
+        return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
 
-def fallback_rule(integral):
+def fallback_rule(integral, solver):
     return DontKnowRule(*integral)
 
 
-# Cache is used to break cyclic integrals.
-# Need to use the same dummy variable in cached expressions for them to match.
-# Also record "u" of integration by parts, to avoid infinite repetition.
-_integral_cache: dict[Expr, Expr | None] = {}
-_parts_u_cache: dict[Expr, int] = defaultdict(int)
+# Same dummy is used across a whole solve so that cyclic integrals compare equal
+# regardless of which concrete integration variable is in play.
 _cache_dummy = Dummy("z")
+
+
+def _dispatch_key(integral):
+    integrand, symbol = integral
+
+    if symbol not in integrand.free_symbols:
+        return Number
+    for cls in (Symbol, TrigonometricFunction, OrthogonalPolynomial):
+        if isinstance(integrand, cls):
+            return cls
+    return type(integrand)
+
+
+def _integral_is_subclass(*klasses):
+    def _integral_is_subclass_pred(integral):
+        k = _dispatch_key(integral)
+        return k and issubclass(k, klasses)
+    return _integral_is_subclass_pred
+
+
+def _dispatch(integral: IntegralInfo, solver: IntegrationSolver) -> Rule:
+    """Route ``integral`` to the stateless rules, in priority order.
+
+    This is the routing table the solver consults for every sub-integral.  It
+    is a pure function of ``(integral, solver)``: all the decision-making about
+    *what has already been tried* and *whether a branch loops* is handled by the
+    solver around this call, not here.
+    """
+    return _do_one(
+        special_function_rule,
+        _switch(_dispatch_key, {
+            Pow: _do_one(power_rule, inverse_trig_rule,
+                         quadratic_denom_rule,
+                         sqrt_quadratic_rule,
+                         sqrt_fractional_linear_rule),
+            Symbol: power_rule,
+            exp: exp_rule,
+            Add: add_rule,
+            Mul: _do_one(mul_rule, trig_product_rule,
+                         heaviside_rule, quadratic_denom_rule,
+                         sqrt_quadratic_rule,
+                         sqrt_fractional_linear_rule,
+                         trig_cmplx_exp_rule),
+            Derivative: derivative_rule,
+            TrigonometricFunction: trig_rule,
+            Heaviside: heaviside_rule,
+            DiracDelta: dirac_delta_rule,
+            OrthogonalPolynomial: orthogonal_poly_rule,
+            Number: constant_rule
+        }),
+        _do_one(
+            trig_rule,
+            hyperbolic_rule,
+            alternatives(
+                rewrites_rule,
+                substitution_rule,
+                _condition(
+                    _integral_is_subclass(Mul, Pow),
+                    partial_fractions_rule),
+                _condition(
+                    _integral_is_subclass(Mul, Pow),
+                    cancel_rule),
+                _condition(
+                    _integral_is_subclass(Mul),
+                    combine_power_rule),
+                _condition(
+                    _integral_is_subclass(Mul, log,
+                                          *inverse_trig_functions,
+                                          *special_error_functions),
+                    parts_rule),
+                _condition(
+                    _integral_is_subclass(Mul, Pow),
+                    distribute_expand_rule),
+                trig_powers_products_rule,
+                trig_expand_rule
+            ),
+            _condition(_integral_is_subclass(Mul, Pow), nested_pow_rule),
+            trig_substitution_rule
+        ),
+        fallback_rule)(integral, solver)
+
 
 def integral_steps(integrand, symbol, **options):
     """Returns the steps needed to compute an integral.
@@ -2755,91 +3010,32 @@ def integral_steps(integrand, symbol, **options):
         to obtain a result.
 
     """
-    cachekey = integrand.xreplace({symbol: _cache_dummy})
-    if cachekey in _integral_cache:
-        if _integral_cache[cachekey] is None:
-            # Stop this attempt, because it leads around in a loop
-            return DontKnowRule(integrand, symbol)
-        else:
-            # TODO: This is for future development, as currently
-            # _integral_cache gets no values other than None
-            return (_integral_cache[cachekey].xreplace(_cache_dummy, symbol),
-                symbol)
-    else:
-        _integral_cache[cachekey] = None
+    return IntegrationSolver(**options).subsolve(integrand, symbol)
 
-    integral = IntegralInfo(integrand, symbol)
 
-    def key(integral):
-        integrand = integral.integrand
+def integral_steps_with_trace(integrand, symbol, **options) -> IntegrationResult:
+    """Like :func:`integral_steps`, but also return the solver's trace.
 
-        if symbol not in integrand.free_symbols:
-            return Number
-        for cls in (Symbol, TrigonometricFunction, OrthogonalPolynomial):
-            if isinstance(integrand, cls):
-                return cls
-        return type(integrand)
+    Returns an :class:`IntegrationResult` bundling the :class:`Rule` tree
+    (``.rule``) with the ordered list of :class:`RuleStep` the orchestrator
+    recorded while building it (``.trace``).  Use ``.pretty_trace()`` for a
+    readable outline of which rules were tried and how deep.
 
-    def integral_is_subclass(*klasses):
-        def _integral_is_subclass(integral):
-            k = key(integral)
-            return k and issubclass(k, klasses)
-        return _integral_is_subclass
+    Examples
+    ========
 
-    result = do_one(
-        null_safe(special_function_rule),
-        null_safe(switch(key, {
-            Pow: do_one(null_safe(power_rule), null_safe(inverse_trig_rule),
-                        null_safe(quadratic_denom_rule),
-                        null_safe(sqrt_quadratic_rule),
-                        null_safe(sqrt_fractional_linear_rule)),
-            Symbol: power_rule,
-            exp: exp_rule,
-            Add: add_rule,
-            Mul: do_one(null_safe(mul_rule), null_safe(trig_product_rule),
-                        null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
-                        null_safe(sqrt_quadratic_rule),
-                        null_safe(sqrt_fractional_linear_rule),
-                        null_safe(trig_cmplx_exp_rule)),
-            Derivative: derivative_rule,
-            TrigonometricFunction: trig_rule,
-            Heaviside: heaviside_rule,
-            DiracDelta: dirac_delta_rule,
-            OrthogonalPolynomial: orthogonal_poly_rule,
-            Number: constant_rule
-        })),
-        do_one(
-            null_safe(trig_rule),
-            null_safe(hyperbolic_rule),
-            null_safe(alternatives(
-                rewrites_rule,
-                substitution_rule,
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    partial_fractions_rule),
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    cancel_rule),
-                condition(
-                    integral_is_subclass(Mul),
-                    combine_power_rule),
-                condition(
-                    integral_is_subclass(Mul, log,
-                                         *inverse_trig_functions,
-                                         *special_error_functions),
-                    parts_rule),
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    distribute_expand_rule),
-                trig_powers_products_rule,
-                trig_expand_rule
-            )),
-            null_safe(condition(integral_is_subclass(Mul, Pow), nested_pow_rule)),
-            null_safe(trig_substitution_rule)
-        ),
-        fallback_rule)(integral)
-    del _integral_cache[cachekey]
-    return result
+    >>> from sympy import sin
+    >>> from sympy.integrals.manualintegrate import integral_steps_with_trace
+    >>> from sympy.abc import x
+    >>> result = integral_steps_with_trace(sin(x), x)
+    >>> result.rule
+    SinRule(integrand=sin(x), variable=x)
+    >>> print(result.pretty_trace())
+    SinRule: Integral(sin(x), x)
+    """
+    solver = IntegrationSolver(**options)
+    rule = solver.subsolve(integrand, symbol)
+    return IntegrationResult(rule, solver.trace)
 
 
 def manualintegrate(f, var):
@@ -2892,8 +3088,6 @@ def manualintegrate(f, var):
     sympy.integrals.integrals.Integral
     """
     result = integral_steps(f, var).eval()
-    # Clear the cache of u-parts
-    _parts_u_cache.clear()
     # If we got Piecewise with two parts, put generic first
     if isinstance(result, Piecewise) and len(result.args) == 2:
         cond = result.args[0][1]

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from typing import NamedTuple, Callable, Sequence, TYPE_CHECKING
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from functools import wraps
 from inspect import signature
@@ -1301,6 +1301,79 @@ class IntegrationSolver:
         step.outcome = 'fallback' if isinstance(result, DontKnowRule) else 'matched'
         return result
 
+    def try_solve(self, integrand: Expr, symbol: Symbol) -> Rule | None:
+        """Integrate ``integrand``, returning ``None`` if it cannot be solved.
+
+        Unlike :meth:`subsolve` (which always returns a :class:`Rule`, using
+        :class:`DontKnowRule` as a placeholder), this returns ``None`` when the
+        result contains any unsolved piece.  It is the single place where
+        "is this sub-integral solvable?" is judged, so the individual rules no
+        longer have to inspect their own sub-results to prune dead branches.
+        """
+        rule = self.subsolve(integrand, symbol)
+        return None if rule.contains_dont_know() else rule
+
+    def run_candidate(self, candidate: Callable[[], object]) -> Rule | None:
+        """Drive one *candidate* continuation and return its assembled rule.
+
+        A candidate is a zero-argument generator function -- a stateless
+        description of a move.  It ``yield``\\s the sub-integrals it needs and
+        receives the solved :class:`Rule` back; the solver, not the candidate,
+        performs the recursion and the loop detection.  A *required* sub-goal
+        (a bare :class:`IntegralInfo`) that turns out to be unsolvable prunes
+        the whole candidate -- the candidate never has to check.  An *optional*
+        sub-goal (wrapped in :class:`Subgoal` with ``required=False``) is always
+        sent back, solved or not, so the candidate can choose to use it.  The
+        candidate ``return``\\s the finished :class:`Rule`, or ``None`` to
+        withdraw.
+        """
+        gen = candidate()
+        try:
+            goal = next(gen)
+            while True:
+                if isinstance(goal, Subgoal):
+                    info, required = goal.info, goal.required
+                else:
+                    info, required = goal, True
+                rule = self.subsolve(info.integrand, info.symbol)
+                if required and rule.contains_dont_know():
+                    gen.close()
+                    return None
+                goal = gen.send(rule)
+        except StopIteration as stop:
+            return stop.value
+
+    def collect_candidates(
+        self, candidates: Iterable[Callable[[], object]]
+    ) -> list[Rule]:
+        """Drive every candidate, keeping those not withdrawn.
+
+        A candidate is withdrawn (``run_candidate`` returns ``None``) only when
+        one of its *required* sub-goals is unsolvable, so that is the real
+        solvability gate.  A kept rule may still carry an unsolved *optional*
+        piece; that is intentional and matches how the caller assembles
+        piecewise fall-backs.
+        """
+        solved = []
+        for candidate in candidates:
+            rule = self.run_candidate(candidate)
+            if rule is not None:
+                solved.append(rule)
+        return solved
+
+
+class Subgoal(NamedTuple):
+    """A sub-integral a candidate yields to the solver.
+
+    ``required=True`` (the default when a bare :class:`IntegralInfo` is
+    yielded) means the candidate is abandoned if this sub-integral cannot be
+    solved.  ``required=False`` marks an optional sub-integral: the solver
+    always sends the result back and the candidate decides what to do with it.
+    """
+
+    info: IntegralInfo
+    required: bool = True
+
 
 def manual_diff(f, symbol):
     """Derivative of f in form expected by find_substitutions
@@ -1933,8 +2006,8 @@ def _parts_rule(integrand, symbol, solver=None) -> tuple[Expr, Expr, Expr, Expr,
             if rule == pull_out_algebraic:
                 if dv.is_Derivative or dv.has(TrigonometricFunction, HyperbolicFunction) or \
                         isinstance(dv, OrthogonalPolynomial):
-                    v_step = solver.subsolve(dv, symbol)
-                    if v_step.contains_dont_know():
+                    v_step = solver.try_solve(dv, symbol)
+                    if v_step is None:
                         return None
                     else:
                         du = u.diff(symbol)
@@ -1959,8 +2032,8 @@ def _parts_rule(integrand, symbol, solver=None) -> tuple[Expr, Expr, Expr, Expr,
 
             if accept:
                 du = u.diff(symbol)
-                v_step = solver.subsolve(simplify(dv), symbol)
-                if not v_step.contains_dont_know():
+                v_step = solver.try_solve(simplify(dv), symbol)
+                if v_step is not None:
                     v = v_step.eval()
                     return u, dv, v, du, v_step
     return None
@@ -2246,8 +2319,8 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo, solver=None):
     if constant_bases_subs:
         integrand = integrand.subs(constant_bases_subs)
     if base0 is None:
-        substep = solver.subsolve(integrand, x)
-        if not substep.contains_dont_know():
+        substep = solver.try_solve(integrand, x)
+        if substep is not None:
             debug("Integral: {} is rewritten with {} on symbol: {}".format(integral.integrand, integrand, x))
             return RewriteRule(integral.integrand, x, integrand, substep)
         return None
@@ -2261,8 +2334,8 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo, solver=None):
     for base_i, ratio_i, q_i in zip(bases, ratios, qs):
         subs_dict[base_i**(S.One/q_i)] = (ratio_i)**(S.One/q_i) * u**(q0/q_i)
     substituted = integrand.subs(subs_dict).subs(x, x_u) * dx_u
-    substep = solver.subsolve(substituted, u)
-    if not substep.contains_dont_know():
+    substep = solver.try_solve(substituted, u)
+    if substep is not None:
         pieces: list[tuple[Rule, Boolean]] = []
         det = a0*d0 - b0*c0
         _, base0_denom = base0.as_numer_denom()
@@ -2743,8 +2816,8 @@ def trig_substitution_rule(integral, solver):
                         1/cos(theta): sec(theta)
                     })
 
-                substep = solver.subsolve(replaced, theta)
-                if not substep.contains_dont_know():
+                substep = solver.try_solve(replaced, theta)
+                if substep is not None:
                     return TrigSubstitutionRule(integrand, symbol,
                         theta, x_func, replaced, substep, restriction)
 
@@ -2782,55 +2855,63 @@ def dirac_delta_rule(integral: IntegralInfo, solver):
 
 
 def substitution_rule(integral, solver):
+    # A proposer: it enumerates the possible u-substitutions and hands each one
+    # to the solver as a self-contained *candidate*.  The candidate describes
+    # the move -- integrate the substituted integrand, then wrap the result in
+    # the URule (and, when the substitution introduces a constant with poles, a
+    # Piecewise fall-back) -- but it does not integrate anything itself and
+    # never checks whether a sub-integral was solvable.  The solver drives the
+    # candidates, prunes the ones whose (required) substituted integral cannot
+    # be solved, and returns the survivors.
     integrand, symbol = integral
 
     u_var = Dummy("u")
     substitutions = find_substitutions(integrand, symbol, u_var)
-    count = 0
-    if substitutions:
-        debug("List of Substitution Rules")
-        ways = []
-        factored_integrand = integrand.factor()
-        _, denom_integrand = factored_integrand.as_numer_denom()
-        for u_func, c, substituted in substitutions:
-            subrule = solver.subsolve(substituted, u_var)
-            count = count + 1
-            debug("Rule {}: {}".format(count, subrule))
+    if not substitutions:
+        return
+    debug("List of Substitution Rules")
+    factored_integrand = integrand.factor()
+    _, denom_integrand = factored_integrand.as_numer_denom()
 
-            if subrule.contains_dont_know():
-                continue
+    def make_candidate(u_func, c, substituted):
+        def candidate():
+            # Required sub-goal: if this cannot be solved the solver drops the
+            # whole candidate, so no solvability check is needed here.
+            subrule = yield IntegralInfo(substituted, u_var)
 
             if simplify(c - 1) != 0:
                 _, denom_c = c.as_numer_denom()
-                if subrule:
-                    subrule = ConstantTimesRule(c * substituted, u_var, c, substituted, subrule)
+                subrule = ConstantTimesRule(c * substituted, u_var, c, substituted, subrule)
 
                 if denom_c.free_symbols:
                     pieces = []
-                    factors_denom_c = factor_list(denom_c)[1]
-                    for pole, _ in factors_denom_c:
-                        # only substitute poles introduced by the constant c if they were not already poles of the original integrand
+                    for pole, _ in factor_list(denom_c)[1]:
+                        # only handle poles introduced by the constant c that
+                        # were not already poles of the original integrand
                         if not _if_zero_implies_zero(pole, denom_integrand):
                             rewritten_integral = manual_subs(factored_integrand, pole, 0)
                             debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten_integral, symbol))
-                            substep = solver.subsolve(rewritten_integral, symbol)
-
-                            if substep:
-                                substep = RewriteRule(integrand, symbol, rewritten_integral, substep)
-                                pieces.append((
-                                    substep,
-                                    Eq(pole, 0)
-                                ))
+                            # Optional sub-goal: the fall-back branch is kept
+                            # whether or not it can be fully integrated.
+                            substep = yield Subgoal(
+                                IntegralInfo(rewritten_integral, symbol), required=False)
+                            substep = RewriteRule(integrand, symbol, rewritten_integral, substep)
+                            pieces.append((substep, Eq(pole, 0)))
                     if pieces:
                         pieces.append((subrule, True))
                         subrule = PiecewiseRule(substituted, symbol, pieces)
 
-            ways.append(URule(integrand, symbol, u_var, u_func, subrule))
+            return URule(integrand, symbol, u_var, u_func, subrule)
+        return candidate
 
-        if len(ways) > 1:
-            return AlternativeRule(integrand, symbol, ways)
-        elif ways:
-            return ways[0]
+    ways = solver.collect_candidates(
+        make_candidate(u_func, c, substituted)
+        for u_func, c, substituted in substitutions)
+
+    if len(ways) > 1:
+        return AlternativeRule(integrand, symbol, ways)
+    elif ways:
+        return ways[0]
 
 
 partial_fractions_rule = rewriter(


### PR DESCRIPTION
**AI-generated template for discussion purposes only!**

#### AI Generation Disclosure

This refactor was carried out with the assistance of the Claude Code coding
agent (model Claude Opus 4.8). The rearchitecting of `manualintegrate.py` in
this PR is largely agent-generated, then reviewed, tested, and edited by me
before submission.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
