### PR TITLE
Handle recursion errors in the ANTLR LaTeX parser

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1254,8 +1254,6 @@ Param Singh <paramsingh258@gmail.com>
 Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.com>
 Parcly Taxel <reddeloostw@gmail.com>
 Parker Berry <parkereberry@gmail.com> Parker Berry <parker.berry@marquette.edu>
-Parth Dongre <parthvilasdongre@gmail.com> Parthozy <parthvilasdongre@gmail.com>
-Parth Dongre <parthvilasdongre@gmail.com> Parthozyy <dongreparth123@gmail.com>
 Parthozyy <dongreparth123@gmail.com>
 Parthozyy <dongreparth123@gmail.com> Parthozy <parthvilasdongre@gmail.com>
 Pascal Gitz <pascal.gitz@hotmail.ch> PascalGitz <pascal.gitz@hotmail.ch>

--- a/.mailmap
+++ b/.mailmap
@@ -1254,6 +1254,8 @@ Param Singh <paramsingh258@gmail.com>
 Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.com>
 Parcly Taxel <reddeloostw@gmail.com>
 Parker Berry <parkereberry@gmail.com> Parker Berry <parker.berry@marquette.edu>
+Parth Dongre <parthvilasdongre@gmail.com> Parthozy <parthvilasdongre@gmail.com>
+Parth Dongre <parthvilasdongre@gmail.com> Parthozyy <dongreparth123@gmail.com>
 Pascal Gitz <pascal.gitz@hotmail.ch> PascalGitz <pascal.gitz@hotmail.ch>
 Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini+github@gmail.com>
 Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1256,6 +1256,8 @@ Parcly Taxel <reddeloostw@gmail.com>
 Parker Berry <parkereberry@gmail.com> Parker Berry <parker.berry@marquette.edu>
 Parth Dongre <parthvilasdongre@gmail.com> Parthozy <parthvilasdongre@gmail.com>
 Parth Dongre <parthvilasdongre@gmail.com> Parthozyy <dongreparth123@gmail.com>
+Parthozyy <dongreparth123@gmail.com>
+Parthozyy <dongreparth123@gmail.com> Parthozy <parthvilasdongre@gmail.com>
 Pascal Gitz <pascal.gitz@hotmail.ch> PascalGitz <pascal.gitz@hotmail.ch>
 Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini+github@gmail.com>
 Pasquale Cocchini <pasquale.cocchini@gmail.com> pasqo <pasquale.cocchini@gmail.com>

--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -82,7 +82,13 @@ def parse_latex(sympy, strict=False):
     parser.removeErrorListeners()
     parser.addErrorListener(matherror)
 
-    relation = parser.math().relation()
+    try:
+        relation = parser.math().relation()
+    except RecursionError as exc:
+        raise LaTeXParsingError(
+            "LaTeX expression is too deeply nested"
+        ) from exc
+        
     if strict and (relation.start.start != 0 or relation.stop.stop != len(sympy) - 1):
         raise LaTeXParsingError("Invalid LaTeX")
     expr = convert_relation(relation)

--- a/sympy/parsing/latex/_parse_latex_antlr.py
+++ b/sympy/parsing/latex/_parse_latex_antlr.py
@@ -88,7 +88,6 @@ def parse_latex(sympy, strict=False):
         raise LaTeXParsingError(
             "LaTeX expression is too deeply nested"
         ) from exc
-        
     if strict and (relation.start.start != 0 or relation.stop.stop != len(sympy) - 1):
         raise LaTeXParsingError("Invalid LaTeX")
     expr = convert_relation(relation)

--- a/sympy/parsing/tests/test_latex.py
+++ b/sympy/parsing/tests/test_latex.py
@@ -286,6 +286,14 @@ GOOD_PAIRS = [
     (r"3x - 1", _Add(_Mul(3, x), -1))
 ]
 
+def test_deepnesting():
+    # Error is due to teh nesting limit of python
+    import sys
+    from sympy.parsing.latex import parse_latex, LaTeXParsingError
+    depth = sys.getrecursionlimit()
+    latex_string = "(" * depth + "x" + ")" * depth
+    with raises(LaTeXParsingError):
+        parse_latex(latex_string, backend = "antlr")
 
 def test_parseable():
     from sympy.parsing.latex import parse_latex


### PR DESCRIPTION
Fixes  #30000

#### References to other Issues or PRs
Before this change, deeply nested parentheses caused a raw `RecursionError` in the ANTLR LaTeX parser while parsing the expression.

#### Brief description of what is fixed or changed
I caught the recursion error and converted it into a LaTeXParsingError and also added a regression using deeply nested parentheses. 

#### Other comments
I reproduced this error on MacOS Tahoe 26.5.2 arm64 and using Python 3.14.
Lark Parsed the same input correctly and I ran the complete parsing test suite and the results were `139 passed, 1 skipped, 2 xfailed`

#### AI Generation Disclosure
I have used the tool ChatGPT to understand the problem and also it helped me interpret the traceback. It suggested to catch RecursionError around `parser.math().relation()` and suggested the basic regression-test structure. I have typed and learned about the problem and the code and also have tested the final changes myself and verified the authenticity of the code. 

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->