### PR TITLE
[GSoC 2026] Implements combinatorics/character-table

### DIFF
--- a/doc/src/modules/combinatorics/character_table.rst
+++ b/doc/src/modules/combinatorics/character_table.rst
@@ -1,7 +1,7 @@
 .. _combinatorics-character_table:
 
 Character Tables
-=============
+================
 
 .. automodule:: sympy.combinatorics.character_table
 

--- a/doc/src/modules/combinatorics/character_table.rst
+++ b/doc/src/modules/combinatorics/character_table.rst
@@ -1,0 +1,11 @@
+.. _combinatorics-character_table:
+
+Character Tables
+=============
+
+.. automodule:: sympy.combinatorics.character_table
+
+.. autoclass:: CharacterTable
+   :members:
+
+.. autofunction:: dixon_character_table

--- a/doc/src/modules/combinatorics/index.rst
+++ b/doc/src/modules/combinatorics/index.rst
@@ -26,3 +26,4 @@ Contents
    tensor_can.rst
    fp_groups.rst
    pc_groups.rst
+   character_table.rst

--- a/sympy/combinatorics/__init__.py
+++ b/sympy/combinatorics/__init__.py
@@ -14,6 +14,7 @@ from sympy.combinatorics.named_groups import (SymmetricGroup, DihedralGroup,
     CyclicGroup, AlternatingGroup, AbelianGroup, RubikGroup)
 from sympy.combinatorics.pc_groups import PolycyclicGroup, Collector
 from sympy.combinatorics.free_groups import free_group
