### PR TITLE
ENH: assumptions: Deprecate `use_lra_theory`

### DIFF
--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.assumptions.ask import Q
-from sympy.logic.inference import satisfiable
+from sympy.logic.algorithms.dpll2 import dpll_satisfiable
 from sympy.logic.algorithms.lra_theory import LRASolver, UnhandledInput, ALLOWED_PRED
 from sympy.matrices.kind import MatrixKind
 from sympy.core.kind import NumberKind
@@ -71,8 +71,8 @@ def check_satisfiability(prop, _prop, factbase):
     sat_true = _preprocess(sat_true)
     sat_false = _preprocess(sat_false)
 
-    can_be_true = satisfiable(sat_true, theory_solvers=[LRASolver]) is not False
-    can_be_false = satisfiable(sat_false, theory_solvers=[LRASolver]) is not False
+    can_be_true = dpll_satisfiable(sat_true, theory_solvers=[LRASolver]) is not False
+    can_be_false = dpll_satisfiable(sat_false, theory_solvers=[LRASolver]) is not False
 
     if can_be_true and can_be_false:
         return None

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.assumptions.ask import Q
 from sympy.logic.inference import satisfiable
-from sympy.logic.algorithms.lra_theory import UnhandledInput, ALLOWED_PRED
+from sympy.logic.algorithms.lra_theory import LRASolver, UnhandledInput, ALLOWED_PRED
 from sympy.matrices.kind import MatrixKind
 from sympy.core.kind import NumberKind
 from sympy.assumptions.assume import AppliedPredicate
@@ -71,8 +71,8 @@ def check_satisfiability(prop, _prop, factbase):
     sat_true = _preprocess(sat_true)
     sat_false = _preprocess(sat_false)
 
-    can_be_true = satisfiable(sat_true, use_lra_theory=True) is not False
-    can_be_false = satisfiable(sat_false, use_lra_theory=True) is not False
+    can_be_true = satisfiable(sat_true, theory_solvers=[LRASolver]) is not False
+    can_be_false = satisfiable(sat_false, theory_solvers=[LRASolver]) is not False
 
     if can_be_true and can_be_false:
         return None

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -16,7 +16,10 @@ from heapq import heappush, heappop
 from sympy.core.sorting import ordered
 from sympy.assumptions.cnf import EncodedCNF
 
