### PR TITLE
Fix parse_expr(evaluate=False) for factorial

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1904,7 +1904,7 @@ vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>
-vortex-wq <vaastavikumar30@gmail.com>
+vortex-wq <vaastavikumar43@gmail.com>
 w495 <w495@yandex-team.ru>
 wookie184 <wookie1840@gmail.com>
 wuyudi <wuyudi119@163.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1904,6 +1904,7 @@ vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>
+vortex <vaastavikumar30@gmail.com>
 w495 <w495@yandex-team.ru>
 wookie184 <wookie1840@gmail.com>
 wuyudi <wuyudi119@163.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1904,7 +1904,7 @@ vedantc98 <vedantc98@gmail.com>
 vezeli <37907135+vezeli@users.noreply.github.com>
 viocha <66580331+viocha@users.noreply.github.com>
 vishal <vishal.panjwani15@gmail.com>
-vortex <vaastavikumar30@gmail.com>
+vortex-wq <vaastavikumar30@gmail.com>
 w495 <w495@yandex-team.ru>
 wookie184 <wookie1840@gmail.com>
 wuyudi <wuyudi119@163.com>

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1122,7 +1122,7 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         'acosh', 'acoth', 'acsch', 'asech', 'asinh', 'atanh',
         'cos', 'cot', 'csc', 'sec', 'sin', 'tan',
         'cosh', 'coth', 'csch', 'sech', 'sinh', 'tanh',
-        'exp', 'ln', 'log', 'sqrt', 'cbrt',
+        'exp', 'ln', 'log', 'sqrt', 'cbrt', 'factorial',
     )
 
     relational_operators = {

--- a/sympy/parsing/tests/test_sympy_parser.py
+++ b/sympy/parsing/tests/test_sympy_parser.py
@@ -201,13 +201,14 @@ def test_function_evaluate_false():
         'acosh(0)', 'acoth(0)', 'acsch(0)', 'asech(0)', 'asinh(0)', 'atanh(0)',
         'cos(0)', 'cot(0)', 'csc(0)', 'sec(0)', 'sin(0)', 'tan(0)',
         'cosh(0)', 'coth(0)', 'csch(0)', 'sech(0)', 'sinh(0)', 'tanh(0)',
-        'exp(0)', 'log(0)', 'sqrt(0)',
+        'exp(0)', 'log(0)', 'sqrt(0)', 'factorial(5)',
     ]
     for case in inputs:
         expr = parse_expr(case, evaluate=False)
         assert case == str(expr) != str(expr.doit())
     assert str(parse_expr('ln(0)', evaluate=False)) == 'log(0)'
     assert str(parse_expr('cbrt(0)', evaluate=False)) == '0**(1/3)'
+    assert str(parse_expr("factorial(5)+factorial(5)",evaluate=False)) == 'factorial(5) + factorial(5)'
 
 
 def test_issue_10773():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #27774 


#### Brief description of what is fixed or changed
The `'parse_expr'` with `'evaluate=False'` works incorrectly for some types and functions. This PR fixes the case for the factorial code output.

#### Other comments
The change is verified by adding tests and running the code as well which passes all the tests. 

#### AI Generation Disclosure
GPT 5.0 was used for assistance. 

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes
<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
