### PR TITLE
fix(30158): Normalize fractions over exact fields

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1209,6 +1209,7 @@ Nikoleta Glynatsi <GlynatsiNE@cardiff.ac.uk> Nikoleta Glynatsi <glynatsine@cardi
 Nikos Karagiannakis <nikoskaragiannakis@gmail.com>
 Nilabja Bhattacharya <nilabja10201992@gmail.com>
 Nils Schulte <47043622+Schnilz@users.noreply.github.com>
+Nimish Telang <ntelang@gmail.com> Nimish Telang <nimish@telang.net>
 Nimish Telang <ntelang@gmail.com> Nimish Telang <nimish@users.noreply.github.com>
 Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
 Nirmal Sarswat <nirmalsarswat400@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1209,7 +1209,7 @@ Nikoleta Glynatsi <GlynatsiNE@cardiff.ac.uk> Nikoleta Glynatsi <glynatsine@cardi
 Nikos Karagiannakis <nikoskaragiannakis@gmail.com>
 Nilabja Bhattacharya <nilabja10201992@gmail.com>
 Nils Schulte <47043622+Schnilz@users.noreply.github.com>
-Nimish Telang <ntelang@gmail.com>
+Nimish Telang <ntelang@gmail.com> Nimish Telang <nimish@users.noreply.github.com>
 Nirasha Jayalath <64356062+jayalath-jknr@users.noreply.github.com>
 Nirmal Sarswat <nirmalsarswat400@gmail.com>
 Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -3244,10 +3244,14 @@ class PolyElement(
             p = p.mul_ground(cp)
             q = q.mul_ground(cq)
 
-        # Make canonical with respect to sign or quadrant in the case of ZZ_I
-        # or QQ_I. This ensures that the LC of the denominator is canonical by
-        # multiplying top and bottom by a unit of the ring.
-        u = q.canonical_unit()
+        # Make the denominator monic over exact fields without an associated
+        # ring. Otherwise make it canonical with respect to sign or quadrant
+        # in the case of ZZ_I or QQ_I.
+        if (q and domain.is_Exact and domain.is_Field
+                and not domain.has_assoc_Ring):
+            u = domain.quo(domain.one, q.LC)
+        else:
+            u = q.canonical_unit()
         if u == domain.one:
             pass
         elif u == -domain.one:

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2110,6 +2110,15 @@ def test_gcdex():
     raises(DomainError, lambda: invert(x + 1, 2*x + 1, auto=False))
 
 
+def test_invert_algebraic_fraction_field():
+    C = QQ.algebraic_field(sqrt(2))
+    K = C.frac_field(x)
+    f = Poly(sqrt(2)*t, t, domain=K)
+    g = Poly(t + 1, t, domain=K)
+
+    assert invert(f, g) == Poly(-sqrt(2)/2, t, domain=K)
+
+
 def test_revert():
     f = Poly(1 - x**2/2 + x**4/24 - x**6/720)
     g = Poly(61*x**6/720 + 5*x**4/24 + x**2/2 + 1)

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2119,6 +2119,12 @@ def test_invert_algebraic_fraction_field():
     assert invert(f, g) == Poly(-sqrt(2)/2, t, domain=K)
 
 
+def test_invert_finite_fraction_field():
+    K = FF(7).frac_field(x)
+
+    assert invert(2*t, t + 1, domain=K) == 3
+
+
 def test_revert():
     f = Poly(1 - x**2/2 + x**4/24 - x**6/720)
     g = Poly(61*x**6/720 + 5*x**4/24 + x**2/2 + 1)

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1555,6 +1555,12 @@ def test_PolyElement_cancel():
 
     assert f.cancel(g) == ((-x**2 - 4)*t, 4*t**2 + 2*x**2 + 4)
 
+    K = QQ.algebraic_field(sqrt(2))
+    sqrt2 = K.unit
+    R, x = ring("x", K)
+
+    assert (sqrt2*x).cancel(sqrt2*(x + 1)) == (x, x + 1)
+
     R, x, y = ring("x,y", ZZ_I)
     f = x + y + ZZ_I(0, 1) * y
     g = -ZZ_I(0, 1) * x ** 2 + x + y


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30158.

#### Brief description of what is fixed or changed

`Poly.invert()` would raise `NotInvertible` over fraction fields
whose ground domain is an exact field without an associated ring. This affected
both algebraic constants, such as `QQ<sqrt(2)>`, and finite fields, such as
`GF(7)`. This resulted from cases where, say, `sqrt(2)/sqrt(2)` wasn't properly reduced to `one`.

This change makes the denominator monic
when the coefficient domain is an exact field without an associated ring. Domains
that are inexact, are not fields, or have an associated ring are unchanged.

#### AI Generation Disclosure

Codex was used to investigate the issue and assist with drafting the code and
tests.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* polys
  * Fixed `Poly.invert()` incorrectly raising `NotInvertible` over fraction
    fields with exact-field constants.

<!-- END RELEASE NOTES -->