-from sympy.logic.algorithms.theory_solver import TheorySolver
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sympy.logic.algorithms.theory_solver import TheorySolver
 
 
 def dpll_satisfiable(expr, all_models=False,

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -16,10 +16,11 @@ from heapq import heappush, heappop
 from sympy.core.sorting import ordered
 from sympy.assumptions.cnf import EncodedCNF
 
-from sympy.logic.algorithms.lra_theory import LRASolver
+from sympy.logic.algorithms.theory_solver import TheorySolver
 
 
-def dpll_satisfiable(expr, all_models=False, use_lra_theory=False):
+def dpll_satisfiable(expr, all_models=False,
+                      theory_solvers: list[type[TheorySolver]] | None = None):
     """
     Check satisfiability of a propositional sentence.
     It returns a model rather than True when it succeeds.
@@ -47,12 +48,14 @@ def dpll_satisfiable(expr, all_models=False, use_lra_theory=False):
             return (f for f in [False])
         return False
 
-    if use_lra_theory:
-        lra, immediate_conflicts = LRASolver.from_encoded_cnf(expr)
-    else:
-        lra = None
-        immediate_conflicts = []
-    solver = SATSolver(expr.data + immediate_conflicts, expr.variables, set(), expr.symbols, lra_theory=lra)
+    theories = []
+    immediate_conflicts = []
+    for theory_solver in theory_solvers or []:
+        theory, conflicts = theory_solver.from_encoded_cnf(expr)
+        theories.append(theory)
+        immediate_conflicts += conflicts
+
+    solver = SATSolver(expr.data + immediate_conflicts, expr.variables, set(), expr.symbols, theories=theories)
     models = solver._find_model()
 
     if all_models:
@@ -89,7 +92,7 @@ class SATSolver:
 
     def __init__(self, clauses, variables, var_settings, symbols=None,
                 heuristic='vsids', clause_learning='none', INTERVAL=500,
-                 lra_theory = None):
+                 theories: list[TheorySolver] | None = None):
 
         self.var_settings = var_settings
         self.heuristic = heuristic
@@ -138,7 +141,7 @@ class SATSolver:
         self.num_learned_clauses = 0
         self.original_num_clauses = len(self.clauses)
 
-        self.lra = lra_theory
+        self.theories: list[TheorySolver] = theories or []
 
     def _initialize_variables(self, variables):
         """Set up the variable data structures needed."""
@@ -224,16 +227,17 @@ class SATSolver:
                 # Stopping condition for a satisfying theory
                 if 0 == lit:
 
-                    # check if assignment satisfies lra theory
-                    if self.lra:
+                    # check if assignment satisfies every theory
+                    res = None
+                    for theory in self.theories:
                         for enc_var in self.var_settings:
-                            res = self.lra.assert_lit(enc_var)
+                            res = theory.assert_lit(enc_var)
                             if res is not None:
                                 break
-                        res = self.lra.check()
-                        self.lra.reset()
-                    else:
-                        res = None
+                        res = theory.check()
+                        theory.reset()
+                        if res is not None and not res[0]:
+                            break
                     if res is None or res[0]:
                         yield {self.symbols[abs(lit) - 1]:
                                     lit > 0 for lit in self.var_settings}

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -231,7 +231,7 @@ class SATSolver:
                             if res is not None:
                                 break
                         res = self.lra.check()
-                        self.lra.reset_bounds()
+                        self.lra.reset()
                     else:
                         res = None
                     if res is None or res[0]:

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -489,9 +489,10 @@ class LRASolver():
         """
         i = xi.col_idx
         assert i is not None
+        dv = v - xi.assign
         for j, b in enumerate(self.basic):
-            aji = self.A[j, i]
-            b.assign = b.assign + (v - xi.assign)*aji
+            a_ji = self.A[j, i]
+            b.assign = b.assign + dv*a_ji
         xi.assign = v
 
     def check(self):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -400,6 +400,9 @@ class LRASolver():
             A conflict clause that "explains" why
             the literals asserted so far are unsatisfiable.
         """
+        batch = []
+        self.bound_history.append(batch)
+
         if abs(literal) not in self.atom_id_to_boundaries:
             return None
 
@@ -416,7 +419,7 @@ class LRASolver():
 
         res = None
         for boundary in boundaries:
-            res = self._assert_bound(boundary, literal)
+            res = self._assert_bound(boundary, literal, batch)
             if res and res[0] is False:
                 break
 
@@ -427,7 +430,7 @@ class LRASolver():
 
         return res
 
-    def _assert_bound(self, boundary, literal):
+    def _assert_bound(self, boundary, literal, batch):
         """
         Adjusts the upper or lower bound on variable xi if the new bound is
         more limiting. The assignment of variable xi is adjusted to be
@@ -468,7 +471,8 @@ class LRASolver():
             self.result = False, [-conflicting_lit, -literal]
             return self.result
 
-        self.bound_history.append((xi, target_bound, upper))
+        target_literal = xi.upper_literal if upper else xi.lower_literal
+        batch.append((xi, target_bound, target_literal, upper))
 
         xi.set_bound(boundary, literal)
 
@@ -678,12 +682,14 @@ class LRASolver():
         if not self.bound_history:
             raise ValueError("Cannot backtrack, bound_history stack is empty")
 
-        xi, old_bound, upper = self.bound_history.pop()
-
-        if upper:
-            xi.upper = old_bound
-        else:
-            xi.lower = old_bound
+        batch = self.bound_history.pop()
+        for xi, old_bound, old_literal, upper in batch:
+            if upper:
+                xi.upper = old_bound
+                xi.upper_literal = old_literal
+            else:
+                xi.lower = old_bound
+                xi.lower_literal = old_literal
 
         for var in self.all_var:
             var.assign = self.last_assign_snapshot[var]

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -176,6 +176,8 @@ class LRASolver():
 
         self.atom_id_to_boundaries = atom_id_to_boundaries
         self.A = A
+        # initially slack/basic and nonslack/nonbasic mean the same thing.
+        # however, basic/nonbasic can be modified in process meanwhile slack/nonslack stays constant.
         self.basic = slack_variables
         self.nonbasic = nonslack_variables
         self.basic_set = set(slack_variables)
@@ -351,7 +353,7 @@ class LRASolver():
 
         A, _ = linear_eq_to_matrix(A, nonbasic + basic)
         # matrix A is guaranteed to able to be simplified
-        # by removing the non-basic (e.g original) non-atom variables from it
+        # by removing the non-basic (e.g original or nonslack) non-atom variables from it
         # these removed variables will be replaced by linear equation of existing variables.
         nonatom_vars = {i for i in nonbasic if i not in atom_vars}
         A, basic, nonbasic = _reduce_matrix(A, basic, nonbasic, nonatom_vars, testing_mode)
@@ -431,8 +433,10 @@ class LRASolver():
         more limiting. The assignment of variable xi is adjusted to be
         within the new bound if needed.
 
-        Also calls `self._update` to update the assignment for slack variables
+        Also calls `self._update` to update the assignment for basic variables
         to keep all equalities satisfied.
+
+        This method is the combination of AssertUpper and AssertLower in [1]
         """
         if self.result:
             assert self.result[0] != False
@@ -481,8 +485,8 @@ class LRASolver():
 
     def _update(self, xi, v):
         """
-        Updates all slack variables that have equations that contain
-        variable xi so that they stay satisfied given xi is equal to v.
+        Updates all basic variables that have equations that contain
+        nonbasic variable xi so that they stay satisfied given xi is equal to v.
         """
         i = xi.col_idx
         assert i is not None

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -588,32 +588,29 @@ class LRASolver():
                 xj = min(cand, key=lambda v: v.col_idx)
                 M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)
 
-    def _pivot_and_update(self, M, basic, nonbasic, xi, xj, v):
+    def _pivot_and_update(self, i, xi, xj, v):
         """
         Pivots basic variable xi with nonbasic variable xj,
         and sets value of xi to v and adjusts the values of all basic variables
         to keep equations satisfied.
+
+        i is precomputed in check(), it is solely a parameter just for the small optimization, otherwise the method is exactly like [1] paper.
         """
-        i, j = basic[xi], xj.col_idx
+        j = xj.col_idx
         assert j is not None
-        assert M[i, j] != 0
-        theta = (v - xi.assign)*(1/M[i, j])
+        assert self.A[i, j] != 0
+        theta = (v - xi.assign)*(1/self.A[i, j])
         xi.assign = v
         xj.assign = xj.assign + theta
-        for xk in basic:
-            if xk != xi:
-                k = basic[xk]
-                akj = M[k, j]
-                xk.assign = xk.assign + theta*akj
-        # pivot
-        basic[xj] = basic[xi]
-        del basic[xi]
-        nonbasic.add(xi)
-        nonbasic.remove(xj)
-        return self._pivot(M, i, j)
+        for k in range(len(self.basic)):
+            if k != i:
+                self.basic[k].assign = self.basic[k].assign + theta*self.A[k, j]
+        self._pivot(i, j)
+        self.basic[i] = xj
+        self.nonbasic.discard(xj)
+        self.nonbasic.add(xi)
 
-    @staticmethod
-    def _pivot(M, i, j):
+    def _pivot(self, i, j):
         """
         Performs a pivot operation about entry i, j of A by performing
         a series of row operations on A.

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -519,20 +519,16 @@ class LRASolver():
         if self.result:
             return self.result
 
-        from sympy.matrices.dense import Matrix
-        M = self.A.copy()
-        basic = {s: i for i, s in enumerate(self.basic)}  # contains the row index associated with each basic variable
-        nonbasic = set(self.nonbasic)
         while True:
             if self.run_checks:
                 # nonbasic variables must always be within bounds
-                assert all(((nb.assign >= nb.lower) == True) and ((nb.assign <= nb.upper) == True) for nb in nonbasic)
+                assert all(((nb.assign >= nb.lower) == True) and ((nb.assign <= nb.upper) == True) for nb in self.nonbasic)
 
                 # assignments for x must always satisfy Ax = 0
                 # probably have to turn this off when dealing with strict ineq
                 if all(not math.isinf(v.assign.q) for v in self.all_var):
                     X = Matrix([v.assign.q for v in self.all_var])
-                    assert all(abs(val) < 10**(-10) for val in M*X)
+                    assert all(abs(val) < 10**(-10) for val in self._A0*X)
 
                 # check upper and lower match this format:
                 # x <= rat + delta iff x < rat
@@ -543,22 +539,24 @@ class LRASolver():
                 assert all(x.upper.d <= 0 for x in self.all_var)
                 assert all(x.lower.d >= 0 for x in self.all_var)
 
-            cand = [b for b in basic if b.assign < b.lower or b.assign > b.upper]
+            xi = i = None
+            for r in range(len(self.basic)):
+                b = self.basic[r]
+                if b.assign < b.lower or b.assign > b.upper:
+                    if xi is None or b.col_idx < xi.col_idx:  # Bland's rule
+                        xi, i = b, r
 
-            if len(cand) == 0:
+            if xi is None:
                 self.last_assign_snapshot = {var: var.assign for var in self.all_var}
                 return True, self.last_assign_snapshot
 
-            xi = min(cand, key=lambda v: v.col_idx) # Bland's rule
-            i = basic[xi]
-
             if xi.assign < xi.lower:
-                cand = [nb for nb in nonbasic
-                        if (M[i, nb.col_idx] > 0 and nb.assign < nb.upper)
-                        or (M[i, nb.col_idx] < 0 and nb.assign > nb.lower)]
+                cand = [nb for nb in self.nonbasic
+                        if (self.A[i, nb.col_idx] > 0 and nb.assign < nb.upper)
+                        or (self.A[i, nb.col_idx] < 0 and nb.assign > nb.lower)]
                 if len(cand) == 0:
-                    N_plus = [nb for nb in nonbasic if M[i, nb.col_idx] > 0]
-                    N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
+                    N_plus = [nb for nb in self.nonbasic if self.A[i, nb.col_idx] > 0]
+                    N_minus = [nb for nb in self.nonbasic if self.A[i, nb.col_idx] < 0]
 
                     conflict = []
                     conflict += [nb.upper_literal for nb in N_plus]
@@ -567,16 +565,16 @@ class LRASolver():
                     conflict = [-conflicting_lit for conflicting_lit in conflict]
                     return False, conflict
                 xj = min(cand, key=str)
-                M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.lower)
+                self._pivot_and_update(i, xi, xj, xi.lower)
 
             if xi.assign > xi.upper:
