### PR TITLE
Fix Quaternion.exp() producing NaN for purely real quaternions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -578,6 +578,7 @@ Denis Rykov <rykovd@gmail.com>
 Dennis Meckel <meckel@datenschuppen.de>
 Dennis Sweeney <sweeney.427@osu.edu> sweeneyde <sweeney.427@osu.edu>
 Denys Rybalka <rybalka.denis@gmail.com>
+Dev Kumar <devpatna2016@gmail.com>
 Devang Kulshreshtha <devang.kulshreshtha.cse14@itbhu.ac.in>
 Devansh <be19b002@smail.iitm.ac.in> prototypevito <96943731+prototypevito@users.noreply.github.com>
 Devesh Sawant <devesh47cool@gmail.com> dsaw <devesh47cool@gmail.com>

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -1012,6 +1012,11 @@ class Quaternion(Expr):
         q = self
         vector_norm = sqrt(q.b**2 + q.c**2 + q.d**2)
         a = exp(q.a) * cos(vector_norm)
+
+        # Handle purely real quaternions to avoid division by zero
+        if vector_norm.is_zero:
+            return Quaternion(a, 0, 0, 0)
+
         b = exp(q.a) * sin(vector_norm) * q.b / vector_norm
         c = exp(q.a) * sin(vector_norm) * q.c / vector_norm
         d = exp(q.a) * sin(vector_norm) * q.d / vector_norm

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -6,7 +6,7 @@ from sympy.core.numbers import (E, I, Rational, pi)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.functions.elementary.complexes import (Abs, conjugate, im, re, sign)
-from sympy.functions.elementary.exponential import log
+from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (acos, asin, cos, sin, atan2, atan)
 from sympy.integrals.integrals import integrate
@@ -457,3 +457,27 @@ def test_issue_28556():
     q3 = Quaternion(r, 0, 0, 0)
     result3 = q3.log()
     assert result3 == Quaternion(log(r), 0, 0, 0)
+
+
+def test_issue_21576():
+    """Test that Quaternion.exp handles purely real quaternions correctly.
+
+    Previously, Quaternion(a, 0, 0, 0).exp() produced NaN in the vector
+    part because the formula divides by the vector norm, which is zero
+    for purely real quaternions. See issue 21576.
+    """
+    # Test positive real quaternion
+    q1 = Quaternion(1, 0, 0, 0)
+    result1 = q1.exp()
+    assert result1 == Quaternion(E, 0, 0, 0)  # exp(1) = E
+
+    # Test the zero quaternion
+    q2 = Quaternion(0, 0, 0, 0)
+    result2 = q2.exp()
+    assert result2 == Quaternion(1, 0, 0, 0)  # exp(0) = 1
+
+    # Test symbolic real quaternion
+    r = Symbol('r', real=True)
+    q3 = Quaternion(r, 0, 0, 0)
+    result3 = q3.exp()
+    assert result3 == Quaternion(exp(r), 0, 0, 0)


### PR DESCRIPTION
## Summary
For a purely real quaternion (`b == c == d == 0`), `Quaternion.exp()` produces `nan` in the imaginary components instead of `0`. For example:
```python
>>> from sympy import Quaternion
>>> Quaternion(1, 0, 0, 0).exp()
E + nan*i + nan*j + nan*k   # should be E + 0*i + 0*j + 0*k
```
This happens because the formula divides by `vector_norm = sqrt(b**2 + c**2 + d**2)`, which is `0` for a purely real quaternion, giving `0/0 -> nan`.

This was reported in #21576, where the root cause and a fix direction (short-circuit before the division when the vector norm is zero) were discussed and confirmed by a maintainer. The discussion didn't converge on a merged fix at the time.

## Change
`Quaternion.log()` already guards against this exact situation:
```python
# Handle purely real quaternions to avoid division by zero
if vector_norm.is_zero:
    return Quaternion(a, 0, 0, 0)
```
This PR adds the identical guard to `Quaternion.exp()`, so both methods handle the purely-real case the same way, before doing the division that would otherwise produce `nan`.

## Testing
Added `test_issue_21576` in `sympy/algebras/tests/test_quaternion.py`, covering:
- `Quaternion(1, 0, 0, 0).exp() == Quaternion(E, 0, 0, 0)`
- `Quaternion(0, 0, 0, 0).exp() == Quaternion(1, 0, 0, 0)`
- a symbolic real quaternion `Quaternion(r, 0, 0, 0).exp() == Quaternion(exp(r), 0, 0, 0)`

The existing `test_quaternion_functions` assertions for `q1.exp()`/`q1.log()` (with `q1 = Quaternion(1, 2, 3, 4)`, a non-zero vector part) are unaffected, since the new branch only triggers when the vector norm is symbolically zero.

Closes #21576

#### Release notes

<!-- BEGIN RELEASE NOTES -->
* algebras
  * Fixed `Quaternion.exp()` returning `nan` for quaternions with a zero vector part.
<!-- END RELEASE NOTES -->
