### PR TITLE
solvers: fix `valid` so that `solveset(Ne(sqrt(x**2 - 4), 0), x, domain=S.Reals)` returns `(-oo, -2) U (2, oo)`

### DIFF
--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -538,14 +538,14 @@ def solve_univariate_inequality(expr, gen, relational=True, domain=S.Reals, cont
                 #
                 # expanded_e, expr and gen used from enclosing scope
                 v = expanded_e.subs(gen, expand_mul(x))
+                if v.is_extended_real is False:
+                    return S.false
                 try:
                     r = expr.func(v, 0)
                 except TypeError:
                     r = S.false
                 if r in (S.true, S.false):
                     return r
-                if v.is_extended_real is False:
-                    return S.false
                 else:
                     v = v.n(2)
                     if v.is_comparable:

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -3615,3 +3615,15 @@ def test_issue_26077():
         Complement(S.Reals, excluded_points)
     )
     assert solution.as_dummy() == critical_points.as_dummy()
+
+
+def test_solveset_Ne():
+    assert solveset(Ne(sqrt(x**2 - 4), 0), x, domain=S.Reals) == Union(
+        Interval.open(-oo, -2), Interval.open(2, oo))
+    assert solveset(Ne(sqrt(abs(x) - 1), 0), x, domain=S.Reals) == Union(
+        Interval.open(-oo, -1), Interval.open(1, oo))
+    assert solveset(Ne(log(abs(x) - 1), 0), x, domain=S.Reals) == Union(
+        Interval.open(-oo, -2),
+        Interval.open(-2, -1),
+        Interval.open(1, 2),
+        Interval.open(2, oo))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Update:
Related issue:
gh-23028

#### Brief description of what is fixed or changed
Before the fix,

```python
In [1]: solveset(Ne(sqrt(x**2 - 4), 0), x, domain=S.Reals)
Out[1]: (-∞, -2) ∪ (-2, 2) ∪ (2, ∞)
expected result: (-∞, -2) ∪ (2, ∞)

In [2]: solveset(Ne(sqrt(abs(x) - 1), 0), x, domain=S.Reals)
Out[2]: (-∞, -1) ∪ (-1, 1) ∪ (1, ∞)
expected result: (-∞, -1) ∪ (1, ∞)

In [3]: solveset(Ne(log(abs(x) - 1), 0), x, domain=S.Reals)
Out[3]: (-∞, -2) ∪ (-2, 2) ∪ (2, ∞)
expected result: (-∞, -2) ∪ (-2, -1) ∪ (1, 2) ∪ (2, ∞)
```

After the fix, all the code snippets above produce the expected results.

I also added regression tests for all the cases above.

#### Other comments

<details>
<summary>Here is some explanation.</summary>

Take `solveset(Ne(sqrt(x**2 - 4), 0), x, domain=S.Reals)` as an example. 

With `solvify` we get
```python
In [1]: from sympy.solvers.solveset import solvify

In [2]: solvify(sqrt(x**2 - 4), x, S.Reals)
Out[2]: [-2, 2]
```

With `_pt` we get:

```python
In [1]: from sympy.solvers.inequalities import _pt

In [2]: _pt(S.NegativeInfinity, S(-2))
Out[2]: -4

In [3]: _pt(S(2), S.Infinity)
Out[3]: 4

In [4]: _pt(S(-2), S(2))
Out[4]: 0
```

```python
In [5]: gen = Symbol('x')

In [6]: expr = Ne(sqrt(gen**2 - 4), 0)

In [7]: e = expr.lhs - expr.rhs

In [8]: expanded_e = expand_mul(e)

In [9]: str(expanded_e)
Out[9]: 'sqrt(x**2 - 4)'
```

Before the fix,

Case 1, `valid(-4)`
```python
In [10]: v = expanded_e.subs(gen, expand_mul(S(-4))); v
Out[10]: 2⋅√3

In [11]: r = expr.func(v, 0); r
Out[11]: True

In [12]: r in (S.true, S.false)
Out[12]: True
```

Case 2, `valid(4)`
```python
In [13]: v = expanded_e.subs(gen, expand_mul(S(4))); v
Out[13]: 2⋅√3

In [14]: r = expr.func(v, 0); r
Out[14]: True

In [15]: r in (S.true, S.false)
Out[15]: True
```

Case 3, `valid(0)`
```python
In [16]: v = expanded_e.subs(gen, expand_mul(S(0))); v
Out[16]: 2⋅ⅈ

In [17]: r = expr.func(v, 0); r
Out[17]: True

In [18]: r in (S.true, S.false)
Out[18]: True
# Therefore, the interval (-2, 2) is kept, which is incorrect.
```

After the fix, 

Case 1, `valid(-4)`
```python
In [19]: v = expanded_e.subs(gen, expand_mul(S(-4))); v
Out[19]: 2⋅√3

In [20]: v.is_extended_real
Out[20]: True

In [21]: r = expr.func(v, 0); r
Out[21]: True

In [22]: r in (S.true, S.false)
Out[22]: True
```

Case 2, `valid(4)`
```python
In [23]: v = expanded_e.subs(gen, expand_mul(S(4))); v
Out[23]: 2⋅√3

In [24]: v.is_extended_real
Out[24]: True

In [25]: r = expr.func(v, 0); r
Out[25]: True

In [26]: r in (S.true, S.false)
Out[26]: True
```

Case 3, `valid(0)`
```python
In [27]: v = expanded_e.subs(gen, expand_mul(S(0))); v
Out[27]: 2⋅ⅈ

In [28]: v.is_extended_real
Out[28]: False
# Therefore, the interval (-2, 2) is discarded, which is correct.
```

</details>


Update:
By the way, with Mathematica (14.0.0 for Microsoft Windows (64-bit)), I get:
```mathematica
In[1]:= Reduce[Sqrt[x^2 - 4] != 0, x, Reals]

Out[1]= x < -2 || x > 2
```


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
All code was written manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* solvers
  * `solveset(Ne(sqrt(x**2 - 4), 0), x, domain=S.Reals)` now returns `(-∞, -2) ∪ (2, ∞)`.
<!-- END RELEASE NOTES -->