-                cand = [nb for nb in nonbasic
-                        if (M[i, nb.col_idx] < 0 and nb.assign < nb.upper)
-                        or (M[i, nb.col_idx] > 0 and nb.assign > nb.lower)]
+                cand = [nb for nb in self.nonbasic
+                        if (self.A[i, nb.col_idx] < 0 and nb.assign < nb.upper)
+                        or (self.A[i, nb.col_idx] > 0 and nb.assign > nb.lower)]
 
                 if len(cand) == 0:
-                    N_plus = [nb for nb in nonbasic if M[i, nb.col_idx] > 0]
-                    N_minus = [nb for nb in nonbasic if M[i, nb.col_idx] < 0]
+                    N_plus = [nb for nb in self.nonbasic if self.A[i, nb.col_idx] > 0]
+                    N_minus = [nb for nb in self.nonbasic if self.A[i, nb.col_idx] < 0]
 
                     conflict_bounds = []
                     conflict_bounds += [nb.upper_literal for nb in N_minus]
@@ -586,7 +584,7 @@ class LRASolver():
                     conflict = [-conflicting_lit for conflicting_lit in conflict_bounds]
                     return False, conflict
                 xj = min(cand, key=lambda v: v.col_idx)
-                M = self._pivot_and_update(M, basic, nonbasic, xi, xj, xi.upper)
+                self._pivot_and_update(i, xi, xj, xi.upper)
 
     def _pivot_and_update(self, i, xi, xj, v):
         """

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -179,8 +179,7 @@ class LRASolver():
         # initially slack/basic and nonslack/nonbasic mean the same thing.
         # however, basic/nonbasic can be modified in process meanwhile slack/nonslack stays constant.
         self.basic = slack_variables
-        self.nonbasic = nonslack_variables
-        self.basic_set = set(slack_variables)
+        self.nonbasic = set(nonslack_variables)
 
         self.all_var = nonslack_variables + slack_variables
 
@@ -420,7 +419,7 @@ class LRASolver():
             if res and res[0] is False:
                 break
 
-        if self.is_sat and all(b.var not in self.basic_set for b in boundaries):
+        if self.is_sat and all(b.var in self.nonbasic for b in boundaries):
             self.is_sat = res is None
         else:
             self.is_sat = False

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -615,11 +615,10 @@ class LRASolver():
     @staticmethod
     def _pivot(M, i, j):
         """
