### PR TITLE
#30114 Fix solveset inverse function range validation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1249,6 +1249,10 @@ Pablo Galindo Salgado <pablogsal@gmail.com> pablogsal <pablogsal@gmail.com>
 Pablo Puente <ppuedom@gmail.com> <ppuedom@yahoo.com>
 Pablo Zubieta <pabloferz@yahoo.com.mx>
 Padam Rathi <rathipadamr5@gmail.com>
+Palak Khinvasara <palakkhinvasara9@gmail.com> palakkhinvasara <109575264+palakkhinvasara@users.noreply.github.com>
+Palak Khinvasara <palakkhinvasara9@gmail.com> palakkhinvasara <palakkhinvasara9@gmail.com>
+Palak Khinvasara <palakkhinvasara9@gmail.com> palakkhinvasara <palakkhinvasara9@gmail.com>
+Palak khinvasara <palakkhinvasara9@gmail.com>  palak <palakkhinvasara9@gmail.com>
 Pan Peng <pengpanster@gmail.com>
 Param Singh <paramsingh258@gmail.com>
 Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.com>

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -61,12 +61,6 @@ from sympy.utilities import filldedent
 from sympy.utilities.iterables import (numbered_symbols, has_dups,
                                        is_sequence, iterable)
 from sympy.calculus.util import periodicity, continuous_domain, function_range
-from sympy.functions.elementary.trigonometric import (
-    asin, acos, atan, acot, asec, acsc,
-)
-from sympy.functions.elementary.hyperbolic import (
-    acosh, asech,
-)
 
 
 from types import GeneratorType

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -61,6 +61,12 @@ from sympy.utilities import filldedent
 from sympy.utilities.iterables import (numbered_symbols, has_dups,
                                        is_sequence, iterable)
 from sympy.calculus.util import periodicity, continuous_domain, function_range
+from sympy.functions.elementary.trigonometric import (
+    asin, acos, atan, acot, asec, acsc,
+)
+from sympy.functions.elementary.hyperbolic import (
+    acosh, asech,
+)
 
 
 from types import GeneratorType
@@ -222,6 +228,60 @@ def _invert_real(f, g_ys, symbol):
         return (symbol, g_ys)
 
     n = Dummy('n', real=True)
+
+        # Check ranges of inverse trigonometric/hyperbolic functions
+    if isinstance(f, asin):
+        g_ys = g_ys.intersect(Interval(-pi/2, pi/2))
+        if g_ys == S.EmptySet:
+            return (symbol, S.EmptySet)
+        return _invert_real(
+            f.args[0],
+            imageset(Lambda(n, sin(n)), g_ys),
+            symbol
+        )
+
+    if isinstance(f, acos):
+        g_ys = g_ys.intersect(Interval(0, pi))
+        if g_ys == S.EmptySet:
+            return (symbol, S.EmptySet)
+        return _invert_real(
+            f.args[0],
+            imageset(Lambda(n, cos(n)), g_ys),
+            symbol
+        )
+
+    if isinstance(f, atan):
+        g_ys = g_ys.intersect(Interval.open(-pi/2, pi/2))
+        if g_ys == S.EmptySet:
+            return (symbol, S.EmptySet)
+        return _invert_real(
+            f.args[0],
+            imageset(Lambda(n, tan(n)), g_ys),
+            symbol
+        )
+
+    if isinstance(f, acosh):
+        g_ys = g_ys.intersect(Interval(0, oo))
+        if g_ys == S.EmptySet:
+            return (symbol, S.EmptySet)
+
+        return _invert_real(
+            f.args[0],
+            imageset(Lambda(n, cosh(n)), g_ys),
+            symbol
+        )
+
+    if isinstance(f, asech):
+        g_ys = g_ys.intersect(Interval(0, oo))
+        if g_ys == S.EmptySet:
+            return (symbol, S.EmptySet)
+
+        return _invert_real(
+            f.args[0],
+            imageset(Lambda(n, sech(n)), g_ys),
+            symbol
+        )
+    
 
     if isinstance(f, exp) or (f.is_Pow and f.base == S.Exp1):
         return _invert_real(f.exp,
@@ -407,6 +467,60 @@ def _invert_trig_hyp_real(f, g_ys, symbol):
                     return (f, g_ys)
             return _invert_real(f.args[0],
                 imageset(n, acsch(n), g_ys_dom), symbol)
+        
+    elif isinstance(f, (asin, acos, atan, acot, asec, acsc,
+                    acosh, asech)):
+        n = Dummy('n', real=True)
+
+        if isinstance(f, asin):
+            g_ys = g_ys.intersect(Interval(-pi/2, pi/2))
+            if g_ys == S.EmptySet:
+                return (symbol, S.EmptySet)
+            return _invert_real(
+                f.args[0],
+                imageset(n, sin(n), g_ys),
+                symbol
+            )
+
+        if isinstance(f, acos):
+            g_ys = g_ys.intersect(Interval(0, pi))
+            if g_ys == S.EmptySet:
+                return (symbol, S.EmptySet)
+            return _invert_real(
+                f.args[0],
+                imageset(n, cos(n), g_ys),
+                symbol
+            )
+
+        if isinstance(f, atan):
+            g_ys = g_ys.intersect(Interval.open(-pi/2, pi/2))
+            if g_ys == S.EmptySet:
+                return (symbol, S.EmptySet)
+            return _invert_real(
+                f.args[0],
+                imageset(n, tan(n), g_ys),
+                symbol
+            )
+
+        if isinstance(f, acosh):
+            g_ys = g_ys.intersect(Interval(0, oo))
+            if g_ys == S.EmptySet:
+                return (symbol, S.EmptySet)
+            return _invert_real(
+                f.args[0],
+                imageset(n, cosh(n), g_ys),
+                symbol
+            )
+
+        if isinstance(f, asech):
+            g_ys = g_ys.intersect(Interval(0, oo))
+            if g_ys == S.EmptySet:
+                return (symbol, S.EmptySet)
+            return _invert_real(
+                f.args[0],
+                imageset(n, sech(n), g_ys),
+                symbol
+            )    
 
     elif isinstance(f, TrigonometricFunction) and isinstance(g_ys, FiniteSet):
         def _get_trig_inverses(func):

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -275,7 +275,6 @@ def _invert_real(f, g_ys, symbol):
             imageset(Lambda(n, sech(n)), g_ys),
             symbol
         )
