### PR TITLE
fix: correct typos in source

### DIFF
--- a/sympy/multipledispatch/conflict.py
+++ b/sympy/multipledispatch/conflict.py
@@ -57,7 +57,7 @@ def edge(a, b, tie_breaker=hash):
 def ordering(signatures):
     """ A sane ordering of signatures to check, first to last
 
-    Topoological sort of edges as given by ``edge`` and ``supercedes``
+    Topological sort of edges as given by ``edge`` and ``supercedes``
     """
     signatures = list(map(tuple, signatures))
     edges = [(a, b) for a in signatures for b in signatures if edge(a, b)]

--- a/sympy/plotting/series.py
+++ b/sympy/plotting/series.py
@@ -599,7 +599,7 @@ class BaseSeries:
         * to set the number of discretization points along the x, y and z
           directions: ``s.n = [10, 15, 20]``
 
-        The following is highly unreccomended, because it prevents
+        The following is highly unrecommended, because it prevents
         the execution of necessary code in order to keep updated data:
         ``s.n[1] = 15``
         """


### PR DESCRIPTION
Fixes: unreccomended → unrecommended, Topoological → Topological