### PR TITLE
manualintegrate: harden the ratint fallback (stacked on #30144)

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -65,6 +65,7 @@ from .integrals import Integral
 from .rationaltools import ratint
 from sympy.logic.boolalg import And, Boolean
 from sympy.ntheory.factor_ import primefactors
+from sympy.polys.polyerrors import PolynomialError
 from sympy.polys.polytools import degree, factor_list, lcm_list, gcd_list, Poly
 from sympy.simplify.radsimp import fraction
 from sympy.simplify.simplify import simplify
@@ -607,7 +608,10 @@ class RatintRule(AtomicRule):
     __slots__ = ()
 
     def eval(self) -> Expr:
-        return ratint(self.integrand, self.variable)
+        try:
+            return ratint(self.integrand, self.variable)
+        except (PolynomialError, NotImplementedError):
+            return Integral(self.integrand, self.variable)
 
 
 class AlternativeRule(Rule):
@@ -2766,16 +2770,19 @@ def partial_fractions_rule(integral):
     integrand, symbol = integral
     if not integrand.is_rational_function(symbol):
         return
+    debug("Integral: {} is rewritten with apart on symbol: {}".format(integrand, symbol))
 
     rewritten = integrand.apart(symbol)
-    if rewritten == integrand:
-        # If apart cannot decompose the rational function any further,
-        # use ratint as the final fallback for rational integration.
-        return RatintRule(integrand, symbol)
+    if rewritten != integrand:
+        substep = integral_steps(rewritten, symbol)
+        if not substep.contains_dont_know():
+            return RewriteRule(integrand, symbol, rewritten, substep)
 
-    substep = integral_steps(rewritten, symbol)
-    if not isinstance(substep, DontKnowRule):
-        return RewriteRule(integrand, symbol, rewritten, substep)
+    # apart either could not decompose the rational function any further
+    # (it may still have normalized it without splitting it, e.g. with
+    # Float coefficients) or some of the pieces could not be integrated
+    # manually: use ratint as the final fallback for rational integration.
+    return RatintRule(integrand, symbol)
 
 cancel_rule = rewriter(
     # lambda integrand, symbol: integrand.is_algebraic_expr(),

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -264,8 +264,23 @@ def test_manualintegrate_rational():
     # apart splits this into 1/(x + 1) and the undecomposable 1/(x**4 + 1).
     f = (x**4 + x + 2)/((x + 1)*(x**4 + 1))
     F = manualintegrate(f, x)
-    assert F == log(x + 1) - sqrt(2)*log(x**2 - sqrt(2)*x + 1)/8 + \
-        sqrt(2)*log(x**2 + sqrt(2)*x + 1)/8 + sqrt(2)*atan(sqrt(2)*x - 1)/4 + sqrt(2)*atan(sqrt(2)*x + 1)/4
+    assert F == (log(x + 1) - sqrt(2)*log(x**2 - sqrt(2)*x + 1)/8 +
+        sqrt(2)*log(x**2 + sqrt(2)*x + 1)/8 + sqrt(2)*atan(sqrt(2)*x - 1)/4 +
+        sqrt(2)*atan(sqrt(2)*x + 1)/4)
+    assert (F.diff(x) - f).cancel() == 0
+    # undecomposable denominator, reached directly through the Pow key
+    f = 1/(x**4 + 1)
+    F = manualintegrate(f, x)
+    assert not F.has(Integral)
+    assert (F.diff(x) - f).cancel() == 0
+    # apart normalizes but cannot split rational functions with Float
+    # coefficients; ratint still integrates them
+    F = manualintegrate(1/(x**4 + 1.5), x)
+    assert not F.has(Integral)
+    # rational in x with transcendental coefficients
+    f = 1/(x**4 + exp(y))
+    F = manualintegrate(f, x)
+    assert not F.has(Integral)
     assert (F.diff(x) - f).cancel() == 0
 
 


### PR DESCRIPTION
**Note:** This was an experiment to test the creation of stacked PRs.

#### References to other Issues or PRs

Stacked on top of #30144 — this PR contains that PR's commits plus one commit implementing the suggestions from [this review comment](https://github.com/sympy/sympy/pull/30144#issuecomment-5092952626). The base branch `ratint_step` is a mirror of Woodman04's PR head (cross-fork stacks are not supported by the Stacked PRs preview), so only the follow-up commit shows in the diff. If #30144 is updated or merged, this branch should be rebased/retargeted accordingly.

#### Brief description of what is fixed or changed

Hardens the `ratint` fallback introduced in #30144:

* `RatintRule.eval` now guards the `ratint` call against `PolynomialError`/`NotImplementedError`, falling back to an unevaluated `Integral` instead of propagating an exception out of `manualintegrate`. (`ratint` is called with the same `is_rational_function` precondition that `integrate` uses, so this is defensive.)
* Undecomposable rational functions are now detected with `substep.contains_dont_know()` instead of comparing the `apart()` output with the integrand. `apart` can normalize a rational function without actually splitting it (e.g. `apart(1/(x**4 + 1.5), x)` returns `0.667/(0.667*x**4 + 1.0)`), in which case the rewrite recursion dead-ended in the integral cache's loop guard and the fallback was never reached; `manualintegrate(1/(x**4 + 1.5), x)` now integrates instead of returning unevaluated.
* Restores the `debug()` call that the previous `rewriter()`-based rule emitted.
* Tests: the fallback is now also exercised directly through the `Pow` key (`1/(x**4 + 1)`), with `Float` coefficients, and with transcendental coefficients (`1/(x**4 + exp(y))`, which the rule now reaches because the condition was changed to `is_rational_function(symbol)`); the backslash continuation in the new test is replaced with parentheses.

#### Other comments

`sympy/integrals/tests/test_manual.py` and `sympy/integrals/tests/test_integrals.py` pass locally (234 passed).

#### AI Generation Disclosure

This PR was generated by Claude Code (Claude Fable 5), implementing the review suggestions it drafted for #30144 under my direction. All of the diff is AI-generated; I reviewed it before submitting.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
