### PR TITLE
Some FracField optimisations

### DIFF
--- a/sympy/polys/fields.py
+++ b/sympy/polys/fields.py
@@ -540,7 +540,18 @@ class FracElement(DomainElement, DefaultPrinting, CantSympify, Generic[Er]):
         if not f or not g:
             return field.zero
         elif field.is_element(g):
-            return f.new(f.numer*g.numer, f.denom*g.denom)
+            gcd1 = f.numer.gcd(g.denom)
+            gcd2 = f.denom.gcd(g.numer)
+            numer = (f.numer // gcd1) * (g.numer // gcd2)
+            denom = (f.denom // gcd2) * (g.denom // gcd1)
+
+            K = field.domain
+            unit = K.canonical_unit(denom.LC)
+            if not K.is_one(unit):
+                numer *= unit
+                denom *= unit
+
+            return f.raw_new(numer, denom)
         elif field.ring.is_element(g):
             return f.new(f.numer*g, f.denom)
         else:
@@ -579,7 +590,18 @@ class FracElement(DomainElement, DefaultPrinting, CantSympify, Generic[Er]):
         if not g:
             raise ZeroDivisionError
         elif field.is_element(g):
-            return f.new(f.numer*g.denom, f.denom*g.numer)
+            gcd_numer = f.numer.gcd(g.numer)
+            gcd_denom = f.denom.gcd(g.denom)
+            numer = (f.numer // gcd_numer) * (g.denom // gcd_denom)
+            denom = (f.denom // gcd_denom) * (g.numer // gcd_numer)
+
+            K = field.domain
+            unit = K.canonical_unit(denom.LC)
+            if not K.is_one(unit):
+                numer *= unit
+                denom *= unit
+
+            return f.raw_new(numer, denom)
         elif field.ring.is_element(g):
             return f.new(f.numer, f.denom*g)
         else:


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

None
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

A few optimisations in arithmetic with fraction fields.

#### Other comments

This is just something I had lying around in a local branch and I wanted to publish it so it doesn't get lost. This is not ready for merge and the individual changes would need further investigation.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
