### PR TITLE
[PROTOTYPE][DON'T MERGE] integrals: IntegrationSolver carried by IntegralInfo, rule signatures unchanged

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -12,12 +12,20 @@ integration result.
 The ``manualintegrate`` function computes the integral by calling ``eval``
 on the rule returned by ``integral_steps``.
 
+The integrator is split into stateless *rules* and a stateful *solver*
+(``IntegrationSolver``). A rule is a function that accepts an
+``IntegralInfo`` object and the active solver and returns either a ``Rule``
+instance or ``None``; it must not solve subproblems itself, but delegate
+them to ``solver.subsolve``. The solver owns all state of an integration
+run: loop detection, recursion depth, the integration-by-parts ``u``
+counter and a trace of attempted subproblems.
+
 The integrator can be extended with new heuristics and evaluation
 techniques. To do so, extend the ``Rule`` class, implement ``eval`` method,
-then write a function that accepts an ``IntegralInfo`` object and returns
-either a ``Rule`` instance or ``None``. If the new technique requires a new
-match, add the key and call to the antiderivative function to integral_steps.
-To enable simple substitutions, add the match to find_substitutions.
+then write a rule function as described above. If the new technique
+requires a new match, add the key and call to the antiderivative function
+to the ``_integration_strategy`` table. To enable simple substitutions,
+add the match to find_substitutions.
 
 """
 
@@ -69,7 +77,6 @@ from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
 from sympy.simplify.powsimp import powsimp
 from sympy.solvers.solvers import solve
-from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
 
@@ -1169,6 +1176,117 @@ class IntegralInfo(NamedTuple):
     symbol: Symbol
 
 
+class RuleAttempt(NamedTuple):
+    """A record of one subproblem routed through the solver.
+
+    ``rule`` is the step produced for the subproblem; it is a
+    ``DontKnowRule`` if the subproblem could not be solved. ``depth`` is
+    the recursion depth at which the subproblem was attempted (0 for the
+    top-level integral).
+    """
+    integrand: Expr
+    symbol: Symbol
+    rule: Rule
+    depth: int
+
+
+# The same dummy variable must be used in the keys of the solver state
+# (loop detection, parts-u counter) for subproblems in different
+# variables to match.
+_cache_dummy = Dummy("z")
+
+
+class IntegrationSolver:
+    """Stateful orchestrator driving the stateless integration rules.
+
+    The solver owns all state of an integration run, which used to be
+    spread over module-level caches and the recursive calls of the
+    individual rules:
+
+    * loop detection: the set of subproblems currently being attempted,
+      used to break cyclic rewrites;
+    * recursion depth tracking, with an optional ``max_depth`` limit;
+    * the number of times a given ``u`` has been chosen by integration by
+      parts (``parts_u_count``), to stop endless ladders of parts;
+    * a ``trace`` recording every subproblem that was attempted and the
+      rule that resolved it, in post-order (innermost subproblems first).
+
+    Rules receive the solver as an explicit argument and delegate every
+    subproblem to :meth:`subsolve` instead of recursing into one another
+    directly, so this class is the single place where recursion is
+    managed and where new solver-level policies (branching preferences,
+    priorities, ...) can be added.
+
+    Examples
+    ========
+
+    >>> from sympy import tan
+    >>> from sympy.integrals.manualintegrate import IntegrationSolver
+    >>> from sympy.abc import x
+    >>> solver = IntegrationSolver()
+    >>> rule = solver.subsolve(tan(x), x)
+    >>> for attempt in solver.trace:
+    ...     print(attempt.depth, type(attempt.rule).__name__)
+    2 ReciprocalRule
+    1 URule
+    0 RewriteRule
+    """
+
+    def __init__(self, max_depth=None, **options):
+        self.max_depth = max_depth
+        # Reserved for solver-level preferences (e.g. preferred rewrites
+        # of the result, branching heuristics).
+        self.options = options
+        self.trace: list[RuleAttempt] = []
+        self.parts_u_count: dict[Expr, int] = defaultdict(int)
+        self._active: set[Expr] = set()
+        self._depth = 0
+
+    def subsolve(self, integrand, symbol) -> Rule:
+        """Compute the integration steps of a (sub)problem.
+
+        This is the single entry point through which rules request the
+        solution of subproblems. Returns a :class:`Rule`, which is a
+        ``DontKnowRule`` if the subproblem leads around in a loop,
+        exceeds ``max_depth``, or cannot be solved.
+        """
+        key = integrand.xreplace({symbol: _cache_dummy})
+        if key in self._active:
+            # Stop this attempt, because it leads around in a loop
+            return DontKnowRule(integrand, symbol)
+        depth = self._depth
+        if self.max_depth is not None and depth >= self.max_depth:
+            return DontKnowRule(integrand, symbol)
+        self._active.add(key)
+        self._depth = depth + 1
+        try:
+            rule = _integration_strategy(IntegralInfo(integrand, symbol), self)
+        finally:
+            self._depth = depth
+            self._active.discard(key)
+        self.trace.append(RuleAttempt(integrand, symbol, rule, depth))
+        return rule
+
+    def postprocess(self, integrand, result):
+        """Apply preferred rewrites to the final result of an integration."""
+        # If we got Piecewise with two parts, put generic first
+        if isinstance(result, Piecewise) and len(result.args) == 2:
+            cond = result.args[0][1]
+            if isinstance(cond, Eq) and result.args[1][1] == True:
+                result = result.func(
+                    (result.args[1][0], Ne(*cond.args)),
+                    (result.args[0][0], True))
+        # Factor terms like erf(x)*sin(x) that may have been expanded
+        def _has_erf_trig_mul(expr):
+            for sub in expr.find(Mul):
+                if sub.has(erf, erfc, erfi) and sub.has(sin, cos, sinh, cosh):
+                    return True
+            return False
+        if _has_erf_trig_mul(integrand) and _has_erf_trig_mul(result):
+            result = factor_terms(result)
+        return result
+
+
 def manual_diff(f, symbol):
     """Derivative of f in form expected by find_substitutions
 
@@ -1317,22 +1435,46 @@ def find_substitutions(integrand, symbol, u_var):
 
     return results
 
+def _do_one(*rules):
+    """Strategy that returns the result of the first applicable rule."""
+    def do_one_rl(integral, solver):
+        for rule in rules:
+            result = rule(integral, solver)
+            if result is not None:
+                return result
+    return do_one_rl
+
+def _switch(keyfunc, ruledict):
+    """Strategy that dispatches on ``keyfunc(integral)``."""
+    def switch_rl(integral, solver):
+        rule = ruledict.get(keyfunc(integral))
+        if rule is not None:
+            return rule(integral, solver)
+    return switch_rl
+
+def _condition(cond, rule):
+    """Strategy that applies ``rule`` only if ``cond(integral)`` holds."""
+    def condition_rl(integral, solver):
+        if cond(integral):
+            return rule(integral, solver)
+    return condition_rl
+
 def rewriter(condition, rewrite):
     """Strategy that rewrites an integrand."""
-    def _rewriter(integral):
+    def _rewriter(integral, solver):
         integrand, symbol = integral
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewrite, symbol))
         if condition(*integral):
             rewritten = rewrite(*integral)
             if rewritten != integrand:
-                substep = integral_steps(rewritten, symbol)
+                substep = solver.subsolve(rewritten, symbol)
                 if not isinstance(substep, DontKnowRule) and substep:
                     return RewriteRule(integrand, symbol, rewritten, substep)
     return _rewriter
 
 def proxy_rewriter(condition, rewrite):
     """Strategy that rewrites an integrand based on some other criteria."""
-    def _proxy_rewriter(criteria):
+    def _proxy_rewriter(criteria, solver):
         criteria, integral = criteria
         integrand, symbol = integral
         debug("Integral: {} is rewritten with {} on symbol: {} and criteria: {}".format(integrand, rewrite, symbol, criteria))
@@ -1340,20 +1482,20 @@ def proxy_rewriter(condition, rewrite):
         if condition(*args):
             rewritten = rewrite(*args)
             if rewritten != integrand:
-                return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
+                return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
     return _proxy_rewriter
 
 def multiplexer(conditions):
     """Apply the rule that matches the condition, else None"""
-    def multiplexer_rl(expr):
+    def multiplexer_rl(expr, solver):
         for key, rule in conditions.items():
             if key(expr):
-                return rule(expr)
+                return rule(expr, solver)
     return multiplexer_rl
 
 def alternatives(*rules):
     """Strategy that makes an AlternativeRule out of multiple possible results."""
-    def _alternatives(integral):
+    def _alternatives(integral, solver):
         alts = []
         count = 0
         debug("List of Alternative Rules")
@@ -1361,7 +1503,7 @@ def alternatives(*rules):
             count = count + 1
             debug("Rule {}: {}".format(count, rule))
 
-            result = rule(integral)
+            result = rule(integral, solver)
             if (result and not isinstance(result, DontKnowRule) and
                 result != integral and result not in alts):
                 alts.append(result)
@@ -1375,10 +1517,10 @@ def alternatives(*rules):
                 return AlternativeRule(*integral, alts)
     return _alternatives
 
-def constant_rule(integral):
+def constant_rule(integral, solver):
     return ConstantRule(*integral)
 
-def power_rule(integral):
+def power_rule(integral, solver):
     integrand, symbol = integral
     base, expt = integrand.as_base_exp()
 
@@ -1399,13 +1541,13 @@ def power_rule(integral):
             (ConstantRule(1, symbol), True)
         ])
 
-def exp_rule(integral):
+def exp_rule(integral, solver):
     integrand, symbol = integral
     if isinstance(integrand.args[0], Symbol):
         return ExpRule(integrand, symbol, E, integrand.args[0])
 
 
