### PR TITLE
Weierstrass jumps and fixes for definite integration

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -972,6 +972,7 @@ class Expr(Basic, EvalfMixin):
         from sympy.functions.elementary.exponential import log
         from sympy.series.limits import limit, Limit
         from sympy.sets.sets import Interval, Union
+        from sympy.simplify.radsimp import radsimp
         from sympy.solvers.solveset import solveset
 
         if (a is None and b is None):
@@ -1052,17 +1053,33 @@ class Expr(Basic, EvalfMixin):
                         except TypeError:
                             continue
 
-            # sorted, so that the result does not depend on set iteration order
+            # The jumps are summed into a correction that is kept apart from
+            # the endpoint difference B - A, so that radsimp below only touches
+            # the correction and leaves B - A in whatever form it already had.
+            # sorted, so that the result does not depend on set iteration order.
+            correction = S.Zero
             for s in sorted(points, key=default_sort_key):
-                if value is S.NaN:
+                if correction is S.NaN:
                     # no need to keep adding, it will stay NaN
                     break
                 if not s.is_comparable:
                     continue
                 if (a < s) == (s < b) == True:
-                    value += -limit(self, x, s, "+") + limit(self, x, s, "-")
+                    correction += -limit(self, x, s, "+") + limit(self, x, s, "-")
                 elif (b < s) == (s < a) == True:
