### PR TITLE
ci: add name to other-Python install step for readability

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -405,7 +405,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - run: python -m pip install --upgrade pip
-      - env:
+      - name: Install test dependencies
+        env:
           MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           if [[ "$MATRIX_PYTHON_VERSION" == pypy-* ]]; then


### PR DESCRIPTION
## Problem

In `.github/workflows/runtests.yml`, the `tests-other-python` dependency install `run` step is unnamed and longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when installs fail (especially on PyPy where mypy is excluded).

## Changes

Semantics are unchanged: same `MATRIX_PYTHON_VERSION` env, same PyPy vs CPython install branch, and the same pip commands.

- Add `name: Install test dependencies` to the existing install step

## Test plan
- [ ] Confirm the PyPy mypy exclusion logic is unchanged
- [ ] Confirm `pip install -r requirements-dev.txt` still runs for non-PyPy versions
