### PR TITLE
#30159 Fix negative power normalization

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -179,7 +179,7 @@ jobs:
           python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n 2 --max-worker-restart=4 --timeout 60 -k "not test_W19" --durations=50 --durations-min=5
+      - run: pytest -n auto --durations=50 --durations-min=5
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -179,7 +179,7 @@ jobs:
           python-version: '3.14'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-dev.txt
-      - run: pytest -n auto --timeout 10 --durations=50 --durations-min=5
+      - run: pytest -n 2 --max-worker-restart=4 --timeout 60 -k "not test_W19" --durations=50 --durations-min=5
 
   # -------------------- Optional dependency tests ----------------- #
 

--- a/.mailmap
+++ b/.mailmap
@@ -1249,7 +1249,7 @@ Pablo Galindo Salgado <pablogsal@gmail.com> pablogsal <pablogsal@gmail.com>
 Pablo Puente <ppuedom@gmail.com> <ppuedom@yahoo.com>
 Pablo Zubieta <pabloferz@yahoo.com.mx>
 Padam Rathi <rathipadamr5@gmail.com>
-Palak Khinvasara <palakkhinvasara9@gmail.com>  palak <palakkhinvasara9@gmail.com>
+Palak Khinvasara <palakkhinvasara9@gmail.com>
 Pan Peng <pengpanster@gmail.com>
 Param Singh <paramsingh258@gmail.com>
 Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1865,6 +1865,7 @@ numbermaniac <5206120+numbermaniac@users.noreply.github.com>
 oittaa <8972248+oittaa@users.noreply.github.com>
 omahs <73983677+omahs@users.noreply.github.com>
 oxygen dioxide <54425948+oxygen-dioxide@users.noreply.github.com>
+palakkhinvasara <109575264+palakkhinvasara@users.noreply.github.com>
 pekochun <hamburg_hamburger2000@yahoo.co.jp>
 philwillnyc <56197213+philwillnyc@users.noreply.github.com>
 phipf <phipf@online.de>

--- a/.mailmap
+++ b/.mailmap
@@ -1249,6 +1249,7 @@ Pablo Galindo Salgado <pablogsal@gmail.com> pablogsal <pablogsal@gmail.com>
 Pablo Puente <ppuedom@gmail.com> <ppuedom@yahoo.com>
 Pablo Zubieta <pabloferz@yahoo.com.mx>
 Padam Rathi <rathipadamr5@gmail.com>
+Palak Khinvasara <palakkhinvasara9@gmail.com>  palak <palakkhinvasara9@gmail.com>
 Pan Peng <pengpanster@gmail.com>
 Param Singh <paramsingh258@gmail.com>
 Paramjit Singh <paramjit1071@gmail.com> <91942072+parmishh@users.noreply.github.com>

--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -627,7 +627,7 @@ class FracElement(DomainElement, DefaultPrinting, CantSympify, Generic[Er]):
         elif not f:
             raise ZeroDivisionError
         else:
-            return f.raw_new(f.denom**-n, f.numer**-n)
+            return f.new(f.denom**-n, f.numer**-n)
 
     def diff(f, x):
         """Computes partial derivative in ``x``.

--- a/sympy/polys/tests/test_fields.py
+++ b/sympy/polys/tests/test_fields.py
@@ -352,3 +352,7 @@ def test_FracField_index():
     raises(ValueError, lambda: F.index(1))
     raises(ValueError, lambda: F.index(a))
     pass
+
+def test_negative_power_normalization():
+    F, x = field("x", QQ)
+    assert (-x)**-1 == -1/x


### PR DESCRIPTION
#### References to other Issues or PRs

In a fractional function field over Q, negative powers seemingly bypass normalization
#30159 

#### Brief description of what is fixed or changed

Fixed normalization of negative powers for elements of rational function fields.

Previously, expressions such as `(-x)**-1` could produce an unnormalized fraction representation that was not equal to the mathematically equivalent expression `-1/x`.

This change ensures that negative powers use the normal constructor path so that numerator and denominator are cancelled and normalized before creating the resulting `FracElement`.

Added a regression test to verify that negative powers with negative numerators are normalized correctly.


#### Other comments

The positive power behavior remains unchanged. The fix targets the negative exponent branch where swapping numerator and denominator could leave a negative denominator and bypass normalization.


#### AI Generation Disclosure

NO AI USE


#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* polys
  * Fixed normalization of negative powers in rational function fields.

<!-- END RELEASE NOTES -->