### PR TITLE
assumptions: add refine handler for sinh, cosh, tanh

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -382,6 +382,7 @@ Arpit Goyal <agmps18@gmail.com>
 Arshdeep Singh <singh.arshdeep1999@gmail.com>
 Arthur Milchior <arthur@milchior.fr>
 Arthur Ryman <arthur.ryman@gmail.com>
+Arun Lama <lamaarun2001@gmail.com> 128070655+arun-2057@users.noreply.github.com
 Arun Singh <arunsin997@gmail.com> Arun Singh <erarungwl2013@gmail.com>
 Arun sanganal <74652697+ArunSanganal@users.noreply.github.com>
 Aryan Vishwakarma <aryanvishwakarma275@gmail.com> Aryan-202 <aryanvishwakarma275@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -610,7 +610,7 @@ def refine_sinh_cosh_tanh(expr, assumptions):
     ========
 
     >>> from sympy.assumptions.refine import refine_sinh_cosh_tanh
-    >>> from sympy import Symbol, Q, sinh, cosh, tanh
+    >>> from sympy import Q, sinh, cosh, tanh
     >>> from sympy.abc import x
     >>> refine_sinh_cosh_tanh(sinh(x), Q.zero(x))
     0

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -602,6 +602,42 @@ def refine_floor_ceiling(expr, assumptions):
     return expr
 
 
+def refine_sinh_cosh_tanh(expr, assumptions):
+    """
+    Handler for sinh, cosh, tanh.
+
+    Examples
+    ========
+
+    >>> from sympy.assumptions.refine import refine_sinh_cosh_tanh
+    >>> from sympy import Symbol, Q, sinh, cosh, tanh
+    >>> from sympy.abc import x
+    >>> refine_sinh_cosh_tanh(sinh(x), Q.zero(x))
+    0
+    >>> refine_sinh_cosh_tanh(cosh(x), Q.zero(x))
+    1
+    >>> refine_sinh_cosh_tanh(tanh(x), Q.zero(x))
+    0
+    >>> refine_sinh_cosh_tanh(sinh(x), Q.real(x))
+
+    """
+    from sympy.functions.elementary.hyperbolic import sinh, cosh, tanh
+
+    if not isinstance(expr, (sinh, cosh, tanh)):
+        raise TypeError(
+            "refine_sinh_cosh_tanh expects a sinh, cosh or tanh function."
+        )
+
+    arg = expr.args[0]
+
+    if ask(Q.zero(arg), assumptions):
+        if isinstance(expr, (sinh, tanh)):
+            return S.Zero
+        return S.One
+
+    return None
+
+
 handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Abs': refine_abs,
     'Pow': refine_Pow,
@@ -613,6 +649,9 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'MatrixElement': refine_matrixelement,
     'cos': refine_sin_cos,
     'sin': refine_sin_cos,
+    'sinh': refine_sinh_cosh_tanh,
+    'cosh': refine_sinh_cosh_tanh,
+    'tanh': refine_sinh_cosh_tanh,
     'exp': refine_exp,
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from sympy.assumptions.ask import Q
-from sympy.assumptions.refine import refine, refine_sin_cos
+from sympy.assumptions.refine import refine, refine_sin_cos, refine_sinh_cosh_tanh
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.expr import Expr
 from sympy.core.numbers import (I, Rational, nan, pi)
@@ -10,6 +10,7 @@ from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (atan, atan2, cos, sin, tan)
+from sympy.functions.elementary.hyperbolic import (sinh, cosh, tanh)
 from sympy.abc import w, x, y, z
 from sympy.core.relational import Eq, Ne
 from sympy.functions.elementary.piecewise import Piecewise
@@ -320,6 +321,20 @@ def test_sin_cos():
     raises(TypeError, lambda: refine_sin_cos(tan(x), Q.real(x)))
     raises(TypeError, lambda: refine_sin_cos(exp(x), Q.real(x)))
     raises(TypeError, lambda: refine_sin_cos(x, Q.real(x)))
+
+
+def test_sinh_cosh_tanh():
+    assert refine(sinh(x), Q.zero(x)) == 0
+    assert refine(cosh(x), Q.zero(x)) == 1
+    assert refine(tanh(x), Q.zero(x)) == 0
+
+    assert refine(sinh(x), Q.real(x)) == sinh(x)
+    assert refine(cosh(x), Q.real(x)) == cosh(x)
+    assert refine(tanh(x), Q.real(x)) == tanh(x)
+
+    raises(TypeError, lambda: refine_sinh_cosh_tanh(sin(x), Q.real(x)))
+    raises(TypeError, lambda: refine_sinh_cosh_tanh(exp(x), Q.real(x)))
+    raises(TypeError, lambda: refine_sinh_cosh_tanh(x, Q.real(x)))
 
 
 def test_floor_ceiling():


### PR DESCRIPTION
fixes in part #27888

What changed

Before this change, refine(sinh(x), Q.zero(x)), refine(cosh(x), Q.zero(x)), and refine(tanh(x), Q.zero(x)) all returned the unevaluated expressions unchanged. Now they simplify to 0, 1, and 0 respectively under the Q.zero assumption, matching the existing behavior already present for sin and cos via refine_sin_cos.

Before:

>>> refine(sinh(x), Q.zero(x))
sinh(x)


After:

>>> refine(sinh(x), Q.zero(x))
0
Scope

Narrow by design. An initial draft included an imaginary-argument rewrite branch (sinh(I*y) → I*sin(y), etc.), but empirical testing showed it was dead code: SymPy's own automatic evaluation already performs that rewrite at construction time for syntactic forms like I*y, and for opaque symbols declared imaginary, the as_real_imag() decomposition algebraically round-trips back to the original expression. The imaginary branch was removed to keep the handler honest and minimal. No pi-multiple phase logic was added, since hyperbolics lack the clean periodicity analog that justified it for refine_sin_cos.

AI Generation Disclosure

Used Claude to help design the handler, review edge cases, and catch a false-positive issue in an early test draft (the imaginary-rewrite branch appeared to work but was actually dead code due to SymPy's own auto-evaluation). I wrote and understand the final implementation and tests myself.

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added a refine handler so `sinh(x)`, `cosh(x)`, and `tanh(x)` simplify to `0`, `1`, and `0` respectively under the assumption `Q.zero(x)`.
<!-- END RELEASE NOTES -->