### PR TITLE
tensor: replace_with_arrays: fix handling of transposed tensors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -961,7 +961,9 @@ Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
 Kirtan Mali <kirtanmali555@gmail.com> KIRTAN  MALI <43683545+kmm555@users.noreply.github.com>
 Kirtan Mali <kirtanmali555@gmail.com> kmm555 <kirtanmali555@gmail.com>
-Kishore Gopalakrishnan <kishore96@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com> G. Kishore <kishore96@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com> Kishore G <kishore96@gmail.com>
+Kishore Gopalakrishnan <kishore96@gmail.com> Kishore G. <kishore96.work@gmail.com>
 Kiyohito Yamazaki <kyamaz@openql.org>
 Klaus Rettinghaus <klaus.rettinghaus@enote.com>
 Konrad Meyer <konrad.meyer@gmail.com>

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2291,6 +2291,9 @@ class TensExpr(Expr, ABC):
         free_ind2_igv = [i if i.is_up else -i for i in free_ind2]
 
         if free_ind1:
+            if set(free_ind2_igv) != set(free_ind1_igv):
+                raise ValueError(f"incompatible indices: {free_ind2} and {free_ind1}")
+
             permutation = TensExpr._get_indices_permutation(free_ind2_igv, free_ind1_igv)
             array = permutedims(array, permutation)
             inds = [free_ind2[i] for i in permutation]

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2223,6 +2223,9 @@ class TensExpr(Expr, ABC):
 
     @staticmethod
     def _match_indices_with_other_tensor(array, free_ind1, free_ind2, replacement_dict):
+        """
+        Given an array whose axes correspond to the indices given in free_ind2, change the order of the axes to correspond to the indices in free_ind1 (raising/lowering indices if required)
+        """
         from .array import permutedims
 
         index_types1 = [i.tensor_index_type for i in free_ind1]

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2230,7 +2230,7 @@ class TensExpr(Expr, ABC):
 
         index_types1 = [i.tensor_index_type for i in free_ind1]
 
-        # Check if variance of indices needs to be fixed:
+        # Check if indices need to be raised or lowered:
         pos2up = []
         pos2down = []
         free2remaining = free_ind2[:]

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2238,8 +2238,7 @@ class TensExpr(Expr, ABC):
             if index1 in free2remaining:
                 pos2 = free2remaining.index(index1)
                 free2remaining[pos2] = None
-                continue
-            if -index1 in free2remaining:
+            elif -index1 in free2remaining:
                 pos2 = free2remaining.index(-index1)
                 free2remaining[pos2] = None
                 free_ind2[pos2] = index1

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2281,68 +2281,33 @@ class TensExpr(Expr, ABC):
         return inds, array
 
     @staticmethod
-    def _match_indices_with_other_tensor(array, free_ind1, free_ind2, replacement_dict):
+    def _match_indices_permutation(array, free_ind1, free_ind2):
         """
-        Given an array whose axes correspond to the indices given in free_ind2, change the order of the axes to correspond to the indices in free_ind1 (raising/lowering indices if required)
+        Given an array whose axes correspond to the indices given in free_ind2, change the order of the axes to correspond to the indices in free_ind1 (ignoring co/contra-variance)
         """
         from .array import permutedims
 
