### PR TITLE
physics.control: rewrite TransferFunctionMatrix as a StateSpace model

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1690,6 +1690,8 @@ Tschijnmo TSCHAU <tschijnmotschau@gmail.com>
 Tuan Manh Lai <laituan245@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
+Udit Jain <uditjainstjis@gmail.com>
+Udit Jain <uditjainstjis@gmail.com> uditjainstjis <uditjainstjis@gmail.com>
 Unknown <kunda@scribus.net>
 Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -5326,6 +5326,94 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
         expand_mat = self._expr_mat.expand(**hints)
         return _to_TFM(expand_mat, self.var, self.sampling_time)
 
+    def _to_state_space(self, ss_cls, *sampling_time):
+        # Realize each entry as a SISO state-space system and stack the
+        # realizations block-diagonally.  The states of entry ``(i, j)`` form
+        # an independent block that is driven only by input ``j`` and seen
+        # only at output ``i``, so the resulting model has as many states as
+        # the sum of the orders of the individual transfer functions.
+        cells = [tf.doit().rewrite(ss_cls) for tf in self._flat()]
+        ni, no = self.num_inputs, self.num_outputs
+        n = sum(cell.num_states for cell in cells)
+        A, B, C, D = zeros(n, n), zeros(n, ni), zeros(no, n), zeros(no, ni)
+        r = 0
+        for k, cell in enumerate(cells):
+            i, j = divmod(k, ni)
+            m = cell.num_states
+            A[r:r + m, r:r + m] = cell.A
+            B[r:r + m, j:j + 1] = cell.B
+            C[i:i + 1, r:r + m] = cell.C
+            D[i, j] = cell.D[0, 0]
+            r += m
+        return ss_cls(A, B, C, D, *sampling_time)
+
+    def _eval_rewrite_as_StateSpace(self, *args):
+        """
+        Returns a MIMO ``StateSpace`` model equivalent to the transfer
+        function matrix.
+
+        Each entry is realized in controllable canonical form and the
+        realizations are combined block-diagonally, so the conversion is not
+        unique.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import s
+        >>> from sympy.physics.control import TransferFunction, TransferFunctionMatrix, StateSpace
+        >>> tf1 = TransferFunction(1, s + 1, s)
+        >>> tf2 = TransferFunction(1, 2*s + 1, s)
+        >>> tfm = TransferFunctionMatrix([[tf1], [tf2]])
+        >>> tfm.rewrite(StateSpace)
+        StateSpace(Matrix([
+        [-1,    0],
+        [ 0, -1/2]]), Matrix([
+        [1],
+        [1]]), Matrix([
+        [1,   0],
+        [0, 1/2]]), Matrix([
+        [0],
+        [0]]))
+
+        """
+        if not self._is_continuous:
+            raise TypeError("A discrete-time TransferFunctionMatrix cannot "
+                "be rewritten as a continuous StateSpace model.")
+        return self._to_state_space(StateSpace)
+
+    def _eval_rewrite_as_DiscreteStateSpace(self, *args):
+        """
+        Returns a MIMO ``DiscreteStateSpace`` model equivalent to the
+        discrete-time transfer function matrix.
+
+        See :meth:`_eval_rewrite_as_StateSpace` for details of the
+        construction.
+
+        Examples
+        ========
+
+        >>> from sympy.abc import z
+        >>> from sympy.physics.control import DiscreteTransferFunction, TransferFunctionMatrix, DiscreteStateSpace
+        >>> dtf1 = DiscreteTransferFunction(1, z + 1, z, 0.1)
+        >>> dtf2 = DiscreteTransferFunction(1, 2*z + 1, z, 0.1)
+        >>> tfm = TransferFunctionMatrix([[dtf1], [dtf2]])
+        >>> tfm.rewrite(DiscreteStateSpace)
+        DiscreteStateSpace(Matrix([
+        [-1,    0],
+        [ 0, -1/2]]), Matrix([
+        [1],
+        [1]]), Matrix([
+        [1,   0],
+        [0, 1/2]]), Matrix([
+        [0],
+        [0]]), 0.1)
+
+        """
+        if self._is_continuous:
+            raise TypeError("A continuous-time TransferFunctionMatrix cannot "
+                "be rewritten as a DiscreteStateSpace model.")
+        return self._to_state_space(DiscreteStateSpace, self.sampling_time)
+
     @property
     def sampling_time(self):
         return self.args[0][0][0].sampling_time

--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -5327,11 +5327,16 @@ class TransferFunctionMatrix(MIMOLinearTimeInvariant):
         return _to_TFM(expand_mat, self.var, self.sampling_time)
 
     def _to_state_space(self, ss_cls, *sampling_time):
-        # Realize each entry as a SISO state-space system and stack the
-        # realizations block-diagonally.  The states of entry ``(i, j)`` form
-        # an independent block that is driven only by input ``j`` and seen
-        # only at output ``i``, so the resulting model has as many states as
-        # the sum of the orders of the individual transfer functions.
+        """
+        Realizes each entry as a SISO state-space system and stacks the
+        realizations block-diagonally.
+
+        The states of entry ``(i, j)`` form an independent block that is
+        driven only by input ``j`` and seen only at output ``i``, so the
+        resulting model has as many states as the sum of the orders of the
+        individual transfer functions.
+
+        """
         cells = [tf.doit().rewrite(ss_cls) for tf in self._flat()]
         ni, no = self.num_inputs, self.num_outputs
         n = sum(cell.num_states for cell in cells)

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -14,7 +14,7 @@ from sympy.functions.elementary.trigonometric import atan
 from sympy.functions.elementary.complexes import re, im
 from sympy.matrices.dense import eye
 from sympy.physics.control.lti import SISOLinearTimeInvariant
