### PR TITLE
ENH: assumptions: backtracking for `lra_theory`

### DIFF
--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -231,7 +231,7 @@ class SATSolver:
                             if res is not None:
                                 break
                         res = self.lra.check()
-                        self.lra.reset_bounds()
+                        self.lra.reset()
                     else:
                         res = None
                     if res is None or res[0]:

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -489,9 +489,10 @@ class LRASolver():
         """
         i = xi.col_idx
         assert i is not None
+        dv = v - xi.assign
         for j, b in enumerate(self.basic):
-            aji = self.A[j, i]
-            b.assign = b.assign + (v - xi.assign)*aji
+            a_ji = self.A[j, i]
+            b.assign = b.assign + dv*a_ji
         xi.assign = v
 
     def check(self):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -400,6 +400,9 @@ class LRASolver():
             A conflict clause that "explains" why
             the literals asserted so far are unsatisfiable.
         """
+        batch = []
+        self.bound_history.append(batch)
+
         if abs(literal) not in self.atom_id_to_boundaries:
             return None
 
@@ -416,7 +419,7 @@ class LRASolver():
 
         res = None
         for boundary in boundaries:
-            res = self._assert_bound(boundary, literal)
+            res = self._assert_bound(boundary, literal, batch)
             if res and res[0] is False:
                 break
 
@@ -427,7 +430,7 @@ class LRASolver():
 
         return res
 
-    def _assert_bound(self, boundary, literal):
+    def _assert_bound(self, boundary, literal, batch):
         """
         Adjusts the upper or lower bound on variable xi if the new bound is
         more limiting. The assignment of variable xi is adjusted to be
@@ -468,7 +471,8 @@ class LRASolver():
             self.result = False, [-conflicting_lit, -literal]
             return self.result
 
-        self.bound_history.append((xi, target_bound, upper))
+        target_literal = xi.upper_literal if upper else xi.lower_literal
+        batch.append((xi, target_bound, target_literal, upper))
 
         xi.set_bound(boundary, literal)
 
@@ -678,12 +682,14 @@ class LRASolver():
         if not self.bound_history:
             raise ValueError("Cannot backtrack, bound_history stack is empty")
 
-        xi, old_bound, upper = self.bound_history.pop()
-
-        if upper:
-            xi.upper = old_bound
-        else:
-            xi.lower = old_bound
+        batch = self.bound_history.pop()
+        for xi, old_bound, old_literal, upper in batch:
+            if upper:
+                xi.upper = old_bound
+                xi.upper_literal = old_literal
+            else:
+                xi.lower = old_bound
+                xi.lower_literal = old_literal
 
         for var in self.all_var:
             var.assign = self.last_assign_snapshot[var]

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -176,6 +176,8 @@ class LRASolver():
 
         self.atom_id_to_boundaries = atom_id_to_boundaries
         self.A = A
+        # initially slack/basic and nonslack/nonbasic mean the same thing.
+        # however, basic/nonbasic can be modified in process meanwhile slack/nonslack stays constant.
         self.basic = slack_variables
         self.nonbasic = nonslack_variables
         self.basic_set = set(slack_variables)
@@ -351,7 +353,7 @@ class LRASolver():
 
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
         # matrix A is guaranteed to able to be simplified
-        # by removing the non-basic (e.g original) non-atom variables from it
+        # by removing the non-basic (e.g original or nonslack) non-atom variables from it
         # these removed variables will be replaced by linear equation of existing variables.
         nonatom_vars = {i for i in nonbasic if i not in atom_vars}
         A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode)
@@ -431,8 +433,10 @@ class LRASolver():
         more limiting. The assignment of variable xi is adjusted to be
         within the new bound if needed.
 
-        Also calls `self._update` to update the assignment for slack variables
+        Also calls `self._update` to update the assignment for basic variables
         to keep all equalities satisfied.
+
+        This method is the combination of AssertUpper and AssertLower in [1]
         """
         if self.result:
             assert self.result[0] != False