-        index_types1 = [i.tensor_index_type for i in free_ind1]
-
-        # Check if indices need to be raised or lowered:
-        pos2up = []
-        pos2down = []
-        free2remaining = free_ind2[:]
-        for pos1, index1 in enumerate(free_ind1):
-            if index1 in free2remaining:
-                pos2 = free2remaining.index(index1)
-                free2remaining[pos2] = None
-            elif -index1 in free2remaining:
-                pos2 = free2remaining.index(-index1)
-                free2remaining[pos2] = None
-                free_ind2[pos2] = index1
-                if index1.is_up:
-                    pos2up.append(pos2)
-                else:
-                    pos2down.append(pos2)
-            else:
-                index2 = free2remaining[pos1]
-                if index2 is None:
-                    raise ValueError(f"incompatible indices: {free_ind1} and {free_ind2}")
-                free2remaining[pos1] = None
-                free_ind2[pos1] = index1
-                if index1.is_up ^ index2.is_up:
-                    if index1.is_up:
-                        pos2up.append(pos1)
-                    else:
-                        pos2down.append(pos1)
-
-        if len(set(free_ind1) & set(free_ind2)) < len(free_ind1):
-            raise ValueError(f"incompatible indices: {free_ind1} and {free_ind2}")
-        # Raise indices:
-        for pos in pos2up:
-            index_type_pos = index_types1[pos]
-            if index_type_pos not in replacement_dict:
-                raise ValueError("No metric provided to lower index")
-            metric = replacement_dict[index_type_pos]
-            metric_inverse = _TensorDataLazyEvaluator.inverse_matrix(metric)
-            array = TensExpr._contract_and_permute_with_metric(metric_inverse, array, pos, len(free_ind1))
-        # Lower indices:
-        for pos in pos2down:
-            index_type_pos = index_types1[pos]
-            if index_type_pos not in replacement_dict:
-                raise ValueError("No metric provided to lower index")
-            metric = replacement_dict[index_type_pos]
-            array = TensExpr._contract_and_permute_with_metric(metric, array, pos, len(free_ind1))
+        free_ind1_igv = [i if i.is_up else -i for i in free_ind1]
+        free_ind2_igv = [i if i.is_up else -i for i in free_ind2]
 
         if free_ind1:
-            permutation = TensExpr._get_indices_permutation(free_ind2, free_ind1)
+            permutation = TensExpr._get_indices_permutation(free_ind2_igv, free_ind1_igv)
             array = permutedims(array, permutation)
+            inds = [free_ind2[i] for i in permutation]
+        else:
+            inds = free_ind2
 
         if hasattr(array, "ndim") and array.ndim == 0:
             array = array[()]
 
-        return free_ind2, array
+        return inds, array
+
+    def _match_indices_with_other_tensor(self, array, free_ind1, free_ind2, replacement_dict):
+        """
+        Given an array whose axes correspond to the indices given in free_ind2, change the order of the axes to correspond to the indices in free_ind1 (raising/lowering indices if required)
+        """
+        permuted_indices, array = self._match_indices_permutation(array, free_ind1, free_ind2)
+        return self._match_indices_variance(array, free_ind1, permuted_indices, replacement_dict)
 
     def replace_with_arrays(self, replacement_dict, indices=None):
         """

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2222,6 +2222,65 @@ class TensExpr(Expr, ABC):
         return permutedims(array, permu)
 
     @staticmethod
+    def _match_indices_variance(array, free_ind1, free_ind2, replacement_dict):
+        """
+        Given an array whose axes correspond to the indices given in free_ind2,
+        raise/lower indices to match the co/contra-variance of the indices in
+        free_ind1. Unlike _match_indices_with_other_tensor, this does not attempt
+        to match the index labels.
+        """
+        index_types1 = [i.tensor_index_type for i in free_ind1]
+
+        if len(free_ind1) > 0:
+            if len(free_ind1) != len(free_ind2):
+                raise ValueError(f"incompatible indices: {free_ind1} and {free_ind2}")
+
+        try:
+            ndim = array.ndim
+        except AttributeError:
+            ndim = 0
+
+        if len(free_ind2) != ndim:
+            raise ValueError(f"indices ({free_ind2}) do not match dimensionality of the given array ({ndim})")
+
+        # Check if indices need to be raised or lowered:
+        pos2up = []
+        pos2down = []
+        for pos, index1, index2 in zip(range(len(free_ind2)), free_ind1, free_ind2):
+            if index1.is_up ^ index2.is_up:
+                if index1.is_up:
+                    pos2up.append(pos)
+                else:
+                    pos2down.append(pos)
+
+        # Raise indices:
+        for pos in pos2up:
+            index_type_pos = index_types1[pos]
+            if index_type_pos not in replacement_dict:
+                raise ValueError("No metric provided to lower index")
+            metric = replacement_dict[index_type_pos]
+            metric_inverse = _TensorDataLazyEvaluator.inverse_matrix(metric)
+            array = TensExpr._contract_and_permute_with_metric(metric_inverse, array, pos, len(free_ind1))
+
+        # Lower indices:
+        for pos in pos2down:
+            index_type_pos = index_types1[pos]
+            if index_type_pos not in replacement_dict:
+                raise ValueError("No metric provided to lower index")
+            metric = replacement_dict[index_type_pos]
+            array = TensExpr._contract_and_permute_with_metric(metric, array, pos, len(free_ind1))
+
+        if free_ind1:
+            inds = free_ind1
+        else:
+            inds = free_ind2
+
+        if hasattr(array, "ndim") and array.ndim == 0:
+            array = array[()]
+
+        return inds, array
+
+    @staticmethod
     def _match_indices_with_other_tensor(array, free_ind1, free_ind2, replacement_dict):
         """
         Given an array whose axes correspond to the indices given in free_ind2, change the order of the axes to correspond to the indices in free_ind1 (raising/lowering indices if required)
