### PR TITLE
Fix Mathematica parser against Mathematica

### DIFF
--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -642,7 +642,9 @@ class MathematicaParser:
         (INFIX, FLAT, {";": "CompoundExpression"}),
         (INFIX, RIGHT, {"=": "Set", ":=": "SetDelayed", "+=": "AddTo", "-=": "SubtractFrom", "*=": "TimesBy", "/=": "DivideBy"}),
         (INFIX, RIGHT, {"\N{THEREFORE}": "Therefore"}),
-        (INFIX, LEFT, {"//": lambda x, y: [x, y]}),
+        # ``x // y`` is postfix function application, equivalent to ``y[x]``
+        # (e.g. ``expr // Simplify`` means ``Simplify[expr]``).
+        (INFIX, LEFT, {"//": lambda x, y: [y, x]}),
         (POSTFIX, None, {"&": "Function"}),
         (INFIX, LEFT, {"/.": "ReplaceAll"}),
         (INFIX, RIGHT, {"->": "Rule", ":>": "RuleDelayed"}),

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -658,7 +658,7 @@ class MathematicaParser:
         (INFIX, FLAT, {"===": "SameQ", "=!=": "UnsameQ"}),
         (INFIX, FLAT, {"==": "Equal", "!=": "Unequal", "<=": "LessEqual", "<": "Less", ">=": "GreaterEqual", ">": "Greater"}),
         (INFIX, FLAT, {"\N{ALMOST EQUAL TO}": "TildeTilde"}),
-        (INFIX, None, {";;": "Span"}),
+        (INFIX, FLAT, {";;": "Span"}),
         (INFIX, FLAT, {"+": "Plus", "-": "Plus"}),
         (INFIX, FLAT, {"\N{CIRCLED PLUS}": "CirclePlus"}),
         (INFIX, FLAT, {"\N{STAR OPERATOR}": "Star"}),
@@ -670,7 +670,13 @@ class MathematicaParser:
         (PREFIX, None, {"\N{NABLA}": "Del", "\N{WHITE SQUARE}": "Square"}),
         (INFIX, RIGHT, {"^": "Power"}),
         (INFIX, RIGHT, {"@@": "Apply", "/@": "Map", "//@": "MapAll", "@@@": lambda x, y: ["Apply", x, y, ["List", "1"]]}),
-        (POSTFIX, None, {"'": "Derivative", "!": "Factorial", "!!": "Factorial2", "--": "Decrement"}),
+        # ``f @ x`` is prefix function application, equivalent to ``f[x]``.  It
+        # binds tighter than ``^`` and ``@@`` but looser than ``'`` and ``[``.
+        (INFIX, RIGHT, {"@": lambda x, y: [x, y]}),
+        # ``f'`` is ``Derivative[1][f]``; each extra prime raises the order, so
+        # ``f''`` is ``Derivative[2][f]`` (not ``Derivative[Derivative[f]]``).
+        (POSTFIX, None, {"'": lambda x: MathematicaParser._get_derivative(x),
+                         "!": "Factorial", "!!": "Factorial2", "--": "Decrement"}),
         (INFIX, None, {"[": lambda x, y: [x, *y], "[[": lambda x, y: ["Part", x, *y]}),
         (PREFIX, None, {"{": lambda x: ["List", *x], "(": lambda x: x[0],
                         "\N{LEFT-POINTING ANGLE BRACKET}": lambda x: ["AngleBracket", *x]}),
@@ -717,6 +723,15 @@ class MathematicaParser:
     @classmethod
     def _get_inv(cls, x):
         return ["Power", x, "-1"]
+
+    @classmethod
+    def _get_derivative(cls, x):
+        # ``x'`` is ``Derivative[1][x]``.  Stacking primes raises the order:
+        # ``x''`` is ``Derivative[2][x]``, not ``Derivative[Derivative[x]]``.
+        if (isinstance(x, list) and len(x) == 2 and isinstance(x[0], list)
+                and len(x[0]) == 2 and x[0][0] == "Derivative"):
+            return [["Derivative", str(int(x[0][1]) + 1)], x[1]]
+        return [["Derivative", "1"], x]
 
     _regex_tokenizer = None
 
@@ -983,13 +998,26 @@ class MathematicaParser:
                                 size -= 2
                             node_p.append(arg2)
                         elif grouping_strat == self.RIGHT:
-                            while pointer + 2 < size and tokens[pointer+1] == token:
-                                node_p.append([op_name, arg2])
-                                node_p = node_p[-1]
-                                tokens.pop(pointer+1)
-                                arg2 = tokens.pop(pointer+1)
+                            # Collect the whole right-associative chain of
+                            # operands, then nest from the right.  The outermost
+                            # application is left for the ``op_name(*node)`` call
+                            # below (needed when ``op_name`` is a callable, e.g.
+                            # ``@`` or ``@@@``); for a string head the node is
+                            # built here directly.
+                            operands = [arg1, arg2]
+                            while pointer + 2 < size and tokens[pointer + 1] == token:
+                                tokens.pop(pointer + 1)
+                                operands.append(tokens.pop(pointer + 1))
                                 size -= 2
