### PR TITLE
assumptions: add refine handlers for sinh, cosh, and tanh

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -734,6 +734,7 @@ Gurpartap Singh <dhaliwal.gurpartap@gmail.com> Gurpartap Singh <36311440+gurpart
 Gurpartap Singh <dhaliwal.gurpartap@gmail.com> gurpartap0306 <dhaliwal.gurpartap@gmail.com>
 Guru Devanla <grdvnl@gmail.com>
 Gustavo Alvarado <igoutta@protonmail.com> GA. <igoutta@users.noreply.github.com>
+HITESH S P <hiteshsp2004@gmail.com> HITESH-S-P <127004803+HITESH-S-P@users.noreply.github.com>
 Haimo Zhang <zh.hammer.dev@gmail.com>
 Hamish Dickson <hamish.dickson@gmail.com>
 Hampus Malmberg <hampus.malmberg88@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -533,82 +533,49 @@ def refine_sin_cos(expr, assumptions):
         refined_pow = refine_Pow(pow_expr, assumptions)
         return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
 
-def refine_sinh(expr, assumptions):
+def refine_hyperbolic(expr, assumptions):
     """
-    Handler for hyperbolic sine.
-
-    Examples
-    ========
-
-    >>> from sympy import Q, sinh
-    >>> from sympy.assumptions.refine import refine_sinh
-    >>> from sympy.abc import x
-    >>> refine_sinh(sinh(x), Q.zero(x))
-    0
-    >>> refine_sinh(sinh(x), Q.positive(x))
-    sinh(x)
-
+    Handler for hyperbolic functions: sinh, cosh, tanh, coth.
     """
+    from sympy.core.singleton import S
+    from sympy import I, sin, cos, tan, cot
+    from sympy.functions import sinh, cosh, tanh, coth
+    from sympy.assumptions import ask, Q
+
     arg = expr.args[0]
+
     if ask(Q.zero(arg), assumptions):
-        return S.Zero
-    if ask(Q.real(arg), assumptions):
-        if ask(Q.imaginary(arg), assumptions):
-            # sinh(I*y) = I*sin(y) for real y
-            from sympy import I, sin
-            coeff = arg / I
-            if ask(Q.real(coeff), assumptions):
-                return I * sin(coeff)
+        if isinstance(expr, (sinh, tanh)):
+            return S.Zero
+        elif isinstance(expr, cosh):
+            return S.One
+        elif isinstance(expr, coth):
+            return S.ComplexInfinity
+
+    coeff = arg / I
+    if ask(Q.real(coeff), assumptions):
+        if isinstance(expr, sinh):
+            return I * sin(coeff)
+        elif isinstance(expr, cosh):
+            return cos(coeff)
+        elif isinstance(expr, tanh):
+            return I * tan(coeff)
+        elif isinstance(expr, coth):
+            return -I * cot(coeff)
+
     return expr
 
+def refine_sinh(expr, assumptions):
+    return refine_hyperbolic(expr, assumptions)
 
 def refine_cosh(expr, assumptions):
-    """
-    Handler for hyperbolic cosine.
-
-    Examples
-    ========
-
-    >>> from sympy import Q, cosh
-    >>> from sympy.assumptions.refine import refine_cosh
-    >>> from sympy.abc import x
-    >>> refine_cosh(cosh(x), Q.zero(x))
-    1
-
-    """
-    arg = expr.args[0]
-    if ask(Q.zero(arg), assumptions):
-        return S.One
-    if ask(Q.real(arg), assumptions):
-        if ask(Q.imaginary(arg), assumptions):
-            # cosh(I*y) = cos(y) for real y
-            from sympy import I
-            from sympy.functions.elementary.trigonometric import cos
-            coeff = arg / I
-            if ask(Q.real(coeff), assumptions):
-                return cos(coeff)
-    return expr
-
+    return refine_hyperbolic(expr, assumptions)
 
 def refine_tanh(expr, assumptions):
-    """
-    Handler for hyperbolic tangent.
+    return refine_hyperbolic(expr, assumptions)
 
-    Examples
-    ========
-
-    >>> from sympy import Q, tanh
-    >>> from sympy.assumptions.refine import refine_tanh
-    >>> from sympy.abc import x
-    >>> refine_tanh(tanh(x), Q.zero(x))
-    0
-
-    """
-    arg = expr.args[0]
-    if ask(Q.zero(arg), assumptions):
-        return S.Zero
-    return expr
-
+def refine_coth(expr, assumptions):
+    return refine_hyperbolic(expr, assumptions)
 
 def refine_Heaviside(expr, assumptions):
     """
@@ -636,7 +603,6 @@ def refine_Heaviside(expr, assumptions):
     if ask(Q.zero(arg), assumptions):
         return H0
     return expr
-
 
 def refine_floor_ceiling(expr, assumptions):
     """
