### PR TITLE
Fix density(Abs(X))(y) raising ValueError for ConditionSet solutions …

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1438,6 +1438,7 @@ S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
+SANJAY.S <sanjaycdsureshkumar@gmail.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>

--- a/sympy/stats/crv.py
+++ b/sympy/stats/crv.py
@@ -28,6 +28,8 @@ from sympy.polys.polyerrors import PolynomialError
 from sympy.polys.polytools import poly
 from sympy.series.series import series
 from sympy.sets.sets import (FiniteSet, Intersection, Interval, Union)
+from sympy.sets.conditionset import ConditionSet
+from sympy.sets.contains import Contains
 from sympy.solvers.solveset import solveset
 from sympy.solvers.inequalities import reduce_rational_inequalities
 from sympy.stats.rv import (RandomDomain, SingleDomain, ConditionalDomain, is_random,
@@ -535,6 +537,20 @@ class SingleContinuousPSpace(ContinuousPSpace, SinglePSpace):
         if isinstance(gs, Intersection):
             if len(gs.args) == 2 and gs.args[0] is S.Reals:
                 gs = gs.args[1]
+
+        if isinstance(gs, ConditionSet) and gs.base_set.is_FiniteSet:
+            # e.g. solving Abs(X) - y for X gives {-y, y}, but only
+            # when y >= 0; represent this as a Piecewise density instead
+            # of failing outright.
+            condition = gs.condition
+            if isinstance(condition, Contains):
+                sym, condition_set = condition.args
+                condition = condition_set.as_relational(sym)
+            gs = gs.base_set
+            fx = self.compute_density(self.value)
+            fy = sum(fx(g) * abs(g.diff(y)) for g in gs)
+            return Lambda(y, Piecewise((fy, condition), (S.Zero, True)))
+
         if not gs.is_FiniteSet:
             raise ValueError("Can not solve %s for %s" % (expr, self.value))
         fx = self.compute_density(self.value)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1582,3 +1582,14 @@ def test_issue_16318():
 def test_compute_density():
     X = Normal('X', 0, Symbol("sigma")**2)
     raises(ValueError, lambda: density(X**5 + X))
+
+def test_issue_30094():
+    # density(Abs(X))(y) used to raise ValueError because solveset
+    # returns a ConditionSet (not a plain FiniteSet) when solving
+    # Abs(X) - y = 0, since the solutions {-y, y} only hold for y >= 0.
+    # compute_density should build a Piecewise from this instead of failing.
+    X = Normal("X", 0, 1)
+    y = Symbol("y", real=True)
+    result = density(Abs(X))(y)
+    expected = Piecewise((sqrt(2/pi)*exp(-(y**2)/2), y >= 0), (0, True))
+    assert result == expected


### PR DESCRIPTION
Fix density(Abs(X))(y) raising ValueError for ConditionSet solutions

`compute_density` in `SingleContinuousPSpace` solves `expr - y = 0` using `solveset` and expected the result to be a `FiniteSet`. For `Abs(X) = y`, `solveset` correctly returns a `ConditionSet` wrapping the finite solution set `{-y, y}`, valid only when `y >= 0`. Since `compute_density` rejected `ConditionSet` outright, `density(Abs(X))(y)` raised a `ValueError` instead of returning the expected density.

This PR extends `compute_density` to recognize a `ConditionSet` whose base set is a `FiniteSet`. It extracts the validity condition (converting `Contains` conditions into relational form such as `y >= 0` for readability), reuses the existing per-root density computation on the underlying finite set, and wraps the result in a `Piecewise` expression so the density is applied only where the condition holds and is `0` elsewhere.

Fixes #30094

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #30094

#### Brief description of what is fixed or changed

`density(Abs(X))(y)` raised `ValueError` instead of returning a valid density. `compute_density()` solves `expr - y = 0` via `solveset` and expected a plain `FiniteSet` of solutions, but for `Abs(X) - y`, the true solutions `{-y, y}` are only valid when `y >= 0`, so `solveset` correctly returns a `ConditionSet` instead. This PR extends `compute_density()` to recognize a `ConditionSet` whose base set is a `FiniteSet`: it extracts the validity condition (converting `Contains` conditions to relational form such as `y >= 0`), reuses the existing per-root density computation on the underlying finite set, and wraps the result in a `Piecewise` so the density is returned where the condition holds and `0` otherwise.

#### Other comments

Added `test_issue_30094` in `sympy/stats/tests/test_continuous_rv.py`, verifying that `density(Abs(X))(y)` now returns:

```python
Piecewise((sqrt(2/pi)*exp(-y**2/2), y >= 0), (0, True))

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. -->

<!-- BEGIN RELEASE NOTES -->

* stats
  * Fixed `density(Abs(X))(y)` raising `ValueError` instead of returning a `Piecewise` density when the inverse transformation is represented by a `ConditionSet` with a finite solution set.

<!-- END RELEASE NOTES -->