### PR TITLE
Rational integration (ratint) now supports Piecewise

### DIFF
--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -6,6 +6,7 @@ from sympy.core.numbers import I
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol)
 from sympy.functions.elementary.exponential import log
+from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
 from sympy.functions.elementary.trigonometric import atan
 from sympy.polys.polyroots import roots
 from sympy.polys.polytools import cancel
@@ -47,6 +48,23 @@ def ratint(f, x, **flags):
     sympy.integrals.rationaltools.ratint_ratpart
 
     """
+    if not isinstance(f, tuple) and f.has(Piecewise):
+        # A Weierstrass (or similar) substitution followed by a parametric
+        # partial fraction decomposition can hand ratint a Piecewise whose
+        # branches are rational functions selected by conditions on the
+        # parameters, e.g. Piecewise((r1, Eq(a, 1)), (r2, True)). When none of
+        # the conditions involves the integration variable the branches are
+        # just alternative integrands, so integrating each one and keeping the
+        # same conditions gives a valid antiderivative. (When a condition does
+        # depend on x the branches partition the x-axis instead, and mapping
+        # over them would drop the continuity corrections between pieces, so
+        # that case is left to the general Piecewise integration machinery.)
+        folded = piecewise_fold(f)
+        if isinstance(folded, Piecewise) and \
+                not any(c.has(x) for _, c in folded.args):
+            return Piecewise(*[(ratint(e, x, **flags), c)
+                               for e, c in folded.args])
+
     if isinstance(f, tuple):
         p, q = f
     else:

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 from sympy.core.numbers import (I, Rational, pi)
 from sympy.core.singleton import S
+from sympy.core.relational import Eq, Ne
 from sympy.core.symbol import (Dummy, symbols)
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import atan
 from sympy.integrals.integrals import integrate
 from sympy.polys.polytools import Poly
 from sympy.simplify.simplify import simplify
 
 from sympy.integrals.rationaltools import ratint, ratint_logpart, log_to_atan
+from sympy.testing.pytest import raises
 
 from sympy.abc import a, b, x, t
 
@@ -208,3 +211,33 @@ def test_issue_28186():
     P = ratint(p, x)
     res = P.evalf(subs={x:1e100}) - P.evalf(subs={x:0})
     assert abs(res - 2.5) < 1e-10
+
+
+def test_ratint_piecewise():
+    # https://github.com/sympy/sympy/issues/30084
+    # A parametric partial fraction decomposition (e.g. after a Weierstrass
+    # substitution) hands ratint a Piecewise whose rational branches are
+    # selected by conditions on the parameters. ratint used to raise a
+    # PolynomialError on any Piecewise; now it integrates each branch.
+    pw = Piecewise((1/(x + 1), Eq(a, 1)), (1/(x - 1), True))
+    assert ratint(pw, x) == Piecewise(
+        (log(x + 1), Eq(a, 1)), (log(x - 1), True))
+
+    # a Piecewise multiplied by something is folded to the top first
+    assert ratint(x*pw, x) == Piecewise(
+        (x - log(x + 1), Eq(a, 1)), (x + log(x - 1), True))
+
+    # every branch of the result differentiates back to its integrand
+    r = ratint(Piecewise((1/(x**2 - a), Ne(a, 0)), (1/x**2, True)), x)
+    for e, c in r.args:
+        integrand = [ie for ie, ic in
+                     Piecewise((1/(x**2 - a), Ne(a, 0)),
+                               (1/x**2, True)).args if ic == c][0]
+        assert (e.diff(x) - integrand).cancel() == 0
+
+    # conditions that depend on the integration variable are not mapped over:
+    # the branches partition the x-axis rather than selecting an integrand, so
+    # this is left to the general Piecewise machinery (raises, as before)
+    from sympy.polys.polyerrors import PolynomialError
+    raises(PolynomialError,
+           lambda: ratint(Piecewise((1/(x + 1), x > 0), (1/(x - 1), True)), x))


### PR DESCRIPTION

Allow function `ratint( )` to accept a `Piecewise` object.

#### AI Generation Disclosure

Claude Opus 4.8

#### Release Notes


<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