@@ -3267,7 +3326,7 @@ class Tensor(TensExpr):
         free_ind1 = self.get_free_indices()
         free_ind2 = other.get_free_indices()
 
-        return self._match_indices_with_other_tensor(array, free_ind1, free_ind2, replacement_dict)
+        return self._match_indices_variance(array, free_ind1, free_ind2, replacement_dict)
 
     @property
     def data(self):

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -3247,6 +3247,8 @@ class Tensor(TensExpr):
                     raise NotImplementedError(f"{other} with contractions is not implemented")
             # Remove elements in `dum2` from `dum1`:
             dum1 = [pair for pair in dum1 if pair not in dum2]
+
+        #For each pair of dummy indices in self, contract the corresponding (i.e. same position) indices in other.
         if len(dum1) > 0:
             indices1 = self.get_indices()
             indices2 = other.get_indices()

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -2350,6 +2350,13 @@ class TensExpr(Expr, ABC):
         >>> expr.replace_with_arrays({A(i): [1, 2]})
         [[1, 2], [2, 4]]
 
+        Note that the labels used for the indices of the keys of
+        ``replacement_dict`` are not significant; only the position of the index
+        and its co/contra-variance are considered while making the replacement.
+
+        >>> A(i).replace_with_arrays({A(j): [1, 2]})
+        [1, 2]
+
         For contractions, specify the metric of the ``TensorIndexType``, which
         in this case is ``L``, in its covariant form:
 

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1989,6 +1989,7 @@ def test_tensor_replacement():
     i, j, k, l = tensor_indices("i j k l", L)
     A, B, C, D = tensor_heads("A B C D", [L])
     H = TensorHead("H", [L, L])
+    J = TensorHead("J", [L, L])
     K = TensorHead("K", [L]*4)
 
     expr = H(i, j)
@@ -2022,10 +2023,19 @@ def test_tensor_replacement():
     assert expr.replace_with_arrays(repl, [-j, i]) == Array([[1, 3], [-2, -4]])
     assert expr.replace_with_arrays(repl, [-j, -i]) == Array([[1, -3], [-2, 4]])
 
+    # Transpose
+    expr = H(j,i)
+    repl = {H(i,j): [[1,2],[3,4]]}
+    assert expr.replace_with_arrays(repl, [i,j]) == Array([[1,3],[2,4]])
+
     # Not the same indices:
     expr = H(i,k)
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
     assert expr._extract_data(repl) == ([i, k], Array([[1, 2], [3, 4]]))
+
+    expr = H(j, k)
+    repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl, [j,k]) == Array([[1,2],[3,4]])
 
     expr = A(i)*A(-i)
     repl = {A(i): [1,2], L: diag(1, -1)}
@@ -2039,10 +2049,6 @@ def test_tensor_replacement():
     expr = K(i, j, k, -l)
     repl = {K(i,j,k,l): Array([ (i+1) for i in range(2**4)]).reshape(2,2,2,2), L: diag(1, -1)}
     assert expr.replace_with_arrays(repl) == Array([(i+1)*(-1)**i for i in range(2**4)]).reshape(2,2,2,2)