@@ -481,8 +485,8 @@ class LRASolver():
 
     def _update(self, xi, v):
         """
-        Updates all slack variables that have equations that contain
-        variable xi so that they stay satisfied given xi is equal to v.
+        Updates all basic variables that have equations that contain
+        nonbasic variable xi so that they stay satisfied given xi is equal to v.
         """
         i = xi.col_idx
         assert i is not None

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -588,32 +588,29 @@ class LRASolver():
                 xj = min(cand, key=lambda v: v.col_idx)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)
 
-    def _pivot_and_update(self, M, basic, nonbasic, xi, xj, v):
+    def _pivot_and_update(self, i, xi, xj, v):
         """
         Pivots basic variable xi with nonbasic variable xj,
         and sets value of xi to v and adjusts the values of all basic variables
         to keep equations satisfied.
+
+        i is precomputed in check(), it is solely a parameter just for the small optimization, otherwise the method is exactly like [1] paper.
         """
-        i, j = basic[xi], xj.col_idx
+        j = xj.col_idx
         assert j is not None
-        assert M[i, j] != 0
-        theta = (v - xi.assign)*(1/M[i, j])
+        assert self.A[i, j] != 0
+        theta = (v - xi.assign)*(1/self.A[i, j])
         xi.assign = v
         xj.assign = xj.assign + theta
-        for xk in basic:
-            if xk != xi:
-                k = basic[xk]
-                akj = M[k, j]
-                xk.assign = xk.assign + theta*akj
-        # pivot
-        basic[xj] = basic[xi]
-        del basic[xi]
-        nonbasic.add(xi)
-        nonbasic.remove(xj)
-        return self._pivot(M, i, j)
+        for k in range(len(self.basic)):
+            if k != i:
+                self.basic[k].assign = self.basic[k].assign + theta*self.A[k, j]
+        self._pivot(i, j)
+        self.basic[i] = xj
+        self.nonbasic.discard(xj)
+        self.nonbasic.add(xi)
 
