### PR TITLE
improve evaluation speed for Min and Max with many arguments

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -473,7 +473,7 @@ CJ Carey <perimosocordiae@gmail.com>
 Caley Finn <caleyreuben@gmail.com>
 Calvin Jay Ross <calvinjayross@gmail.com>
 Cameron King <v-caking@microsoft.com>
-Carl Kolon <carl@kolon.org> cckolon <83992614+cckolon@users.noreply.github.com>
+Carl Kolon <carl@kolon.org> <83992614+cckolon@users.noreply.github.com>
 Carl Sandrock <carl.sandrock@up.ac.za>
 Carlos Cordoba <ccordoba12@gmail.com>
 Carlos García Montoro <TrilceAC@gmail.com> Carlos García Montoro <cgarcia@ific.uv.es>

--- a/.mailmap
+++ b/.mailmap
@@ -473,7 +473,7 @@ CJ Carey <perimosocordiae@gmail.com>
 Caley Finn <caleyreuben@gmail.com>
 Calvin Jay Ross <calvinjayross@gmail.com>
 Cameron King <v-caking@microsoft.com>
-Carl Kolon <carl@kolon.org>
+Carl Kolon <carl@kolon.org> cckolon <83992614+cckolon@users.noreply.github.com>
 Carl Sandrock <carl.sandrock@up.ac.za>
 Carlos Cordoba <ccordoba12@gmail.com>
 Carlos García Montoro <TrilceAC@gmail.com> Carlos García Montoro <cgarcia@ific.uv.es>

--- a/.mailmap
+++ b/.mailmap
@@ -473,6 +473,7 @@ CJ Carey <perimosocordiae@gmail.com>
 Caley Finn <caleyreuben@gmail.com>
 Calvin Jay Ross <calvinjayross@gmail.com>
 Cameron King <v-caking@microsoft.com>
+Carl Kolon <carl@kolon.org>
 Carl Sandrock <carl.sandrock@up.ac.za>
 Carlos Cordoba <ccordoba12@gmail.com>
 Carlos García Montoro <TrilceAC@gmail.com> Carlos García Montoro <cgarcia@ific.uv.es>

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -572,8 +572,8 @@ class MinMaxBase(Expr, LatticeOp):
             else:
                 yield arg
 
-    @staticmethod
-    def _is_sign_constrained(x: Expr) -> bool:
+    @classmethod
+    def _is_sign_constrained(cls, x: Expr) -> bool:
         """
         check if x is guaranteed to be positive, negative, etc., which
         implies that we need to consider it when comparing to other,

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -598,45 +598,30 @@ class MinMaxBase(Expr, LatticeOp):
     def _split_values(cls, values: Iterable[Expr]) -> tuple[set[Expr], set[Expr], set[Expr]]:
         """
         Split an iterable of values into three sets:
-        - `extreme_numbers`: number values that are more extreme than all
-          other values (greater for Max, less for Min). There may be more
-          than one because not all numerical values can be compared
-          directly (e.g. `sin(1)**2 + cos(1)**2 > 1` does not resolve).
+        - `numbers`: number values that can be compared easily.
         - `unconstrained_symbols`: bare symbols that are not
           sign-constrained. We don't need to pairwise compare these.
-        - `rest`: all other values
+        - `rest`: all other values.
         """
-        extreme_numbers: set[Expr] = set()
+        numbers: set[Expr] = set()
         unconstrained_symbols: set[Expr] = set()
         rest: set[Expr] = set()
         for value in values:
             if value.is_number:
-                if value in extreme_numbers:
-                    continue
-                is_new_extreme = True
-                for extreme_number in list(extreme_numbers):
-                    comparison = cls._is_more_extreme(value, extreme_number)
-                    if comparison == False:
-                        is_new_extreme = False
-                        break
-                    elif comparison == True:
-                        extreme_numbers.remove(extreme_number)
-                    # undecidable: keep both
-                if is_new_extreme:
-                    extreme_numbers.add(value)
+                numbers.add(value)
             elif isinstance(value, Symbol) and not cls._is_sign_constrained(value):
                 unconstrained_symbols.add(value)
             else:
                 rest.add(value)
-        return extreme_numbers, unconstrained_symbols, rest
+        return numbers, unconstrained_symbols, rest
 
     @classmethod
     def _find_localzeros(cls, values: Iterable[Expr]) -> set[Expr]:
-        extreme_numbers, unconstrained_symbols, rest = cls._split_values(values)
-        if extreme_numbers:
-            rest.update(extreme_numbers)
+        numbers, unconstrained_symbols, rest = cls._split_values(values)
         localzeros: set[Expr] = set()
-        for value in rest:
+        # compare numbers first because they can be eliminated faster
+        to_compare = list(numbers) + list(rest)
+        for value in to_compare:
             is_new_zero = True
             if value in localzeros:
                 continue

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -670,7 +670,8 @@ class MinMaxBase(Expr, LatticeOp):
         for i in range(2):
             if x == y:
                 return True
-            t, f = Max, Min
+            t: type[Max] | type[Min] = Max
+            f: type[Max] | type[Min] = Min
             for op in "><":
                 for j in range(2):
                     try:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -579,12 +579,12 @@ class MinMaxBase(Expr, LatticeOp):
         implies that we need to consider it when comparing to other,
         unrelated expressions.
         """