-
-    expr = H(j, k)
-    repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
-    raises(ValueError, lambda: expr._extract_data(repl))
 
     expr = A(i)
     repl = {B(i): [1, 2]}
@@ -2091,6 +2097,18 @@ def test_tensor_replacement():
         L: Array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]]),
     }
     assert expr._extract_data(repl) == ([], 4)
+
+    # Transposed replacement array
+    repl = {
+        H(i, j): [[1, 2], [3, 4]],
+        J(i, j): [[1, 3], [2, 4]], #transpose of above
+        L: diag(1,1),
+        }
+    expr_1 = H(i,k)*H(-k,j)
+    expr_2 = H(i,k)*J(j,-k)
+    arr_1 = expr_1.replace_with_arrays(repl)
+    assert arr_1 == Array([[7,10],[15,22]])
+    assert expr_2.replace_with_arrays(repl) == arr_1
 
     # Replace with array, raise exception if indices are not compatible:
     expr = A(i)*A(j)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2159,6 +2159,10 @@ def test_tensmul_replacement():
     repl = {A(i): [1, 2], K(i,j,k,l): Array([1]*2**4).reshape(2,2,2,2), L: diag(1, -1)}
     assert expr._extract_data(repl) == ([], 0)
 
+    # bug 28949
+    expr = I(l, -m, -k) * I(k, -i, -j)
+    repl = {I(i, -k, -l): Array.zeros(2,2,2), L: diag(1, 1)}
+    assert expr._extract_data(repl) == ([l, -m, -i, -j], Array.zeros(2,2,2,2))
 
 def test_tensadd_replacement():
     L = TensorIndexType("L")
@@ -2188,7 +2192,6 @@ def test_tensadd_replacement():
     repl = {H(i, j): [[1, 2], [3, 4]]}
     assert expr.replace_with_arrays(repl, [i, j]) == Array([[0, -1], [1, 0]])
     assert expr.replace_with_arrays(repl, [j, i]) == Array([[0, 1], [-1, 0]])
-
 
 def test_rewrite_tensor_to_Indexed():
     L = TensorIndexType("L", dim=4)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1985,12 +1985,9 @@ def test_tensor_alternative_construction():
 
 def test_tensor_replacement():
     L = TensorIndexType("L")
-    L2 = TensorIndexType("L2", dim=2)
     i, j, k, l, m = tensor_indices("i j k l m", L)
     A, B, C, D = tensor_heads("A B C D", [L])
     H = TensorHead("H", [L, L])
-    J = TensorHead("J", [L, L])
-    I = TensorHead("I", [L]*3)
     K = TensorHead("K", [L]*4)
 
     expr = H(i, j)
@@ -2024,6 +2021,50 @@ def test_tensor_replacement():
     assert expr.replace_with_arrays(repl, [-j, i]) == Array([[1, 3], [-2, -4]])
     assert expr.replace_with_arrays(repl, [-j, -i]) == Array([[1, -3], [-2, 4]])
 