-def combine_power_rule(integral):
+def combine_power_rule(integral, solver):
     """
     Strategy that simplifies the exponent of a power.
     exp(a*x**2) * exp(b*x) -> exp((a*x**2 + b*x))
@@ -1425,11 +1567,11 @@ def combine_power_rule(integral):
     simplified = powsimp(integrand, combine='exp')
 
     if simplified != integrand:
-        steps = integral_steps(simplified, symbol)
+        steps = solver.subsolve(simplified, symbol)
         return RewriteRule(integrand, symbol, simplified, steps)
 
 
-def orthogonal_poly_rule(integral):
+def orthogonal_poly_rule(integral, solver):
     orthogonal_poly_classes = {
         jacobi: JacobiRule,
         gegenbauer: GegenbauerRule,
@@ -1459,7 +1601,7 @@ _wilds: list[Wild] = []
 _symbol = Dummy('x')
 
 
-def special_function_rule(integral):
+def special_function_rule(integral, solver):
     integrand, symbol = integral
     if not _special_function_patterns:
         a = Wild('a', exclude=[_symbol], properties=[lambda x: not x.is_zero])
@@ -1517,7 +1659,7 @@ def _add_degenerate_step(generic_cond, generic_step: Rule, degenerate_step: Rule
     return PiecewiseRule(generic_step.integrand, generic_step.variable, subfunctions)
 
 
-def nested_pow_rule(integral: IntegralInfo):
+def nested_pow_rule(integral: IntegralInfo, solver=None):
     # nested (c*(a+b*x)**d)**e
     integrand, x = integral
 
@@ -1570,11 +1712,13 @@ def nested_pow_rule(integral: IntegralInfo):
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
-def inverse_trig_rule(integral: IntegralInfo, degenerate=True):
+def inverse_trig_rule(integral: IntegralInfo, solver=None, degenerate=True):
     """
     Set degenerate=False on recursive call where coefficient of quadratic term
     is assumed non-zero.
     """
+    if solver is None:
+        solver = IntegrationSolver()
     integrand, symbol = integral
     base, exp = integrand.as_base_exp()
     a = Wild('a', exclude=[symbol])
@@ -1611,7 +1755,7 @@ def inverse_trig_rule(integral: IntegralInfo, degenerate=True):
     elif b.is_zero:
         degenerate_step = ConstantRule(a ** exp, symbol)
     else:
-        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo((a + b * symbol) ** exp, symbol))
+        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo((a + b * symbol) ** exp, symbol), solver)
 
     if simplify(2*exp + 1) == 0:
         h, k = -b/(2*c), a - b**2/(4*c)  # rewrite base to k + c*(symbol-h)**2
@@ -1646,20 +1790,20 @@ def inverse_trig_rule(integral: IntegralInfo, degenerate=True):
         return _add_degenerate_step(generic_cond, step, degenerate_step)
 
 
-def add_rule(integral):
+def add_rule(integral, solver):
     integrand, symbol = integral
-    results = [integral_steps(g, symbol)
+    results = [solver.subsolve(g, symbol)
               for g in integrand.as_ordered_terms()]
     return None if None in results else AddRule(integrand, symbol, results)
 
 
-def mul_rule(integral: IntegralInfo):
+def mul_rule(integral: IntegralInfo, solver):
     integrand, symbol = integral
 
     # Constant times function case
     coeff, f = integrand.as_independent(symbol)
     if coeff != 1:
-        next_step = integral_steps(f, symbol)
+        next_step = solver.subsolve(f, symbol)
         if next_step is not None:
             return ConstantTimesRule(integrand, symbol, coeff, f, next_step)
 
@@ -1667,9 +1811,11 @@ def mul_rule(integral: IntegralInfo):
 special_error_functions = (erf, erfc, erfi, fresnelc, fresnels, Ci, Chi, Si, Shi, Ei, li)
 
 
-def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None:
+def _parts_rule(integrand, symbol, solver=None) -> tuple[Expr, Expr, Expr, Expr, Rule] | None:
     # LIATE rule:
     # log, inverse trig, algebraic, trigonometric, exponential
+    if solver is None:
+        solver = IntegrationSolver()
     def pull_out_algebraic(integrand):
         integrand = integrand.cancel().together()
         # iterating over Piecewise args would not work here
@@ -1758,7 +1904,7 @@ def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None
             if rule == pull_out_algebraic:
                 if dv.is_Derivative or dv.has(TrigonometricFunction, HyperbolicFunction) or \
                         isinstance(dv, OrthogonalPolynomial):
-                    v_step = integral_steps(dv, symbol)
+                    v_step = solver.subsolve(dv, symbol)
                     if v_step.contains_dont_know():
                         return None
                     else:
@@ -1784,18 +1930,18 @@ def _parts_rule(integrand, symbol) -> tuple[Expr, Expr, Expr, Expr, Rule] | None
 
             if accept:
                 du = u.diff(symbol)
-                v_step = integral_steps(simplify(dv), symbol)
+                v_step = solver.subsolve(simplify(dv), symbol)
                 if not v_step.contains_dont_know():
                     v = v_step.eval()
                     return u, dv, v, du, v_step
     return None
 
 
-def parts_rule(integral):
+def parts_rule(integral, solver):
     integrand, symbol = integral
     constant, integrand = integrand.as_coeff_Mul()
 
-    result = _parts_rule(integrand, symbol)
+    result = _parts_rule(integrand, symbol, solver)
 
     steps = []
     if result:
@@ -1809,9 +1955,9 @@ def parts_rule(integral):
         # Set a limit on the number of times u can be used
         if isinstance(u, (sin, cos, exp, sinh, cosh)):
             cachekey = u.xreplace({symbol: _cache_dummy})
-            if _parts_u_cache[cachekey] > 2:
+            if solver.parts_u_count[cachekey] > 2:
                 return
-            _parts_u_cache[cachekey] += 1
+            solver.parts_u_count[cachekey] += 1
 
         # Try cyclic integration by parts a few times
         for _ in range(4):
@@ -1832,7 +1978,7 @@ def parts_rule(integral):
 
             # _parts_rule is sensitive to constants, factor it out
             next_constant, next_integrand = (v * du).as_coeff_Mul()
-            result = _parts_rule(next_integrand, symbol)
+            result = _parts_rule(next_integrand, symbol, solver)
 
             if result:
                 u, dv, v, du, v_step = result
@@ -1846,7 +1992,7 @@ def parts_rule(integral):
         if steps:
             u, dv, v, du, v_step = steps[0]
             return PartsRule(integrand, symbol, u, dv, v_step, make_second_step(steps[1:], v * du))
-        return integral_steps(integrand, symbol)
+        return solver.subsolve(integrand, symbol)
 
     if steps:
         u, dv, v, du, v_step = steps[0]
@@ -1857,7 +2003,7 @@ def parts_rule(integral):
         return rule
 
 
-def trig_rule(integral):
+def trig_rule(integral, solver):
     integrand, symbol = integral
     if integrand == sin(symbol):
         return SinRule(integrand, symbol)
@@ -1883,9 +2029,9 @@ def trig_rule(integral):
     else:
         return
 
-    return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
+    return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
 
-def trig_product_rule(integral: IntegralInfo):
+def trig_product_rule(integral: IntegralInfo, solver):
     integrand, symbol = integral
     if integrand == sec(symbol) * tan(symbol):
         return SecTanRule(integrand, symbol)
@@ -1893,7 +2039,7 @@ def trig_product_rule(integral: IntegralInfo):
         return CscCotRule(integrand, symbol)
 
 
-def trig_cmplx_exp_rule(integral: IntegralInfo):
+def trig_cmplx_exp_rule(integral: IntegralInfo, solver):
     """
     Strategy that rewrites sin, cos, sinh, and cosh in terms of complex exponentials.
     Useful for integration techniques that handle exponentials better.
@@ -1928,11 +2074,11 @@ def trig_cmplx_exp_rule(integral: IntegralInfo):
 
     if rewritten != integrand:
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten, symbol))
-        steps = integral_steps(rewritten, symbol)
+        steps = solver.subsolve(rewritten, symbol)
         return RewriteRule(integrand, symbol, rewritten, steps)
 
 
-def quadratic_denom_rule(integral):
+def quadratic_denom_rule(integral, solver):
     integrand, symbol = integral
     a = Wild('a', exclude=[symbol, 0])
     b = Wild('b', exclude=[symbol, 0])
@@ -1946,11 +2092,11 @@ def quadratic_denom_rule(integral):
         # skips degenerate case if b != 0 or if b = 0 would cause null denominator
         if not _if_zero_implies_zero(b, c):
             substituted = integrand.subs(b, 0)
-            substep = integral_steps(substituted, symbol)
+            substep = solver.subsolve(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(b, 0)))
         if not _if_zero_implies_zero(c, b):
             substituted = integrand.subs(c, 0)
-            substep = integral_steps(substituted, symbol)
+            substep = solver.subsolve(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(c, 0)))
         if b.is_extended_real and c.is_extended_real:
             positive_cond = c/b > 0
@@ -1988,7 +2134,7 @@ def quadratic_denom_rule(integral):
         u = Dummy('u')
         u_func = symbol + c/(2*b)
         integrand2 = integrand.subs(symbol, u - c / (2*b))
-        next_step = integral_steps(integrand2, u)
+        next_step = solver.subsolve(integrand2, u)
         if next_step:
             return URule(integrand2, symbol, u, u_func, next_step)
         else:
@@ -2005,13 +2151,13 @@ def quadratic_denom_rule(integral):
         numer2 = - const*d + b
         u = Dummy('u')
         step1 = URule(integrand, symbol,
-                      u, denominator, integral_steps(u**(-1), u))
+                      u, denominator, solver.subsolve(u**(-1), u))
         if const != 1:
             step1 = ConstantTimesRule(const*numer1/denominator, symbol,
                                       const, numer1/denominator, step1)
         if numer2.is_zero:
             return step1
-        step2 = integral_steps(numer2/denominator, symbol)
+        step2 = solver.subsolve(numer2/denominator, symbol)
         substeps = AddRule(integrand, symbol, [step1, step2])
         rewriten = const*numer1/denominator+numer2/denominator
         return RewriteRule(integrand, symbol, rewriten, substeps)
@@ -2019,10 +2165,12 @@ def quadratic_denom_rule(integral):
     return
 
 
-def sqrt_fractional_linear_rule(integral : IntegralInfo):
+def sqrt_fractional_linear_rule(integral : IntegralInfo, solver=None):
     """
     Substitute common ((a*x + b)/(c*x + d))**(1/n)
     """
+    if solver is None:
+        solver = IntegrationSolver()
     integrand, x = integral
     a = Wild('a', exclude=[x])
     b = Wild('b', exclude=[x])
@@ -2070,7 +2218,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     if constant_bases_subs:
         integrand = integrand.subs(constant_bases_subs)
     if base0 is None:
-        substep = integral_steps(integrand, x)
+        substep = solver.subsolve(integrand, x)
         if not substep.contains_dont_know():
             debug("Integral: {} is rewritten with {} on symbol: {}".format(integral.integrand, integrand, x))
             return RewriteRule(integral.integrand, x, integrand, substep)
@@ -2085,7 +2233,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     for base_i, ratio_i, q_i in zip(bases, ratios, qs):
         subs_dict[base_i**(S.One/q_i)] = (ratio_i)**(S.One/q_i) * u**(q0/q_i)
     substituted = integrand.subs(subs_dict).subs(x, x_u) * dx_u
-    substep = integral_steps(substituted, u)
+    substep = solver.subsolve(substituted, u)
     if not substep.contains_dont_know():
         pieces: list[tuple[Rule, Boolean]] = []
         det = a0*d0 - b0*c0
@@ -2101,14 +2249,14 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
                 const_val = a0 / c0
                 subs_a = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
                 simplified_a = integrand.subs(subs_a)
-                degenerate_step_a = integral_steps(simplified_a, x)
+                degenerate_step_a = solver.subsolve(simplified_a, x)
                 pieces.append((degenerate_step_a, (And(Eq(det, 0), Ne(c0, 0)))))
             if not c0_implies_d0:
                 const_val = b0 / d0
                 subs_b = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
                 simplified_b = integrand.subs(subs_b)
                 simplified_b = simplified_b.subs({a0: 0, c0: 0}) # if det = 0, c = 0 and d != 0, a must be 0
-                degenerate_step_b = integral_steps(simplified_b, x)
+                degenerate_step_b = solver.subsolve(simplified_b, x)
                 pieces.append((degenerate_step_b, (And(Eq(det, 0), Eq(c0, 0)))))
         step: Rule = URule(integrand, x, u, u_x, substep)
         if pieces:
@@ -2121,7 +2269,9 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
     return None
 
 
-def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
+def sqrt_quadratic_rule(integral: IntegralInfo, solver=None, degenerate=True):
+    if solver is None:
+        solver = IntegrationSolver()
     integrand, x = integral
     a = Wild('a', exclude=[x])
     b = Wild('b', exclude=[x])
@@ -2140,10 +2290,10 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
     if not degenerate or generic_cond is S.true:
         degenerate_step = None
     elif b.is_zero:
-        degenerate_step = integral_steps(f*sqrt(a)**n, x)
+        degenerate_step = solver.subsolve(f*sqrt(a)**n, x)
     else:
         degenerate_integrand = f*sqrt(a + b*x)**n
-        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo(degenerate_integrand, x))
+        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo(degenerate_integrand, x), solver)
         if degenerate_step is None:
             # since  sqrt_fractional_linear_rule does not guarantee a solution
             # we create a DontKnowRule so that _add_degenerate_step adds the degenerate condition
@@ -2168,7 +2318,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
                 if A != 1:
                     linear_step = ConstantTimesRule(A*pre_substitute, x, A, pre_substitute, linear_step)
             if B != 0:
-                constant_step = inverse_trig_rule(IntegralInfo(1/denom, x), degenerate=False)
+                constant_step = inverse_trig_rule(IntegralInfo(1/denom, x), solver, degenerate=False)
                 if B != 1:
                     constant_step = ConstantTimesRule(B/denom, x, B, 1/denom, constant_step)  # type: ignore
             if linear_step and constant_step:
@@ -2191,7 +2341,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
             square_base = sqrt(c)*x + b/(2*sqrt(c))
             nested = Pow(Pow(square_base, 2, evaluate=False), S(n)/2, evaluate=False)
             rewritten = const*nested
-            substep = nested_pow_rule(IntegralInfo(rewritten, x))
+            substep = nested_pow_rule(IntegralInfo(rewritten, x), solver)
             return RewriteRule(integrand, x, rewritten, substep)
 
         if delta.is_zero is True:
@@ -2205,12 +2355,12 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
 
         rewrite_expr = Derivative(constant_term, x) + coeff * expr
         derive_expr = Derivative(constant_term, x)
-        derive_step = integral_steps(derive_expr, x)
+        derive_step = solver.subsolve(derive_expr, x)
 
         if coeff == 0:
             substep = derive_step
         else:
-            next_step = integral_steps(expr, x)
+            next_step = solver.subsolve(expr, x)
             if not next_step:
                 next_step = DontKnowRule(expr, x)
 
@@ -2250,7 +2400,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
         if not quotient.is_zero:
             # n is increasing by 2 at each step, we will fall in one of the cases above
             quotient_integrand = quotient.as_expr() * sqrt(root_base)**(n + 2)
-            quotient_step = sqrt_quadratic_rule(IntegralInfo(quotient_integrand, x), degenerate=False)
+            quotient_step = sqrt_quadratic_rule(IntegralInfo(quotient_integrand, x), solver, degenerate=False)
             terms.append(quotient_integrand)
             steps.append(quotient_step)
         if not rest.is_zero:
@@ -2300,7 +2450,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
-def hyperbolic_rule(integral: tuple[Expr, Symbol]):
+def hyperbolic_rule(integral: tuple[Expr, Symbol], solver):
     integrand, symbol = integral
     if isinstance(integrand, HyperbolicFunction) and integrand.args[0] == symbol:
         if integrand.func == sinh:
@@ -2377,12 +2527,12 @@ def uncurry(func):
     return uncurry_rl
 
 def trig_rewriter(rewrite):
-    def trig_rewriter_rl(args):
+    def trig_rewriter_rl(args, solver):
         a, b, m, n, integrand, symbol = args
         rewritten = rewrite(a, b, m, n, integrand, symbol)
         if rewritten != integrand:
             debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewrite, symbol))
-            return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
+            return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
     return trig_rewriter_rl
 
 sincos_botheven_condition = uncurry(
@@ -2435,7 +2585,7 @@ cotcsc_cotodd = trig_rewriter(
                                     cot(a*symbol) *
                                     csc(b*symbol) ** n ))
 
-def trig_sincos_rule(integral):
+def trig_sincos_rule(integral, solver):
     integrand, symbol = integral
 
     if any(integrand.has(f) for f in (sin, cos)):
@@ -2450,9 +2600,9 @@ def trig_sincos_rule(integral):
             sincos_cosodd_condition: sincos_cosodd
         })(tuple(
             [match.get(i, S.Zero) for i in (a, b, m, n)] +
-            [integrand, symbol]))
+            [integrand, symbol]), solver)
 
-def trig_tansec_rule(integral):
+def trig_tansec_rule(integral, solver):
     integrand, symbol = integral
 
     integrand = integrand.subs({
@@ -2471,9 +2621,9 @@ def trig_tansec_rule(integral):
             tan_tansquared_condition: tan_tansquared
         })(tuple(
             [match.get(i, S.Zero) for i in (a, b, m, n)] +
-            [integrand, symbol]))
+            [integrand, symbol]), solver)
 
-def trig_cotcsc_rule(integral):
+def trig_cotcsc_rule(integral, solver):
     integrand, symbol = integral
     integrand = integrand.subs({
         1 / sin(symbol): csc(symbol),
@@ -2492,9 +2642,9 @@ def trig_cotcsc_rule(integral):
             cotcsc_csceven_condition: cotcsc_csceven
         })(tuple(
             [match.get(i, S.Zero) for i in (a, b, m, n)] +
-            [integrand, symbol]))
+            [integrand, symbol]), solver)
 
-def trig_sindouble_rule(integral):
+def trig_sindouble_rule(integral, solver):
     integrand, symbol = integral
     a = Wild('a', exclude=[sin(2*symbol)])
     match = integrand.match(sin(2*symbol)*a)
@@ -2502,16 +2652,15 @@ def trig_sindouble_rule(integral):
         sin_double = 2*sin(symbol)*cos(symbol)/sin(2*symbol)
         rewritten = integrand * sin_double
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, integrand * sin_double, symbol))
-        substeps = integral_steps(rewritten, symbol)
+        substeps = solver.subsolve(rewritten, symbol)
         return RewriteRule(integrand, symbol, rewritten, substeps)
 