-        return any(getattr(x, attr) is not None for attr in (
-            'is_positive', 'is_negative',
-            'is_nonnegative', 'is_nonpositive',
-            'is_extended_positive', 'is_extended_negative',
-            'is_extended_nonnegative', 'is_extended_nonpositive',
-        ))
+        return bool(
+            x.is_extended_positive or
+            x.is_extended_negative or
+            x.is_extended_nonnegative or
+            x.is_extended_nonpositive
+        )
 
     @classmethod
     def _is_more_extreme(cls, x: Expr, y: Expr) -> Boolean:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 from sympy.core import S, sympify, NumberKind
 from sympy.utilities.iterables import sift
 from sympy.core.add import Add
@@ -15,12 +16,15 @@ from sympy.core.power import Pow
 from sympy.core.relational import Eq, Relational
 from sympy.core.singleton import Singleton
 from sympy.core.sorting import ordered
-from sympy.core.symbol import Dummy
+from sympy.core.symbol import Dummy, Symbol
 from sympy.core.rules import Transform
 from sympy.core.logic import fuzzy_and, fuzzy_or, _torf
 from sympy.core.traversal import walk
 from sympy.core.numbers import Integer
-from sympy.logic.boolalg import And, Or
+from sympy.logic.boolalg import And, Or, Boolean
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def _minmax_as_Piecewise(op, *args):
@@ -568,35 +572,98 @@ class MinMaxBase(Expr, LatticeOp):
             else:
                 yield arg
 
-    @classmethod
-    def _find_localzeros(cls, values, **options):
+    @staticmethod
+    def _is_sign_constrained(x: Expr) -> bool:
         """
-        Sequentially allocate values to localzeros.
-
-        When a value is identified as being more extreme than another member it
-        replaces that member; if this is never true, then the value is simply
-        appended to the localzeros.
+        check if x is guaranteed to be positive, negative, etc., which
+        implies that we need to consider it when comparing to other,
+        unrelated expressions.
         """
-        localzeros = set()
-        for v in values:
-            is_newzero = True
-            localzeros_ = list(localzeros)
-            for z in localzeros_:
-                if id(v) == id(z):
-                    is_newzero = False
-                else:
-                    con = cls._is_connected(v, z)
-                    if con:
-                        is_newzero = False
-                        if con is True or con == cls:
-                            localzeros.remove(z)
-                            localzeros.update([v])
-            if is_newzero:
-                localzeros.update([v])
-        return localzeros
+        return any(getattr(x, attr) is not None for attr in (
+            'is_positive', 'is_negative',
+            'is_nonnegative', 'is_nonpositive',
+            'is_extended_positive', 'is_extended_negative',
+            'is_extended_nonnegative', 'is_extended_nonpositive',
+        ))
 
     @classmethod
