### PR TITLE
physics.control: realize constant transfer functions with zero states

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1690,6 +1690,8 @@ Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
 Tuan Manh Lai <laituan245@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
+Udit Jain <uditjainstjis@gmail.com>
+Udit Jain <uditjainstjis@gmail.com> uditjainstjis <uditjainstjis@gmail.com>
 Unknown <kunda@scribus.net>
 Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1458,17 +1458,25 @@ class TransferFunctionBase(SISOLinearTimeInvariant, ABC):
         num_coeffs = num_poly.all_coeffs()
         den_coeffs = den_poly.all_coeffs()
 
+        # A constant (degree-0) transfer function has no dynamics, so its
+        # controllable canonical realization has zero states.  Returning a
+        # 1x1 zero state instead introduces an unobservable and
+        # uncontrollable phantom state ``x' = 0*x + 0*u`` that then propagates
+        # through interconnections such as ``Parallel`` (see issue #29179).
+        # Emitting empty ``A``, ``B`` and ``C`` matrices keeps the realization
+        # minimal and consistent with the "number of states equals the
+        # denominator degree" rule used for the non-constant case below.
         if n == 0:
             return (
-                Matrix([zeros(1)]),
-                Matrix([zeros(1)]),
-                Matrix([zeros(1)]),
+                Matrix(0, 0, []),
+                Matrix(0, 1, []),
+                Matrix(1, 0, []),
                 Matrix([num_coeffs[0] / den_coeffs[0]]),
             )
 
         if self.num == self.den:
             return (
-                Matrix([zeros(1)]), Matrix([zeros(1)]), Matrix([zeros(1)]), Matrix([1])
+                Matrix(0, 0, []), Matrix(0, 1, []), Matrix(1, 0, []), Matrix([1])
             )
 
         diff = n - num_poly.degree()

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1458,14 +1458,6 @@ class TransferFunctionBase(SISOLinearTimeInvariant, ABC):
         num_coeffs = num_poly.all_coeffs()
         den_coeffs = den_poly.all_coeffs()
 
-        # A constant (degree-0) transfer function has no dynamics, so its
-        # controllable canonical realization has zero states.  Returning a
-        # 1x1 zero state instead introduces an unobservable and
-        # uncontrollable phantom state ``x' = 0*x + 0*u`` that then propagates
-        # through interconnections such as ``Parallel`` (see issue #29179).
-        # Emitting empty ``A``, ``B`` and ``C`` matrices keeps the realization
-        # minimal and consistent with the "number of states equals the
-        # denominator degree" rule used for the non-constant case below.
         if n == 0:
             return (
                 Matrix(0, 0, []),

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -26,7 +26,7 @@ from sympy.physics.control.lti import (
     TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback, StateSpace,
     DiscreteStateSpace, create_state_space, gbt, bilinear, forward_diff,
     backward_diff, phase_margin, gain_margin)
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises
 
 from math import isclose
 
@@ -43,7 +43,6 @@ TF5 = TransferFunction(k, p, s)
 TF6 = TransferFunction(k*s + p, k*s + p, s)
 
 
-@XFAIL
 def test_state_space_rewrite_from_pr_27651():
     c0, c1, c2 = symbols('c0, c1, c2', real=True)
     a0, a1, a2, a3 = symbols('a0, a1, a2, a3', real=True)
@@ -3520,14 +3519,18 @@ def test_conversion():
                    Matrix([[k/tau]]))
     assert SS1.rewrite(TransferFunction)[0][0] == TF4
 
+    # A constant transfer function has no dynamics, so it is realized with
+    # zero states (empty A, B and C matrices) rather than a phantom state.
     SS2 = TF5.rewrite(StateSpace)
     assert SS2 == \
-        StateSpace(Matrix([[0]]), Matrix([[0]]), Matrix([[0]]), Matrix([[k/p]]))
+        StateSpace(Matrix(0, 0, []), Matrix(0, 1, []), Matrix(1, 0, []),
+                   Matrix([[k/p]]))
     assert SS2.rewrite(TransferFunction)[0][0] == TF5
 
     SS3 = TF6.rewrite(StateSpace)
     assert SS3 == \
-        StateSpace(Matrix([[0]]), Matrix([[0]]), Matrix([[0]]), Matrix([[1]]))
+        StateSpace(Matrix(0, 0, []), Matrix(0, 1, []), Matrix(1, 0, []),
+                   Matrix([[1]]))
 
     # TransferFunction cannot be converted to DiscreteStateSpace
     raises(TypeError, lambda: TF1.rewrite(DiscreteStateSpace))

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -3519,8 +3519,6 @@ def test_conversion():
                    Matrix([[k/tau]]))
     assert SS1.rewrite(TransferFunction)[0][0] == TF4
 
-    # A constant transfer function has no dynamics, so it is realized with
-    # zero states (empty A, B and C matrices) rather than a phantom state.
     SS2 = TF5.rewrite(StateSpace)
     assert SS2 == \
         StateSpace(Matrix(0, 0, []), Matrix(0, 1, []), Matrix(1, 0, []),


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29179

#### Brief description of what is fixed or changed

A constant (degree-0) transfer function was being realized with a single
state whose `A`, `B` and `C` matrices were all `[[0]]`. That state is both
uncontrollable and unobservable (its equation is `x' = 0*x + 0*u`), so it is a
phantom that carries no information. `TransferFunctionBase._StateSpace_matrices_equivalent`
produced it for both the `n == 0` case and the `self.num == self.den` case.

The phantom leaked into interconnections. `Parallel(StateSpace, StateSpace).doit()`
stacks the operands block-diagonally, so a constant term contributed an extra
empty state equation to the merged system, which is what the issue reported.

The fix realizes a constant transfer function with zero states by returning
empty `A` (0x0), `B` (0x1) and `C` (1x0) matrices, keeping only the feedthrough
term in `D`. The number of states now equals the denominator degree, matching
the non-constant branch, and the realization still round-trips back to the
original transfer function. Because the method lives on the shared
`TransferFunctionBase`, the same fix applies to `DiscreteTransferFunction`.

With this change `t.rewrite(StateSpace).doit()` and `t.doit().rewrite(StateSpace)`
agree for the example in the issue, and neither has the extra state equation.

#### Other comments

The previously `@XFAIL`ed regression test `test_state_space_rewrite_from_pr_27651`
now passes and has been enabled. The constant-conversion assertions in
`test_conversion` were updated to expect the zero-state realization. Full
`sympy/physics/control/tests/` (71 tests) and the `lti.py` doctests (106) pass
locally.

#### AI Generation Disclosure

The code and test changes in this PR were written with the assistance of an AI
tool (Claude, by Anthropic). This covers the edited lines in
`sympy/physics/control/lti.py` (the two constant-case return branches in
`_StateSpace_matrices_equivalent` and the explanatory comment) and in
`sympy/physics/control/tests/test_lti.py` (the updated `test_conversion`
assertions, the removal of the `@XFAIL` decorator, and the import change). The
changes were reviewed, run, and verified by a human before submission.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Constant (degree-0) ``TransferFunction`` objects are now realized as
    ``StateSpace`` models with zero states instead of an extra unobservable and
    uncontrollable state. This also fixes an extra empty state equation produced
    by ``Parallel(StateSpace, StateSpace).doit()`` when a constant transfer
    function is involved.
<!-- END RELEASE NOTES -->