-def trig_powers_products_rule(integral):
-    return do_one(null_safe(trig_sincos_rule),
-                  null_safe(trig_tansec_rule),
-                  null_safe(trig_cotcsc_rule),
-                  null_safe(trig_sindouble_rule))(integral)
+trig_powers_products_rule = _do_one(trig_sincos_rule,
+                                    trig_tansec_rule,
+                                    trig_cotcsc_rule,
+                                    trig_sindouble_rule)
 
-def trig_substitution_rule(integral):
+def trig_substitution_rule(integral, solver):
     integrand, symbol = integral
     A = Wild('a', exclude=[0, symbol])
     B = Wild('b', exclude=[0, symbol])
@@ -2566,23 +2715,23 @@ def trig_substitution_rule(integral):
                         1/cos(theta): sec(theta)
                     })
 
-                substep = integral_steps(replaced, theta)
+                substep = solver.subsolve(replaced, theta)
                 if not substep.contains_dont_know():
                     return TrigSubstitutionRule(integrand, symbol,
                         theta, x_func, replaced, substep, restriction)
 
-def heaviside_rule(integral):
+def heaviside_rule(integral, solver):
     integrand, symbol = integral
     pattern, m, b, g = heaviside_pattern(symbol)
     match = integrand.match(pattern)
     if match and 0 != match[g]:
         # f = Heaviside(m*x + b)*g
-        substep = integral_steps(match[g], symbol)
+        substep = solver.subsolve(match[g], symbol)
         m, b = match[m], match[b]
         return HeavisideRule(integrand, symbol, m*symbol + b, -b/m, substep)
 
 
-def dirac_delta_rule(integral: IntegralInfo):
+def dirac_delta_rule(integral: IntegralInfo, solver):
     integrand, x = integral
     if len(integrand.args) == 1:
         n = S.Zero
@@ -2604,7 +2753,7 @@ def dirac_delta_rule(integral: IntegralInfo):
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
-def substitution_rule(integral):
+def substitution_rule(integral, solver):
     integrand, symbol = integral
 
     u_var = Dummy("u")
@@ -2616,7 +2765,7 @@ def substitution_rule(integral):
         factored_integrand = integrand.factor()
         _, denom_integrand = factored_integrand.as_numer_denom()
         for u_func, c, substituted in substitutions:
-            subrule = integral_steps(substituted, u_var)
+            subrule = solver.subsolve(substituted, u_var)
             count = count + 1
             debug("Rule {}: {}".format(count, subrule))
 
@@ -2636,7 +2785,7 @@ def substitution_rule(integral):
                         if not _if_zero_implies_zero(pole, denom_integrand):
                             rewritten_integral = manual_subs(factored_integrand, pole, 0)
                             debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten_integral, symbol))
-                            substep = integral_steps(rewritten_integral, symbol)
+                            substep = solver.subsolve(rewritten_integral, symbol)
 
                             if substep:
                                 substep = RewriteRule(integrand, symbol, rewritten_integral, substep)
@@ -2677,7 +2826,7 @@ trig_expand_rule = rewriter(
         len({a.args[0] for a in integrand.atoms(TrigonometricFunction)}) > 1),
     lambda integrand, symbol: integrand.expand(trig=True))
 
-def derivative_rule(integral):
+def derivative_rule(integral, solver):
     integrand = integral[0]
     diff_variables = integrand.variables
     undifferentiated_function = integrand.expr
@@ -2691,24 +2840,91 @@ def derivative_rule(integral):
     else:
         return ConstantRule(*integral)
 
-def rewrites_rule(integral):
+def rewrites_rule(integral, solver):
     integrand, symbol = integral
 
     if integrand.match(1/cos(symbol)):
         rewritten = integrand.subs(1/cos(symbol), sec(symbol))
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten, symbol))
-        return RewriteRule(integrand, symbol, rewritten, integral_steps(rewritten, symbol))
+        return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
 
-def fallback_rule(integral):
+def fallback_rule(integral, solver):
     return DontKnowRule(*integral)
 
 
-# Cache is used to break cyclic integrals.
-# Need to use the same dummy variable in cached expressions for them to match.
-# Also record "u" of integration by parts, to avoid infinite repetition.
-_integral_cache: dict[Expr, Expr | None] = {}
-_parts_u_cache: dict[Expr, int] = defaultdict(int)
-_cache_dummy = Dummy("z")
+def _integrand_key(integral):
+    integrand, symbol = integral
+    if symbol not in integrand.free_symbols:
+        return Number
+    for cls in (Symbol, TrigonometricFunction, OrthogonalPolynomial):
+        if isinstance(integrand, cls):
+            return cls
+    return type(integrand)
+
+
+def _integral_is_subclass(*klasses):
+    def _check(integral):
+        k = _integrand_key(integral)
+        return k and issubclass(k, klasses)
+    return _check
+
+
+# The strategy table consulted by IntegrationSolver.subsolve for every
+# subproblem. Entries are stateless rules with signature
+# (integral, solver) -> Rule | None.
+_integration_strategy = _do_one(
+    special_function_rule,
+    _switch(_integrand_key, {
+        Pow: _do_one(power_rule, inverse_trig_rule,
+                     quadratic_denom_rule,
+                     sqrt_quadratic_rule,
+                     sqrt_fractional_linear_rule),
+        Symbol: power_rule,
+        exp: exp_rule,
+        Add: add_rule,
+        Mul: _do_one(mul_rule, trig_product_rule,
+                     heaviside_rule, quadratic_denom_rule,
+                     sqrt_quadratic_rule,
+                     sqrt_fractional_linear_rule,
+                     trig_cmplx_exp_rule),
+        Derivative: derivative_rule,
+        TrigonometricFunction: trig_rule,
+        Heaviside: heaviside_rule,
+        DiracDelta: dirac_delta_rule,
+        OrthogonalPolynomial: orthogonal_poly_rule,
+        Number: constant_rule
+    }),
+    _do_one(
+        trig_rule,
+        hyperbolic_rule,
+        alternatives(
+            rewrites_rule,
+            substitution_rule,
+            _condition(
+                _integral_is_subclass(Mul, Pow),
+                partial_fractions_rule),
+            _condition(
+                _integral_is_subclass(Mul, Pow),
+                cancel_rule),
+            _condition(
+                _integral_is_subclass(Mul),
+                combine_power_rule),
+            _condition(
+                _integral_is_subclass(Mul, log,
+                                      *inverse_trig_functions,
+                                      *special_error_functions),
+                parts_rule),
+            _condition(
+                _integral_is_subclass(Mul, Pow),
+                distribute_expand_rule),
+            trig_powers_products_rule,
+            trig_expand_rule
+        ),
+        _condition(_integral_is_subclass(Mul, Pow), nested_pow_rule),
+        trig_substitution_rule
+    ),
+    fallback_rule)
+
 
 def integral_steps(integrand, symbol, **options):
     """Returns the steps needed to compute an integral.
@@ -2755,91 +2971,32 @@ def integral_steps(integrand, symbol, **options):
         to obtain a result.
 
     """
-    cachekey = integrand.xreplace({symbol: _cache_dummy})
-    if cachekey in _integral_cache:
-        if _integral_cache[cachekey] is None:
-            # Stop this attempt, because it leads around in a loop
-            return DontKnowRule(integrand, symbol)
-        else:
-            # TODO: This is for future development, as currently
-            # _integral_cache gets no values other than None
-            return (_integral_cache[cachekey].xreplace(_cache_dummy, symbol),
-                symbol)
-    else:
-        _integral_cache[cachekey] = None
+    return IntegrationSolver(**options).subsolve(integrand, symbol)
 
-    integral = IntegralInfo(integrand, symbol)
 
-    def key(integral):
-        integrand = integral.integrand
+def integral_steps_with_trace(integrand, symbol, **options):
+    """Like :func:`integral_steps`, but also return the solver's trace.
 
-        if symbol not in integrand.free_symbols:
-            return Number
-        for cls in (Symbol, TrigonometricFunction, OrthogonalPolynomial):
-            if isinstance(integrand, cls):
-                return cls
-        return type(integrand)
+    Returns the tuple ``(rule, trace)``, where ``trace`` is the list of
+    :class:`RuleAttempt` records of every subproblem attempted by the
+    solver, in post-order (innermost subproblems first).
 
-    def integral_is_subclass(*klasses):
-        def _integral_is_subclass(integral):
-            k = key(integral)
-            return k and issubclass(k, klasses)
-        return _integral_is_subclass
+    Examples
+    ========
 
-    result = do_one(
-        null_safe(special_function_rule),
-        null_safe(switch(key, {
-            Pow: do_one(null_safe(power_rule), null_safe(inverse_trig_rule),
-                        null_safe(quadratic_denom_rule),
-                        null_safe(sqrt_quadratic_rule),
-                        null_safe(sqrt_fractional_linear_rule)),
-            Symbol: power_rule,
-            exp: exp_rule,
-            Add: add_rule,
-            Mul: do_one(null_safe(mul_rule), null_safe(trig_product_rule),
-                        null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
-                        null_safe(sqrt_quadratic_rule),
-                        null_safe(sqrt_fractional_linear_rule),
-                        null_safe(trig_cmplx_exp_rule)),
-            Derivative: derivative_rule,
-            TrigonometricFunction: trig_rule,
-            Heaviside: heaviside_rule,
-            DiracDelta: dirac_delta_rule,
-            OrthogonalPolynomial: orthogonal_poly_rule,
-            Number: constant_rule
-        })),
-        do_one(
-            null_safe(trig_rule),
-            null_safe(hyperbolic_rule),
-            null_safe(alternatives(
-                rewrites_rule,
-                substitution_rule,
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    partial_fractions_rule),
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    cancel_rule),
-                condition(
-                    integral_is_subclass(Mul),
-                    combine_power_rule),
-                condition(
-                    integral_is_subclass(Mul, log,
-                                         *inverse_trig_functions,
-                                         *special_error_functions),
-                    parts_rule),
-                condition(
-                    integral_is_subclass(Mul, Pow),
-                    distribute_expand_rule),
-                trig_powers_products_rule,
-                trig_expand_rule
-            )),
-            null_safe(condition(integral_is_subclass(Mul, Pow), nested_pow_rule)),
-            null_safe(trig_substitution_rule)
-        ),
-        fallback_rule)(integral)
-    del _integral_cache[cachekey]
-    return result
+    >>> from sympy import tan
+    >>> from sympy.integrals.manualintegrate import integral_steps_with_trace
+    >>> from sympy.abc import x
+    >>> rule, trace = integral_steps_with_trace(tan(x), x)
+    >>> for attempt in trace:
+    ...     print(attempt.depth, type(attempt.rule).__name__)
+    2 ReciprocalRule
+    1 URule
+    0 RewriteRule
+    """
+    solver = IntegrationSolver(**options)
+    rule = solver.subsolve(integrand, symbol)
+    return rule, solver.trace
 
 
 def manualintegrate(f, var):
