### PR TITLE
Fix typo "their" in Development Workflow Process

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1127,7 +1127,7 @@ Michael Greminger <michael.greminger@gmail.com> mgreminger <michael.greminger@gm
 Michael Hohenstein <michael@hohenste.in>
 Michael Mayorov <marchael@kb.csu.ru>
 Michael Mueller <michaeldmueller7@gmail.com>
-Michael Newman <michael.b.newman@gmail.com>
+Michael Newman <michael.b.newman@gmail.com> Michael Newman <michael.newman@avalabs.org>
 Michael S. Hansen <michael.hansen@nih.gov>
 Michael Sparapany <msparapa@purdue.edu>
 Michael Zingale <michael.zingale@stonybrook.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -1127,6 +1127,7 @@ Michael Greminger <michael.greminger@gmail.com> mgreminger <michael.greminger@gm
 Michael Hohenstein <michael@hohenste.in>
 Michael Mayorov <marchael@kb.csu.ru>
 Michael Mueller <michaeldmueller7@gmail.com>
+Michael Newman <michael.b.newman@gmail.com>
 Michael S. Hansen <michael.hansen@nih.gov>
 Michael Sparapany <msparapa@purdue.edu>
 Michael Zingale <michael.zingale@stonybrook.edu>

--- a/doc/src/contributing/new-contributors-guide/workflow-process.md
+++ b/doc/src/contributing/new-contributors-guide/workflow-process.md
@@ -658,7 +658,7 @@ time of the next SymPy release.
 Joe Bloggs <joe@bloggs.com>
 ```
 
-The first line their says that the .mailmap file was "reordered". This is because the file should be in alphabetical order. The script will have moved your name into the correct position so now you can see the change as:
+The first line there says that the .mailmap file was "reordered". This is because the file should be in alphabetical order. The script will have moved your name into the correct position so now you can see the change as:
 
 ```bash
 $ git diff


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

N/A

#### Brief description of what is fixed or changed

Fixed incorrect word usage `their` to `there` in Development Workflow Process.

#### Other comments

First contribution.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