-                    value += limit(self, x, s, "+") - limit(self, x, s, "-")
+                    correction += limit(self, x, s, "+") - limit(self, x, s, "-")
+
+            if correction is not S.Zero:
+                # A correction comes over a common denominator built from the
+                # nested radicals the Weierstrass substitution leaves in the
+                # antiderivative, e.g. 2*pi/(sqrt(2)*sqrt(2*sqrt(2) + 3) -
+                # sqrt(2*sqrt(2) + 3)) for 1/(sqrt(2) + cos(x)) over a period;
+                # radsimp denests those and cancels the denominator to the
+                # 2*pi one expects. It is skipped for a non-finite correction
+                # so that the oo/nan of a genuine pole is passed through.
+                if correction.is_finite:
+                    correction = radsimp(correction)
+                value += correction
 
         return value
 

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -968,9 +968,10 @@ class Expr(Basic, EvalfMixin):
 
         """
         from sympy.calculus.accumulationbounds import AccumBounds
+        from sympy.calculus.singularities import singularities as _singularities
         from sympy.functions.elementary.exponential import log
         from sympy.series.limits import limit, Limit
-        from sympy.sets.sets import Interval
+        from sympy.sets.sets import Interval, Union
         from sympy.solvers.solveset import solveset
 
         if (a is None and b is None):
@@ -1012,26 +1013,56 @@ class Expr(Basic, EvalfMixin):
                 domain = Interval(a, b)
             else:
                 domain = Interval(b, a)
-            # check the singularities of self within the interval
-            # if singularities is a ConditionSet (not iterable), catch the exception and pass
-            singularities = solveset(self.cancel().as_numer_denom()[1], x,
-                domain=domain)
-            for logterm in self.atoms(log):
-                singularities = singularities | solveset(logterm.args[0], x,
-                    domain=domain)
+            # Where self may jump: the zeros of its denominator and of the
+            # arguments of its logarithms, plus whatever _singularities finds.
+            # The last is what catches a pole buried in the argument of
+            # another function, e.g. the pole of tan(x/2) in log(tan(x/2) + I)
+            # left by the Weierstrass substitution, since it rewrites tan,
+            # cot, sec and csc (and the hyperbolic ones) over cos/cosh first.
+            # Only that call may fail quietly; the other two still raise
+            # NotImplementedError, so an antiderivative that cannot be
+            # analysed leaves the integral unevaluated instead of silently
+            # picking up a wrong value.
+            candidates = [solveset(self.cancel().as_numer_denom()[1], x,
+                domain=domain)]
+            candidates += [solveset(t.args[0], x, domain=domain)
+                for t in self.atoms(log)]
             try:
-                for s in singularities:
-                    if value is S.NaN:
-                        # no need to keep adding, it will stay NaN
-                        break
-                    if not s.is_comparable:
-                        continue
-                    if (a < s) == (s < b) == True:
-                        value += -limit(self, x, s, "+") + limit(self, x, s, "-")
-                    elif (b < s) == (s < a) == True:
-                        value += limit(self, x, s, "+") - limit(self, x, s, "-")
-            except TypeError:
+                candidates.append(_singularities(self, x, domain))
+            except NotImplementedError:
                 pass
+
+            # Take only the pieces known to be finite, and take them piece by
+            # piece: an infinite or unsized one (an ImageSet over the integers,
+            # a ConditionSet) would either never finish being listed or hide
+            # the points found by the others. Dropping such a piece only means
+            # the jumps it covers stay uncorrected, as they were before any of
+            # this looked for them.
+            points = set()
+            for candidate in candidates:
+                pieces = candidate.args if isinstance(candidate, Union) \
+                    else (candidate,)
+                for piece in pieces:
+                    # is_finite_set does not guarantee the elements can be
+                    # listed: Intersection({1, x}, Interval(0, 3)) is finite
+                    # but raises TypeError when iterated over
+                    if piece.is_finite_set:
+                        try:
+                            points.update(piece)
+                        except TypeError:
+                            continue
+
+            # sorted, so that the result does not depend on set iteration order
+            for s in sorted(points, key=default_sort_key):
+                if value is S.NaN:
+                    # no need to keep adding, it will stay NaN
+                    break
+                if not s.is_comparable:
+                    continue
+                if (a < s) == (s < b) == True:
+                    value += -limit(self, x, s, "+") + limit(self, x, s, "-")
+                elif (b < s) == (s < a) == True:
+                    value += limit(self, x, s, "+") - limit(self, x, s, "-")
 
         return value
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -31,6 +31,7 @@ from sympy.printing.str import sstr
 from sympy.series.order import O
 from sympy.sets.sets import Interval
 from sympy.simplify.gammasimp import gammasimp
+from sympy.simplify.radsimp import radsimp
 from sympy.simplify.simplify import simplify
 from sympy.simplify.trigsimp import trigsimp
 from sympy.tensor.indexed import (Idx, IndexedBase)
@@ -2262,3 +2263,42 @@ def test_issue_29909():
 
     assert integrate(f, x) == F
     assert F.diff(x).equals(f)
+
+
+def test_weierstrass_jump():
+    # The antiderivative of 1/(a + cos(x)) is built with the Weierstrass
+    # substitution and jumps at the poles of tan(x/2). Those jumps sit inside
+    # the argument of a log, where neither the denominator of the
+    # antiderivative nor the zeros of its logarithms reveal them, so they used
+    # to go uncorrected and the integral of a positive function came out as 0.
+    # 1/(a + cos(x)) over a full period is 2*pi/sqrt(a**2 - 1).
+    def check(f, a, b, expected):
+        r = integrate(f, (x, a, b))
+        assert not r.has(Integral)
+        assert abs(r.n(20) - expected.n(20)) < 1e-15
+
+    # radsimp is needed: the result is an unsimplified nested radical
+    assert radsimp(integrate(1/(sqrt(2) + cos(x)), (x, 0, 2*pi))) == 2*pi
+    check(1/(sqrt(2) + cos(x)), 0, 2*pi, 2*pi)
+    check(1/(sqrt(5) + cos(x)), 0, 2*pi, 2*pi/sqrt(4))
+    check(1/(sqrt(2) + cos(x)), -pi, pi, 2*pi)
+    assert integrate(1/(2 + cos(x)), (x, 0, 2*pi)) == 2*sqrt(3)*pi/3
+    assert integrate(1/(2 + sin(x)), (x, 0, 2*pi)) == 2*sqrt(3)*pi/3
+
+    # an interval containing the pole without being symmetric about it, and
+    # the same interval reversed, which takes the other branch of the
+    # correction
+    check(1/(sqrt(2) + cos(x)), 1, 5, Integral(1/(sqrt(2) + cos(x)), (x, 1, 5)))
+    check(1/(sqrt(2) + cos(x)), 5, 1, -Integral(1/(sqrt(2) + cos(x)), (x, 1, 5)))
+    # an interval free of poles must be left alone
+    check(1/(sqrt(2) + cos(x)), 0, 1, Integral(1/(sqrt(2) + cos(x)), (x, 0, 1)))
+    # several poles inside the interval
+    check(1/(2 + cos(x)), 0, 6*pi, 3*2*sqrt(3)*pi/3)
+
+    # the candidate singularities here include an ImageSet over the integers;
+    # enumerating it does not terminate, so only the finite parts may be used
+    assert integrate(1/(2 + cos(x))**2, (x, 0, 2*pi)) == 4*sqrt(3)*pi/9
+
+    # a genuine pole of the integrand must still not yield a finite value
+    assert integrate(1/(1 - cos(x)), (x, 0, 2*pi)) is S.Infinity
+    assert integrate(1/x, (x, -1, 1)) is S.NaN

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -31,7 +31,6 @@ from sympy.printing.str import sstr
 from sympy.series.order import O
 from sympy.sets.sets import Interval
 from sympy.simplify.gammasimp import gammasimp
-from sympy.simplify.radsimp import radsimp
 from sympy.simplify.simplify import simplify
 from sympy.simplify.trigsimp import trigsimp
 from sympy.tensor.indexed import (Idx, IndexedBase)
@@ -2271,34 +2270,40 @@ def test_weierstrass_jump():
     # the argument of a log, where neither the denominator of the
     # antiderivative nor the zeros of its logarithms reveal them, so they used
     # to go uncorrected and the integral of a positive function came out as 0.
-    # 1/(a + cos(x)) over a full period is 2*pi/sqrt(a**2 - 1).
-    def check(f, a, b, expected):
-        r = integrate(f, (x, a, b))
-        assert not r.has(Integral)
-        assert abs(r.n(20) - expected.n(20)) < 1e-15
+    # These jumps only appear in the log-form antiderivative that an
+    # irrational coefficient produces, so the two discriminating cases below
+    # (which return 0 or a period-shifted value without the fix) must use one.
+    # A rational coefficient instead gives an atan/floor antiderivative that
+    # was already correct, so it does not exercise the fix. Only sqrt(2) is
+    # used, and only twice: integrating it is slow, and sqrt(5) in particular
+    # drives heurisch into a pathological retry.
 
-    # radsimp is needed: the result is an unsimplified nested radical
-    assert radsimp(integrate(1/(sqrt(2) + cos(x)), (x, 0, 2*pi))) == 2*pi
-    check(1/(sqrt(2) + cos(x)), 0, 2*pi, 2*pi)
-    check(1/(sqrt(5) + cos(x)), 0, 2*pi, 2*pi/sqrt(4))
-    check(1/(sqrt(2) + cos(x)), -pi, pi, 2*pi)
+    # The fix lives in Expr._eval_interval, the routine integrate() uses to
+    # evaluate an antiderivative at the limits, so F._eval_interval(x, a, b)
+    # below is exactly what integrate(1/(sqrt(2) + cos(x)), (x, a, b)) returns.
+    # The sqrt(2) integrand is slow to integrate, so its antiderivative is
+    # formed once and both branches of the correction are driven through it.
+    F = integrate(1/(sqrt(2) + cos(x)), x)
+    # forward branch, full period: the reported bug (returned 0 without the
+    # fix). Its correction comes over a nested-radical denominator that radsimp
+    # denests to exactly 2*pi, as Mathematica gives; the raw result is compared
+    # so that clean-up is guarded too.
+    assert F._eval_interval(x, S(0), 2*pi) == 2*pi
+    # reversed limits take the other branch of the correction
+    assert F._eval_interval(x, 2*pi, S(0)) == -2*pi
+
+    # cheap exact-value sanity checks on the atan/floor path, over one period
+    # and several; 1/(a + cos(x)) over a full period is 2*pi/sqrt(a**2 - 1)
     assert integrate(1/(2 + cos(x)), (x, 0, 2*pi)) == 2*sqrt(3)*pi/3
     assert integrate(1/(2 + sin(x)), (x, 0, 2*pi)) == 2*sqrt(3)*pi/3
+    assert integrate(1/(2 + cos(x)), (x, 0, 6*pi)) == 2*sqrt(3)*pi
 
-    # an interval containing the pole without being symmetric about it, and
-    # the same interval reversed, which takes the other branch of the
-    # correction
-    check(1/(sqrt(2) + cos(x)), 1, 5, Integral(1/(sqrt(2) + cos(x)), (x, 1, 5)))
-    check(1/(sqrt(2) + cos(x)), 5, 1, -Integral(1/(sqrt(2) + cos(x)), (x, 1, 5)))
-    # an interval free of poles must be left alone
-    check(1/(sqrt(2) + cos(x)), 0, 1, Integral(1/(sqrt(2) + cos(x)), (x, 0, 1)))
-    # several poles inside the interval
-    check(1/(2 + cos(x)), 0, 6*pi, 3*2*sqrt(3)*pi/3)
-
-    # the candidate singularities here include an ImageSet over the integers;
-    # enumerating it does not terminate, so only the finite parts may be used
+    # regression guard for the fix itself: the candidate singularities of this
+    # antiderivative include an ImageSet over the integers, which must not be
+    # enumerated or _eval_interval would never terminate
     assert integrate(1/(2 + cos(x))**2, (x, 0, 2*pi)) == 4*sqrt(3)*pi/9
 
-    # a genuine pole of the integrand must still not yield a finite value
+    # a genuine pole of the integrand must still not yield a finite value; the
+    # radsimp clean-up must not touch these oo/nan results
     assert integrate(1/(1 - cos(x)), (x, 0, 2*pi)) is S.Infinity
     assert integrate(1/x, (x, -1, 1)) is S.NaN


### PR DESCRIPTION
Definite integration is returning wrong results if the function is discontinuous in that range.

This PR attempts at solving this issue.

#### AI Generation Disclosure

Claude Opus 4.8

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