@@ -2891,22 +3048,6 @@ def manualintegrate(f, var):
     sympy.integrals.integrals.Integral.doit
     sympy.integrals.integrals.Integral
     """
-    result = integral_steps(f, var).eval()
-    # Clear the cache of u-parts
-    _parts_u_cache.clear()
-    # If we got Piecewise with two parts, put generic first
-    if isinstance(result, Piecewise) and len(result.args) == 2:
-        cond = result.args[0][1]
-        if isinstance(cond, Eq) and result.args[1][1] == True:
-            result = result.func(
-                (result.args[1][0], Ne(*cond.args)),
-                (result.args[0][0], True))
-    # Factor terms like erf(x)*sin(x) that may have been expanded
-    def _has_erf_trig_mul(expr):
-        for sub in expr.find(Mul):
-            if sub.has(erf, erfc, erfi) and sub.has(sin, cos, sinh, cosh):
-                return True
-        return False
-    if _has_erf_trig_mul(f) and _has_erf_trig_mul(result):
-        result = factor_terms(result)
-    return result
+    solver = IntegrationSolver()
+    rule = solver.subsolve(f, var)
+    return solver.postprocess(f, rule.eval())

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -14,11 +14,12 @@ on the rule returned by ``integral_steps``.
 
 The integrator is split into stateless *rules* and a stateful *solver*
 (``IntegrationSolver``). A rule is a function that accepts an
-``IntegralInfo`` object and the active solver and returns either a ``Rule``
-instance or ``None``; it must not solve subproblems itself, but delegate
-them to ``solver.subsolve``. The solver owns all state of an integration
-run: loop detection, recursion depth, the integration-by-parts ``u``
-counter and a trace of attempted subproblems.
+``IntegralInfo`` object — an ``(integrand, symbol)`` pair that also
+carries the active solver — and returns either a ``Rule`` instance or
+``None``; it must not solve subproblems recursively itself, but delegate
+them to the solver through ``integral.subsolve``. The solver owns all
+state of an integration run: loop detection, recursion depth, the
+integration-by-parts ``u`` counter and a trace of attempted subproblems.
 
 The integrator can be extended with new heuristics and evaluation
 techniques. To do so, extend the ``Rule`` class, implement ``eval`` method,
@@ -77,6 +78,7 @@ from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
 from sympy.simplify.powsimp import powsimp
 from sympy.solvers.solvers import solve
+from sympy.strategies.core import switch, do_one, null_safe, condition
 from sympy.utilities.iterables import iterable
 from sympy.utilities.misc import debug
 
@@ -1171,9 +1173,38 @@ class EllipticERule(AtomicRule):
         return elliptic_e(self.variable, self.d/self.a)*sqrt(self.a)
 
 
-class IntegralInfo(NamedTuple):
-    integrand: Expr
-    symbol: Symbol
+class IntegralInfo(tuple):
+    """A subproblem handed to the integration rules.
+
+    Behaves exactly like the ``(integrand, symbol)`` named tuple it used
+    to be (unpacking, indexing, ``*`` expansion), but additionally
+    carries the :class:`IntegrationSolver` of the current integration
+    run, so that rules can delegate subproblems through
+    :meth:`subsolve` while keeping their plain ``(integral)`` signature
+    and without any global state. If no solver is given, a fresh one is
+    created, so a rule can also be called standalone on a bare
+    ``IntegralInfo(integrand, symbol)``.
+    """
+
+    def __new__(cls, integrand, symbol, solver=None):
+        self = tuple.__new__(cls, (integrand, symbol))
+        self.solver = IntegrationSolver() if solver is None else solver
+        return self
+
+    @property
+    def integrand(self) -> Expr:
+        return self[0]
+
+    @property
+    def symbol(self) -> Symbol:
+        return self[1]
+
+    def subsolve(self, integrand, symbol) -> Rule:
+        """Delegate a subproblem to the solver of this integration run."""
+        return self.solver.subsolve(integrand, symbol)
+
+    def __repr__(self):
+        return 'IntegralInfo(integrand=%r, symbol=%r)' % (self[0], self[1])
 
 
 class RuleAttempt(NamedTuple):
@@ -1211,8 +1242,9 @@ class IntegrationSolver:
     * a ``trace`` recording every subproblem that was attempted and the
       rule that resolved it, in post-order (innermost subproblems first).
 
-    Rules receive the solver as an explicit argument and delegate every
-    subproblem to :meth:`subsolve` instead of recursing into one another
+    Rules receive the solver through the :class:`IntegralInfo` they are
+    passed and delegate every subproblem to :meth:`subsolve` (usually as
+    ``integral.subsolve``) instead of recursing into one another
     directly, so this class is the single place where recursion is
     managed and where new solver-level policies (branching preferences,
     priorities, ...) can be added.
@@ -1260,7 +1292,7 @@ class IntegrationSolver:
         self._active.add(key)
         self._depth = depth + 1
         try:
-            rule = _integration_strategy(IntegralInfo(integrand, symbol), self)
+            rule = _integration_strategy(IntegralInfo(integrand, symbol, self))
         finally:
             self._depth = depth
             self._active.discard(key)
@@ -1435,46 +1467,22 @@ def find_substitutions(integrand, symbol, u_var):
 
     return results
 
-def _do_one(*rules):
-    """Strategy that returns the result of the first applicable rule."""
-    def do_one_rl(integral, solver):
-        for rule in rules:
-            result = rule(integral, solver)
-            if result is not None:
-                return result
-    return do_one_rl
-
-def _switch(keyfunc, ruledict):
-    """Strategy that dispatches on ``keyfunc(integral)``."""
-    def switch_rl(integral, solver):
-        rule = ruledict.get(keyfunc(integral))
-        if rule is not None:
-            return rule(integral, solver)
-    return switch_rl
-
-def _condition(cond, rule):
-    """Strategy that applies ``rule`` only if ``cond(integral)`` holds."""
-    def condition_rl(integral, solver):
-        if cond(integral):
-            return rule(integral, solver)
-    return condition_rl
-
 def rewriter(condition, rewrite):
     """Strategy that rewrites an integrand."""
-    def _rewriter(integral, solver):
+    def _rewriter(integral):
         integrand, symbol = integral
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewrite, symbol))
         if condition(*integral):
             rewritten = rewrite(*integral)
             if rewritten != integrand:
-                substep = solver.subsolve(rewritten, symbol)
+                substep = integral.subsolve(rewritten, symbol)
                 if not isinstance(substep, DontKnowRule) and substep:
                     return RewriteRule(integrand, symbol, rewritten, substep)
     return _rewriter
 
 def proxy_rewriter(condition, rewrite):
     """Strategy that rewrites an integrand based on some other criteria."""
-    def _proxy_rewriter(criteria, solver):
+    def _proxy_rewriter(criteria):
         criteria, integral = criteria
         integrand, symbol = integral
         debug("Integral: {} is rewritten with {} on symbol: {} and criteria: {}".format(integrand, rewrite, symbol, criteria))
@@ -1482,20 +1490,20 @@ def proxy_rewriter(condition, rewrite):
         if condition(*args):
             rewritten = rewrite(*args)
             if rewritten != integrand:
-                return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
+                return RewriteRule(integrand, symbol, rewritten, integral.subsolve(rewritten, symbol))
     return _proxy_rewriter
 
 def multiplexer(conditions):
     """Apply the rule that matches the condition, else None"""
-    def multiplexer_rl(expr, solver):
+    def multiplexer_rl(expr):
         for key, rule in conditions.items():
             if key(expr):
-                return rule(expr, solver)
+                return rule(expr)
     return multiplexer_rl
 
 def alternatives(*rules):
     """Strategy that makes an AlternativeRule out of multiple possible results."""
-    def _alternatives(integral, solver):
+    def _alternatives(integral):
         alts = []
         count = 0
         debug("List of Alternative Rules")
@@ -1503,7 +1511,7 @@ def alternatives(*rules):
             count = count + 1
             debug("Rule {}: {}".format(count, rule))
 
-            result = rule(integral, solver)
+            result = rule(integral)
             if (result and not isinstance(result, DontKnowRule) and
                 result != integral and result not in alts):
                 alts.append(result)
@@ -1517,10 +1525,10 @@ def alternatives(*rules):
                 return AlternativeRule(*integral, alts)
     return _alternatives
 
-def constant_rule(integral, solver):
+def constant_rule(integral):
     return ConstantRule(*integral)
 
-def power_rule(integral, solver):
+def power_rule(integral):
     integrand, symbol = integral
     base, expt = integrand.as_base_exp()
 
@@ -1541,13 +1549,13 @@ def power_rule(integral, solver):
             (ConstantRule(1, symbol), True)
         ])
 
-def exp_rule(integral, solver):
+def exp_rule(integral):
     integrand, symbol = integral
     if isinstance(integrand.args[0], Symbol):
         return ExpRule(integrand, symbol, E, integrand.args[0])
 
 
-def combine_power_rule(integral, solver):
+def combine_power_rule(integral):
     """
     Strategy that simplifies the exponent of a power.
     exp(a*x**2) * exp(b*x) -> exp((a*x**2 + b*x))