-    def _is_connected(cls, x, y):
+    def _is_more_extreme(cls, x: Expr, y: Expr) -> Boolean:
+        if cls == Min:
+            return x < y
+        if cls == Max:
+            return x > y
+        raise NotImplementedError(f"Unknown operation: {cls}")
+
+    @classmethod
+    def _split_values(cls, values: Iterable[Expr]) -> tuple[set[Expr], set[Expr], set[Expr]]:
+        """
+        Split an iterable of values into three sets:
+        - `extreme_numbers`: number values that are more extreme than all
+          other values (greater for Max, less for Min). There may be more
+          than one because not all numerical values can be compared
+          directly (e.g. `sin(1)**2 + cos(1)**2 > 1` does not resolve).
+        - `unconstrained_symbols`: bare symbols that are not
+          sign-constrained. We don't need to pairwise compare these.
+        - `rest`: all other values
+        """
+        extreme_numbers: set[Expr] = set()
+        unconstrained_symbols: set[Expr] = set()
+        rest: set[Expr] = set()
+        for value in values:
+            if value.is_number:
+                if value in extreme_numbers:
+                    continue
+                is_new_extreme = True
+                for extreme_number in list(extreme_numbers):
+                    comparison = cls._is_more_extreme(value, extreme_number)
+                    if comparison == False:
+                        is_new_extreme = False
+                        break
+                    elif comparison == True:
+                        extreme_numbers.remove(extreme_number)
+                    # undecidable: keep both
+                if is_new_extreme:
+                    extreme_numbers.add(value)
+            elif isinstance(value, Symbol) and not cls._is_sign_constrained(value):
+                unconstrained_symbols.add(value)
+            else:
+                rest.add(value)
+        return extreme_numbers, unconstrained_symbols, rest
+
+    @classmethod
+    def _find_localzeros(cls, values: Iterable[Expr]) -> set[Expr]:
+        extreme_numbers, unconstrained_symbols, rest = cls._split_values(values)
+        if extreme_numbers:
+            rest.update(extreme_numbers)
+        localzeros: set[Expr] = set()
+        for value in rest:
+            is_new_zero = True
+            if value in localzeros:
+                continue
+            for zero in list(localzeros):
+                if con := cls._is_connected(value, zero):
+                    is_new_zero = False
+                    if con is True or con == cls:
+                        localzeros.remove(zero)
+                        localzeros.add(value)
+            if is_new_zero:
+                localzeros.add(value)
+        unconstrained_symbol_zeros: set[Expr] = set()
+        for symbol in unconstrained_symbols:
+            is_new_zero = True
+            for zero in list(localzeros):
+                if con := cls._is_connected(symbol, zero):
+                    is_new_zero = False
+                    if con is True or con == cls:
+                        localzeros.remove(zero)
+                        unconstrained_symbol_zeros.add(symbol)
+            if is_new_zero:
+                unconstrained_symbol_zeros.add(symbol)
+        return localzeros | unconstrained_symbol_zeros
+
+
+    @classmethod
+    def _is_connected(cls, x: Expr, y: Expr) -> bool | type[Min] | type[Max]:
         """
         Check if x and y are connected somehow.
         """

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -21,7 +21,7 @@ from sympy.core.rules import Transform
 from sympy.core.logic import fuzzy_and, fuzzy_or, _torf
 from sympy.core.traversal import walk
 from sympy.core.numbers import Integer
-from sympy.logic.boolalg import And, Or, Boolean
+from sympy.logic.boolalg import And, Or
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -587,14 +587,6 @@ class MinMaxBase(Expr, LatticeOp):
         )
 
     @classmethod
-    def _is_more_extreme(cls, x: Expr, y: Expr) -> Boolean:
-        if cls == Min:
-            return x < y
-        if cls == Max:
-            return x > y
-        raise NotImplementedError(f"Unknown operation: {cls}")
-
-    @classmethod
     def _split_values(cls, values: Iterable[Expr]) -> tuple[set[Expr], set[Expr], set[Expr]]:
         """
         Split an iterable of values into three sets:

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -598,29 +598,29 @@ class MinMaxBase(Expr, LatticeOp):
     def _split_values(cls, values: Iterable[Expr]) -> tuple[set[Expr], set[Expr], set[Expr]]:
         """
         Split an iterable of values into three sets:
-        - `numbers`: number values that can be compared easily.
+        - `comparables`: values that can be compared easily.
         - `unconstrained_symbols`: bare symbols that are not
           sign-constrained. We don't need to pairwise compare these.
         - `rest`: all other values.
         """
-        numbers: set[Expr] = set()
+        comparables: set[Expr] = set()
         unconstrained_symbols: set[Expr] = set()
         rest: set[Expr] = set()
         for value in values:
-            if value.is_number:
-                numbers.add(value)
+            if value.is_comparable:
+                comparables.add(value)
             elif isinstance(value, Symbol) and not cls._is_sign_constrained(value):
                 unconstrained_symbols.add(value)
             else:
                 rest.add(value)
-        return numbers, unconstrained_symbols, rest
+        return comparables, unconstrained_symbols, rest
 
     @classmethod
     def _find_localzeros(cls, values: Iterable[Expr]) -> set[Expr]:
-        numbers, unconstrained_symbols, rest = cls._split_values(values)
+        comparables, unconstrained_symbols, rest = cls._split_values(values)
         localzeros: set[Expr] = set()
-        # compare numbers first because they can be eliminated faster
-        to_compare = list(numbers) + list(rest)
+        # compare comparables first because they can be eliminated faster
+        to_compare = list(comparables) + list(rest)
         for value in to_compare:
             is_new_zero = True
             if value in localzeros:

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -20,6 +20,8 @@ from sympy.testing.pytest import raises, skip, ignore_warnings
 
 def test_Min():
     from sympy.abc import x, y, z
+    from sympy.functions.elementary.complexes import Abs, re
+    from sympy.functions.elementary.exponential import exp
     n = Symbol('n', negative=True)
     n_ = Symbol('n_', negative=True)
     nn = Symbol('nn', nonnegative=True)
@@ -71,6 +73,11 @@ def test_Min():
     assert Min(p, 0) == 0
     assert Min(0, oo) == 0
     assert Min(oo, 0) == 0
+    assert Min(-2, p) == -2
+    assert Min(-2, nn) == -2
+    assert Min(-2, p, nn, p_) == -2
+    assert unchanged(Min, 3, p)
+    assert unchanged(Min, 3, nn)
     assert Min(nn, nn) == nn
     assert unchanged(Min, nn, p)
     assert Min(p, nn) == Min(nn, p)
@@ -89,6 +96,10 @@ def test_Min():
     # lists
     assert Min() is S.Infinity
     assert Min(x) == x
+    assert Min(x, x) == x
+    assert Min(x, (x+x)/2) == x
+    assert Min(x, x-2) == x-2
+    assert Min(x, x+2) == x
     assert Min(x, y) == Min(y, x)
     assert Min(x, y, z) == Min(z, y, x)
     assert Min(x, Min(y, z)) == Min(z, y, x)
@@ -142,6 +153,33 @@ def test_Min():
     assert m.is_nonnegative is None
     assert m.is_negative is None
 
+    # unrelated complex symbols where simplification is possible
+    assert Min(Abs(x)**2, -Abs(y)**2 - 1) == -Abs(y)**2 - 1
+    assert Min(Abs(x), -Abs(y) - 1) == -Abs(y) - 1
+    assert Min(Abs(x), -2) == -2
+    assert Min(Abs(x), 0) == 0
+    assert Min(exp(re(x)), -Abs(y)) == -Abs(y)
+    assert Min(re(x)**2, -Abs(y)**2 - 1) == -Abs(y)**2 - 1
+
+    # same idea with real symbols (x**2 is nonnegative without Abs)
+    xr = Symbol('xr', real=True)
+    yr = Symbol('yr', real=True)
+    assert Min(xr**2, -yr**2 - 1) == -yr**2 - 1
+    assert Min(xr**2, -2) == -2
+    assert Min(xr**2, 0) == 0
+    assert Min(exp(xr), -yr**2 - 1) == -yr**2 - 1
+    assert Min(-xr**2 - 1, yr**2) == -xr**2 - 1
+    assert unchanged(Min, xr, yr)
+
+    s = sin(1)**2 + cos(1)**2
+    # s > 1 does not resolve, so result should stay unevaluated
+    assert Min(1, s) == Min(1, s, evaluate=False)
+    assert Min(2, 1, s) == Min(1, s, evaluate=False)
+
+    # extended_positive infinite vs unconstrained real finite
+    M = Symbol('M', extended_positive=True, infinite=True)
+    assert Min(xr, M) == xr
+
 
 def test_Max():
     from sympy.abc import x, y, z
@@ -158,12 +196,23 @@ def test_Max():
 
     assert Max() is S.NegativeInfinity
     assert Max(x) == x
+    assert Max(x, x) == x
+    assert Max(x, (x+x)/2) == x
+    assert Max(x, x-2) == x
+    assert Max(x, x+2) == x+2
+
     assert Max(x, y) == Max(y, x)
     assert Max(x, y, z) == Max(z, y, x)
     assert Max(x, Max(y, z)) == Max(z, y, x)
     assert Max(x, Min(y, oo)) == Max(x, y)
     assert Max(n, -oo, n_, p, 2) == Max(p, 2)
     assert Max(n, -oo, n_, p) == p
+    # bare positive / nonnegative symbols vs numbers
+    assert Max(-5, p) == p
+    assert Max(-1, nn) == nn
+    assert Max(-5, p, nn, p_) == Max(p, nn, p_)
+    assert unchanged(Max, 2, p)
+    assert unchanged(Max, 2, nn)
     assert Max(2, x, p, n, -oo, S.NegativeInfinity, n_, p, 2) == Max(2, x, p)
     assert Max(0, x, 1, y) == Max(1, x, y)
     assert Max(r, r + 1, r - 1) == 1 + r
@@ -208,6 +257,20 @@ def test_Max():
     assert m.is_nonnegative is True
     assert m.is_negative is False
 
+    s = sin(1)**2 + cos(1)**2
+    assert Max(1, s) == Max(1, s, evaluate=False)
+    assert Max(0, 1, s) == Max(1, s, evaluate=False)
+
+    M = Symbol('M', extended_positive=True, infinite=True)
+    assert Max(r, M) == M
+
+def test_composed_min_max():
+    x = Symbol('x', real=True)
+    y = Symbol('y', real=True)
+    assert Min(x, Max(x, y)) == x
+    assert Max(x, Min(x, y)) == x
+    assert Min(1, Max(x,1)) == 1
+    assert Max(1, Min(x,1)) == 1
 
 def test_minmax_assumptions():
     r = Symbol('r', real=True)

--- a/sympy/functions/elementary/tests/test_miscellaneous.py
+++ b/sympy/functions/elementary/tests/test_miscellaneous.py
@@ -8,7 +8,8 @@ from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.external import import_module
-from sympy.functions.elementary.exponential import log
+from sympy.functions.elementary.complexes import Abs, re
+from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.miscellaneous import (sqrt, cbrt, root, Min,
                                                       Max, real_root, Rem)
@@ -20,8 +21,6 @@ from sympy.testing.pytest import raises, skip, ignore_warnings
 
 def test_Min():
     from sympy.abc import x, y, z
-    from sympy.functions.elementary.complexes import Abs, re
-    from sympy.functions.elementary.exponential import exp
     n = Symbol('n', negative=True)
     n_ = Symbol('n_', negative=True)
     nn = Symbol('nn', nonnegative=True)
@@ -339,6 +338,15 @@ def test_minmax_assumptions():
             else:
                 assert ext(x, y).is_prime is None
 
+def test_minmax_infinite_symbols():
+    r = Symbol('r', real=True)
+    w = Symbol('w', extended_real=True, infinite=True)
+
+    assert w.is_extended_positive is None
+    assert w.is_extended_negative is None
+    # w might be positive or negative infinity
+    assert Min(r, w) == Min(r, w, evaluate=False)
+    assert Max(r, w) == Max(r, w, evaluate=False)
 
 def test_issue_8413():
     x = Symbol('x', real=True)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #16249 

#### Brief description of what is fixed or changed

Min and Max are currently slow when called with many arguments, mostly because they require pairwise comparisons of all arguments. This PR improves speed by first splitting the arguments into constants, unconstrained symbols, and other values. This allows a fair bit of simplification before the full pairwise comparison, especially when many of the arguments are constants or unconstrained symbols.

I ran the following code on my Macbook before and after the change:
```python
import time

from sympy import symbols, Min

start_time = time.time()
Min(*symbols(names='x:100'))
end_time = time.time()
print(f"Time taken: {end_time - start_time} seconds")
```
before: Time taken: 1.0753211975097656 seconds
after: Time taken: 0.0012416839599609375 seconds

I also added a number of test assertions for Max/Min behavior I was concerned about, and added type annotations to the relevant files to make editing easier in my IDE.

#### Other comments

This is my first PR to sympy! I've been a fan for years. I've tried to follow the guidance here and on the site but please tell me if I've done anything wrong and I'll correct it.

#### AI Generation Disclosure

The code and docstrings are human-written (as is this PR description). I used Claude 5 Opus and Grok 4.5 in Cursor to review my changes and suggest test cases.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Sped up Max/Min by pruning the number of pairwise comparisons between arguments
<!-- END RELEASE NOTES -->