+from sympy.combinatorics.character_table import CharacterTable
 
 __all__ = [
     'Permutation', 'Cycle',
@@ -41,4 +42,6 @@ __all__ = [
     'PolycyclicGroup', 'Collector',
 
     'free_group',
+
+    'CharacterTable',
 ]

--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -413,14 +413,14 @@ def _sort_characters(rows: list[list], dom: Domain):
             break
 
 
-def dixon_character_table(conjugacy_classes: Sequence[CC]) -> CharacterTable:
+def dixon_character_table(conjugacy_classes: Sequence[set[Permutation]]) -> CharacterTable:
     """
     Compute the character table of a permutation group from its conjugacy classes
     using Dixon's algorithm.
 
     Parameters
     ==========
-    conjugacy_classes : Sequence[CC]
+    conjugacy_classes : Sequence[set[Permutation]]
         The conjugacy classes of the group.
 
     Examples

--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -35,7 +35,8 @@ class CharacterTable(MutableDenseMatrix):
     and columns corresponding to conjugacy classes. Each entry is the value of the
     character on the conjugacy class, which is the trace of the representation matrix.
 
-    The trivial character is always the first row, and the identity class is the first column.
+    The trivial character is always the first row, and the identity class is
+    the first column if the order of the conjugacy classes is not specified.
 
     Examples
     ========
@@ -87,10 +88,15 @@ class CharacterTable(MutableDenseMatrix):
     def conjugacy_class_reps(self) -> list[Permutation]:
         return self._conjugacy_class_reps
 
+    def copy(self):
+        cp = self._fromrep(self._rep.copy())
+        cp._conjugacy_class_reps = self._conjugacy_class_reps.copy()
+        return cp
+
     @property
     def zeta_order(self) -> int:
         if self._rep.domain.is_CyclotomicField:
-            return self._rep.domain.zeta_order
+            return self._rep.domain.zeta_order # type: ignore
         return 1
 
     @classmethod
@@ -101,6 +107,9 @@ class CharacterTable(MutableDenseMatrix):
 def _compute_cmmatrices(
     cc: Sequence[CC], dom: Domain
 ) -> Generator[DomainMatrix, None, None]:
+    """
+    Compute the class multiplication matrices.
+    """
     n = len(cc)
     rmul = Permutation.rmul_with_af
     for ind in range(n):
@@ -125,7 +134,7 @@ def dixon_prime(order: int | MPZ, exponent: int | MPZ) -> int | MPZ:
     if order == 1:
         # trivial group => exponent == 1
         return 3
-    p = 2 * isqrt(order)
+    p = int(2 * isqrt(order))
     while True:
         p = nextprime(p + 1)
         if p % exponent == 1:
@@ -155,8 +164,8 @@ def _simultaneous_diagonalize(
                 new_spaces.append(S)
                 continue
             _, pivots = S.rref()
-            N0 = N.extract(range(S.shape[1]), pivots)
-            for _, __, sub_S in (S * N0).transpose().ground_eigenvects():
+            N1 = N.extract(range(S.shape[1]), pivots)
+            for _, __, sub_S in (S * N1).transpose().ground_eigenvects():
                 # sub_S: (sub_dim x dim), S: (dim x n) -> (sub_dim x n)
                 sub_S = sub_S.transpose().rref()[0]
                 new_spaces.append(sub_S * S)
@@ -204,26 +213,26 @@ def _get_powermap(cc: Sequence[CC], exponent: int | MPZ) -> list[list[int]]:
     return pm
 
 
-def _normalize_fp(cc: Sequence[CC], esd: DomainMatrix) -> list[list]:
-    Fp = esd.domain
+def _normalize_fp(cc: Sequence[CC], X: DomainMatrix) -> list[list]:
+    Fp = X.domain
     p = Fp.mod  # type: ignore
     n = len(cc)
-    rows = esd.to_list()
+    rows = X.to_list()
     cc_sizes = [Fp(len(c)) for c in cc]
-    G_order = sum(len(cc[t]) for t in range(len(cc)))
+    order = Fp(sum(len(cc[t]) for t in range(len(cc))))
 
     inv_map = _get_invmap(cc)
     normalized_rows = []
     for row in rows:
         # 1. normalize so the first class is 1
-        scale = 1 / Fp(row[0])
+        scale = 1 / row[0]
         row = [x * scale for x in row]
 
         # 2. chi(1)^2 * sum |Ci| * row[i] * row[inv_i] = |G|
         dot = sum(cc_sizes[k] * row[k] * row[inv_map[k]] for k in range(n))
 
         # chi1_sq = |G| / dot
-        chi1_sq = Fp(G_order) / dot
+        chi1_sq = order / dot
 
         root = sqrt_mod(int(chi1_sq), p)
         if root is None:
@@ -245,7 +254,7 @@ def _get_global_conductor(
     """
     n = len(rows)
     gal_m = [a for a in range(m) if gcd(a, m) == 1]
-    p_factors = primefactors(m)[::-1]
+    p_factors = primefactors(int(m))[::-1]
 
     for p in p_factors:
         while m % p == 0:
@@ -274,8 +283,14 @@ def _get_global_conductor(
     return m
 
 
-def _lift_to_minimal_field(normalized_rows, pm, k, e, Fp):
-    n = len(normalized_rows)
+def _lift_to_minimal_field(
+    rows: list[list], pm: list[list[int]], k, e, Fp
+) -> DomainMatrix:
+    """
+    Lift the normalized character table from Fp to the
+    k-th cyclotomic field.
+    """
+    n = len(rows)
     p = Fp.mod
     half_p = p // 2
 
@@ -284,7 +299,7 @@ def _lift_to_minimal_field(normalized_rows, pm, k, e, Fp):
         int_rows = []
         for i in range(n):
             # abs(every entry) <= sqrt(|G|) <= p//2
-            row = [ZZ(int(v)) for v in normalized_rows[i]]
+            row = [ZZ(int(v)) for v in rows[i]]
             row = [v if v <= half_p else v - p for v in row]
             int_rows.append(row)
         _sort_characters(int_rows, ZZ)
@@ -317,25 +332,24 @@ def _lift_to_minimal_field(normalized_rows, pm, k, e, Fp):
 
     dM = []
     for i in range(n):
-        char_row_fp = normalized_rows[i]
-        row_anps = []
+        row = rows[i]
+        row_anps: list[ANP] = []
 
         for j in range(n):
             # [chi(g^A1), chi(g^A2), ...] mod p
-            b_vec_data = []
+            b_data = []
             for A in gal_lifted:
-                class_of_gA = pm[j][A % e]
-                b_vec_data.append([char_row_fp[class_of_gA]])
+                b_data.append([row[pm[j][A % e]]])
 
-            b_vec = DomainMatrix(b_vec_data, (phi, 1), Fp)
+            b = DomainMatrix(b_data, (phi, 1), Fp)
 
             # c = V^-1 * b
-            c_vec = (V_inv * b_vec).to_list_flat()
+            c = (V_inv * b).to_list_flat()
 
-            c_ints = [int(v) for v in c_vec]
-            c_ints = [v if v <= half_p else v - p for v in c_ints]
+            c = [int(v) for v in c]
+            c = [v if v <= half_p else v - p for v in c]
 
-            row_anps.append(ANP(c_ints[::-1], dom.mod, QQ))
+            row_anps.append(ANP(c[::-1], dom.mod, QQ))
 
         dM.append(row_anps)
 
@@ -378,20 +392,34 @@ def dixon_character_table(conjugacy_classes: Sequence[CC]) -> CharacterTable:
              "Handbook of Computational Group Theory"
     """
     cc = conjugacy_classes
-    order = sum(len(cc[t]) for t in range(len(cc)))
+    size = [len(c) for c in cc]
+    order = sum(size)
+    identity = size.index(1)
     exponent = lcm(*(int(next(iter(c)).order()) for c in cc))
     p = dixon_prime(order, exponent)
     Fp = FiniteField(p)
 
-    mats = _compute_cmmatrices(cc, Fp)
-    esd = _simultaneous_diagonalize(mats)
+    # move the identity class to the front
+    if identity != 0:
+        cc = list(cc)
+        cc[identity], cc[0] = cc[0], cc[identity]
 
-    normalized = _normalize_fp(cc, esd)
+    mats = _compute_cmmatrices(cc, Fp)
+    X = _simultaneous_diagonalize(mats)
+
+    rows = _normalize_fp(cc, X)
     pm = _get_powermap(cc, exponent)
 
-    conductor = _get_global_conductor(normalized, pm, exponent)
-    dm = _lift_to_minimal_field(normalized, pm, conductor, exponent, Fp)
+    conductor = _get_global_conductor(rows, pm, exponent)
+    dm = _lift_to_minimal_field(rows, pm, conductor, exponent, Fp)
+
+    # restore the place of the identity class
+    if identity != 0:
+        _rows = list(range(dm.shape[0]))
+        _cols = _rows[:]
+        _cols[0], _cols[identity] = _cols[identity], _cols[0]
+        dm = dm.extract(_rows, _cols)
 
     tbl = CharacterTable._fromrep(dm)
-    tbl._conjugacy_class_reps = [next(iter(c)) for c in cc]
+    tbl._conjugacy_class_reps = [next(iter(c)) for c in conjugacy_classes]
     return tbl

--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sympy.combinatorics.permutations import Permutation
+from sympy.external.gmpy import gcd, lcm, sqrt as isqrt
+from sympy.matrices.dense import MutableDenseMatrix
+from sympy.ntheory import sqrt_mod, nextprime, primitive_root, primefactors
+from sympy.polys.domains import ZZ, QQ, FiniteField
+from sympy.polys.matrices.domainmatrix import DomainMatrix
+from sympy.polys.polyclasses import ANP
+
+if TYPE_CHECKING:
+    from typing import Protocol, Iterable, Iterator, Generator, Sequence
+    from sympy.combinatorics.perm_groups import PermutationGroup
+    from sympy.external.gmpy import MPZ
+    from sympy.polys.domains.domain import Domain
+
+    class CC(Protocol):
+        """Protocol for a conjugacy class."""
+
+        def __len__(self) -> int: ...
+        def __iter__(self) -> Iterator[Permutation]: ...
+        def __contains__(self, i: Permutation, /) -> bool: ...
+
+
+class CharacterTable(MutableDenseMatrix):
+    r"""
+    A class for creating the character table of a finite group.
+
+    Explanation
+    ============
+
+    The character table is a complex matrix with rows corresponding to characters
+    and columns corresponding to conjugacy classes. Each entry is the value of the
+    character on the conjugacy class, which is the trace of the representation matrix.
+
+    The trivial character is always the first row, and the identity class is the first column.
+
+    Examples
+    ========
+
+    >>> from sympy.combinatorics import CharacterTable, SymmetricGroup, AlternatingGroup
+    >>> CharacterTable.from_perm_group(SymmetricGroup(4)) # doctest: +SKIP
+    Matrix([
+     [1,  1,  1,  1,  1],
+     [1, -1,  1, -1,  1],
+     [2,  0,  2,  0, -1],
+     [3, -1, -1,  1,  0],
+     [3,  1, -1, -1,  0]])
+
+    The character table builds upon DomainMatrix, from which users can access the
+    the values of the characters as domain elements. The domain of a character table is
+    either ZZ or a cyclotomic field.
+
+    >>> M = CharacterTable.from_perm_group(AlternatingGroup(4))
+    >>> M # doctest: +SKIP
+    Matrix([
+     [1,          1,          1,  1],
+     [1, -1 - zeta3,      zeta3,  1],
+     [1,      zeta3, -1 - zeta3,  1],
+     [3,          0,          0, -1]])
+    >>> M._rep.domain
+    QQ<zeta3>
+    >>> M.zeta_order
+    3
+
+    The order of the columns matches the order of the conjugacy classes,
+    which can be accessed with the method `conjugacy_class_reps`.
+
+    >>> M.conjugacy_class_reps() # doctest: +SKIP
+    [Permutation(3), Permutation(0, 2, 3), Permutation(0, 1, 3), Permutation(0, 2)(1, 3)]
+
+    References
+    ==========
+    .. [1] Holt, D., Eick, B., O'Brien, E.
+           "Handbook of Computational Group Theory"
+
+    .. [2] https://en.wikipedia.org/wiki/Character_table
+
+    .. [3] https://docs.gap-system.org/doc/ref/manual.pdf
+
+    """
+
+    _conjugacy_class_reps: list[Permutation]
+
+    def conjugacy_class_reps(self) -> list[Permutation]:
+        return self._conjugacy_class_reps
+
+    @property
+    def zeta_order(self) -> int:
+        if self._rep.domain.is_CyclotomicField:
+            return self._rep.domain.zeta_order
+        return 1
+
+    @classmethod
+    def from_perm_group(cls, G: PermutationGroup) -> CharacterTable:
+        return dixon_character_table(G.conjugacy_classes())
+
+
+def _compute_cmmatrices(
+    cc: Sequence[CC], dom: Domain
+) -> Generator[DomainMatrix, None, None]:
+    n = len(cc)
+    rmul = Permutation.rmul_with_af
+    for ind in range(n):
+        m = [[-1] * n for _ in range(n)]
+        for i in range(n):
+            for j in range(n):
+                if m[i][j] != -1:
+                    continue
+                m[i] = [0] * n
+                for g in cc[ind]:
+                    for t in range(n):
+                        out = next(iter(cc[t]))
+                        # out = g^{-1} * h
+                        h = rmul(out, g)
+                        if h in cc[i]:
+                            m[i][t] += 1
+        yield DomainMatrix.from_list(m, dom)
+
+
+def dixon_prime(order: int | MPZ, exponent: int | MPZ) -> int | MPZ:
+    """Find a prime p so that `p > 2*sqrt(order)` and `p%exponent == 1`."""
+    if order == 1:
+        # trivial group => exponent == 1
+        return 3
+    p = 2 * isqrt(order)
+    while True:
+        p = nextprime(p + 1)
+        if p % exponent == 1:
+            break
+    return p
+
+
+def _simultaneous_diagonalize(
+    mats: Iterable[DomainMatrix], check_dim: bool = True
+) -> DomainMatrix:
+    """
+    Compute the simultaneous diagonalization of a list of DomainMatrices.
+    Returns Z such that `Z * N * Z.inv()` is diagonal for all N in mats
+    and Z is on the same domain as mats (assuming Z exists).
+    """
+    it = iter(mats)
+    N0 = next(it)
+    spaces = [S for _, __, S in N0.ground_eigenvects()]
+    n = N0.shape[0]
+    for N in it:
+        if len(spaces) == n:
+            break
+
+        new_spaces = []
+        for S in spaces:
+            if S.shape[0] <= 1:
+                new_spaces.append(S)
+                continue
+            _, pivots = S.rref()
+            N0 = N.extract(range(S.shape[1]), pivots)
+            for _, __, sub_S in (S * N0).transpose().ground_eigenvects():
+                # sub_S: (sub_dim x dim), S: (dim x n) -> (sub_dim x n)
+                sub_S = sub_S.transpose().rref()[0]
+                new_spaces.append(sub_S * S)
+        spaces = new_spaces
+
+    if check_dim and len(spaces) != n:
+        # not expected to happen here
+        raise ValueError("Failed to compute the common eigenspace decomposition.")
+
+    return DomainMatrix.vstack(*spaces)
+
+
+def _get_invmap(cc: Sequence[CC]) -> list[int]:
+    """Compute `inv_map[i] = j` such that `class[i]**-1 == class[j]`."""
+    inv_map = [-1] * len(cc)
+    reps = [next(iter(c)) for c in cc]
+    inv_reps = [~g for g in reps]
+    for i, ig in enumerate(inv_reps):
+        if inv_map[i] != -1:
+            continue
+        for j, c in enumerate(cc):
+            if ig in c:
+                inv_map[i] = j
+                inv_map[j] = i
+                break
+    return inv_map
+
+
+def _get_powermap(cc: Sequence[CC], exponent: int | MPZ) -> list[list[int]]:
+    """Compute `pm[i][pow] = k` such that `class[i]**pow == k`."""
+    n = len(cc)
+    pm = [[-1] * exponent for _ in range(n)]
+    reps = [next(iter(c)) for c in cc]
+    rmul = Permutation.rmul_with_af
+    identity = rmul(reps[0], ~reps[0])
+    for i in range(n):
+        g = reps[i]
+        gk = identity
+        for k in range(exponent):
+            for t in range(n):
+                if gk in cc[t]:
+                    pm[i][k] = t
+                    break
+            gk = rmul(gk, g)
+    return pm
+
+
+def _normalize_fp(cc: Sequence[CC], esd: DomainMatrix) -> list[list]:
+    Fp = esd.domain
+    p = Fp.mod  # type: ignore
+    n = len(cc)
+    rows = esd.to_list()
+    cc_sizes = [Fp(len(c)) for c in cc]
+    G_order = sum(len(cc[t]) for t in range(len(cc)))
+
+    inv_map = _get_invmap(cc)
+    normalized_rows = []
+    for row in rows:
+        # 1. normalize so the first class is 1
+        scale = 1 / Fp(row[0])
+        row = [x * scale for x in row]
+
+        # 2. chi(1)^2 * sum |Ci| * row[i] * row[inv_i] = |G|
+        dot = sum(cc_sizes[k] * row[k] * row[inv_map[k]] for k in range(n))
+
+        # chi1_sq = |G| / dot
+        chi1_sq = Fp(G_order) / dot
+
+        root = sqrt_mod(int(chi1_sq), p)
+        if root is None:
+            # not expected to happen
+            raise ValueError(f"Failed to compute sqrt({chi1_sq}) on {Fp}")
+        chi1 = Fp(root)
+
+        normalized_rows.append([x * chi1 for x in row])
+
+    return normalized_rows
+
+
+def _get_global_conductor(
+    rows: list[list], pm: list[list[int]], m: int | MPZ
+) -> int | MPZ:
+    """
+    Find the smallest natural number k such that all values of the
+    character table can be embedded in the k-th cyclotomic field.
+    """
+    n = len(rows)
+    gal_m = [a for a in range(m) if gcd(a, m) == 1]
+    p_factors = primefactors(m)[::-1]
+
+    for p in p_factors:
+        while m % p == 0:
+            # test invariance under m//p
+            m = m // p
+            r = 1 % m
+
+            fixed = True
+            for a in gal_m:
+                if a % m != r:
+                    continue
+                for i in range(n):
+                    row = rows[i]
+                    for j in range(n):
+                        if row[pm[j][a]] != row[j]:
+                            fixed = False
+                            break
+                    if not fixed:
+                        break
+                if not fixed:
+                    break
+
+            if not fixed:
+                m = m * p  # restore
+                break
+    return m
+
+
+def _lift_to_minimal_field(normalized_rows, pm, k, e, Fp):
+    n = len(normalized_rows)
+    p = Fp.mod
+    half_p = p // 2
+
+    if k == 1:
+        # integer character table
+        int_rows = []
+        for i in range(n):
+            # abs(every entry) <= sqrt(|G|) <= p//2
+            row = [ZZ(int(v)) for v in normalized_rows[i]]
+            row = [v if v <= half_p else v - p for v in row]
+            int_rows.append(row)
+        _sort_characters(int_rows, ZZ)
+        return DomainMatrix(int_rows, (n, n), ZZ)
+
+    dom = QQ.cyclotomic_field(k)
+
+    x = Fp(primitive_root(p)) ** ((p - 1) // k)
+
+    gal = [a for a in range(k) if gcd(a, k) == 1]
+    phi = len(gal)
+
+    # V[a, i] = (x**a)**i
+    V = []
+    for a in gal:
+        xa = x**a
+        row = [xa**i for i in range(phi)]
+        V.append(row)
+
+    V_mat = DomainMatrix(V, (phi, phi), Fp)
+    V_inv = V_mat.inv()
+
+    # for a in (Z/k)*, find A in (Z/exp)* that A = a (mod k)
+    gal_lifted = []
+    for a in gal:
+        A = a
+        while gcd(A, e) != 1:
+            A += k
+        gal_lifted.append(A)
+
+    dM = []
+    for i in range(n):
+        char_row_fp = normalized_rows[i]
+        row_anps = []
+
+        for j in range(n):
+            # [chi(g^A1), chi(g^A2), ...] mod p
+            b_vec_data = []
+            for A in gal_lifted:
+                class_of_gA = pm[j][A % e]
+                b_vec_data.append([char_row_fp[class_of_gA]])
+
+            b_vec = DomainMatrix(b_vec_data, (phi, 1), Fp)
+
+            # c = V^-1 * b
+            c_vec = (V_inv * b_vec).to_list_flat()
+
+            c_ints = [int(v) for v in c_vec]
+            c_ints = [v if v <= half_p else v - p for v in c_ints]
+
+            row_anps.append(ANP(c_ints[::-1], dom.mod, QQ))
+
+        dM.append(row_anps)
+
+    _sort_characters(dM, dom)
+    return DomainMatrix(dM, (n, n), dom)
+
+
+def _sort_characters(rows: list[list], dom: Domain):
+    """
+    Sort the character table and move the trivial
+    character to the first row. Done in-place.
+    """
+    one = dom.one
+    rows.sort()
+    for i in range(len(rows)):
+        if all(v == one for v in rows[i]):
+            rows[0], rows[i] = rows[i], rows[0]
+            break
+
+
+def dixon_character_table(conjugacy_classes: Sequence[CC]) -> CharacterTable:
+    """
+    Compute the character table of a finite group from its conjugacy classes
+    using Dixon's algorithm.
+
+    Parameters
+    ==========
+    conjugacy_classes : Sequence[CC]
+        The conjugacy classes of the group.
+
+    References
+    ==========
+    .. [1] Dixon, J.
+             "High Speed Computation of Group Characters"
+
+    .. [2] Schneider, J.
+             "Dixon's character table algorithm revisited""
+
+    .. [3] Holt, D., Eick, B., O'Brien, E.
+             "Handbook of Computational Group Theory"
+    """
+    cc = conjugacy_classes
+    order = sum(len(cc[t]) for t in range(len(cc)))
+    exponent = lcm(*(int(next(iter(c)).order()) for c in cc))
+    p = dixon_prime(order, exponent)
+    Fp = FiniteField(p)
+
+    mats = _compute_cmmatrices(cc, Fp)
+    esd = _simultaneous_diagonalize(mats)
+
+    normalized = _normalize_fp(cc, esd)
+    pm = _get_powermap(cc, exponent)
+
+    conductor = _get_global_conductor(normalized, pm, exponent)
+    dm = _lift_to_minimal_field(normalized, pm, conductor, exponent, Fp)
+
+    tbl = CharacterTable._fromrep(dm)
+    tbl._conjugacy_class_reps = [next(iter(c)) for c in cc]
+    return tbl

--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -35,8 +35,7 @@ class CharacterTable(MutableDenseMatrix):
     and columns corresponding to conjugacy classes. Each entry is the value of the
     character on the conjugacy class, which is the trace of the representation matrix.
 
-    The trivial character is always the first row, and the identity class is
-    the first column if the order of the conjugacy classes is not specified.
+    The trivial character is always the first row of the character table.
 
     Examples
     ========
@@ -86,7 +85,7 @@ class CharacterTable(MutableDenseMatrix):
     _conjugacy_class_reps: list[Permutation]
 
     def conjugacy_class_reps(self) -> list[Permutation]:
-        return self._conjugacy_class_reps
+        return self._conjugacy_class_reps[:]
 
     def copy(self):
         cp = self._fromrep(self._rep.copy())
@@ -95,12 +94,55 @@ class CharacterTable(MutableDenseMatrix):
 
     @property
     def zeta_order(self) -> int:
+        """
+        Returns the order of the primitive root of unity of the underlying
+        cyclotomic field.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import CharacterTable, AlternatingGroup
+        >>> CharacterTable.from_perm_group(AlternatingGroup(3)).zeta_order
+        3
+        >>> CharacterTable.from_perm_group(AlternatingGroup(5)).zeta_order
+        5
+
+        It returns 1 if the character table is over ZZ.
+
+        >>> from sympy.combinatorics import SymmetricGroup
+        >>> CharacterTable.from_perm_group(SymmetricGroup(4)).zeta_order
+        1
+        """
         if self._rep.domain.is_CyclotomicField:
             return self._rep.domain.zeta_order # type: ignore
         return 1
 
     @classmethod
     def from_perm_group(cls, G: PermutationGroup) -> CharacterTable:
+        """
+        Create a character table from a permutation group.
+
+        Parameters
+        ==========
+        G : PermutationGroup
+            The permutation group for which to create the character table.
+
+        Returns
+        ========
+        CharacterTable
+            The character table of the permutation group.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics import CharacterTable, AlternatingGroup
+        >>> CharacterTable.from_perm_group(AlternatingGroup(4)) # doctest: +SKIP
+        Matrix([
+         [1,          1,          1,  1],
+         [1, -1 - zeta3,      zeta3,  1],
+         [1,      zeta3, -1 - zeta3,  1],
+         [3,          0,          0, -1]])
+        """
         return dixon_character_table(G.conjugacy_classes())
 
 
@@ -372,7 +414,7 @@ def _sort_characters(rows: list[list], dom: Domain):
 
 def dixon_character_table(conjugacy_classes: Sequence[CC]) -> CharacterTable:
     """
-    Compute the character table of a finite group from its conjugacy classes
+    Compute the character table of a permutation group from its conjugacy classes
     using Dixon's algorithm.
 
     Parameters
@@ -380,13 +422,26 @@ def dixon_character_table(conjugacy_classes: Sequence[CC]) -> CharacterTable:
     conjugacy_classes : Sequence[CC]
         The conjugacy classes of the group.
 
+    Examples
+    ==========
+
+    >>> from sympy.combinatorics.character_table import dixon_character_table
+    >>> from sympy.combinatorics import AlternatingGroup
+    >>> G = AlternatingGroup(4)
+    >>> dixon_character_table(G.conjugacy_classes()) # doctest: +SKIP
+    Matrix([
+     [1,          1,          1,  1],
+     [1, -1 - zeta3,      zeta3,  1],
+     [1,      zeta3, -1 - zeta3,  1],
+     [3,          0,          0, -1]])
+
     References
     ==========
     .. [1] Dixon, J.
              "High Speed Computation of Group Characters"
 
     .. [2] Schneider, J.
-             "Dixon's character table algorithm revisited""
+             "Dixon's character table algorithm revisited"
 
     .. [3] Holt, D., Eick, B., O'Brien, E.
              "Handbook of Computational Group Theory"
@@ -394,15 +449,22 @@ def dixon_character_table(conjugacy_classes: Sequence[CC]) -> CharacterTable:
     cc = conjugacy_classes
     size = [len(c) for c in cc]
     order = sum(size)
-    identity = size.index(1)
     exponent = lcm(*(int(next(iter(c)).order()) for c in cc))
     p = dixon_prime(order, exponent)
     Fp = FiniteField(p)
 
     # move the identity class to the front
+    for i, c in enumerate(cc):
+        if next(iter(c)).is_identity:
+            identity = i
+            break
+    else:
+        raise ValueError("No identity class found")
+
     if identity != 0:
         cc = list(cc)
         cc[identity], cc[0] = cc[0], cc[identity]
+
 
     mats = _compute_cmmatrices(cc, Fp)
     X = _simultaneous_diagonalize(mats)

--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -89,7 +89,7 @@ class CharacterTable(MutableDenseMatrix):
 
     def copy(self):
         cp = self._fromrep(self._rep.copy())
-        cp._conjugacy_class_reps = self._conjugacy_class_reps.copy()
+        cp._conjugacy_class_reps = self.conjugacy_class_reps()
         return cp
 
     @property
@@ -173,9 +173,10 @@ def _compute_cmmatrices(
 
 def dixon_prime(order: int | MPZ, exponent: int | MPZ) -> int | MPZ:
     """Find a prime p so that `p > 2*sqrt(order)` and `p%exponent == 1`."""
-    if order == 1:
-        # trivial group => exponent == 1
+    if exponent == 1:
+        # trivial group <=> exponent == 1
         return 3
+
     p = int(2 * isqrt(order))
     while True:
         p = nextprime(p + 1)
@@ -447,11 +448,6 @@ def dixon_character_table(conjugacy_classes: Sequence[CC]) -> CharacterTable:
              "Handbook of Computational Group Theory"
     """
     cc = conjugacy_classes
-    size = [len(c) for c in cc]
-    order = sum(size)
-    exponent = lcm(*(int(next(iter(c)).order()) for c in cc))
-    p = dixon_prime(order, exponent)
-    Fp = FiniteField(p)
 
     # move the identity class to the front
     for i, c in enumerate(cc):
@@ -465,6 +461,11 @@ def dixon_character_table(conjugacy_classes: Sequence[CC]) -> CharacterTable:
         cc = list(cc)
         cc[identity], cc[0] = cc[0], cc[identity]
 
+    size = [len(c) for c in cc]
+    order = sum(size)
+    exponent = lcm(*(int(next(iter(c)).order()) for c in cc))
+    p = dixon_prime(order, exponent)
+    Fp = FiniteField(p)
 
     mats = _compute_cmmatrices(cc, Fp)
     X = _simultaneous_diagonalize(mats)

--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -10,11 +10,10 @@ from sympy.polys.domains import ZZ, QQ, FiniteField
 from sympy.polys.matrices.domainmatrix import DomainMatrix
 from sympy.polys.polyclasses import ANP
 from sympy.printing.defaults import DefaultPrinting
-from sympy.printing.str import StrPrinter
+from sympy.printing.repr import srepr
 
 if TYPE_CHECKING:
-    from typing import Protocol, Iterable, Iterator, Generator, Sequence
-    from typing_extensions import Self
+    from typing import Protocol, Iterable, Iterator, Sequence
     from sympy.combinatorics.perm_groups import PermutationGroup
     from sympy.core import Expr
     from sympy.polys.domains.domain import Domain, Er
@@ -43,18 +42,17 @@ class CharacterTable(DefaultPrinting):
     Examples
     ========
 
-    >>> from sympy.combinatorics import CharacterTable, SymmetricGroup, AlternatingGroup
-    >>> CharacterTable(SymmetricGroup(4)) # doctest: +SKIP
-    CharacterTable([
-     [1,  1,  1,  1,  1],
-     [1, -1,  1, -1,  1],
-     [2,  0,  2,  0, -1],
-     [3, -1, -1,  1,  0],
-     [3,  1, -1, -1,  0]])
+    The character table of a permutation group is computed by calling the
+    `character_table` method on the group.
+
+    >>> from sympy.combinatorics import SymmetricGroup, AlternatingGroup
+    >>> M = SymmetricGroup(4).character_table()
+    >>> type(M)
+    <class 'sympy.combinatorics.character_table.CharacterTable'>
 
     Calling `.as_matrix()` on the character table returns a matrix.
 
-    >>> CharacterTable(SymmetricGroup(4)).as_matrix() # doctest: +SKIP
+    >>> M.as_matrix()
     Matrix([
      [1,  1,  1,  1,  1],
      [1, -1,  1, -1,  1],
@@ -66,9 +64,9 @@ class CharacterTable(DefaultPrinting):
     the values of the characters as domain elements. The domain of a character table is
     either ZZ or a cyclotomic field.
 
-    >>> M = CharacterTable(AlternatingGroup(4))
-    >>> M # doctest: +SKIP
-    CharacterTable([
+    >>> M = AlternatingGroup(4).character_table()
+    >>> M.as_matrix()
+    Matrix([
      [1,          1,          1,  1],
      [1, -1 - zeta3,      zeta3,  1],
      [1,      zeta3, -1 - zeta3,  1],
@@ -82,7 +80,7 @@ class CharacterTable(DefaultPrinting):
     which can be accessed with the method `conjugacy_class_reps`.
 
     >>> M.conjugacy_class_reps() # doctest: +SKIP
-    [Permutation(3), Permutation(0, 2, 3), Permutation(0, 1, 3), Permutation(0, 2)(1, 3)]
+    [(3), (0 3 1), (3)(0 2 1), (0 3)(1 2)]
 
     References
     ==========
@@ -97,15 +95,9 @@ class CharacterTable(DefaultPrinting):
     _rep: DomainMatrix
     _conjugacy_class_reps: list[Permutation]
 
-    def __new__(cls, G: PermutationGroup):
-        return cls.from_perm_group(G)
-
-    @classmethod
-    def new(cls, rep: DomainMatrix, conjugacy_class_reps: list[Permutation]) -> Self:
-        obj = super().__new__(cls)
-        obj._rep = rep
-        obj._conjugacy_class_reps = conjugacy_class_reps
-        return obj
+    def __init__(self, rep: DomainMatrix, conjugacy_class_reps: list[Permutation]):
+        self._rep = rep
+        self._conjugacy_class_reps = conjugacy_class_reps
 
     def conjugacy_class_reps(self) -> list[Permutation]:
         return self._conjugacy_class_reps[:]
@@ -123,15 +115,8 @@ class CharacterTable(DefaultPrinting):
     def shape(self) -> tuple[int, int]:
         return self._rep.shape
 
-    def __str__(self) -> str:
-        return "CharacterTable(%s)" % str(self.tolist())
-
-    def _format_str(self, printer=None) -> str:
-        if not printer:
-            printer = StrPrinter()
-        linefeed = "\n" if self.shape[0] > 1 else ""
-        table = self.as_matrix().table(printer, rowsep=',\n')
-        return "CharacterTable([%s%s])" % (linefeed, table)
+    def __repr__(self):
+        return srepr(self)
 
     @property
     def zeta_order(self) -> int:
@@ -143,15 +128,15 @@ class CharacterTable(DefaultPrinting):
         ========
 
         >>> from sympy.combinatorics import CharacterTable, AlternatingGroup
-        >>> CharacterTable(AlternatingGroup(3)).zeta_order
+        >>> AlternatingGroup(3).character_table().zeta_order
         3
-        >>> CharacterTable(AlternatingGroup(5)).zeta_order
+        >>> AlternatingGroup(5).character_table().zeta_order
         5
 
         It returns 1 if the character table is over ZZ.
 
         >>> from sympy.combinatorics import SymmetricGroup
-        >>> CharacterTable(SymmetricGroup(4)).zeta_order
+        >>> SymmetricGroup(4).character_table().zeta_order
         1
         """
         if self._rep.domain.is_CyclotomicField:
@@ -177,7 +162,7 @@ class CharacterTable(DefaultPrinting):
         ========
 
         >>> from sympy.combinatorics import CharacterTable, AlternatingGroup
-        >>> CharacterTable.from_perm_group(AlternatingGroup(4)) # doctest: +SKIP
+        >>> CharacterTable.from_perm_group(AlternatingGroup(4)).as_matrix()
         Matrix([
          [1,          1,          1,  1],
          [1, -1 - zeta3,      zeta3,  1],
@@ -189,7 +174,7 @@ class CharacterTable(DefaultPrinting):
 
 def _compute_cmmatrices(
     cc: Sequence[CC], dom: Domain[Er]
-) -> Generator[DomainMatrix, None, None]:
+) -> Iterator[DomainMatrix]:
     """
     Compute the class multiplication matrices.
     """
@@ -233,6 +218,9 @@ def _simultaneous_diagonalize(
     Compute the simultaneous diagonalization of a list of DomainMatrices.
     Returns Z such that `Z * N * Z.inv()` is diagonal for all N in mats
     and Z is on the same domain as mats (assuming Z exists).
+
+    This is used internally for computing the simultaneous diagonalization
+    of class multiplication matrices, where such Z must exist.
     """
     it = iter(mats)
     N0 = next(it)
@@ -472,8 +460,8 @@ def dixon_character_table(conjugacy_classes: Sequence[set[Permutation]]) -> Char
     >>> from sympy.combinatorics.character_table import dixon_character_table
     >>> from sympy.combinatorics import AlternatingGroup
     >>> G = AlternatingGroup(4)
-    >>> dixon_character_table(G.conjugacy_classes())
-    CharacterTable([
+    >>> dixon_character_table(G.conjugacy_classes()).as_matrix()
+    Matrix([
      [1,          1,          1,  1],
      [1, -1 - zeta3,      zeta3,  1],
      [1,      zeta3, -1 - zeta3,  1],
@@ -527,4 +515,4 @@ def dixon_character_table(conjugacy_classes: Sequence[set[Permutation]]) -> Char
         dm = dm.extract(_rows, _cols)
 
     conjugacy_class_reps = [next(iter(c)) for c in conjugacy_classes]
-    return CharacterTable.new(dm, conjugacy_class_reps)
+    return CharacterTable(dm, conjugacy_class_reps)

--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -127,7 +127,7 @@ class CharacterTable(DefaultPrinting):
         Examples
         ========
 
-        >>> from sympy.combinatorics import CharacterTable, AlternatingGroup
+        >>> from sympy.combinatorics import AlternatingGroup
         >>> AlternatingGroup(3).character_table().zeta_order
         3
         >>> AlternatingGroup(5).character_table().zeta_order

--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -6,7 +6,7 @@ from sympy.combinatorics.permutations import Permutation
 from sympy.external.gmpy import gcd, lcm, sqrt as isqrt
 from sympy.matrices.dense import MutableDenseMatrix
 from sympy.ntheory import sqrt_mod, nextprime, primitive_root, primefactors
-from sympy.polys.domains import ZZ, QQ, FiniteField
+from sympy.polys.domains import ZZ, QQ, FiniteField, EXRAW
 from sympy.polys.matrices.domainmatrix import DomainMatrix
 from sympy.polys.polyclasses import ANP
 from sympy.printing.defaults import DefaultPrinting
@@ -106,7 +106,10 @@ class CharacterTable(DefaultPrinting):
         return self._rep.copy()
 
     def as_matrix(self) -> MutableDenseMatrix:
-        return MutableDenseMatrix._fromrep(self._rep)
+        rep = self._rep.to_sparse()
+        if not rep.domain.is_ZZ:
+            rep = rep.convert_to(EXRAW)
+        return MutableDenseMatrix._fromrep(rep)
 
     def tolist(self) -> list[list[Expr]]:
         return self.as_matrix().tolist()
@@ -267,7 +270,7 @@ def _get_invmap(cc: Sequence[CC]) -> list[int]:
 
 
 def _get_powermap(cc: Sequence[CC], exponent: int) -> list[list[int]]:
-    """Compute `pm[i][pow] = k` such that `class[i]**pow == k`."""
+    """Compute `pm[i][pow] = k` such that `class[i]**pow == class[k]`."""
     n = len(cc)
     pm = [[-1] * exponent for _ in range(n)]
     reps = [next(iter(c)) for c in cc]
@@ -358,7 +361,7 @@ def _get_global_conductor(
 
 
 def _lift_to_minimal_field(
-    rows: list[list], pm: list[list[int]], k, e, Fp
+    rows: list[list], pm: list[list[int]], k: int, e: int, Fp: FiniteField
 ) -> DomainMatrix:
     """
     Lift the normalized character table from Fp to the

--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -9,12 +9,15 @@ from sympy.ntheory import sqrt_mod, nextprime, primitive_root, primefactors
 from sympy.polys.domains import ZZ, QQ, FiniteField
 from sympy.polys.matrices.domainmatrix import DomainMatrix
 from sympy.polys.polyclasses import ANP
+from sympy.printing.defaults import DefaultPrinting
+from sympy.printing.str import StrPrinter
 
 if TYPE_CHECKING:
     from typing import Protocol, Iterable, Iterator, Generator, Sequence
+    from typing_extensions import Self
     from sympy.combinatorics.perm_groups import PermutationGroup
-    from sympy.external.gmpy import MPZ
-    from sympy.polys.domains.domain import Domain
+    from sympy.core import Expr
+    from sympy.polys.domains.domain import Domain, Er
 
     class CC(Protocol):
         """Protocol for a conjugacy class."""
@@ -24,7 +27,7 @@ if TYPE_CHECKING:
         def __contains__(self, i: Permutation, /) -> bool: ...
 
 
-class CharacterTable(MutableDenseMatrix):
+class CharacterTable(DefaultPrinting):
     r"""
     A class for creating the character table of a finite group.
 
@@ -41,7 +44,17 @@ class CharacterTable(MutableDenseMatrix):
     ========
 
     >>> from sympy.combinatorics import CharacterTable, SymmetricGroup, AlternatingGroup
-    >>> CharacterTable.from_perm_group(SymmetricGroup(4)) # doctest: +SKIP
+    >>> CharacterTable(SymmetricGroup(4)) # doctest: +SKIP
+    CharacterTable([
+     [1,  1,  1,  1,  1],
+     [1, -1,  1, -1,  1],
+     [2,  0,  2,  0, -1],
+     [3, -1, -1,  1,  0],
+     [3,  1, -1, -1,  0]])
+
+    Calling `.as_matrix()` on the character table returns a matrix.
+
+    >>> CharacterTable(SymmetricGroup(4)).as_matrix() # doctest: +SKIP
     Matrix([
      [1,  1,  1,  1,  1],
      [1, -1,  1, -1,  1],
@@ -53,9 +66,9 @@ class CharacterTable(MutableDenseMatrix):
     the values of the characters as domain elements. The domain of a character table is
     either ZZ or a cyclotomic field.
 
-    >>> M = CharacterTable.from_perm_group(AlternatingGroup(4))
+    >>> M = CharacterTable(AlternatingGroup(4))
     >>> M # doctest: +SKIP
-    Matrix([
+    CharacterTable([
      [1,          1,          1,  1],
      [1, -1 - zeta3,      zeta3,  1],
      [1,      zeta3, -1 - zeta3,  1],
@@ -81,16 +94,44 @@ class CharacterTable(MutableDenseMatrix):
     .. [3] https://docs.gap-system.org/doc/ref/manual.pdf
 
     """
-
+    _rep: DomainMatrix
     _conjugacy_class_reps: list[Permutation]
+
+    def __new__(cls, G: PermutationGroup):
+        return cls.from_perm_group(G)
+
+    @classmethod
+    def new(cls, rep: DomainMatrix, conjugacy_class_reps: list[Permutation]) -> Self:
+        obj = super().__new__(cls)
+        obj._rep = rep
+        obj._conjugacy_class_reps = conjugacy_class_reps
+        return obj
 
     def conjugacy_class_reps(self) -> list[Permutation]:
         return self._conjugacy_class_reps[:]
 
-    def copy(self):
-        cp = self._fromrep(self._rep.copy())
-        cp._conjugacy_class_reps = self.conjugacy_class_reps()
-        return cp
+    def as_domain_matrix(self) -> DomainMatrix:
+        return self._rep.copy()
+
+    def as_matrix(self) -> MutableDenseMatrix:
+        return MutableDenseMatrix._fromrep(self._rep)
+
+    def tolist(self) -> list[list[Expr]]:
+        return self.as_matrix().tolist()
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return self._rep.shape
+
+    def __str__(self) -> str:
+        return "CharacterTable(%s)" % str(self.tolist())
+
+    def _format_str(self, printer=None) -> str:
+        if not printer:
+            printer = StrPrinter()
+        linefeed = "\n" if self.shape[0] > 1 else ""
+        table = self.as_matrix().table(printer, rowsep=',\n')
+        return "CharacterTable([%s%s])" % (linefeed, table)
 
     @property
     def zeta_order(self) -> int:
@@ -102,15 +143,15 @@ class CharacterTable(MutableDenseMatrix):
         ========
 
         >>> from sympy.combinatorics import CharacterTable, AlternatingGroup
-        >>> CharacterTable.from_perm_group(AlternatingGroup(3)).zeta_order
+        >>> CharacterTable(AlternatingGroup(3)).zeta_order
         3
-        >>> CharacterTable.from_perm_group(AlternatingGroup(5)).zeta_order
+        >>> CharacterTable(AlternatingGroup(5)).zeta_order
         5
 
         It returns 1 if the character table is over ZZ.
 
         >>> from sympy.combinatorics import SymmetricGroup
-        >>> CharacterTable.from_perm_group(SymmetricGroup(4)).zeta_order
+        >>> CharacterTable(SymmetricGroup(4)).zeta_order
         1
         """
         if self._rep.domain.is_CyclotomicField:
@@ -147,7 +188,7 @@ class CharacterTable(MutableDenseMatrix):
 
 
 def _compute_cmmatrices(
-    cc: Sequence[CC], dom: Domain
+    cc: Sequence[CC], dom: Domain[Er]
 ) -> Generator[DomainMatrix, None, None]:
     """
     Compute the class multiplication matrices.
@@ -171,7 +212,7 @@ def _compute_cmmatrices(
         yield DomainMatrix.from_list(m, dom)
 
 
-def dixon_prime(order: int | MPZ, exponent: int | MPZ) -> int | MPZ:
+def _dixon_prime(order: int, exponent: int) -> int:
     """Find a prime p so that `p > 2*sqrt(order)` and `p%exponent == 1`."""
     if exponent == 1:
         # trivial group <=> exponent == 1
@@ -237,7 +278,7 @@ def _get_invmap(cc: Sequence[CC]) -> list[int]:
     return inv_map
 
 
-def _get_powermap(cc: Sequence[CC], exponent: int | MPZ) -> list[list[int]]:
+def _get_powermap(cc: Sequence[CC], exponent: int) -> list[list[int]]:
     """Compute `pm[i][pow] = k` such that `class[i]**pow == k`."""
     n = len(cc)
     pm = [[-1] * exponent for _ in range(n)]
@@ -256,9 +297,11 @@ def _get_powermap(cc: Sequence[CC], exponent: int | MPZ) -> list[list[int]]:
     return pm
 
 
-def _normalize_fp(cc: Sequence[CC], X: DomainMatrix) -> list[list]:
+def _normalize_fp(cc: Sequence[CC], X: DomainMatrix, p: int) -> list[list]:
+    """
+    Scale the eigenvectors to match the character table.
+    """
     Fp = X.domain
-    p = Fp.mod  # type: ignore
     n = len(cc)
     rows = X.to_list()
     cc_sizes = [Fp(len(c)) for c in cc]
@@ -289,15 +332,15 @@ def _normalize_fp(cc: Sequence[CC], X: DomainMatrix) -> list[list]:
 
 
 def _get_global_conductor(
-    rows: list[list], pm: list[list[int]], m: int | MPZ
-) -> int | MPZ:
+    rows: list[list[Er]], pm: list[list[int]], m: int
+) -> int:
     """
     Find the smallest natural number k such that all values of the
     character table can be embedded in the k-th cyclotomic field.
     """
     n = len(rows)
     gal_m = [a for a in range(m) if gcd(a, m) == 1]
-    p_factors = primefactors(int(m))[::-1]
+    p_factors = primefactors(m)[::-1]
 
     for p in p_factors:
         while m % p == 0:
@@ -400,7 +443,7 @@ def _lift_to_minimal_field(
     return DomainMatrix(dM, (n, n), dom)
 
 
-def _sort_characters(rows: list[list], dom: Domain):
+def _sort_characters(rows: list[list[Er]], dom: Domain[Er]):
     """
     Sort the character table and move the trivial
     character to the first row. Done in-place.
@@ -429,8 +472,8 @@ def dixon_character_table(conjugacy_classes: Sequence[set[Permutation]]) -> Char
     >>> from sympy.combinatorics.character_table import dixon_character_table
     >>> from sympy.combinatorics import AlternatingGroup
     >>> G = AlternatingGroup(4)
-    >>> dixon_character_table(G.conjugacy_classes()) # doctest: +SKIP
-    Matrix([
+    >>> dixon_character_table(G.conjugacy_classes())
+    CharacterTable([
      [1,          1,          1,  1],
      [1, -1 - zeta3,      zeta3,  1],
      [1,      zeta3, -1 - zeta3,  1],
@@ -463,14 +506,14 @@ def dixon_character_table(conjugacy_classes: Sequence[set[Permutation]]) -> Char
 
     size = [len(c) for c in cc]
     order = sum(size)
-    exponent = lcm(*(int(next(iter(c)).order()) for c in cc))
-    p = dixon_prime(order, exponent)
+    exponent = int(lcm(*(int(next(iter(c)).order()) for c in cc)))
+    p = _dixon_prime(order, exponent)
     Fp = FiniteField(p)
 
     mats = _compute_cmmatrices(cc, Fp)
     X = _simultaneous_diagonalize(mats)
 
-    rows = _normalize_fp(cc, X)
+    rows = _normalize_fp(cc, X, p)
     pm = _get_powermap(cc, exponent)
 
     conductor = _get_global_conductor(rows, pm, exponent)
@@ -483,6 +526,5 @@ def dixon_character_table(conjugacy_classes: Sequence[set[Permutation]]) -> Char
         _cols[0], _cols[identity] = _cols[identity], _cols[0]
         dm = dm.extract(_rows, _cols)
 
-    tbl = CharacterTable._fromrep(dm)
-    tbl._conjugacy_class_reps = [next(iter(c)) for c in conjugacy_classes]
-    return tbl
+    conjugacy_class_reps = [next(iter(c)) for c in conjugacy_classes]
+    return CharacterTable.new(dm, conjugacy_class_reps)

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 from math import factorial as _factorial, log, prod
 from itertools import chain, product
 
@@ -19,6 +20,10 @@ from sympy.ntheory import primefactors, sieve
 from sympy.ntheory.factor_ import (factorint, multiplicity)
 from sympy.ntheory.primetest import isprime
 from sympy.utilities.iterables import has_variety, is_sequence, uniq
+
+if TYPE_CHECKING:
+    from sympy.combinatorics.character_table import CharacterTable
+
 
 rmul = Permutation.rmul_with_af
 _af_new = Permutation._af_new
@@ -5141,6 +5146,26 @@ class PermutationGroup(Basic):
             gen.append(Permutation(p))
 
         return PermutationGroup(gen)
+
+    def character_table(self) -> CharacterTable:
+        """
+        Computes the character table of the permutation group.
+
+        Examples
+        ========
+        >>> from sympy.combinatorics import AlternatingGroup
+
+        >>> M = AlternatingGroup(4).character_table()
+        >>> M.as_matrix()
+        Matrix([
+         [1,          1,          1,  1],
+         [1, -1 - zeta3,      zeta3,  1],
+         [1,      zeta3, -1 - zeta3,  1],
+         [3,          0,          0, -1]])
+
+        """
+        from sympy.combinatorics.character_table import CharacterTable
+        return CharacterTable.from_perm_group(self)
 
 
 def _orbit(degree, generators, alpha, action='tuples'):

--- a/sympy/combinatorics/tests/test_character_table.py
+++ b/sympy/combinatorics/tests/test_character_table.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from sympy import Matrix, sqrt, I
+from sympy.combinatorics.permutations import Permutation
+from sympy.combinatorics.perm_groups import PermutationGroup
+from sympy.combinatorics.named_groups import SymmetricGroup, AlternatingGroup
+from sympy.combinatorics.galois import (
+    S1TransitiveSubgroups,
+    S2TransitiveSubgroups,
+    S3TransitiveSubgroups,
+    S4TransitiveSubgroups,
+    S5TransitiveSubgroups,
+    S6TransitiveSubgroups
+)
+from sympy.combinatorics.character_table import CharacterTable, dixon_character_table
+
+import pytest
+
+def _cmp_tbl(tbl1, tbl2):
+    # compare character tables numerically up to permutations of rows
+    tbl1 = Matrix(tbl1).n(15).tolist()
+    tbl2 = Matrix(tbl2).n(15).tolist()
+    return {tuple(row) for row in tbl1} == {tuple(row) for row in tbl2}
+
+
+def test_dixon_character_table():
+    # trivial group
+    G = PermutationGroup(Permutation(size=2))
+    tbl = dixon_character_table(G.conjugacy_classes())
+    assert tbl._rep.domain.is_ZZ
+    assert _cmp_tbl(tbl, [[1]])
+
+    # S4
+    G = SymmetricGroup(4)
+    cc = [
+        Permutation([[3]]),
+        Permutation([[0,1],[3]]),
+        Permutation([[0,1],[2,3]]),
+        Permutation([[0,1,2],[3]]),
+        Permutation([[0,1,2,3]])
+    ]
+    cc = [G.conjugacy_class(c) for c in cc]
+    tbl = dixon_character_table(cc)
+    expected = [
+        [1, 1, 1, 1, 1],
+        [1, -1, 1, 1, -1],
+        [2, 0, 2, -1, 0],
+        [3, 1, -1, 0, -1],
+        [3, -1, -1, 0, 1],
+    ]
+    assert tbl._rep.domain.is_ZZ
+    assert _cmp_tbl(tbl, expected)
+
+    # A4
+    G = AlternatingGroup(4)
+    cc = [
+        Permutation([[3]]),
+        Permutation([[1,2,3]]),
+        Permutation([[1,3,2]]),
+        Permutation([[0,1],[2,3]])
+    ]
+    cc = [G.conjugacy_class(c) for c in cc]
+    tbl = dixon_character_table(cc)
+    dom = tbl._rep.domain
+    assert dom.is_CyclotomicField and dom.zeta_order == 3
+    w = (-1 + sqrt(3)*I)/2
+    expected = [
+        [1, 1, 1, 1],
+        [1, w, w**2, 1],
+        [1, w**2, w, 1],
+        [3, 0, 0, -1],
+    ]
+    assert _cmp_tbl(tbl, expected)
+
+    # C₅ ⋊ C₄
+    G = PermutationGroup(
+        Permutation([[0,1,3,4,2]]),
+        Permutation([[1,4,2,3]])
+    )
+    cc = [
+        Permutation([[4]]),
+        Permutation([[1,2],[3,4]]),
+        Permutation([[1,3,2,4]]),
+        Permutation([[1,4,2,3]]),
+        Permutation([[0,1,3,4,2]])
+    ]
+    cc = [G.conjugacy_class(c) for c in cc]
+    tbl = dixon_character_table(cc)
+    dom = tbl._rep.domain
+    assert dom.is_CyclotomicField and dom.zeta_order == 4
+    expected =  [
+        [1, 1, 1, 1, 1],
+        [1, 1, -1, -1, 1],
+        [1, -1, -I, I, 1],
+        [1, -1, I, -I, 1],
+        [4, 0, 0, 0, -1],
+    ]
+    assert _cmp_tbl(tbl, expected)
+
+
+GROUPS = [
+    member
+    for enum_cls in (
+        S1TransitiveSubgroups,
+        S2TransitiveSubgroups,
+        S3TransitiveSubgroups,
+        S4TransitiveSubgroups,
+        S5TransitiveSubgroups,
+        S6TransitiveSubgroups,
+    )
+    for member in enum_cls
+]
+
+@pytest.mark.parametrize("group", GROUPS, ids=lambda g: g.value)
+def test_generic_character_table(group):
+    G = group.get_perm_group()
+    tbl = CharacterTable.from_perm_group(G)
+    cc = G.conjugacy_classes()
+    reps = tbl.conjugacy_class_reps()
+    assert all(r in c for r, c in zip(reps, cc))
+
+    order = G.order()
+    assert tbl.shape[0] == tbl.shape[1] == len(cc)
+    assert all(v == 1 for v in tbl[0, :])
+    assert tbl[:, 0].dot(tbl[:, 0]) == order
+
+    tblh = tbl.H
+    x = tblh * tbl
+    assert x.is_diagonal()
+    assert list(x.diagonal()) == [order//len(c) for c in cc]

--- a/sympy/combinatorics/tests/test_character_table.py
+++ b/sympy/combinatorics/tests/test_character_table.py
@@ -110,6 +110,12 @@ def test_dixon_character_table():
     ]
     assert tbl._conjugacy_class_reps[1] == Permutation(2)
 
+    g = Permutation(0, 1, 2, 3)
+    cc = [{g**2}, {g**3}, {g**4}, {g}]
+    tbl = dixon_character_table(cc)
+    assert list(tbl[:, 2]) == [1, 1, 1, 1]
+    assert tbl._conjugacy_class_reps == [g**2, g**3, g**4, g]
+
 
 GROUPS = [
     member

--- a/sympy/combinatorics/tests/test_character_table.py
+++ b/sympy/combinatorics/tests/test_character_table.py
@@ -72,7 +72,7 @@ def test_dixon_character_table():
     ]
     assert _cmp_tbl(tbl, expected)
 
-    # C₅ ⋊ C₄
+    # F5
     G = PermutationGroup(
         Permutation([[0,1,3,4,2]]),
         Permutation([[1,4,2,3]])

--- a/sympy/combinatorics/tests/test_character_table.py
+++ b/sympy/combinatorics/tests/test_character_table.py
@@ -97,6 +97,19 @@ def test_dixon_character_table():
     ]
     assert _cmp_tbl(tbl, expected)
 
+    cc = [
+        {Permutation(0, 1, 2), Permutation(0, 2, 1)},
+        {Permutation(2)},
+        {Permutation(0, 2), Permutation(1, 2), Permutation(2)(0, 1)},
+    ]
+    tbl = dixon_character_table(cc)
+    assert tbl.tolist() == [
+        [1, 1, 1],
+        [1, 1, -1],
+        [-1, 2, 0],
+    ]
+    assert tbl._conjugacy_class_reps[1] == Permutation(2)
+
 
 GROUPS = [
     member

--- a/sympy/combinatorics/tests/test_character_table.py
+++ b/sympy/combinatorics/tests/test_character_table.py
@@ -12,7 +12,7 @@ from sympy.combinatorics.galois import (
     S5TransitiveSubgroups,
     S6TransitiveSubgroups
 )
-from sympy.combinatorics.character_table import CharacterTable, dixon_character_table
+from sympy.combinatorics.character_table import dixon_character_table
 
 import pytest
 
@@ -24,16 +24,16 @@ def _cmp_tbl(tbl1, tbl2):
 
 
 def test_character_table():
-    tbl = CharacterTable(SymmetricGroup(1))
+    tbl = SymmetricGroup(1).character_table()
     assert (tbl.as_matrix() - Matrix([[1]])).is_zero_matrix
 
-    tbl = CharacterTable(SymmetricGroup(2))
+    tbl = SymmetricGroup(2).character_table()
     assert tbl.tolist() == [[1, 1], [1, -1]]
     assert (tbl.as_matrix() - Matrix([[1, 1], [1, -1]])).is_zero_matrix
     assert tbl.shape == (2, 2)
     assert tbl.zeta_order == 1
 
-    tbl = CharacterTable(AlternatingGroup(3))
+    tbl = AlternatingGroup(3).character_table()
     assert tbl.as_matrix()._rep.domain.is_CyclotomicField
     assert tbl.zeta_order == 3
 
@@ -148,7 +148,7 @@ GROUPS = [
 @pytest.mark.parametrize("group", GROUPS, ids=lambda g: g.value)
 def test_generic_character_table(group):
     G = group.get_perm_group()
-    table = CharacterTable(G)
+    table = G.character_table()
     cc = G.conjugacy_classes()
     reps = table.conjugacy_class_reps()
     assert all(r in c for r, c in zip(reps, cc))

--- a/sympy/combinatorics/tests/test_character_table.py
+++ b/sympy/combinatorics/tests/test_character_table.py
@@ -25,16 +25,16 @@ def _cmp_tbl(tbl1, tbl2):
 
 def test_character_table():
     tbl = SymmetricGroup(1).character_table()
-    assert (tbl.as_matrix() - Matrix([[1]])).is_zero_matrix
+    assert tbl.as_matrix() == Matrix([[1]])
 
     tbl = SymmetricGroup(2).character_table()
     assert tbl.tolist() == [[1, 1], [1, -1]]
-    assert (tbl.as_matrix() - Matrix([[1, 1], [1, -1]])).is_zero_matrix
+    assert tbl.as_matrix() == Matrix([[1, 1], [1, -1]])
     assert tbl.shape == (2, 2)
     assert tbl.zeta_order == 1
 
     tbl = AlternatingGroup(3).character_table()
-    assert tbl.as_matrix()._rep.domain.is_CyclotomicField
+    assert tbl.as_matrix()._rep.domain.is_EXRAW
     assert tbl.zeta_order == 3
 
 
@@ -154,12 +154,14 @@ def test_generic_character_table(group):
     assert all(r in c for r, c in zip(reps, cc))
 
     tbl = table.as_matrix()
-    order = G.order()
+    order = int(G.order())
     assert tbl.shape[0] == tbl.shape[1] == len(cc)
     assert all(v == 1 for v in tbl[0, :])
     assert tbl[:, 0].dot(tbl[:, 0]) == order
 
-    tblh = tbl.H
+    tbl = table._rep
+    tblh = tbl.adjoint()
     x = tblh * tbl
-    assert x.is_diagonal()
-    assert list(x.diagonal()) == [order//len(c) for c in cc]
+    dom = x.domain
+    assert x.is_diagonal
+    assert list(x.diagonal()) == [dom(order//len(c)) for c in cc]

--- a/sympy/combinatorics/tests/test_character_table.py
+++ b/sympy/combinatorics/tests/test_character_table.py
@@ -23,12 +23,27 @@ def _cmp_tbl(tbl1, tbl2):
     return {tuple(row) for row in tbl1} == {tuple(row) for row in tbl2}
 
 
+def test_character_table():
+    tbl = CharacterTable(SymmetricGroup(1))
+    assert (tbl.as_matrix() - Matrix([[1]])).is_zero_matrix
+
+    tbl = CharacterTable(SymmetricGroup(2))
+    assert tbl.tolist() == [[1, 1], [1, -1]]
+    assert (tbl.as_matrix() - Matrix([[1, 1], [1, -1]])).is_zero_matrix
+    assert tbl.shape == (2, 2)
+    assert tbl.zeta_order == 1
+
+    tbl = CharacterTable(AlternatingGroup(3))
+    assert tbl.as_matrix()._rep.domain.is_CyclotomicField
+    assert tbl.zeta_order == 3
+
+
 def test_dixon_character_table():
     # trivial group
     G = PermutationGroup(Permutation(size=2))
     tbl = dixon_character_table(G.conjugacy_classes())
     assert tbl._rep.domain.is_ZZ
-    assert _cmp_tbl(tbl, [[1]])
+    assert _cmp_tbl(tbl.as_matrix(), [[1]])
 
     # S4
     G = SymmetricGroup(4)
@@ -49,7 +64,7 @@ def test_dixon_character_table():
         [3, -1, -1, 0, 1],
     ]
     assert tbl._rep.domain.is_ZZ
-    assert _cmp_tbl(tbl, expected)
+    assert _cmp_tbl(tbl.as_matrix(), expected)
 
     # A4
     G = AlternatingGroup(4)
@@ -70,7 +85,7 @@ def test_dixon_character_table():
         [1, w**2, w, 1],
         [3, 0, 0, -1],
     ]
-    assert _cmp_tbl(tbl, expected)
+    assert _cmp_tbl(tbl.as_matrix(), expected)
 
     # F5
     G = PermutationGroup(
@@ -95,7 +110,7 @@ def test_dixon_character_table():
         [1, -1, I, -I, 1],
         [4, 0, 0, 0, -1],
     ]
-    assert _cmp_tbl(tbl, expected)
+    assert _cmp_tbl(tbl.as_matrix(), expected)
 
     cc = [
         {Permutation(0, 1, 2), Permutation(0, 2, 1)},
@@ -113,7 +128,7 @@ def test_dixon_character_table():
     g = Permutation(0, 1, 2, 3)
     cc = [{g**2}, {g**3}, {g**4}, {g}]
     tbl = dixon_character_table(cc)
-    assert list(tbl[:, 2]) == [1, 1, 1, 1]
+    assert list(tbl.as_matrix()[:, 2]) == [1, 1, 1, 1]
     assert tbl._conjugacy_class_reps == [g**2, g**3, g**4, g]
 
 
@@ -133,11 +148,12 @@ GROUPS = [
 @pytest.mark.parametrize("group", GROUPS, ids=lambda g: g.value)
 def test_generic_character_table(group):
     G = group.get_perm_group()
-    tbl = CharacterTable.from_perm_group(G)
+    table = CharacterTable(G)
     cc = G.conjugacy_classes()
-    reps = tbl.conjugacy_class_reps()
+    reps = table.conjugacy_class_reps()
     assert all(r in c for r, c in zip(reps, cc))
 
+    tbl = table.as_matrix()
     order = G.order()
     assert tbl.shape[0] == tbl.shape[1] == len(cc)
     assert all(v == 1 for v in tbl[0, :])

--- a/sympy/polys/domains/finitefield.py
+++ b/sympy/polys/domains/finitefield.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from types import ModuleType
+    from sympy.external.gmpy import MPZ
 
 
 if GROUND_TYPES == 'flint':
@@ -214,7 +215,7 @@ class FiniteField(Field, SimpleDomain):
     has_assoc_Field = True
 
     dom = None
-    mod = None
+    mod: MPZ
 
     def __init__(self, mod, symmetric=True):
         from sympy.polys.domains import ZZ

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1925,6 +1925,9 @@ class LatexPrinter(Printer):
         perm_str = self._print(P.args[0])
         return "P_{%s}" % perm_str
 
+    def _print_CharacterTable(self, P):
+        return self._print(P.as_matrix())
+
     def _print_NDimArray(self, expr: NDimArray):
 
         if expr.ndim == 0:

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -184,6 +184,10 @@ class ReprPrinter(Printer):
                 l[-1].append(expr[i, j])
         return '%s(%s)' % (expr.__class__.__name__, self._print(l))
 
+    def _print_CharacterTable(self, expr):
+        return "CharacterTable(%s, %s)" % (
+            self._print(expr._rep), self._print(expr._conjugacy_class_reps))
+
     def _print_BooleanTrue(self, expr):
         return "true"
 

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -403,7 +403,8 @@ class StrPrinter(Printer):
         )
 
     def _print_CharacterTable(self, P):
-        return P._format_str(self)
+        return "CharacterTable(%s, %s)" % (
+            self._print(P._rep), self._print(P._conjugacy_class_reps))
 
     def _print_ElementwiseApplyFunction(self, expr):
         return "{}.({})".format(

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -402,6 +402,9 @@ class StrPrinter(Printer):
             [self.parenthesize(arg, precedence(expr)) for arg in expr.args]
         )
 
+    def _print_CharacterTable(self, P):
+        return P._format_str(self)
+
     def _print_ElementwiseApplyFunction(self, expr):
         return "{}.({})".format(
             expr.function,

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -4,7 +4,6 @@ from sympy.algebras.quaternion import Quaternion
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.combinatorics.free_groups import free_group
 from sympy.combinatorics.permutations import Cycle, Permutation, AppliedPermutation
-from sympy.combinatorics.character_table import CharacterTable
 from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum
 from sympy.core.containers import Tuple, Dict
@@ -3133,9 +3132,9 @@ def test_PermutationMatrix():
 
 def test_CharacterTable():
     from sympy.combinatorics.named_groups import SymmetricGroup
-    tbl = CharacterTable(SymmetricGroup(1))
+    tbl = SymmetricGroup(1).character_table()
     assert latex(tbl) == '\\left[\\begin{matrix}1\\end{matrix}\\right]'
-    tbl = CharacterTable(SymmetricGroup(2))
+    tbl = SymmetricGroup(2).character_table()
     assert latex(tbl) == '\\left[\\begin{matrix}1 & 1\\\\1 & -1\\end{matrix}\\right]'
 
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -4,6 +4,7 @@ from sympy.algebras.quaternion import Quaternion
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.combinatorics.free_groups import free_group
 from sympy.combinatorics.permutations import Cycle, Permutation, AppliedPermutation
+from sympy.combinatorics.character_table import CharacterTable
 from sympy.concrete.products import Product
 from sympy.concrete.summations import Sum
 from sympy.core.containers import Tuple, Dict
@@ -3128,6 +3129,14 @@ def test_PermutationMatrix():
     p = Permutation(0, 3)(1, 2)
     assert latex(PermutationMatrix(p)) == \
         r'P_{\left( 0\; 3\right)\left( 1\; 2\right)}'
+
+
+def test_CharacterTable():
+    from sympy.combinatorics.named_groups import SymmetricGroup
+    tbl = CharacterTable(SymmetricGroup(1))
+    assert latex(tbl) == '\\left[\\begin{matrix}1\\end{matrix}\\right]'
+    tbl = CharacterTable(SymmetricGroup(2))
+    assert latex(tbl) == '\\left[\\begin{matrix}1 & 1\\\\1 & -1\\end{matrix}\\right]'
 
 
 def test_issue_21758():

--- a/sympy/printing/tests/test_repr.py
+++ b/sympy/printing/tests/test_repr.py
@@ -146,6 +146,15 @@ def test_empty_Matrix():
     sT(ones(0, 0), "MutableDenseMatrix([])")
 
 
+def test_CharacterTable():
+    from sympy.combinatorics.named_groups import SymmetricGroup
+    tbl = SymmetricGroup(1).character_table()
+    assert srepr(tbl) == "CharacterTable(DomainMatrix([[1]], (1, 1), ZZ), [Permutation(0)])"
+
+    tbl = SymmetricGroup(2).character_table()
+    assert srepr(tbl) == "CharacterTable(DomainMatrix([[1, 1], [1, -1]], (2, 2), ZZ), [Permutation(1), Permutation(0, 1)])"
+
+
 def test_Rational():
     sT(Rational(1, 3), "Rational(1, 3)")
     sT(Rational(-1, 3), "Rational(-1, 3)")

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -4,6 +4,7 @@ from sympy.algebras.quaternion import Quaternion
 from sympy.assumptions.ask import Q
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.combinatorics.partitions import Partition
+from sympy.combinatorics.character_table import CharacterTable
 from sympy.concrete.summations import (Sum, summation)
 from sympy.core.add import Add
 from sympy.core.containers import (Dict, Tuple)
@@ -1036,6 +1037,17 @@ def test_MatrixSlice():
     assert str(X[0:1, 0:1]) == 'X[:1, :1]'
     assert str(X[0:1:2, 0:1:2]) == 'X[:1:2, :1:2]'
     assert str((Y + Z)[2:, 2:]) == '(Y + Z)[2:, 2:]'
+
+
+def test_CharacterTable_str():
+    from sympy.combinatorics.named_groups import SymmetricGroup
+    tbl = CharacterTable(SymmetricGroup(1))
+    assert str(tbl) == sstr(tbl) == 'CharacterTable([[1]])'
+
+    tbl = CharacterTable(SymmetricGroup(2))
+    assert str(tbl) == 'CharacterTable([[1, 1], [1, -1]])'
+    assert sstr(tbl) == 'CharacterTable([\n[1,  1],\n[1, -1]])'
+
 
 def test_true_false():
     assert str(true) == repr(true) == sstr(true) == "True"

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -4,7 +4,6 @@ from sympy.algebras.quaternion import Quaternion
 from sympy.assumptions.ask import Q
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.combinatorics.partitions import Partition
-from sympy.combinatorics.character_table import CharacterTable
 from sympy.concrete.summations import (Sum, summation)
 from sympy.core.add import Add
 from sympy.core.containers import (Dict, Tuple)
@@ -1041,12 +1040,11 @@ def test_MatrixSlice():
 
 def test_CharacterTable_str():
     from sympy.combinatorics.named_groups import SymmetricGroup
-    tbl = CharacterTable(SymmetricGroup(1))
-    assert str(tbl) == sstr(tbl) == 'CharacterTable([[1]])'
+    tbl = SymmetricGroup(1).character_table()
+    assert str(tbl) == sstr(tbl) == 'CharacterTable(DomainMatrix([[1]], (1, 1), ZZ), [(0)])'
 
-    tbl = CharacterTable(SymmetricGroup(2))
-    assert str(tbl) == 'CharacterTable([[1, 1], [1, -1]])'
-    assert sstr(tbl) == 'CharacterTable([\n[1,  1],\n[1, -1]])'
+    tbl = SymmetricGroup(2).character_table()
+    assert str(tbl) == sstr(tbl) == 'CharacterTable(DomainMatrix([[1, 1], [1, -1]], (2, 2), ZZ), [(1), (0 1)])'
 
 
 def test_true_false():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

This PR adds a `CharacterTable` class and implements Dixon's algorithm for computing the character table of a permutation group.

The character table of a finite group is a complex matrix over a cyclotomic field.  The algorithm first computes the modular  character table over a FiniteField (modulo a prime) using some linear algebra, and then converts it back to the cyclotomic field. Note that the rows and columns of the character table correspond to characters and conjugacy classes, respectively, so the order of the rows or columns might vary.



#### Other comments

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
 
I discussed with Gemini for the algorithm to embed the character table on a minimal cyclotomic field. And I wrote the rest of  code and tests myself. I also asked ChatGPT (codex) to review my code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Added the `CharacterTable` class and supports for computing character tables of permutation groups using Dixon's algorithm. Permutation groups now have a `character_table` method to return this.
<!-- END RELEASE NOTES -->