+    expr = K(i, j, k, -l)
+    repl = {K(i,j,k,l): Array([ (i+1) for i in range(2**4)]).reshape(2,2,2,2), L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl) == Array([(i+1)*(-1)**i for i in range(2**4)]).reshape(2,2,2,2)
+
+def test_tensor_replacement_invalid():
+    L = TensorIndexType("L")
+    L2 = TensorIndexType("L2", dim=2)
+    i, j, k, l, m = tensor_indices("i j k l m", L)
+    A, B, C, D = tensor_heads("A B C D", [L])
+
+    expr = A(i)
+    repl = {B(i): [1, 2]}
+    raises(ValueError, lambda: expr._extract_data(repl))
+
+    expr = A(i)
+    repl = {A(i): [[1, 2], [3, 4]]}
+    raises(ValueError, lambda: expr._extract_data(repl))
+
+    # Replace with array, raise exception if indices are not compatible:
+    expr = A(i)*A(j)
+    repl = {A(i): [1, 2]}
+    raises(ValueError, lambda: expr.replace_with_arrays(repl, [j]))
+
+    # Raise exception if array dimension is not compatible:
+    expr = A(i)
+    repl = {A(i): [[1, 2]]}
+    raises(ValueError, lambda: expr.replace_with_arrays(repl, [i]))
+
+    # TensorIndexType with dimension, wrong dimension in replacement array:
+    u1, u2, u3 = tensor_indices("u1:4", L2)
+    U = TensorHead("U", [L2])
+    expr = U(u1)*U(-u2)
+    repl = {U(u1): [[1]]}
+    raises(ValueError, lambda: expr.replace_with_arrays(repl, [u1, -u2]))
+
+def test_tensor_replacement_transpose():
+    L = TensorIndexType("L")
+    i, j, k, l, m = tensor_indices("i j k l m", L)
+    A, B, C, D = tensor_heads("A B C D", [L])
+    H = TensorHead("H", [L, L])
+    J = TensorHead("J", [L, L])
+    I = TensorHead("I", [L]*3)
+    K = TensorHead("K", [L]*4)
+
     # Transpose
     expr = H(j,i)
     repl = {H(i,j): [[1,2],[3,4]]}
@@ -2039,15 +2080,53 @@ def test_tensor_replacement():
     repl = {K(i,j,k,l): arr, L: diag(1, -1)}
     assert expr.replace_with_arrays(repl, [j,k,l,i]) == arr
 
+    # Transposed replacement array
+    repl = {
+        H(i, j): [[1, 2], [3, 4]],
+        J(i, j): [[1, 3], [2, 4]], #transpose of above
+        L: diag(1,1),
+        }
+    expr_1 = H(i,k)*H(-k,j)
+    expr_2 = H(i,k)*J(j,-k)
+    arr_1 = expr_1.replace_with_arrays(repl)
+    assert arr_1 == Array([[7,10],[15,22]])
+    assert expr_2.replace_with_arrays(repl) == arr_1
+
+def test_tensor_replacement_contract():
+    L = TensorIndexType("L")
+    i, j, k, l, m = tensor_indices("i j k l m", L)
+    A, B, C, D = tensor_heads("A B C D", [L])
+    H = TensorHead("H", [L, L])
+    K = TensorHead("K", [L]*4)
+
+    # Tensors with contractions in replacements:
+    expr = K(i, j, k, -k)
+    repl = {K(i, j, k, -k): [[1, 2], [3, 4]]}
+    assert expr._extract_data(repl) == ([i, j], Array([[1, 2], [3, 4]]))
+
+    expr = H(i, -i)
+    repl = {H(i, -i): 42}
+    assert expr._extract_data(repl) == ([], 42)
+
+    expr = H(i, -i)
+    repl = {
+        H(-i, -j): Array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]]),
+        L: Array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]]),
+    }
+    assert expr._extract_data(repl) == ([], 4)
+
+
+def test_tensor_replacement_index_mismatch():
+    L = TensorIndexType("L")
+    i, j, k, l, m = tensor_indices("i j k l m", L)
+    A, B, C, D = tensor_heads("A B C D", [L])
+    H = TensorHead("H", [L, L])
+    K = TensorHead("K", [L]*4)
+
     # Not the same indices:
     expr = H(i,k)
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
     assert expr._extract_data(repl) == ([i, k], Array([[1, 2], [3, 4]]))
-
-    expr = K(j, k, l, m)
-    arr = Array(range(2**4)).reshape(2,2,2,2)
-    repl = {K(j,k,l,i): arr, L: diag(1, -1)}
-    assert expr.replace_with_arrays(repl, [j,k,l,m]) == arr
 
     expr = H(j, k)
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
@@ -2055,8 +2134,20 @@ def test_tensor_replacement():
 
     expr = K(j, k, l, m)
     arr = Array(range(2**4)).reshape(2,2,2,2)
