### PR TITLE
Fix logcombine KeyError on coefficients that are their own negation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1013,6 +1013,7 @@ Lorenzo Contento <lorenzo.contento@gmail.com> Lorenzo Contento <lcontento@users.
 Lorenzo Contento <lorenzo.contento@gmail.com> lcontento <lcontento@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> <louisabraham@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> louisabraham <louis.abraham@yahoo.fr>
+LuShadowX <supyallukshyadl1@gmail.com>
 Luca Bertoni <lucabertoni@gmail.com> luca-berton1 <kaiserverbalkint@gmail.com>
 Luca Weihs <astronomicalcuriosity@gmail.com>
 Lucas Gallindo <lgallindo@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1014,6 +1014,7 @@ Lorenzo Contento <lorenzo.contento@gmail.com> lcontento <lcontento@users.noreply
 Louis Abraham <louis.abraham@yahoo.fr> <louisabraham@users.noreply.github.com>
 Louis Abraham <louis.abraham@yahoo.fr> louisabraham <louis.abraham@yahoo.fr>
 LuShadowX <supyallukshyadl1@gmail.com>
+LuShadowX <supyallukshyadl1@gmail.com> Shadow_Lu <xshadowlu13@gmail.com>
 Luca Bertoni <lucabertoni@gmail.com> luca-berton1 <kaiserverbalkint@gmail.com>
 Luca Weihs <astronomicalcuriosity@gmail.com>
 Lucas Gallindo <lgallindo@gmail.com>

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1119,7 +1119,11 @@ def logcombine(expr, force=False):
         for k in ordered(list(log1.keys())):
             if k not in log1:  # already popped as -k
                 continue
-            if -k in log1:
+            # ``zoo`` and ``nan`` are their own negation, so ``-k`` can be
+            # ``k`` itself; only take the divide branch for distinct keys,
+            # otherwise ``num`` and ``den`` below are the same key and the
+            # second ``log1.pop`` raises ``KeyError``.
+            if -k in log1 and k != -k:
                 # figure out which has the minus sign; the one with
                 # more op counts should be the one
                 num, den = k, -k

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -535,6 +535,14 @@ def test_logcombine_complex_coeff():
         i + log(x**2)
 
 
+def test_logcombine_self_negating_coeff():
+    # zoo is its own negation, which used to make logcombine pop the same
+    # dict key twice and raise KeyError (also surfaced through simplify).
+    x = symbols('x', positive=True)
+    assert logcombine(zoo*log(x)) == zoo*log(x)
+    assert simplify(zoo*log(x)) == zoo*log(x)
+
+
 def test_issue_5950():
     x, y = symbols("x,y", positive=True)
     assert logcombine(log(3) - log(2)) == log(Rational(3,2), evaluate=False)


### PR DESCRIPTION
#### References to other Issues or PRs

None (found via fuzzing).

#### Brief description of what is fixed or changed

`logcombine` (and therefore `simplify`) raised a raw `KeyError` on expressions with a coefficient that equals its own negation, such as `zoo`:

```python
>>> from sympy import symbols, log, zoo, simplify
>>> p = symbols('p', positive=True)
>>> simplify(zoo*log(p))
KeyError: zoo
```

In the branch that divides logs with oppositely-signed coefficients, `num, den = k, -k`. For `zoo` (and `nan`), `-k == k`, so `num` and `den` are the same dict key and the second `log1.pop` raised `KeyError`. The fix only takes that branch when `k != -k`; otherwise the term is handled by the existing single-coefficient path.

Now `simplify(zoo*log(p))` returns `zoo*log(p)` and normal log-combining is unchanged (e.g. `logcombine(3*log(p) - 3*log(q)) == log(p**3/q**3)`). Added a regression test; the full `test_simplify.py` passes locally.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* simplify
  * Fixed a `KeyError` in `logcombine` (and `simplify`) for terms whose coefficient is its own negation, such as `zoo`.
<!-- END RELEASE NOTES -->