### PR TITLE
Fix SciPy printer precedence for composite special functions

### DIFF
--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -384,14 +384,14 @@ class SciPyPrinter(NumPyPrinter):
             self._print(expr.args[2]))
 
     def _print_lowergamma(self, expr):
-        return "{0}({2})*{1}({2}, {3})".format(
+        return "({0}({2})*{1}({2}, {3}))".format(
             self._module_format('scipy.special.gamma'),
             self._module_format('scipy.special.gammainc'),
             self._print(expr.args[0]),
             self._print(expr.args[1]))
 
     def _print_uppergamma(self, expr):
-        return "{0}({2})*{1}({2}, {3})".format(
+        return "({0}({2})*{1}({2}, {3}))".format(
             self._module_format('scipy.special.gamma'),
             self._module_format('scipy.special.gammaincc'),
             self._print(expr.args[0]),
@@ -401,11 +401,11 @@ class SciPyPrinter(NumPyPrinter):
         betainc = self._module_format('scipy.special.betainc')
         beta = self._module_format('scipy.special.beta')
         args = [self._print(arg) for arg in expr.args]
-        return f"({betainc}({args[0]}, {args[1]}, {args[3]}) - {betainc}({args[0]}, {args[1]}, {args[2]})) \
-            * {beta}({args[0]}, {args[1]})"
+        return f"(({betainc}({args[0]}, {args[1]}, {args[3]}) - {betainc}({args[0]}, {args[1]}, {args[2]})) \
+            * {beta}({args[0]}, {args[1]}))"
 
     def _print_betainc_regularized(self, expr):
-        return "{0}({1}, {2}, {4}) - {0}({1}, {2}, {3})".format(
+        return "({0}({1}, {2}, {4}) - {0}({1}, {2}, {3}))".format(
             self._module_format('scipy.special.betainc'),
             self._print(expr.args[0]),
             self._print(expr.args[1]),

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -1751,6 +1751,27 @@ def test_issue_16536():
     assert abs(uppergamma(1, 3) - F(1, 3)) <= 1e-10
 
 
+def test_issue_30199_scipy_composite_printer_parentheses():
+    if not scipy:
+        skip("scipy not installed")
+
+    a, b, t, lo, hi = symbols("a b t lo hi", positive=True)
+    substitutions = {a: 2.5, b: 3.0, t: 0.4, lo: 0.1, hi: 0.4}
+    expressions = [
+        1 / lowergamma(a, t),
+        uppergamma(a, t)**2,
+        1 / betainc(a, b, lo, hi),
+        betainc_regularized(a, b, lo, hi)**2,
+    ]
+
+    for expr in expressions:
+        args = tuple(sorted(expr.free_symbols, key=lambda symbol: symbol.name))
+        generated = lambdify(args, expr, modules="scipy")
+        values = [substitutions[arg] for arg in args]
+        expected = float(expr.subs(substitutions).evalf(50))
+        assert abs(generated(*values) - expected) <= 1e-10 * max(1, abs(expected))
+
+
 def test_issue_22726():
     if not numpy:
         skip("numpy not installed")


### PR DESCRIPTION
<!-- BEGIN RELEASE NOTES -->
  * printing
  * Fixed SciPy code printer precedence for `lowergamma`, `uppergamma`, `betainc`, and `betainc_regularized` so an enclosing multiplication, reciprocal, or power applies to the whole expansion.

<!-- END RELEASE NOTES -->

Fixes #30199.

Parenthesize the complete SciPy-printer expansion for `lowergamma`, `uppergamma`, `betainc`, and `betainc_regularized`, so an enclosing multiplication, reciprocal, or power applies to the expansion rather than its last term.

Adds focused `lambdify(..., modules="scipy")` regression coverage for representative reciprocal and square contexts.

Tests: `pytest sympy/utilities/tests/test_lambdify.py -k "issue_30199 or issue_16536"`; direct high-precision `evalf` comparison for all four contexts.