@@ -1567,11 +1575,11 @@ def combine_power_rule(integral, solver):
     simplified = powsimp(integrand, combine='exp')
 
     if simplified != integrand:
-        steps = solver.subsolve(simplified, symbol)
+        steps = integral.subsolve(simplified, symbol)
         return RewriteRule(integrand, symbol, simplified, steps)
 
 
-def orthogonal_poly_rule(integral, solver):
+def orthogonal_poly_rule(integral):
     orthogonal_poly_classes = {
         jacobi: JacobiRule,
         gegenbauer: GegenbauerRule,
@@ -1601,7 +1609,7 @@ _wilds: list[Wild] = []
 _symbol = Dummy('x')
 
 
-def special_function_rule(integral, solver):
+def special_function_rule(integral):
     integrand, symbol = integral
     if not _special_function_patterns:
         a = Wild('a', exclude=[_symbol], properties=[lambda x: not x.is_zero])
@@ -1659,7 +1667,7 @@ def _add_degenerate_step(generic_cond, generic_step: Rule, degenerate_step: Rule
     return PiecewiseRule(generic_step.integrand, generic_step.variable, subfunctions)
 
 
-def nested_pow_rule(integral: IntegralInfo, solver=None):
+def nested_pow_rule(integral: IntegralInfo):
     # nested (c*(a+b*x)**d)**e
     integrand, x = integral
 
@@ -1712,13 +1720,11 @@ def nested_pow_rule(integral: IntegralInfo, solver=None):
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
-def inverse_trig_rule(integral: IntegralInfo, solver=None, degenerate=True):
+def inverse_trig_rule(integral: IntegralInfo, degenerate=True):
     """
     Set degenerate=False on recursive call where coefficient of quadratic term
     is assumed non-zero.
     """
-    if solver is None:
-        solver = IntegrationSolver()
     integrand, symbol = integral
     base, exp = integrand.as_base_exp()
     a = Wild('a', exclude=[symbol])
@@ -1755,7 +1761,8 @@ def inverse_trig_rule(integral: IntegralInfo, solver=None, degenerate=True):
     elif b.is_zero:
         degenerate_step = ConstantRule(a ** exp, symbol)
     else:
-        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo((a + b * symbol) ** exp, symbol), solver)
+        degenerate_step = sqrt_fractional_linear_rule(
+            IntegralInfo((a + b * symbol) ** exp, symbol, integral.solver))
 
     if simplify(2*exp + 1) == 0:
         h, k = -b/(2*c), a - b**2/(4*c)  # rewrite base to k + c*(symbol-h)**2
@@ -1790,20 +1797,20 @@ def inverse_trig_rule(integral: IntegralInfo, solver=None, degenerate=True):
         return _add_degenerate_step(generic_cond, step, degenerate_step)
 
 
-def add_rule(integral, solver):
+def add_rule(integral):
     integrand, symbol = integral
-    results = [solver.subsolve(g, symbol)
+    results = [integral.subsolve(g, symbol)
               for g in integrand.as_ordered_terms()]
     return None if None in results else AddRule(integrand, symbol, results)
 
 
-def mul_rule(integral: IntegralInfo, solver):
+def mul_rule(integral: IntegralInfo):
     integrand, symbol = integral
 
     # Constant times function case
     coeff, f = integrand.as_independent(symbol)
     if coeff != 1:
-        next_step = solver.subsolve(f, symbol)
+        next_step = integral.subsolve(f, symbol)
         if next_step is not None:
             return ConstantTimesRule(integrand, symbol, coeff, f, next_step)
 
@@ -1937,8 +1944,9 @@ def _parts_rule(integrand, symbol, solver=None) -> tuple[Expr, Expr, Expr, Expr,
     return None
 
 
-def parts_rule(integral, solver):
+def parts_rule(integral):
     integrand, symbol = integral
+    solver = integral.solver
     constant, integrand = integrand.as_coeff_Mul()
 
     result = _parts_rule(integrand, symbol, solver)
@@ -2003,7 +2011,7 @@ def parts_rule(integral, solver):
         return rule
 
 
-def trig_rule(integral, solver):
+def trig_rule(integral):
     integrand, symbol = integral
     if integrand == sin(symbol):
         return SinRule(integrand, symbol)
@@ -2029,9 +2037,9 @@ def trig_rule(integral, solver):
     else:
         return
 
-    return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
+    return RewriteRule(integrand, symbol, rewritten, integral.subsolve(rewritten, symbol))
 
-def trig_product_rule(integral: IntegralInfo, solver):
+def trig_product_rule(integral: IntegralInfo):
     integrand, symbol = integral
     if integrand == sec(symbol) * tan(symbol):
         return SecTanRule(integrand, symbol)
@@ -2039,7 +2047,7 @@ def trig_product_rule(integral: IntegralInfo, solver):
         return CscCotRule(integrand, symbol)
 
 
-def trig_cmplx_exp_rule(integral: IntegralInfo, solver):
+def trig_cmplx_exp_rule(integral: IntegralInfo):
     """
     Strategy that rewrites sin, cos, sinh, and cosh in terms of complex exponentials.
     Useful for integration techniques that handle exponentials better.
@@ -2074,11 +2082,11 @@ def trig_cmplx_exp_rule(integral: IntegralInfo, solver):
 
     if rewritten != integrand:
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten, symbol))
-        steps = solver.subsolve(rewritten, symbol)
+        steps = integral.subsolve(rewritten, symbol)
         return RewriteRule(integrand, symbol, rewritten, steps)
 
 
-def quadratic_denom_rule(integral, solver):
+def quadratic_denom_rule(integral):
     integrand, symbol = integral
     a = Wild('a', exclude=[symbol, 0])
     b = Wild('b', exclude=[symbol, 0])
@@ -2092,11 +2100,11 @@ def quadratic_denom_rule(integral, solver):
         # skips degenerate case if b != 0 or if b = 0 would cause null denominator
         if not _if_zero_implies_zero(b, c):
             substituted = integrand.subs(b, 0)
-            substep = solver.subsolve(substituted, symbol)
+            substep = integral.subsolve(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(b, 0)))
         if not _if_zero_implies_zero(c, b):
             substituted = integrand.subs(c, 0)
-            substep = solver.subsolve(substituted, symbol)
+            substep = integral.subsolve(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(c, 0)))
         if b.is_extended_real and c.is_extended_real:
             positive_cond = c/b > 0
@@ -2134,7 +2142,7 @@ def quadratic_denom_rule(integral, solver):
         u = Dummy('u')
         u_func = symbol + c/(2*b)
         integrand2 = integrand.subs(symbol, u - c / (2*b))
-        next_step = solver.subsolve(integrand2, u)
+        next_step = integral.subsolve(integrand2, u)
         if next_step:
             return URule(integrand2, symbol, u, u_func, next_step)
         else:
@@ -2151,13 +2159,13 @@ def quadratic_denom_rule(integral, solver):
         numer2 = - const*d + b
         u = Dummy('u')
         step1 = URule(integrand, symbol,
-                      u, denominator, solver.subsolve(u**(-1), u))
+                      u, denominator, integral.subsolve(u**(-1), u))
         if const != 1:
             step1 = ConstantTimesRule(const*numer1/denominator, symbol,
                                       const, numer1/denominator, step1)
         if numer2.is_zero:
             return step1
-        step2 = solver.subsolve(numer2/denominator, symbol)
+        step2 = integral.subsolve(numer2/denominator, symbol)
         substeps = AddRule(integrand, symbol, [step1, step2])
         rewriten = const*numer1/denominator+numer2/denominator
         return RewriteRule(integrand, symbol, rewriten, substeps)
@@ -2165,12 +2173,10 @@ def quadratic_denom_rule(integral, solver):
     return
 
 
-def sqrt_fractional_linear_rule(integral : IntegralInfo, solver=None):
+def sqrt_fractional_linear_rule(integral : IntegralInfo):
     """
     Substitute common ((a*x + b)/(c*x + d))**(1/n)
     """
-    if solver is None:
-        solver = IntegrationSolver()
     integrand, x = integral
     a = Wild('a', exclude=[x])
     b = Wild('b', exclude=[x])
@@ -2218,7 +2224,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo, solver=None):
     if constant_bases_subs:
         integrand = integrand.subs(constant_bases_subs)
     if base0 is None:
-        substep = solver.subsolve(integrand, x)
+        substep = integral.subsolve(integrand, x)
         if not substep.contains_dont_know():
             debug("Integral: {} is rewritten with {} on symbol: {}".format(integral.integrand, integrand, x))
             return RewriteRule(integral.integrand, x, integrand, substep)
@@ -2233,7 +2239,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo, solver=None):
     for base_i, ratio_i, q_i in zip(bases, ratios, qs):
         subs_dict[base_i**(S.One/q_i)] = (ratio_i)**(S.One/q_i) * u**(q0/q_i)
     substituted = integrand.subs(subs_dict).subs(x, x_u) * dx_u
-    substep = solver.subsolve(substituted, u)
+    substep = integral.subsolve(substituted, u)
     if not substep.contains_dont_know():
         pieces: list[tuple[Rule, Boolean]] = []
         det = a0*d0 - b0*c0
@@ -2249,14 +2255,14 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo, solver=None):
                 const_val = a0 / c0
                 subs_a = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
                 simplified_a = integrand.subs(subs_a)
-                degenerate_step_a = solver.subsolve(simplified_a, x)
+                degenerate_step_a = integral.subsolve(simplified_a, x)
                 pieces.append((degenerate_step_a, (And(Eq(det, 0), Ne(c0, 0)))))
             if not c0_implies_d0:
                 const_val = b0 / d0
                 subs_b = {base_i: ratio_i * const_val for base_i, ratio_i in zip(bases, ratios)}
                 simplified_b = integrand.subs(subs_b)
                 simplified_b = simplified_b.subs({a0: 0, c0: 0}) # if det = 0, c = 0 and d != 0, a must be 0
-                degenerate_step_b = solver.subsolve(simplified_b, x)
+                degenerate_step_b = integral.subsolve(simplified_b, x)
                 pieces.append((degenerate_step_b, (And(Eq(det, 0), Eq(c0, 0)))))
         step: Rule = URule(integrand, x, u, u_x, substep)
         if pieces:
@@ -2269,9 +2275,7 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo, solver=None):
     return None
 
 
-def sqrt_quadratic_rule(integral: IntegralInfo, solver=None, degenerate=True):
-    if solver is None:
-        solver = IntegrationSolver()
+def sqrt_quadratic_rule(integral: IntegralInfo, degenerate=True):
     integrand, x = integral
     a = Wild('a', exclude=[x])
     b = Wild('b', exclude=[x])
@@ -2290,10 +2294,11 @@ def sqrt_quadratic_rule(integral: IntegralInfo, solver=None, degenerate=True):
     if not degenerate or generic_cond is S.true:
         degenerate_step = None
     elif b.is_zero:
-        degenerate_step = solver.subsolve(f*sqrt(a)**n, x)
+        degenerate_step = integral.subsolve(f*sqrt(a)**n, x)
     else:
         degenerate_integrand = f*sqrt(a + b*x)**n
-        degenerate_step = sqrt_fractional_linear_rule(IntegralInfo(degenerate_integrand, x), solver)
+        degenerate_step = sqrt_fractional_linear_rule(
+            IntegralInfo(degenerate_integrand, x, integral.solver))
         if degenerate_step is None:
             # since  sqrt_fractional_linear_rule does not guarantee a solution
             # we create a DontKnowRule so that _add_degenerate_step adds the degenerate condition
@@ -2318,7 +2323,8 @@ def sqrt_quadratic_rule(integral: IntegralInfo, solver=None, degenerate=True):
                 if A != 1:
                     linear_step = ConstantTimesRule(A*pre_substitute, x, A, pre_substitute, linear_step)
             if B != 0:
-                constant_step = inverse_trig_rule(IntegralInfo(1/denom, x), solver, degenerate=False)
+                constant_step = inverse_trig_rule(
+                    IntegralInfo(1/denom, x, integral.solver), degenerate=False)
                 if B != 1:
                     constant_step = ConstantTimesRule(B/denom, x, B, 1/denom, constant_step)  # type: ignore
             if linear_step and constant_step:
@@ -2341,7 +2347,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, solver=None, degenerate=True):
             square_base = sqrt(c)*x + b/(2*sqrt(c))
             nested = Pow(Pow(square_base, 2, evaluate=False), S(n)/2, evaluate=False)
             rewritten = const*nested
-            substep = nested_pow_rule(IntegralInfo(rewritten, x), solver)
+            substep = nested_pow_rule(IntegralInfo(rewritten, x, integral.solver))
             return RewriteRule(integrand, x, rewritten, substep)
 
         if delta.is_zero is True:
@@ -2355,12 +2361,12 @@ def sqrt_quadratic_rule(integral: IntegralInfo, solver=None, degenerate=True):
 
         rewrite_expr = Derivative(constant_term, x) + coeff * expr
         derive_expr = Derivative(constant_term, x)
-        derive_step = solver.subsolve(derive_expr, x)
+        derive_step = integral.subsolve(derive_expr, x)
 
         if coeff == 0:
             substep = derive_step
         else:
-            next_step = solver.subsolve(expr, x)
+            next_step = integral.subsolve(expr, x)
             if not next_step:
                 next_step = DontKnowRule(expr, x)
 
@@ -2400,7 +2406,8 @@ def sqrt_quadratic_rule(integral: IntegralInfo, solver=None, degenerate=True):
         if not quotient.is_zero:
             # n is increasing by 2 at each step, we will fall in one of the cases above
             quotient_integrand = quotient.as_expr() * sqrt(root_base)**(n + 2)
-            quotient_step = sqrt_quadratic_rule(IntegralInfo(quotient_integrand, x), solver, degenerate=False)
+            quotient_step = sqrt_quadratic_rule(
+                IntegralInfo(quotient_integrand, x, integral.solver), degenerate=False)
             terms.append(quotient_integrand)
             steps.append(quotient_step)
         if not rest.is_zero:
@@ -2450,7 +2457,7 @@ def sqrt_quadratic_rule(integral: IntegralInfo, solver=None, degenerate=True):
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
-def hyperbolic_rule(integral: tuple[Expr, Symbol], solver):
+def hyperbolic_rule(integral: tuple[Expr, Symbol]):
     integrand, symbol = integral
     if isinstance(integrand, HyperbolicFunction) and integrand.args[0] == symbol:
         if integrand.func == sinh:
@@ -2527,12 +2534,15 @@ def uncurry(func):
     return uncurry_rl
 
 def trig_rewriter(rewrite):
-    def trig_rewriter_rl(args, solver):
-        a, b, m, n, integrand, symbol = args
+    def trig_rewriter_rl(args):
+        # the fifth element is an IntegralInfo carrying the (possibly
+        # normalized) integrand together with the active solver
+        a, b, m, n, integral, symbol = args
+        integrand = integral.integrand
         rewritten = rewrite(a, b, m, n, integrand, symbol)
         if rewritten != integrand:
             debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewrite, symbol))
-            return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
+            return RewriteRule(integrand, symbol, rewritten, integral.subsolve(rewritten, symbol))
     return trig_rewriter_rl
 
 sincos_botheven_condition = uncurry(
@@ -2585,7 +2595,7 @@ cotcsc_cotodd = trig_rewriter(
                                     cot(a*symbol) *
                                     csc(b*symbol) ** n ))
 
-def trig_sincos_rule(integral, solver):
+def trig_sincos_rule(integral):
     integrand, symbol = integral
 
     if any(integrand.has(f) for f in (sin, cos)):
@@ -2600,9 +2610,9 @@ def trig_sincos_rule(integral, solver):
             sincos_cosodd_condition: sincos_cosodd
         })(tuple(
             [match.get(i, S.Zero) for i in (a, b, m, n)] +
-            [integrand, symbol]), solver)
+            [integral, symbol]))
 
-def trig_tansec_rule(integral, solver):
+def trig_tansec_rule(integral):
     integrand, symbol = integral
 
     integrand = integrand.subs({
@@ -2621,9 +2631,9 @@ def trig_tansec_rule(integral, solver):
             tan_tansquared_condition: tan_tansquared
         })(tuple(
             [match.get(i, S.Zero) for i in (a, b, m, n)] +
-            [integrand, symbol]), solver)
+            [IntegralInfo(integrand, symbol, integral.solver), symbol]))
 
-def trig_cotcsc_rule(integral, solver):
+def trig_cotcsc_rule(integral):
     integrand, symbol = integral
     integrand = integrand.subs({
         1 / sin(symbol): csc(symbol),
@@ -2642,9 +2652,9 @@ def trig_cotcsc_rule(integral, solver):
             cotcsc_csceven_condition: cotcsc_csceven
         })(tuple(
             [match.get(i, S.Zero) for i in (a, b, m, n)] +
-            [integrand, symbol]), solver)
+            [IntegralInfo(integrand, symbol, integral.solver), symbol]))
 
-def trig_sindouble_rule(integral, solver):
+def trig_sindouble_rule(integral):
     integrand, symbol = integral
     a = Wild('a', exclude=[sin(2*symbol)])
     match = integrand.match(sin(2*symbol)*a)
@@ -2652,15 +2662,15 @@ def trig_sindouble_rule(integral, solver):
         sin_double = 2*sin(symbol)*cos(symbol)/sin(2*symbol)
         rewritten = integrand * sin_double
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, integrand * sin_double, symbol))
-        substeps = solver.subsolve(rewritten, symbol)
+        substeps = integral.subsolve(rewritten, symbol)
         return RewriteRule(integrand, symbol, rewritten, substeps)
 
-trig_powers_products_rule = _do_one(trig_sincos_rule,
-                                    trig_tansec_rule,
-                                    trig_cotcsc_rule,
-                                    trig_sindouble_rule)
+trig_powers_products_rule = do_one(null_safe(trig_sincos_rule),
+                                   null_safe(trig_tansec_rule),
+                                   null_safe(trig_cotcsc_rule),
+                                   null_safe(trig_sindouble_rule))
 
-def trig_substitution_rule(integral, solver):
+def trig_substitution_rule(integral):
     integrand, symbol = integral
     A = Wild('a', exclude=[0, symbol])
     B = Wild('b', exclude=[0, symbol])
@@ -2715,23 +2725,23 @@ def trig_substitution_rule(integral, solver):
                         1/cos(theta): sec(theta)
                     })
 
-                substep = solver.subsolve(replaced, theta)
+                substep = integral.subsolve(replaced, theta)
                 if not substep.contains_dont_know():
                     return TrigSubstitutionRule(integrand, symbol,
                         theta, x_func, replaced, substep, restriction)
 
-def heaviside_rule(integral, solver):
+def heaviside_rule(integral):
     integrand, symbol = integral
     pattern, m, b, g = heaviside_pattern(symbol)
     match = integrand.match(pattern)
     if match and 0 != match[g]:
         # f = Heaviside(m*x + b)*g
-        substep = solver.subsolve(match[g], symbol)
+        substep = integral.subsolve(match[g], symbol)
         m, b = match[m], match[b]
         return HeavisideRule(integrand, symbol, m*symbol + b, -b/m, substep)
 
 
-def dirac_delta_rule(integral: IntegralInfo, solver):
+def dirac_delta_rule(integral: IntegralInfo):
     integrand, x = integral
     if len(integrand.args) == 1:
         n = S.Zero
@@ -2753,7 +2763,7 @@ def dirac_delta_rule(integral: IntegralInfo, solver):
     return _add_degenerate_step(generic_cond, generic_step, degenerate_step)
 
 
-def substitution_rule(integral, solver):
+def substitution_rule(integral):
     integrand, symbol = integral
 
     u_var = Dummy("u")
@@ -2765,7 +2775,7 @@ def substitution_rule(integral, solver):
         factored_integrand = integrand.factor()
         _, denom_integrand = factored_integrand.as_numer_denom()
         for u_func, c, substituted in substitutions:
-            subrule = solver.subsolve(substituted, u_var)
+            subrule = integral.subsolve(substituted, u_var)
             count = count + 1
             debug("Rule {}: {}".format(count, subrule))
 
@@ -2785,7 +2795,7 @@ def substitution_rule(integral, solver):
                         if not _if_zero_implies_zero(pole, denom_integrand):
                             rewritten_integral = manual_subs(factored_integrand, pole, 0)
                             debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten_integral, symbol))
-                            substep = solver.subsolve(rewritten_integral, symbol)
+                            substep = integral.subsolve(rewritten_integral, symbol)
 
                             if substep:
                                 substep = RewriteRule(integrand, symbol, rewritten_integral, substep)
@@ -2826,7 +2836,7 @@ trig_expand_rule = rewriter(
         len({a.args[0] for a in integrand.atoms(TrigonometricFunction)}) > 1),
     lambda integrand, symbol: integrand.expand(trig=True))
 
-def derivative_rule(integral, solver):
+def derivative_rule(integral):
     integrand = integral[0]
     diff_variables = integrand.variables
     undifferentiated_function = integrand.expr
@@ -2840,15 +2850,15 @@ def derivative_rule(integral, solver):
     else:
         return ConstantRule(*integral)
 
-def rewrites_rule(integral, solver):
+def rewrites_rule(integral):
     integrand, symbol = integral
 
     if integrand.match(1/cos(symbol)):
         rewritten = integrand.subs(1/cos(symbol), sec(symbol))
         debug("Integral: {} is rewritten with {} on symbol: {}".format(integrand, rewritten, symbol))
-        return RewriteRule(integrand, symbol, rewritten, solver.subsolve(rewritten, symbol))
+        return RewriteRule(integrand, symbol, rewritten, integral.subsolve(rewritten, symbol))
 
-def fallback_rule(integral, solver):
+def fallback_rule(integral):
     return DontKnowRule(*integral)
 
 
@@ -2871,57 +2881,57 @@ def _integral_is_subclass(*klasses):
 
 # The strategy table consulted by IntegrationSolver.subsolve for every
 # subproblem. Entries are stateless rules with signature
-# (integral, solver) -> Rule | None.
-_integration_strategy = _do_one(
-    special_function_rule,
-    _switch(_integrand_key, {
-        Pow: _do_one(power_rule, inverse_trig_rule,
-                     quadratic_denom_rule,
-                     sqrt_quadratic_rule,
-                     sqrt_fractional_linear_rule),
+# (integral) -> Rule | None; the IntegralInfo carries the active solver.
+_integration_strategy = do_one(
+    null_safe(special_function_rule),
+    null_safe(switch(_integrand_key, {
+        Pow: do_one(null_safe(power_rule), null_safe(inverse_trig_rule),
+                    null_safe(quadratic_denom_rule),
+                    null_safe(sqrt_quadratic_rule),
+                    null_safe(sqrt_fractional_linear_rule)),
         Symbol: power_rule,
         exp: exp_rule,
         Add: add_rule,
-        Mul: _do_one(mul_rule, trig_product_rule,
-                     heaviside_rule, quadratic_denom_rule,
-                     sqrt_quadratic_rule,
-                     sqrt_fractional_linear_rule,
-                     trig_cmplx_exp_rule),
+        Mul: do_one(null_safe(mul_rule), null_safe(trig_product_rule),
+                    null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
+                    null_safe(sqrt_quadratic_rule),
+                    null_safe(sqrt_fractional_linear_rule),
+                    null_safe(trig_cmplx_exp_rule)),
         Derivative: derivative_rule,
         TrigonometricFunction: trig_rule,
         Heaviside: heaviside_rule,
         DiracDelta: dirac_delta_rule,
         OrthogonalPolynomial: orthogonal_poly_rule,
         Number: constant_rule
-    }),
-    _do_one(
-        trig_rule,
-        hyperbolic_rule,
-        alternatives(
+    })),
+    do_one(
+        null_safe(trig_rule),
+        null_safe(hyperbolic_rule),
+        null_safe(alternatives(
             rewrites_rule,
             substitution_rule,
-            _condition(
+            condition(
                 _integral_is_subclass(Mul, Pow),
                 partial_fractions_rule),
-            _condition(
+            condition(
                 _integral_is_subclass(Mul, Pow),
                 cancel_rule),
-            _condition(
+            condition(
                 _integral_is_subclass(Mul),
                 combine_power_rule),
-            _condition(
+            condition(
                 _integral_is_subclass(Mul, log,
                                       *inverse_trig_functions,
                                       *special_error_functions),
                 parts_rule),
-            _condition(
+            condition(
                 _integral_is_subclass(Mul, Pow),
                 distribute_expand_rule),
             trig_powers_products_rule,
             trig_expand_rule
-        ),
-        _condition(_integral_is_subclass(Mul, Pow), nested_pow_rule),
-        trig_substitution_rule
+        )),
+        null_safe(condition(_integral_is_subclass(Mul, Pow), nested_pow_rule)),
+        null_safe(trig_substitution_rule)
     ),
     fallback_rule)
 


### PR DESCRIPTION
**This is a prototype generated by Fable (Claude Fable 5, via Claude Code) — for discussion only, not for review or merging.**

#### References to other Issues or PRs

Prototype for the ideas discussed in #30087. Alternative to #30116: same `IntegrationSolver` architecture, but the **rule functions keep their original signatures**.

#### Brief description of what is fixed or changed

Like #30116, this introduces an `IntegrationSolver` that owns all state of an integration run — loop detection (replacing the `_integral_cache` sentinel dance), recursion depth with an optional `max_depth`, the integration-by-parts `u` counter (replacing the global `_parts_u_cache`), a trace of attempted subproblems (exposed via the new `integral_steps_with_trace`), and the preferred output rewrites that used to be inlined in `manualintegrate` (now `solver.postprocess`). No module-level mutable state remains.

The difference is **how rules reach the solver**. Instead of threading a `solver` argument through every rule function, `IntegralInfo` — which every rule already receives — carries it:

* `IntegralInfo` remains an `(integrand, symbol)` tuple: unpacking (`integrand, symbol = integral`), indexing and `*integral` expansion all work exactly as before, so **rule bodies and signatures are untouched** (`def substitution_rule(integral): ...`).
* It additionally holds the `IntegrationSolver` of the current run; rules delegate subproblems with `integral.subsolve(subintegrand, symbol)` instead of recursing into `integral_steps`. This matches the issue's phrasing that rules "receive an expression (and any necessary context)": the subproblem and its solving context travel together, with no global or hidden state (no `contextvars`).
* A bare `IntegralInfo(integrand, symbol)` gets a fresh solver, so standalone rule invocations (e.g. from `Rule.eval` methods) keep working unchanged.

Because rules are single-argument functions again, the original `do_one`/`null_safe`/`switch`/`condition` combinators from `sympy.strategies` are kept, and `multiplexer`/`alternatives`/`rewriter` stay in their original one-argument form — making this variant's diff noticeably smaller and less invasive than #30116 (~311+/160− vs ~339+/198−, with far less signature churn).

**Backwards compatibility**: public API and results unchanged — `manualintegrate`, `integral_steps` (same signature and doctests), `find_substitutions`, `manual_subs` and `_parts_rule` keep their contracts (`_parts_rule` gains only an optional trailing `solver=None` parameter, used internally by `parts_rule` to share run state).

Tests run locally, all green: `test_manual.py` (36), `test_integrals.py` (198), `test_limits.py` (174), doctests of `manualintegrate.py` (4).

The branch contains #30116's commit plus one commit on top converting to this scheme, so the two approaches can be compared commit-by-commit.

#### AI Generation Disclosure

This prototype was generated by the Claude Code coding agent running the model Claude Fable 5 ("Fable"), at the request of and under the direction of the PR author. It is posted to give the discussion in #30087 something concrete to look at; it is **not** intended for review or merging.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