-    @staticmethod
-    def _pivot(M, i, j):
+    def _pivot(self, i, j):
         """
         Performs a pivot operation about entry i, j of A by performing
         a series of row operations on A.

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -519,20 +519,16 @@ class LRASolver():
         if self.result:
             return self.result
 
-        from sympy.matrices.dense import Matrix
-        M = self.A.copy()
-        basic = {s: i for i, s in enumerate(self.basic)}  # contains the row index associated with each basic variable
-        nonbasic = set(self.nonbasic)
         while True:
             if self.run_checks:
                 # nonbasic variables must always be within bounds
-                assert all(((nb.assign >= nb.lower) == True) and ((nb.assign <= nb.upper) == True) for nb in nonbasic)
+                assert all(((nb.assign >= nb.lower) == True) and ((nb.assign <= nb.upper) == True) for nb in self.nonbasic)
 
                 # assignments for x must always satisfy Ax = 0
                 # probably have to turn this off when dealing with strict ineq
                 if all(not math.isinf(v.assign.q) for v in self.all_var):
                     X = Matrix([v.assign.q for v in self.all_var])
-                    assert all(abs(val) < 10**(-10) for val in M*X)
+                    assert all(abs(val) < 10**(-10) for val in self._A0*X)
 
                 # check upper and lower match this format:
                 # x <= rat + delta iff x < rat
@@ -543,22 +539,24 @@ class LRASolver():
                 assert all(x.upper.d <= 0 for x in self.all_var)
                 assert all(x.lower.d >= 0 for x in self.all_var)
 
-            cand = [b for b in basic if b.assign < b.lower or b.assign > b.upper]
+            xi = i = None
+            for r in range(len(self.basic)):
+                b = self.basic[r]
+                if b.assign < b.lower or b.assign > b.upper:
+                    if xi is None or b.col_idx < xi.col_idx:  # Bland's rule
+                        xi, i = b, r
 
-            if len(cand) == 0:
+            if xi is None:
                 self.last_assign_snapshot = {var: var.assign for var in self.all_var}
                 return True, self.last_assign_snapshot
 
-            xi = min(cand, key=lambda v: v.col_idx) # Bland's rule
-            i = basic[xi]
-
             if xi.assign < xi.lower:
-                cand = [nb for nb in nonbasic
-                        if (M[i, nb.col_idx] > 0 and nb.assign < nb.upper)
-                        or (M[i, nb.col_idx] < 0 and nb.assign > nb.lower)]
+                cand = [nb for nb in self.nonbasic
+                        if (self.A[i, nb.col_idx] > 0 and nb.assign < nb.upper)
+                        or (self.A[i, nb.col_idx] < 0 and nb.assign > nb.lower)]
                 if len(cand) == 0:
-                    N_plus = [nb for nb in nonbasic if M[i, nb.col_idx] > 0]
-                    N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
+                    N_plus = [nb for nb in self.nonbasic if self.A[i, nb.col_idx] > 0]
+                    N_minus = [nb for nb in self.nonbasic if self.A[i, nb.col_idx] < 0]
 
                     conflict = []
                     conflict += [nb.upper_literal for nb in N_plus]
@@ -567,16 +565,16 @@ class LRASolver():
                     conflict = [-conflicting_lit for conflicting_lit in conflict]
                     return False, conflict
                 xj = min(cand, key=str)
-                M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.lower)
+                self._pivot_and_update(i, xi, xj, xi.lower)
 
             if xi.assign > xi.upper:
-                cand = [nb for nb in nonbasic
-                        if (M[i, nb.col_idx] < 0 and nb.assign < nb.upper)
-                        or (M[i, nb.col_idx] > 0 and nb.assign > nb.lower)]
+                cand = [nb for nb in self.nonbasic
+                        if (self.A[i, nb.col_idx] < 0 and nb.assign < nb.upper)
+                        or (self.A[i, nb.col_idx] > 0 and nb.assign > nb.lower)]
 
                 if len(cand) == 0:
-                    N_plus = [nb for nb in nonbasic if M[i, nb.col_idx] > 0]
-                    N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
+                    N_plus = [nb for nb in self.nonbasic if self.A[i, nb.col_idx] > 0]
+                    N_minus = [nb for nb in self.nonbasic if self.A[i, nb.col_idx] < 0]
 
                     conflict_bounds = []
                     conflict_bounds += [nb.upper_literal for nb in N_minus]
@@ -586,7 +584,7 @@ class LRASolver():
                     conflict = [-conflicting_lit for conflicting_lit in conflict_bounds]
                     return False, conflict
                 xj = min(cand, key=lambda v: v.col_idx)
-                M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)
+                self._pivot_and_update(i, xi, xj, xi.upper)
 
     def _pivot_and_update(self, i, xi, xj, v):
         """

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -179,8 +179,7 @@ class LRASolver():
         # initially slack/basic and nonslack/nonbasic mean the same thing.
         # however, basic/nonbasic can be modified in process meanwhile slack/nonslack stays constant.
         self.basic = slack_variables
-        self.nonbasic = nonslack_variables
-        self.basic_set = set(slack_variables)
+        self.nonbasic = set(nonslack_variables)
 
         self.all_var = nonslack_variables + slack_variables
 
@@ -420,7 +419,7 @@ class LRASolver():
             if res and res[0] is False:
                 break
 
-        if self.is_sat and all(b.var not in self.basic_set for b in boundaries):
+        if self.is_sat and all(b.var in self.nonbasic for b in boundaries):
             self.is_sat = res is None
         else:
             self.is_sat = False

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -615,11 +615,10 @@ class LRASolver():
     @staticmethod
     def _pivot(M, i, j):
         """
-        Performs a pivot operation about entry i, j of M by performing
-        a series of row operations on a copy of M and returning the result.
-        The original M is left unmodified.
+        Performs a pivot operation about entry i, j of A by performing
+        a series of row operations on A.
 
-        Conceptually, M represents a system of equations and pivoting
+        Conceptually, A represents a system of equations and pivoting
         can be thought of as rearranging equation i to be in terms of
         variable j and then substituting in the rest of the equations
         to get rid of other occurrences of variable j.
@@ -630,7 +629,9 @@ class LRASolver():
         >>> from sympy.matrices.dense import Matrix
         >>> from sympy.logic.algorithms.lra_theory import LRASolver
         >>> from sympy import var
-        >>> Matrix(3, 3, var('a:i'))
+        >>> lra = LRASolver.__new__(LRASolver)
+        >>> lra.A = Matrix(3, 3, var('a:i'))
+        >>> lra.A
         Matrix([
         [a, b, c],
         [d, e, f],
@@ -641,7 +642,8 @@ class LRASolver():
         0 = d*x + e*y + f*z
         0 = g*x + h*y + i*z
 
-        >>> LRASolver._pivot(_, 1, 0)
+        >>> lra._pivot(1, 0)
+        >>> lra.A
         Matrix([
         [ 0, -a*e/d + b, -a*f/d + c],
         [-1,       -e/d,       -f/d],
@@ -654,16 +656,13 @@ class LRASolver():
         0 = -x + (-e/d)*y + (-f/d)*z
         0 = 0 + (h - e*g/d)*y + (i - f*g/d)*z
         """