@@ -677,7 +643,6 @@ def refine_floor_ceiling(expr, assumptions):
         return Add(*gaussian_integer_terms) + expr.func(Add(*nongausian_intergers_terms))
     return expr
 
-
 handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Abs': refine_abs,
     'Pow': refine_Pow,
@@ -696,4 +661,5 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'sinh': refine_sinh,
     'cosh': refine_cosh,
     'tanh': refine_tanh,
+    'coth': refine_coth,
 }

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -533,6 +533,82 @@ def refine_sin_cos(expr, assumptions):
         refined_pow = refine_Pow(pow_expr, assumptions)
         return (pow_expr if refined_pow is None else refined_pow) * sin(rem)
 
+def refine_sinh(expr, assumptions):
+    """
+    Handler for hyperbolic sine.
+
+    Examples
+    ========
+
+    >>> from sympy import Q, sinh
+    >>> from sympy.assumptions.refine import refine_sinh
+    >>> from sympy.abc import x
+    >>> refine_sinh(sinh(x), Q.zero(x))
+    0
+    >>> refine_sinh(sinh(x), Q.positive(x))
+    sinh(x)
+
+    """
+    arg = expr.args[0]
+    if ask(Q.zero(arg), assumptions):
+        return S.Zero
+    if ask(Q.real(arg), assumptions):
+        if ask(Q.imaginary(arg), assumptions):
+            # sinh(I*y) = I*sin(y) for real y
+            from sympy import I, sin
+            coeff = arg / I
+            if ask(Q.real(coeff), assumptions):
+                return I * sin(coeff)
+    return expr
+
+
+def refine_cosh(expr, assumptions):
+    """
+    Handler for hyperbolic cosine.
+
+    Examples
+    ========
+
+    >>> from sympy import Q, cosh
+    >>> from sympy.assumptions.refine import refine_cosh
+    >>> from sympy.abc import x
+    >>> refine_cosh(cosh(x), Q.zero(x))
+    1
+
+    """
+    arg = expr.args[0]
+    if ask(Q.zero(arg), assumptions):
+        return S.One
+    if ask(Q.real(arg), assumptions):
+        if ask(Q.imaginary(arg), assumptions):
+            # cosh(I*y) = cos(y) for real y
+            from sympy import I
+            from sympy.functions.elementary.trigonometric import cos
+            coeff = arg / I
+            if ask(Q.real(coeff), assumptions):
+                return cos(coeff)
+    return expr
+
+
+def refine_tanh(expr, assumptions):
+    """
+    Handler for hyperbolic tangent.
+
+    Examples
+    ========
+
+    >>> from sympy import Q, tanh
+    >>> from sympy.assumptions.refine import refine_tanh
+    >>> from sympy.abc import x
+    >>> refine_tanh(tanh(x), Q.zero(x))
+    0
+
+    """
+    arg = expr.args[0]
+    if ask(Q.zero(arg), assumptions):
+        return S.Zero
+    return expr
+
 
 def refine_Heaviside(expr, assumptions):
     """
@@ -617,4 +693,7 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
+    'sinh': refine_sinh,
+    'cosh': refine_cosh,
+    'tanh': refine_tanh,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -354,3 +354,42 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+def test_refine_sinh():
+    from sympy import sinh, I, sin
+    x = Symbol('x')
+
+    # sinh(0) = 0
+    assert refine(sinh(x), Q.zero(x)) == 0
+
+    # sinh is defined for real x (no simplification, just stays)
+    assert refine(sinh(x), Q.positive(x)) == sinh(x)
+
+    # Imaginary argument: sinh(I*x) = I*sin(x)
+    assert refine(sinh(I*x), Q.real(x)) == I*sin(x)
+
+
+def test_refine_cosh():
+    from sympy import cosh, I, cos
+    x = Symbol('x')
+
+    # cosh(0) = 1
+    assert refine(cosh(x), Q.zero(x)) == 1
+
+    # cosh is always >= 1 for real x
+    assert refine(cosh(x), Q.real(x)) == cosh(x)
+
+    # Imaginary argument: cosh(I*x) = cos(x)
+    assert refine(cosh(I*x), Q.real(x)) == cos(x)
+
+
+def test_refine_tanh():
+    from sympy import tanh
+    x = Symbol('x')
+
+    # tanh(0) = 0
+    assert refine(tanh(x), Q.zero(x)) == 0
+
+    # No simplification for general positive x
+    assert refine(tanh(x), Q.positive(x)) == tanh(x)
+

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -341,7 +341,6 @@ def test_floor_ceiling():
     assert refine(floor(floor(x)+ floor(y))) == floor(x) + floor(y)
     assert refine(ceiling(ceiling(x) - ceiling(y))) == ceiling(x) - ceiling(y)
 
-
 def test_Heaviside():
     assert refine(Heaviside(x), Q.positive(x)) == 1
     assert refine(Heaviside(x), Q.negative(x)) == 0
@@ -368,7 +367,6 @@ def test_refine_sinh():
     # Imaginary argument: sinh(I*x) = I*sin(x)
     assert refine(sinh(I*x), Q.real(x)) == I*sin(x)
 
-
 def test_refine_cosh():
     from sympy import cosh, I, cos
     x = Symbol('x')
@@ -382,7 +380,6 @@ def test_refine_cosh():
     # Imaginary argument: cosh(I*x) = cos(x)
     assert refine(cosh(I*x), Q.real(x)) == cos(x)
 
-
 def test_refine_tanh():
     from sympy import tanh
     x = Symbol('x')
@@ -392,4 +389,3 @@ def test_refine_tanh():
 
     # No simplification for general positive x
     assert refine(tanh(x), Q.positive(x)) == tanh(x)
-

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -389,3 +389,16 @@ def test_refine_tanh():
 
     # No simplification for general positive x
     assert refine(tanh(x), Q.positive(x)) == tanh(x)
+
+def test_refine_coth():
+    from sympy import coth, cot, zoo, I
+    x = Symbol('x')
+
+    # coth(0) -> zoo (ComplexInfinity)
+    assert refine(coth(x), Q.zero(x)) == zoo
+
+    # coth(I*x) -> -I*cot(x) when x is real
+    assert refine(coth(I*x), Q.real(x)) == -I*cot(x)
+
+    # No simplification for general positive x
+    assert refine(coth(x), Q.positive(x)) == coth(x)

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -402,3 +402,4 @@ def test_refine_coth():
 
     # No simplification for general positive x
     assert refine(coth(x), Q.positive(x)) == coth(x)
+    

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -402,4 +402,3 @@ def test_refine_coth():
 
     # No simplification for general positive x
     assert refine(coth(x), Q.positive(x)) == coth(x)
-    


### PR DESCRIPTION
Add new refine handlers for hyperbolic functions (sinh, cosh, tanh) that simplify expressions under assumptions:
- sinh(x) -> 0 when x is zero
- cosh(x) -> 1 when x is zero
- tanh(x) -> 0 when x is zero
- sinh(I*x) -> I*sin(x) when x is real
- cosh(I*x) -> cos(x) when x is real

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Part of #27888

#### Brief description of what is fixed or changed
Added refine handlers for hyperbolic functions (`sinh`, `cosh`, `tanh`) so that
`refine()` can simplify expressions involving these functions under assumptions.
**New simplifications enabled:**
- `refine(sinh(x), Q.zero(x))` → `0`
- `refine(cosh(x), Q.zero(x))` → `1`
- `refine(tanh(x), Q.zero(x))` → `0`
- `refine(sinh(I*x), Q.real(x))` → `I*sin(x)`
- `refine(cosh(I*x), Q.real(x))` → `cos(x)`
This follows the same pattern as existing handlers for `sin`/`cos` (PR #28873)
and `tan`/`cot` (PR #29324).

#### Other comments
I observed hyperbolic functions were
unhandled by `refine` after checking all open and closed PRs tagged under
`assumptions.refine`.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
- **Tool used:** Antigravity
- **AI-generated parts:** Refined the code formatting and wording in `sympy/assumptions/refine.py`.
- **Human-authored/reviewed parts:** I designed the underlying math and simplification logic, wrote the unit tests in `sympy/assumptions/tests/test_refine.py` and verified all tests pass locally.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added refine handlers for `sinh`, `cosh`, and `tanh` to enable
    simplification of hyperbolic functions under assumptions.

<!-- END RELEASE NOTES -->