+    repl = {K(j,k,l,i): arr, L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl, [j,k,l,m]) == arr
+
+    expr = K(j, k, l, m)
+    arr = Array(range(2**4)).reshape(2,2,2,2)
     repl = {K(i,j,k,l): arr, L: diag(1, -1)}
     assert expr.replace_with_arrays(repl, [j,k,l,m]) == arr
+
+def test_tensmul_replacement():
+    L = TensorIndexType("L")
+    i, j, k, l, m = tensor_indices("i j k l m", L)
+    A, B, C, D = tensor_heads("A B C D", [L])
+    I = TensorHead("I", [L]*3)
+    K = TensorHead("K", [L]*4)
 
     expr = A(i)*A(-i)
     repl = {A(i): [1,2], L: diag(1, -1)}
@@ -2067,19 +2158,13 @@ def test_tensor_replacement():
     repl = {A(i): [1, 2], K(i,j,k,l): Array([1]*2**4).reshape(2,2,2,2), L: diag(1, -1)}
     assert expr._extract_data(repl) == ([], 0)
 
-    expr = K(i, j, k, -l)
-    repl = {K(i,j,k,l): Array([ (i+1) for i in range(2**4)]).reshape(2,2,2,2), L: diag(1, -1)}
-    assert expr.replace_with_arrays(repl) == Array([(i+1)*(-1)**i for i in range(2**4)]).reshape(2,2,2,2)
 
-    expr = A(i)
-    repl = {B(i): [1, 2]}
-    raises(ValueError, lambda: expr._extract_data(repl))
+def test_tensadd_replacement():
+    L = TensorIndexType("L")
+    i, j, k, l, m = tensor_indices("i j k l m", L)
+    A, B, C, D = tensor_heads("A B C D", [L])
+    H = TensorHead("H", [L, L])
 
-    expr = A(i)
-    repl = {A(i): [[1, 2], [3, 4]]}
-    raises(ValueError, lambda: expr._extract_data(repl))
-
-    # TensAdd:
     expr = A(k)*H(i, j) + B(k)*H(i, j)
     repl = {A(k): [1], B(k): [1], H(i, j): [[1, 2],[3,4]], L:diag(1,1)}
     assert expr._extract_data(repl) == ([k, i, j], Array([[[2, 4], [6, 8]]]))
@@ -2102,51 +2187,6 @@ def test_tensor_replacement():
     repl = {H(i, j): [[1, 2], [3, 4]]}
     assert expr.replace_with_arrays(repl, [i, j]) == Array([[0, -1], [1, 0]])
     assert expr.replace_with_arrays(repl, [j, i]) == Array([[0, 1], [-1, 0]])
-
-    # Tensors with contractions in replacements:
-    expr = K(i, j, k, -k)
-    repl = {K(i, j, k, -k): [[1, 2], [3, 4]]}
-    assert expr._extract_data(repl) == ([i, j], Array([[1, 2], [3, 4]]))
-
-    expr = H(i, -i)
-    repl = {H(i, -i): 42}
-    assert expr._extract_data(repl) == ([], 42)
-
-    expr = H(i, -i)
-    repl = {
-        H(-i, -j): Array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]]),
-        L: Array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, -1]]),
-    }
-    assert expr._extract_data(repl) == ([], 4)
-
-    # Transposed replacement array
-    repl = {
-        H(i, j): [[1, 2], [3, 4]],
-        J(i, j): [[1, 3], [2, 4]], #transpose of above
-        L: diag(1,1),
-        }
-    expr_1 = H(i,k)*H(-k,j)
-    expr_2 = H(i,k)*J(j,-k)
-    arr_1 = expr_1.replace_with_arrays(repl)
-    assert arr_1 == Array([[7,10],[15,22]])
-    assert expr_2.replace_with_arrays(repl) == arr_1
-
-    # Replace with array, raise exception if indices are not compatible:
-    expr = A(i)*A(j)
-    repl = {A(i): [1, 2]}
-    raises(ValueError, lambda: expr.replace_with_arrays(repl, [j]))
-
-    # Raise exception if array dimension is not compatible:
-    expr = A(i)
-    repl = {A(i): [[1, 2]]}
-    raises(ValueError, lambda: expr.replace_with_arrays(repl, [i]))
-
-    # TensorIndexType with dimension, wrong dimension in replacement array:
-    u1, u2, u3 = tensor_indices("u1:4", L2)
-    U = TensorHead("U", [L2])
-    expr = U(u1)*U(-u2)
-    repl = {U(u1): [[1]]}
-    raises(ValueError, lambda: expr.replace_with_arrays(repl, [u1, -u2]))
 
 
 def test_rewrite_tensor_to_Indexed():

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2068,6 +2068,7 @@ def test_tensor_replacement_transpose():
     # Transpose
     expr = H(j,i)
     repl = {H(i,j): [[1,2],[3,4]]}