-from sympy.polys.polytools import factor
+from sympy.polys.polytools import cancel, factor
 from sympy.polys.rootoftools import CRootOf
 from sympy.simplify.simplify import simplify
 from sympy.core.containers import Tuple
@@ -2864,6 +2864,58 @@ def test_TransferFunctionMatrix_construction():
     # all transfer function should have the same sampling time.
     raises(ValueError, lambda: TransferFunctionMatrix([[dtf1, dtf2],
                                                        [dtf3, dtf1]]))
+
+def test_TransferFunctionMatrix_rewrite_StateSpace():
+    tf1 = TransferFunction(1, s + 1, s)
+    tf2 = TransferFunction(1, 2*s + 1, s)
+
+    # SIMO: previously raised AttributeError (issue #28678).
+    G = TransferFunctionMatrix([[tf1], [tf2]])
+    ss = G.rewrite(StateSpace)
+    assert ss == StateSpace(
+        Matrix([[-1, 0], [0, Rational(-1, 2)]]),
+        Matrix([[1], [1]]),
+        Matrix([[1, 0], [0, Rational(1, 2)]]),
+        Matrix([[0], [0]]))
+    assert (ss.num_states, ss.num_inputs, ss.num_outputs) == (2, 1, 2)
+    # Round-trips back to the original transfer function matrix.
+    back = ss.rewrite(TransferFunction)
+    assert cancel(back[0][0].to_expr() - tf1.to_expr()) == 0
+    assert cancel(back[1][0].to_expr() - tf2.to_expr()) == 0
+
+    # MIMO round-trip.
+    tf3 = TransferFunction(3, s + 2, s)
+    tf4 = TransferFunction(1, s + 3, s)
+    G2 = TransferFunctionMatrix([[tf1, tf3], [tf2, tf4]])
+    ss2 = G2.rewrite(StateSpace)
+    assert (ss2.num_states, ss2.num_inputs, ss2.num_outputs) == (4, 2, 2)
+    back2 = ss2.rewrite(TransferFunction)
+    for i, row in enumerate(G2.args[0]):
+        for j, tf in enumerate(row):
+            assert cancel(back2[i][j].to_expr() - tf.to_expr()) == 0
+
+    # Discrete-time systems.
+    dtf1 = DiscreteTransferFunction(1, z + 1, z, 0.1)
+    dtf2 = DiscreteTransferFunction(1, 2*z + 1, z, 0.1)
+    DG = TransferFunctionMatrix([[dtf1], [dtf2]])
+    dss = DG.rewrite(DiscreteStateSpace)
+    assert dss == DiscreteStateSpace(
+        Matrix([[-1, 0], [0, Rational(-1, 2)]]),
+        Matrix([[1], [1]]),
+        Matrix([[1, 0], [0, Rational(1, 2)]]),
+        Matrix([[0], [0]]), 0.1)
+
+    # Series/Parallel entries are collapsed before realization.
+    G3 = TransferFunctionMatrix([[Series(tf1, tf2)], [Parallel(tf1, tf2)]])
+    back3 = G3.rewrite(StateSpace).rewrite(TransferFunction)
+    for i in range(2):
+        assert cancel(back3[i][0].to_expr()
+                      - G3.args[0][i][0].doit().to_expr()) == 0
+
+    # Continuous/discrete mismatches are rejected.
+    raises(TypeError, lambda: G.rewrite(DiscreteStateSpace))
+    raises(TypeError, lambda: DG.rewrite(StateSpace))
+
 
 def test_TransferFunctionMatrix_functions():
     tf5 = TransferFunction(a1*s**2 + a2*s - a0, s + a0, s)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #28678

#### Brief description of what is fixed or changed

`TransferFunctionMatrix` had no state-space rewrite, so
`tfm.rewrite(StateSpace)` fell through to the generic rewrite path and raised
`AttributeError: 'StateSpace' object has no attribute 'var'`.

This adds `_eval_rewrite_as_StateSpace` and `_eval_rewrite_as_DiscreteStateSpace`.
Each entry is realized in controllable canonical form and the realizations are
stacked block-diagonally, so entry `(i, j)` contributes states that are driven
only by input `j` and observed only at output `i`. Both methods share one small
`_to_state_space` helper. The result round-trips back to the original transfer
function matrix.

#### Other comments

The two methods together add fewer lines than either of the previous attempts
by reusing a shared helper and a single assembly loop. Tests cover the SIMO
example from the issue, a MIMO round-trip, discrete-time systems, Series/Parallel
entries, and the continuous/discrete mismatch errors.

#### AI Generation Disclosure

The code and tests in this PR were written with the assistance of an AI tool
(Claude, by Anthropic): the `_to_state_space` helper and the two
`_eval_rewrite_as_*StateSpace` methods added to `TransferFunctionMatrix` in
`sympy/physics/control/lti.py`, and the new `test_TransferFunctionMatrix_rewrite_StateSpace`
test in `sympy/physics/control/tests/test_lti.py`. The changes were reviewed,
run, and verified by a human before submission.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * ``TransferFunctionMatrix`` can now be rewritten as a ``StateSpace`` (or, for
    discrete-time systems, ``DiscreteStateSpace``) model. Previously
    ``TransferFunctionMatrix.rewrite(StateSpace)`` raised an ``AttributeError``.
<!-- END RELEASE NOTES -->