-                            node_p.append(arg2)
+                            rest = operands[-1]
+                            for left in reversed(operands[1:-1]):
+                                rest = ([op_name, left, rest] if isinstance(op_name, str)
+                                        else op_name(left, rest))
+                            node.clear()
+                            if isinstance(op_name, str):
+                                node.extend([op_name, operands[0], rest])
+                            else:
+                                node.extend([operands[0], rest])
                         elif grouping_strat == self.LEFT:
                             while pointer + 1 < size and tokens[pointer+1] == token:
                                 if isinstance(op_name, str):

--- a/sympy/parsing/mathematica.py
+++ b/sympy/parsing/mathematica.py
@@ -1005,7 +1005,30 @@ class MathematicaParser:
                     elif op_type == self.PREFIX:
                         if grouping_strat is not None:
                             raise TypeError("'Prefix' op_type should not have a grouping strat")
-                        if pointer == size - 1 or self._is_op(tokens[pointer + 1]):
+                        if token in ("#", "##"):
+                            # Slot (``#``) and SlotSequence (``##``) have special
+                            # argument rules that mirror the Wolfram Language:
+                            #   #        -> Slot[1]
+                            #   #3       -> Slot[3]           (positional: integer)
+                            #   #name    -> Slot["name"]      (named: a string, i.e.
+                            #                                  ["_Str", "name"] here)
+                            #   ##       -> SlotSequence[1]
+                            #   ##3      -> SlotSequence[3]
+                            #   ##name   -> SlotSequence[1]*name  (SlotSequence only
+                            #                                      takes integer indices,
+                            #                                      so ``name`` is a
+                            #                                      separate factor)
+                            nxt = tokens[pointer + 1] if pointer + 1 < size else None
+                            is_number = isinstance(nxt, str) and re.fullmatch(self._number, nxt) is not None
+                            if nxt is None or self._is_op(nxt) or (token == "##" and not is_number):
+                                tokens[pointer] = self._missing_arguments_default[token]()
+                            elif is_number:
+                                node.append(tokens.pop(pointer + 1))
+                                size -= 1
+                            else:  # ``#`` followed by a named slot
+                                node.append(["_Str", tokens.pop(pointer + 1)])
+                                size -= 1
+                        elif pointer == size - 1 or self._is_op(tokens[pointer + 1]):
                             tokens[pointer] = self._missing_arguments_default[token]()
                         else:
                             node.append(tokens.pop(pointer+1))

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -282,13 +282,19 @@ def test_parser_mathematica_tokenizer():
         [["Pattern", "y", ["Blank"]], ["Pattern", "z", ["Blank"]]],
     ]
 
-    # Slots for lambda functions
+    # Slots for lambda functions.  A positional slot (``#3``) carries an
+    # integer index; a named slot (``#name``) carries a string, which in the
+    # FullForm list is ``["_Str", "name"]`` (matching Mathematica's Slot["name"]).
     assert chain("#") == ["Slot", "1"]
     assert chain("#3") == ["Slot", "3"]
-    assert chain("#n") == ["Slot", "n"]
-    assert chain("#name") == ["Slot", "name"]
+    assert chain("#n") == ["Slot", ["_Str", "n"]]
+    assert chain("#name") == ["Slot", ["_Str", "name"]]
     assert chain("##") == ["SlotSequence", "1"]
-    assert chain("##a") == ["SlotSequence", "a"]
+    assert chain("##3") == ["SlotSequence", "3"]
+    # ``SlotSequence`` only takes an integer index, so ``##name`` is
+    # ``SlotSequence[1] * name`` (implicit multiplication), not a named slot.
+    assert chain("##a") == ["Times", ["SlotSequence", "1"], "a"]
+    assert chain("##name") == ["Times", ["SlotSequence", "1"], "name"]
 
     # Lambda functions
     assert chain("x&") == ["Function", "x"]

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -306,6 +306,57 @@ def test_parser_mathematica_tokenizer():
     assert chain("#1 + #2 & [x, y]") == [["Function", ["Plus", ["Slot", "1"], ["Slot", "2"]]], "x", "y"]
     assert chain("#1^2#2^3&") == ["Function", ["Times", ["Power", ["Slot", "1"], "2"], ["Power", ["Slot", "2"], "3"]]]
 