+    assert expr._extract_data(repl) == ([j,i], Array([[1,2],[3,4]]))
     assert expr.replace_with_arrays(repl, [i,j]) == Array([[1,3],[2,4]])
 
     expr = I(j, k, l)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -2056,6 +2056,11 @@ def test_tensor_replacement_invalid():
     repl = {U(u1): [[1]]}
     raises(ValueError, lambda: expr.replace_with_arrays(repl, [u1, -u2]))
 
+    # mismatch between specified indices and the free indices of the expression
+    expr = A(i)
+    repl = {A(j): [1,2]}
+    raises(ValueError, lambda: expr.replace_with_arrays(repl, indices=[k]))
+
 def test_tensor_replacement_transpose():
     L = TensorIndexType("L")
     i, j, k, l, m = tensor_indices("i j k l m", L)

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -11,7 +11,7 @@ from sympy.core.decorators import call_highest_priority
 from sympy.core.symbol import symbols
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.integrals import integrate
-from sympy.tensor.array import Array
+from sympy.tensor.array import Array, permutedims
 from sympy.tensor.tensor import TensorIndexType, tensor_indices, TensorSymmetry, \
     get_symmetric_group_sgs, TensorIndex, tensor_mul, TensAdd, \
     riemann_cyclic_replace, riemann_cyclic, TensMul, tensor_heads, \
@@ -2085,6 +2085,11 @@ def test_tensor_replacement_transpose():
     arr = Array(range(2**4)).reshape(2,2,2,2)
     repl = {K(i,j,k,l): arr, L: diag(1, -1)}
     assert expr.replace_with_arrays(repl, [j,k,l,i]) == arr
