### PR TITLE
Fix Quaternion.exp() returning nan for purely real quaternions

### DIFF
--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -1012,6 +1012,11 @@ class Quaternion(Expr):
         q = self
         vector_norm = sqrt(q.b**2 + q.c**2 + q.d**2)
         a = exp(q.a) * cos(vector_norm)
+
+        # Handle purely real quaternions to avoid division by zero
+        if vector_norm.is_zero:
+            return Quaternion(a, 0, 0, 0)
+
         b = exp(q.a) * sin(vector_norm) * q.b / vector_norm
         c = exp(q.a) * sin(vector_norm) * q.c / vector_norm
         d = exp(q.a) * sin(vector_norm) * q.d / vector_norm

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -6,7 +6,7 @@ from sympy.core.numbers import (E, I, Rational, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.complexes import (Abs, conjugate, im, re, sign)
-from sympy.functions.elementary.exponential import log
+from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (acos, asin, cos, sin, atan2, atan)
 from sympy.integrals.integrals import integrate
@@ -173,6 +173,11 @@ def test_quaternion_functions():
                2 * sqrt(29) * E * sin(sqrt(29)) / 29,
                3 * sqrt(29) * E * sin(sqrt(29)) / 29,
                4 * sqrt(29) * E * sin(sqrt(29)) / 29)
+    # exp of a purely real quaternion must not divide by a zero vector norm
+    assert q0.exp() == Quaternion(1, 0, 0, 0)
+    assert Quaternion(2, 0, 0, 0).exp() == Quaternion(exp(2), 0, 0, 0)
+    assert Quaternion(x, 0, 0, 0).exp() == Quaternion(exp(x), 0, 0, 0)
+
     assert q1.log() == \
     Quaternion(log(sqrt(30)),
                2 * sqrt(29) * acos(sqrt(30)/30) / 29,


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29295

#### Brief description of what is fixed or changed

`Quaternion.exp()` computed the vector part as `exp(a)*sin(||v||)*b/||v||` without
guarding against `||v|| == 0`. For a purely real quaternion the vector norm is zero,
so each component became `0/0` and the result had `nan` components:

```
>>> Quaternion(0, 0, 0, 0).exp()
1 + nan*i + nan*j + nan*k
>>> Quaternion(2, 0, 0, 0).exp()
exp(2) + nan*i + nan*j + nan*k
```

Since `exp(a + 0i + 0j + 0k)` is just `exp(a)`, the vector part should be zero.
`Quaternion.log()` already contains exactly this guard, so `exp()` now does the
same thing: when `vector_norm.is_zero`, return `Quaternion(exp(a), 0, 0, 0)`
before performing the division. With the fix:

```
>>> Quaternion(0, 0, 0, 0).exp()
1 + 0*i + 0*j + 0*k
>>> Quaternion(2, 0, 0, 0).exp()
exp(2) + 0*i + 0*j + 0*k
```

#### Other comments

Regression assertions were added to `test_quaternion_functions`, covering the zero
quaternion, a numeric real quaternion and a symbolic real quaternion. `exp` had to
be added to the imports of the test module. Reverting only the change in
`quaternion.py` makes the new assertions fail with
`assert 1 + nan*i + nan*j + nan*k == 1 + 0*i + 0*j + 0*k`, so the test is not
vacuous. `sympy/algebras/tests/test_quaternion.py` passes: 19 passed, 2 deselected.

#### AI Generation Disclosure

This patch was prepared with AI assistance (Claude). The one-line-guard change in
`sympy/algebras/quaternion.py` (lines returning early when `vector_norm.is_zero`)
and the three added assertions plus the `exp` import in
`sympy/algebras/tests/test_quaternion.py` were AI-generated, then reviewed, run and
verified by me against the issue reproducer and the existing test suite.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Fixed `Quaternion.exp()` returning `nan` vector components for purely real
    quaternions, e.g. `Quaternion(0, 0, 0, 0).exp()` now gives `Quaternion(1, 0, 0, 0)`.
<!-- END RELEASE NOTES -->