+    # Assignment operators
+    assert chain("a=b") == ["Set", "a", "b"]
+    assert chain("a:=b") == ["SetDelayed", "a", "b"]
+    assert chain("a+=b") == ["AddTo", "a", "b"]
+    assert chain("a-=b") == ["SubtractFrom", "a", "b"]
+    assert chain("a*=b") == ["TimesBy", "a", "b"]
+    assert chain("a/=b") == ["DivideBy", "a", "b"]
+
+    # Rules, replacement and conditions
+    assert chain("a->b") == ["Rule", "a", "b"]
+    assert chain("a:>b") == ["RuleDelayed", "a", "b"]
+    assert chain("a/;b") == ["Condition", "a", "b"]
+
+    # Comparison operators
+    assert chain("a>b") == ["Greater", "a", "b"]
+    assert chain("a>=b") == ["GreaterEqual", "a", "b"]
+    assert chain("a<b") == ["Less", "a", "b"]
+    assert chain("a<=b") == ["LessEqual", "a", "b"]
+    assert chain("a===b") == ["SameQ", "a", "b"]
+    assert chain("a=!=b") == ["UnsameQ", "a", "b"]
+
+    # Function application operators.  ``@`` is prefix application and ``//``
+    # is postfix; ``@@``/``@@@`` are Apply, ``/@``/``//@`` are Map/MapAll.
+    assert chain("f@x") == ["f", "x"]
+    assert chain("a@b@c") == ["a", ["b", "c"]]         # right associative
+    assert chain("f@@x") == ["Apply", "f", "x"]
+    assert chain("f@@@x") == ["Apply", "f", "x", ["List", "1"]]
+    assert chain("f/@x") == ["Map", "f", "x"]
+    assert chain("f//@x") == ["MapAll", "f", "x"]
+
+    # Derivative: ``f'`` is ``Derivative[1][f]``; primes accumulate the order.
+    assert chain("f'") == [["Derivative", "1"], "f"]
+    assert chain("f''") == [["Derivative", "2"], "f"]
+    assert chain("x'[t]") == [[["Derivative", "1"], "x"], "t"]
+
+    # Postfix operators and Alternatives / PatternTest / Repeated
+    assert chain("a--") == ["Decrement", "a"]
+    assert chain("a!!") == ["Factorial2", "a"]
+    assert chain("a|b|c") == ["Alternatives", "a", "b", "c"]
+    assert chain("a?b") == ["PatternTest", "a", "b"]
+    assert chain("a..") == ["Repeated", "a"]
+    assert chain("a...") == ["RepeatedNull", "a"]
+
+    # Span (``;;``) flattens into a single node with up to three arguments
+    assert chain("a;;b") == ["Span", "a", "b"]
+    assert chain("a;;b;;c") == ["Span", "a", "b", "c"]
+    assert chain("a[[b;;c]]") == ["Part", "a", ["Span", "b", "c"]]
+
+    # Typed blank via the infix ``_`` (e.g. ``x_Integer``)
+    assert chain("x_Integer") == ["Pattern", "x", ["Blank", "Integer"]]
+
     # Strings inside Mathematica expressions:
     assert chain('"abc"') == ["_Str", "abc"]
     assert chain('"a\\"b"') == ["_Str", 'a"b']

--- a/sympy/parsing/tests/test_mathematica.py
+++ b/sympy/parsing/tests/test_mathematica.py
@@ -227,9 +227,10 @@ def test_parser_mathematica_tokenizer():
     assert chain("a/.b") == ["ReplaceAll", "a", "b"]
     assert chain("a/.b/.c/.d") == ["ReplaceAll", ["ReplaceAll", ["ReplaceAll", "a", "b"], "c"], "d"]
 
-    assert chain("a//b") == ["a", "b"]
-    assert chain("a//b//c") == [["a", "b"], "c"]
-    assert chain("a//b//c//d") == [[["a", "b"], "c"], "d"]
+    # ``//`` is postfix application: ``x // f`` is ``f[x]`` (left associative).
+    assert chain("a//b") == ["b", "a"]
+    assert chain("a//b//c") == ["c", ["b", "a"]]
+    assert chain("a//b//c//d") == ["d", ["c", ["b", "a"]]]
 
     # Not operator
     assert chain("!x") == ["Not", "x"]
@@ -273,6 +274,13 @@ def test_parser_mathematica_tokenizer():
     assert chain("y___") == ["Pattern", "y", ["BlankNullSequence"]]
     assert chain("a[b_.,c_]") == ["a", ["Optional", ["Pattern", "b", ["Blank"]]], ["Pattern", "c", ["Blank"]]]
     assert chain("b_. c") == ["Times", ["Optional", ["Pattern", "b", ["Blank"]]], "c"]
+    # Patterns in head position, i.e. ``Pattern[F, Blank[]][Pattern[x, Blank[]]]``
+    assert chain("F_[x_]") == [["Pattern", "F", ["Blank"]], ["Pattern", "x", ["Blank"]]]
+    assert chain("F_[x_, y_[z_]]") == [
+        ["Pattern", "F", ["Blank"]],
+        ["Pattern", "x", ["Blank"]],
+        [["Pattern", "y", ["Blank"]], ["Pattern", "z", ["Blank"]]],
+    ]
 
     # Slots for lambda functions
     assert chain("#") == ["Slot", "1"]


### PR DESCRIPTION
#### References to other Issues or PRs

Correct several Wolfram-language parsing discrepancies found against Mathematica.

Add regression tests for previously-untested operators.

#### AI Generation Disclosure

The code changes and tests in this PR were generated with Claude Code (Anthropic, Claude Opus 4.8).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