+
+    expr = K(j, k, l, i)
+    arr = Array(range(2**4)).reshape(2,2,2,2)
+    repl = {K(i,j,k,l): arr, L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl, [j,i,l,k]) == permutedims(arr, [0,3,2,1])
 
     # Transposed replacement array
     repl = {

--- a/sympy/tensor/tests/test_tensor.py
+++ b/sympy/tensor/tests/test_tensor.py
@@ -1986,10 +1986,11 @@ def test_tensor_alternative_construction():
 def test_tensor_replacement():
     L = TensorIndexType("L")
     L2 = TensorIndexType("L2", dim=2)
-    i, j, k, l = tensor_indices("i j k l", L)
+    i, j, k, l, m = tensor_indices("i j k l m", L)
     A, B, C, D = tensor_heads("A B C D", [L])
     H = TensorHead("H", [L, L])
     J = TensorHead("J", [L, L])
+    I = TensorHead("I", [L]*3)
     K = TensorHead("K", [L]*4)
 
     expr = H(i, j)
@@ -2028,14 +2029,34 @@ def test_tensor_replacement():
     repl = {H(i,j): [[1,2],[3,4]]}
     assert expr.replace_with_arrays(repl, [i,j]) == Array([[1,3],[2,4]])
 
+    expr = I(j, k, l)
+    arr = Array(range(2**3)).reshape(2,2,2)
+    repl = {I(l,j,k): arr, L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl, [j,k,l]) == arr
+
+    expr = K(j, k, l, i)
+    arr = Array(range(2**4)).reshape(2,2,2,2)
+    repl = {K(i,j,k,l): arr, L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl, [j,k,l,i]) == arr
+
     # Not the same indices:
     expr = H(i,k)
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
     assert expr._extract_data(repl) == ([i, k], Array([[1, 2], [3, 4]]))
 
+    expr = K(j, k, l, m)
+    arr = Array(range(2**4)).reshape(2,2,2,2)
+    repl = {K(j,k,l,i): arr, L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl, [j,k,l,m]) == arr
+
     expr = H(j, k)
     repl = {H(i,j): [[1,2],[3,4]], L: diag(1, -1)}
     assert expr.replace_with_arrays(repl, [j,k]) == Array([[1,2],[3,4]])
+
+    expr = K(j, k, l, m)
+    arr = Array(range(2**4)).reshape(2,2,2,2)
+    repl = {K(i,j,k,l): arr, L: diag(1, -1)}
+    assert expr.replace_with_arrays(repl, [j,k,l,m]) == arr
 
     expr = A(i)*A(-i)
     repl = {A(i): [1,2], L: diag(1, -1)}


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


Fixes #28949

Supersedes PR #29686

#### Brief description of what is fixed or changed

The labels used for the indices of the keys of `replacement_dict` are not significant as far as `Tensor._extract_data` is concerned; only the position of the index and its co/contra-variance need to considered. E.g., `replacement_dict={A(i,j): [1, 2]}` is equivalent to `replacement_dict={A(j,i): [1, 2]}` but is not equivalent to `replacement_dict={A(i,-j): [1, 2]}`. The docstring of `replace_with_arrays` has been updated to mention this.

This change allows `replace_with_arrays` to handle some cases where it is possible to replace a tensor by the transpose of the given array. None of the existing tests are broken by this change.

Handling of higher-order (>2) transposed tensors was earlier broken (wrong results); this is now fixed, and corresponding tests have been added.

#### Other comments

Before this PR:
```python
IPython console for SymPy 1.14.0 (Python 3.14.4-64-bit) (ground types: gmpy)

These commands were executed:
>>> from sympy import *
>>> x, y, z, t = symbols('x y z t')
>>> k, m, n = symbols('k m n', integer=True)
>>> f, g, h = symbols('f g h', cls=Function)
>>> init_printing()

Documentation can be found at https://docs.sympy.org/1.14.0/

In [1]: import sympy.tensor.tensor as tens

In [2]: R2 = tens.TensorIndexType("R2", dim=2, dummy_name="r")

In [3]: i,j,a = symbols("i j a", cls=tens.TensorIndex, tensor_index_type=R2)

In [5]: H = symbols("H", cls=tens.TensorHead, index_types=[R2,R2])

In [6]: repl = {
   ...:        H(i, j): [[1, 2], [3, 4]],
   ...:        R2: diag(1,1),
   ...:        }

In [7]: ( H(j,i) ).replace_with_arrays(repl)
Out[7]: 
⎡1  3⎤
⎢    ⎥
⎣2  4⎦

In [8]: ( H(j,a) ).replace_with_arrays(repl)

ValueError: incompatible indices: [j, a] and [i, j]

```
After this PR:
```python
In [6]: ( H(j,a) ).replace_with_arrays(repl)
Out[6]: 
⎡1  3⎤
⎢    ⎥
⎣2  4⎦

```

I've also added a test for the case mentioned in bug #28949

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* tensor
  * The handling of the arguments of `replace_with_arrays` has changed: (1) in the keys of `replacement_dict`, the names of the indices are no longer significant (e.g., `replacement_dict={A(i,j): [[1, 2],[3,4]]}` is equivalent to `replacement_dict={A(j,i): [[1, 2],[3,4]]}` but is not equivalent to `replacement_dict={A(i,-j): [[1, 2],[3,4]]}`); and (2) if specified, `indices` must be a permutation (index raising/lowering is allowed) of the free indices of the expression
  * `replace_with_arrays`:  transposes of tensors of rank > 2 are now correctly calculated.
 <!-- END RELEASE NOTES -->