-        Mij = M[i, j]
-        if Mij == 0:
+        Aij = self.A[i, j]
+        if Aij == 0:
             raise ZeroDivisionError("Tried to pivot about zero-valued entry.")
-        A = M.copy()
-        A[i, :] = -A[i, :]/Mij
-        for row in range(M.shape[0]):
+        self.A[i, :] = -self.A[i, :]/Aij
+        for row in range(self.A.shape[0]):
             if row != i:
-                A[row, :] = A[row, :] + A[row, j] * A[i, :]
-
-        return A
+                self.A[row, :] = self.A[row, :] + self.A[row, j] * self.A[i, :]
 
     def backtrack(self):
         """

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -176,11 +176,11 @@ class LRASolver():
 
         self.atom_id_to_boundaries = atom_id_to_boundaries
         self.A = A
-        self.slack = slack_variables
-        self.nonslack = nonslack_variables
-        self.all_var = nonslack_variables + slack_variables
+        self.basic = slack_variables
+        self.nonbasic = nonslack_variables
+        self.basic_set = set(slack_variables)
 
-        self.slack_set = set(slack_variables)
+        self.all_var = nonslack_variables + slack_variables
 
         self.is_sat = True  # While True, all constraints asserted so far are satisfiable
         self.result = None  # always one of: (True, assignment), (False, conflict clause), None
@@ -418,7 +418,7 @@ class LRASolver():
             if res and res[0] is False:
                 break
 
-        if self.is_sat and all(b.var not in self.slack_set for b in boundaries):
+        if self.is_sat and all(b.var not in self.basic_set for b in boundaries):
             self.is_sat = res is None
         else:
             self.is_sat = False
@@ -468,7 +468,7 @@ class LRASolver():
 
         xi.set_bound(boundary, literal)
 
-        if xi in self.nonslack and xi.assign * s > c_norm:
+        if xi in self.nonbasic and xi.assign * s > c_norm:
             self._update(xi, ci)
 
         if self.run_checks and all(not math.isinf(v.assign.q)
@@ -486,7 +486,7 @@ class LRASolver():
         """
         i = xi.col_idx
         assert i is not None
-        for j, b in enumerate(self.slack):
+        for j, b in enumerate(self.basic):
             aji = self.A[j, i]
             b.assign = b.assign + (v - xi.assign)*aji
         xi.assign = v
@@ -517,8 +517,8 @@ class LRASolver():
 
         from sympy.matrices.dense import Matrix
         M = self.A.copy()
-        basic = {s: i for i, s in enumerate(self.slack)}  # contains the row index associated with each basic variable
-        nonbasic = set(self.nonslack)
+        basic = {s: i for i, s in enumerate(self.basic)}  # contains the row index associated with each basic variable
+        nonbasic = set(self.nonbasic)
         while True:
             if self.run_checks:
                 # nonbasic variables must always be within bounds

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -176,6 +176,7 @@ class LRASolver():
 
         self.atom_id_to_boundaries = atom_id_to_boundaries
         self.A = A
+        self._A0 = A.copy() if self.run_checks else None
         # initially slack/basic and nonslack/nonbasic mean the same thing.
         # however, basic/nonbasic can be modified in process meanwhile slack/nonslack stays constant.
         self.basic = slack_variables