-        Performs a pivot operation about entry i, j of M by performing
-        a series of row operations on a copy of M and returning the result.
-        The original M is left unmodified.
+        Performs a pivot operation about entry i, j of A by performing
+        a series of row operations on A.
 
-        Conceptually, M represents a system of equations and pivoting
+        Conceptually, A represents a system of equations and pivoting
         can be thought of as rearranging equation i to be in terms of
         variable j and then substituting in the rest of the equations
         to get rid of other occurrences of variable j.
@@ -630,7 +629,9 @@ class LRASolver():
         >>> from sympy.matrices.dense import Matrix
         >>> from sympy.logic.algorithms.lra_theory import LRASolver
         >>> from sympy import var
-        >>> Matrix(3, 3, var('a:i'))
+        >>> lra = LRASolver.__new__(LRASolver)
+        >>> lra.A = Matrix(3, 3, var('a:i'))
+        >>> lra.A
         Matrix([
         [a, b, c],
         [d, e, f],
@@ -641,7 +642,8 @@ class LRASolver():
         0 = d*x + e*y + f*z
         0 = g*x + h*y + i*z
 
-        >>> LRASolver._pivot(_, 1, 0)
+        >>> lra._pivot(1, 0)
+        >>> lra.A
         Matrix([
         [ 0, -a*e/d + b, -a*f/d + c],
         [-1,       -e/d,       -f/d],
@@ -654,16 +656,13 @@ class LRASolver():
         0 = -x + (-e/d)*y + (-f/d)*z
         0 = 0 + (h - e*g/d)*y + (i - f*g/d)*z
         """
-        Mij = M[i, j]
-        if Mij == 0:
+        Aij = self.A[i, j]
+        if Aij == 0:
             raise ZeroDivisionError("Tried to pivot about zero-valued entry.")
-        A = M.copy()
-        A[i, :] = -A[i, :]/Mij
-        for row in range(M.shape[0]):
+        self.A[i, :] = -self.A[i, :]/Aij
+        for row in range(self.A.shape[0]):
             if row != i:
-                A[row, :] = A[row, :] + A[row, j] * A[i, :]
-
-        return A
+                self.A[row, :] = self.A[row, :] + self.A[row, j] * self.A[i, :]
 
     def backtrack(self):
         """

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -127,6 +127,7 @@ from sympy.core.singleton import S
 from sympy.core.numbers import Rational, oo
 from sympy.matrices.dense import Matrix
 from sympy.utilities.iterables import sift
+from sympy.logic.algorithms.theory_solver import TheorySolver
 import math
 
 
@@ -142,7 +143,7 @@ ALLOWED_PRED = {Q.eq: Eq, Q.gt: Gt, Q.lt: Lt, Q.le: Le, Q.ge: Ge}
 # if true ~Q.gt(x, y) implies Q.le(x, y)
 HANDLE_NEGATION = True
 
-class LRASolver():
+class LRASolver(TheorySolver):
     """
     Linear Arithmetic Solver for DPLL(T) implemented with an algorithm based on
     the Dual Simplex method. Uses Bland's pivoting rule to avoid cycling.
@@ -190,8 +191,8 @@ class LRASolver():
         self.bound_history = []
         self.last_assign_snapshot = {var: var.assign for var in self.all_var}
 
-    @staticmethod
-    def from_encoded_cnf(encoded_cnf, testing_mode=False):
+    @classmethod
+    def from_encoded_cnf(cls, encoded_cnf, testing_mode=False):
         """
         Creates an LRASolver from an EncodedCNF object
         and a list of conflict clauses for propositions
@@ -362,8 +363,8 @@ class LRASolver():
         for idx, var in enumerate(nonbasic + basic):
             var.col_idx = idx
 
-        solver = LRASolver(A, basic, nonbasic, atom_id_to_boundaries,
-                           s_subs, testing_mode)
+        solver = cls(A, basic, nonbasic, atom_id_to_boundaries,
+                     s_subs, testing_mode)
         return solver, conflicts
 
     def reset(self):

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -176,11 +176,11 @@ class LRASolver():
 
         self.atom_id_to_boundaries = atom_id_to_boundaries
         self.A = A
-        self.slack = slack_variables
-        self.nonslack = nonslack_variables
-        self.all_var = nonslack_variables + slack_variables
+        self.basic = slack_variables
+        self.nonbasic = nonslack_variables
+        self.basic_set = set(slack_variables)
 
-        self.slack_set = set(slack_variables)
+        self.all_var = nonslack_variables + slack_variables
 
         self.is_sat = True  # While True, all constraints asserted so far are satisfiable
         self.result = None  # always one of: (True, assignment), (False, conflict clause), None
@@ -418,7 +418,7 @@ class LRASolver():
             if res and res[0] is False:
                 break
 
-        if self.is_sat and all(b.var not in self.slack_set for b in boundaries):
+        if self.is_sat and all(b.var not in self.basic_set for b in boundaries):
             self.is_sat = res is None
         else:
             self.is_sat = False
@@ -468,7 +468,7 @@ class LRASolver():
 
         xi.set_bound(boundary, literal)
 
-        if xi in self.nonslack and xi.assign * s > c_norm:
+        if xi in self.nonbasic and xi.assign * s > c_norm:
             self._update(xi, ci)
 
         if self.run_checks and all(not math.isinf(v.assign.q)
@@ -486,7 +486,7 @@ class LRASolver():
         """
         i = xi.col_idx
         assert i is not None
-        for j, b in enumerate(self.slack):
+        for j, b in enumerate(self.basic):
             aji = self.A[j, i]
             b.assign = b.assign + (v - xi.assign)*aji
         xi.assign = v
@@ -517,8 +517,8 @@ class LRASolver():
 
         from sympy.matrices.dense import Matrix
         M = self.A.copy()
-        basic = {s: i for i, s in enumerate(self.slack)}  # contains the row index associated with each basic variable
-        nonbasic = set(self.nonslack)
+        basic = {s: i for i, s in enumerate(self.basic)}  # contains the row index associated with each basic variable
+        nonbasic = set(self.nonbasic)
         while True:
             if self.run_checks:
                 # nonbasic variables must always be within bounds

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -176,6 +176,7 @@ class LRASolver():
 
         self.atom_id_to_boundaries = atom_id_to_boundaries
         self.A = A
+        self._A0 = A.copy() if self.run_checks else None
         # initially slack/basic and nonslack/nonbasic mean the same thing.
         # however, basic/nonbasic can be modified in process meanwhile slack/nonslack stays constant.
         self.basic = slack_variables
@@ -476,9 +477,8 @@ class LRASolver():
 
         if self.run_checks and all(not math.isinf(v.assign.q)
                                    for v in self.all_var):
-            M = self.A
             X = Matrix([v.assign.q for v in self.all_var])
-            assert all(abs(val) < 10 ** (-10) for val in M * X)
+            assert all(abs(val) < 10 ** (-10) for val in self._A0 * X)
 
         return None
 

--- a/sympy/logic/algorithms/lra_theory.py
+++ b/sympy/logic/algorithms/lra_theory.py
@@ -366,7 +366,7 @@ class LRASolver():
                            s_subs, testing_mode)
         return solver, conflicts
 
-    def reset_bounds(self):
+    def reset(self):
         """
         Resets the state of the LRASolver to before
         anything was asserted.

--- a/sympy/logic/algorithms/theory_solver.py
+++ b/sympy/logic/algorithms/theory_solver.py
@@ -29,3 +29,6 @@ class TheorySolver(Protocol):
 
     def check(self) -> tuple[Literal[True], Model] | tuple[Literal[False], ConflictClause]:
         ...
+
+    def reset(self) -> None:
+        ...

--- a/sympy/logic/algorithms/theory_solver.py
+++ b/sympy/logic/algorithms/theory_solver.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Optional, Protocol, Union, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from sympy.assumptions.cnf import EncodedCNF
+
+ConflictClause = list[int]
+Model = Any
+
+
+@runtime_checkable
+class TheorySolver(Protocol):
+    """
+    This class implements parameter X of a DPLL(X) engine.
+    Each Theory  can be instantiated with a specialized solver
+    called Solvert_T for a given Theory T.
+    """
+    @classmethod
+    def from_encoded_cnf(
+        cls, encoded_cnf: EncodedCNF
+    ) -> tuple[TheorySolver, list[ConflictClause]]:
+        ...
+
+    def assert_lit(
+        self, literal: int
+    ) -> Optional[tuple[Literal[False], ConflictClause]]:
+        ...
+
+    def check(self) -> Union[tuple[Literal[True], Model], tuple[Literal[False], ConflictClause]]:
+        ...

--- a/sympy/logic/algorithms/theory_solver.py
+++ b/sympy/logic/algorithms/theory_solver.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal, Optional, Protocol, Union, TYPE_CHECKING, runtime_checkable
+from typing import Any, Literal, Protocol, TYPE_CHECKING, runtime_checkable
 
 if TYPE_CHECKING:
     from sympy.assumptions.cnf import EncodedCNF
@@ -24,8 +24,8 @@ class TheorySolver(Protocol):
 
     def assert_lit(
         self, literal: int
-    ) -> Optional[tuple[Literal[False], ConflictClause]]:
+    ) -> tuple[Literal[False], ConflictClause] | None:
         ...
 
-    def check(self) -> Union[tuple[Literal[True], Model], tuple[Literal[False], ConflictClause]]:
+    def check(self) -> tuple[Literal[True], Model] | tuple[Literal[False], ConflictClause]:
         ...

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -31,7 +31,7 @@ def literal_symbol(literal):
         raise ValueError("Argument must be a boolean literal.")
 
 
-def satisfiable(expr, algorithm=None, all_models=False, minimal=False, use_lra_theory=False):
+def satisfiable(expr, algorithm=None, all_models=False, minimal=False, theory_solvers=None):
     """
     Check satisfiability of a propositional sentence.
     Returns a model when it succeeds.
@@ -73,9 +73,9 @@ def satisfiable(expr, algorithm=None, all_models=False, minimal=False, use_lra_t
     UNSAT
 
     """
-    if use_lra_theory:
+    if theory_solvers:
         if algorithm is not None and algorithm != "dpll2":
-            raise ValueError(f"Currently only dpll2 can handle using lra theory. {algorithm} is not handled.")
+            raise ValueError(f"Currently only dpll2 can handle theory solvers. {algorithm} is not handled.")
         algorithm = "dpll2"
 
     if algorithm is None or algorithm == "pycosat":
@@ -104,7 +104,7 @@ def satisfiable(expr, algorithm=None, all_models=False, minimal=False, use_lra_t
         return dpll_satisfiable(expr)
     elif algorithm == "dpll2":
         from sympy.logic.algorithms.dpll2 import dpll_satisfiable
-        return dpll_satisfiable(expr, all_models, use_lra_theory=use_lra_theory)
+        return dpll_satisfiable(expr, all_models, theory_solvers=theory_solvers)
     elif algorithm == "pycosat":
         from sympy.logic.algorithms.pycosat_wrapper import pycosat_satisfiable
         return pycosat_satisfiable(expr, all_models)

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -31,7 +31,7 @@ def literal_symbol(literal):
         raise ValueError("Argument must be a boolean literal.")
 
 
-def satisfiable(expr, algorithm=None, all_models=False, minimal=False, theory_solvers=None):
+def satisfiable(expr, algorithm=None, all_models=False, minimal=False):
     """
     Check satisfiability of a propositional sentence.
     Returns a model when it succeeds.
@@ -73,11 +73,6 @@ def satisfiable(expr, algorithm=None, all_models=False, minimal=False, theory_so
     UNSAT
 
     """
-    if theory_solvers:
-        if algorithm is not None and algorithm != "dpll2":
-            raise ValueError(f"Currently only dpll2 can handle theory solvers. {algorithm} is not handled.")
-        algorithm = "dpll2"
-
     if algorithm is None or algorithm == "pycosat":
         pycosat = import_module('pycosat')
         if pycosat is not None:
@@ -104,7 +99,7 @@ def satisfiable(expr, algorithm=None, all_models=False, minimal=False, theory_so
         return dpll_satisfiable(expr)
     elif algorithm == "dpll2":
         from sympy.logic.algorithms.dpll2 import dpll_satisfiable
-        return dpll_satisfiable(expr, all_models, theory_solvers=theory_solvers)
+        return dpll_satisfiable(expr, all_models)
     elif algorithm == "pycosat":
         from sympy.logic.algorithms.pycosat_wrapper import pycosat_satisfiable
         return pycosat_satisfiable(expr, all_models)

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -12,6 +12,7 @@ from sympy.logic.algorithms.dpll import dpll, dpll_satisfiable, \
     find_pure_symbol_int_repr, find_unit_clause_int_repr, \
     unit_propagate_int_repr
 from sympy.logic.algorithms.dpll2 import dpll_satisfiable as dpll2_satisfiable
+from sympy.logic.algorithms.lra_theory import LRASolver
 
 from sympy.logic.algorithms.z3_wrapper import z3_satisfiable
 from sympy.assumptions.cnf import CNF, EncodedCNF
@@ -405,7 +406,7 @@ def test_z3_vs_lra_dpll2():
         cnf = And(*clauses)
         return boolean_formula_to_encoded_cnf(cnf)
 
-    lra_dpll2_satisfiable = lambda x: dpll2_satisfiable(x, use_lra_theory=True)
+    lra_dpll2_satisfiable = lambda x: dpll2_satisfiable(x, theory_solvers=[LRASolver])
 
     for _ in range(50):
         cnf = make_random_cnf(num_clauses=10, num_constraints=15, num_var=2)
@@ -441,7 +442,7 @@ def test_issue_27733():
     encoding[Q.lt(x, 0)] = 12
 
     cnf = EncodedCNF(clauses, encoding)
-    assert satisfiable(cnf, use_lra_theory=True) is False
+    assert satisfiable(cnf, theory_solvers=[LRASolver]) is False
 
 
 def test_issue_27733_second_fix():
@@ -450,4 +451,4 @@ def test_issue_27733_second_fix():
     clauses = [[1, 2], [-3, -4]]
     encoding = {Q.gt(x0, x1): 1, Q.lt(x1, x0): 2, Q.le(x1, x0): 3, Q.ge(x0, x1): 4}
     cnf = EncodedCNF(clauses, encoding)
-    assert satisfiable(cnf, use_lra_theory=True) is False
+    assert satisfiable(cnf, theory_solvers=[LRASolver]) is False

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -442,7 +442,7 @@ def test_issue_27733():
     encoding[Q.lt(x, 0)] = 12
 
     cnf = EncodedCNF(clauses, encoding)
-    assert satisfiable(cnf, theory_solvers=[LRASolver]) is False
+    assert dpll2_satisfiable(cnf, theory_solvers=[LRASolver]) is False
 
 
 def test_issue_27733_second_fix():
@@ -451,4 +451,4 @@ def test_issue_27733_second_fix():
     clauses = [[1, 2], [-3, -4]]
     encoding = {Q.gt(x0, x1): 1, Q.lt(x1, x0): 2, Q.le(x1, x0): 3, Q.ge(x0, x1): 4}
     cnf = EncodedCNF(clauses, encoding)
-    assert satisfiable(cnf, theory_solvers=[LRASolver]) is False
+    assert dpll2_satisfiable(cnf, theory_solvers=[LRASolver]) is False

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -442,7 +442,10 @@ def test_pivot():
         for _ in range(5):
             i, j = randint(0, 4), randint(0, 4)
             if m[i, j] != 0:
-                assert LRASolver._pivot(m, i, j).rref() == rref
+                lra = LRASolver.__new__(LRASolver)
+                lra.A = m.copy()
+                lra._pivot(i, j)
+                assert lra.A.rref() == rref
 
 
 def test_reset_bounds():

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -113,8 +113,8 @@ def test_from_encoded_cnf():
     enc = boolean_formula_to_encoded_cnf(phi)
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
     assert lra.A.shape == (0, 3)
-    assert str(lra.slack) == '[]'
-    assert str(lra.nonslack) == '[x, _s1, _s2]'
+    assert str(lra.basic) == '[]'
+    assert str(lra.nonbasic) == '[x, _s1, _s2]'
     assert lra.A == Matrix(0,3, [])
     actual = {tuple(sorted((str(b.var), b.bound, b.upper, b.strict) for b in bs)) for bs in lra.atom_id_to_boundaries.values()}
     expected = {

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -114,7 +114,7 @@ def test_from_encoded_cnf():
     lra, _ = LRASolver.from_encoded_cnf(enc, testing_mode=True)
     assert lra.A.shape == (0, 3)
     assert str(lra.basic) == '[]'
-    assert str(lra.nonbasic) == '[x, _s1, _s2]'
+    assert {str(v) for v in lra.nonbasic} == {'x', '_s1', '_s2'}
     assert lra.A == Matrix(0,3, [])
     actual = {tuple(sorted((str(b.var), b.bound, b.upper, b.strict) for b in bs)) for bs in lra.atom_id_to_boundaries.values()}
     expected = {

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -514,8 +514,8 @@ def test_example_from_paper():
     # Extracts the variables stored in the solver
     var_x = next(v for v in lra.all_var if str(v.var) == 'x')
     # var_y has been removed from A after the simplification
-    # var_s1 is a slack variable which corresponds for -x + y <= 1
-    # var_s2 is a slack variable which corresponds for -x - y <= 3
+    # var_s1 is a basic variable which corresponds for -x + y <= 1
+    # var_s2 is a basic variable which corresponds for -x - y <= 3
     _s1 = lra.s_subs[-x + y]
     _s2 = lra.s_subs[-x - y]
     var_s1 = next(v for v in lra.all_var if v.var == _s1)

--- a/sympy/logic/tests/test_lra_theory.py
+++ b/sympy/logic/tests/test_lra_theory.py
@@ -448,9 +448,9 @@ def test_pivot():
                 assert lra.A.rref() == rref
 
 
-def test_reset_bounds():
+def test_reset():
     """
-    Tests that reset_bounds properly resets all state variables to their default values.
+    Tests that reset properly resets all state variables to their default values.
     """
     # Test solver behavior after reset
     bf = Q.ge(x, 1) & Q.lt(x, 1)
@@ -462,7 +462,7 @@ def test_reset_bounds():
             lra.assert_lit(lit)
 
     assert lra.check()[0] == False
-    lra.reset_bounds()
+    lra.reset()
     assert lra.check()[0] == True
 
     # Test individual state variable resets
@@ -482,7 +482,7 @@ def test_reset_bounds():
         for var in lra.all_var:
             setattr(var, attr_name, test_value)
 
-        lra.reset_bounds()
+        lra.reset()
 
         for var in lra.all_var:
             actual_value = getattr(var, attr_name)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
The new github stack feature would be nice here but I couldn't make it work sadly. It doesn't work on sympy?

Revival of https://github.com/sympy/sympy/pull/28274
depends on:
* https://github.com/sympy/sympy/pull/30098
* https://github.com/sympy/sympy/pull/30118
#### Brief description of what is fixed or changed
dpll2 file will need a little more changes for backtracking for theories to be implemented properly. The PR change itself should not be dependent on the lra backtracking but on lra refactor (mistake on my part), but the general theory backtracking will depend on this PR

#### Other comments
Before we add EUF to dpll2 I think we should properly implement lra and its backtracking. using both EUF and lra at the same time should not be allowed technically before the communication between the theories are implemented. This PR does not have any guards for that

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Majority claude written

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