-    
 
     if isinstance(f, exp) or (f.is_Pow and f.base == S.Exp1):
         return _invert_real(f.exp,
@@ -461,7 +460,7 @@ def _invert_trig_hyp_real(f, g_ys, symbol):
                     return (f, g_ys)
             return _invert_real(f.args[0],
                 imageset(n, acsch(n), g_ys_dom), symbol)
-        
+
     elif isinstance(f, (asin, acos, atan, acot, asec, acsc,
                     acosh, asech)):
         n = Dummy('n', real=True)
@@ -514,7 +513,7 @@ def _invert_trig_hyp_real(f, g_ys, symbol):
                 f.args[0],
                 imageset(n, sech(n), g_ys),
                 symbol
-            )    
+            )
 
     elif isinstance(f, TrigonometricFunction) and isinstance(g_ys, FiniteSet):
         def _get_trig_inverses(func):

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3626,4 +3626,4 @@ def test_inverse_trig_range_check():
     assert solveset(Eq(acos(x), -1), x, domain=S.Reals) == S.EmptySet
 
     assert solveset(Eq(atan(x), 2), x, domain=S.Reals) == S.EmptySet
-    assert solveset(Eq(acosh(x), -1), x, domain=S.Reals) == S.EmptySet    
+    assert solveset(Eq(acosh(x), -1), x, domain=S.Reals) == S.EmptySet

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3615,3 +3615,15 @@ def test_issue_26077():
         Complement(S.Reals, excluded_points)
     )
     assert solution.as_dummy() == critical_points.as_dummy()
+
+def test_inverse_trig_range_check():
+    x = symbols('x')
+
+    assert solveset(Eq(asin(x), 2), x, domain=S.Reals) == S.EmptySet
+    assert solveset(Eq(asin(x), -2), x, domain=S.Reals) == S.EmptySet
+
+    assert solveset(Eq(acos(x), 4), x, domain=S.Reals) == S.EmptySet
+    assert solveset(Eq(acos(x), -1), x, domain=S.Reals) == S.EmptySet
+
+    assert solveset(Eq(atan(x), 2), x, domain=S.Reals) == S.EmptySet
+    assert solveset(Eq(acosh(x), -1), x, domain=S.Reals) == S.EmptySet    


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30114 

#### Brief description of what is fixed or changed

Fixed an issue in `solveset` where equations involving inverse trigonometric and hyperbolic functions could return invalid solutions when the right-hand side was outside the principal range of the inverse function.

For example, equations such as:

* `asin(x) = 2`
* `acos(x) = 4`
* `atan(x) = 2`
* `acosh(x) = -1`

were incorrectly inverted to values like `sin(2)`, `cos(4)`, or `cosh(1)` instead of returning no real solutions.

The fix adds range validation before applying inverse transformations so that only values within the valid range of the inverse function are considered.

Added regression tests covering inverse trigonometric and hyperbolic functions with invalid real-domain inputs.

#### Other comments

The change is limited to real-domain inversion in `solveset`. Existing trigonometric inversion behavior remains unchanged.

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* solvers

  * Fixed `solveset` returning invalid real solutions for inverse trigonometric and hyperbolic equations outside their valid ranges.

<!-- END RELEASE NOTES -->