@@ -476,9 +477,8 @@ class LRASolver():
 
         if self.run_checks and all(not math.isinf(v.assign.q)
                                    for v in self.all_var):
-            M = self.A
             X = Matrix([v.assign.q for v in self.all_var])
-            assert all(abs(val) < 10 ** (-10) for val in M * X)
+            assert all(abs(val) < 10 ** (-10) for val in self._A0 * X)
 
         return None
 

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -366,7 +366,7 @@ class LRASolver():
                            s_subs, testing_mode)
         return solver, conflicts
 
-    def reset_bounds(self):
+    def reset(self):
         """
         Resets the state of the LRASolver to before
         anything was asserted.

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -442,7 +442,10 @@ def test_pivot():
         for _ in range(5):
             i, j = randint(0, 4), randint(0, 4)
             if m[i, j] != 0:
-                assert LRASolver._pivot(m, i, j).rref() == rref
+                lra = LRASolver.__new__(LRASolver)
+                lra.A = m.copy()
+                lra._pivot(i, j)
+                assert lra.A.rref() == rref
 
 
 def test_reset_bounds():

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -113,8 +113,8 @@ def test_from_encoded_cnf():
     enc = boolean_formula_to_encoded_cnf(phi)
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
     assert lra.A.shape == (0, 3)
-    assert str(lra.slack) == '[]'
-    assert str(lra.nonslack) == '[x, _s1, _s2]'
+    assert str(lra.basic) == '[]'
+    assert str(lra.nonbasic) == '[x, _s1, _s2]'
     assert lra.A == Matrix(0,3, [])
     actual = {tuple(sorted((str(b.var), b.bound, b.upper, b.strict) for b in bs)) for bs in lra.atom_id_to_boundaries.values()}
     expected = {

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -114,7 +114,7 @@ def test_from_encoded_cnf():
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
     assert lra.A.shape == (0, 3)
     assert str(lra.basic) == '[]'
-    assert str(lra.nonbasic) == '[x, _s1, _s2]'
+    assert {str(v) for v in lra.nonbasic} == {'x', '_s1', '_s2'}
     assert lra.A == Matrix(0,3, [])
     actual = {tuple(sorted((str(b.var), b.bound, b.upper, b.strict) for b in bs)) for bs in lra.atom_id_to_boundaries.values()}
     expected = {

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -514,8 +514,8 @@ def test_example_from_paper():
     # Extracts the variables stored in the solver
     var_x = next(v for v in lra.all_var if str(v.var) == 'x')
     # var_y has been removed from A after the simplification
-    # var_s1 is a slack variable which corresponds for -x + y <= 1
-    # var_s2 is a slack variable which corresponds for -x - y <= 3
+    # var_s1 is a basic variable which corresponds for -x + y <= 1
+    # var_s2 is a basic variable which corresponds for -x - y <= 3
     _s1 = lra.s_subs[-x + y]
     _s2 = lra.s_subs[-x - y]
     var_s1 = next(v for v in lra.all_var if v.var == _s1)

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -448,9 +448,9 @@ def test_pivot():
                 assert lra.A.rref() == rref
 
 
-def test_reset_bounds():
+def test_reset():
     """
-    Tests that reset_bounds properly resets all state variables to their default values.
+    Tests that reset properly resets all state variables to their default values.
     """
     # Test solver behavior after reset
     bf = Q.ge(x, 1) & Q.lt(x, 1)
@@ -462,7 +462,7 @@ def test_reset_bounds():
             lra.assert_lit(lit)
 
     assert lra.check()[0] == False
-    lra.reset_bounds()
+    lra.reset()
     assert lra.check()[0] == True
 
     # Test individual state variable resets
@@ -482,7 +482,7 @@ def test_reset_bounds():
         for var in lra.all_var:
             setattr(var, attr_name, test_value)
 
-        lra.reset_bounds()
+        lra.reset()
 
         for var in lra.all_var:
             actual_value = getattr(var, attr_name)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

depends on
* https://github.com/sympy/sympy/pull/30096
#### Brief description of what is fixed or changed
Still draft

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
