### PR TITLE
logic: add IPASIR style interface to SATSolver (part 1)

### DIFF
--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -313,6 +313,11 @@ class SATSolver:
     ###############################
     #    IPASIR Style Interface   #
     ###############################
+
+    # The following code is not implemented fully, there are
+    # a lot of things that can be added to the Interface. This is
+    # the most minimalistic version of it. Add new required features as TODO.
+
     """
     A subset of the IPASIR standard for incremental SAT solving, using the
     names that CaDiCaL gives them in its C++ API. Only the parts needed to
@@ -529,7 +534,7 @@ class SATSolver:
             self._clause_buffer.append(lit)
             return
 
-        cls = self._clause_buffer
+        clause_to_add = self._clause_buffer
         self._clause_buffer = []
 
         # The decisions were made without this clause, so the search restarts.
@@ -540,22 +545,23 @@ class SATSolver:
         if self._status == IpasirStatus.SATISFIABLE:
             self._status = IpasirStatus.UNKNOWN
 
-        cls_num = len(self.clauses)
-        self.clauses.append(cls)
+        clause_num = len(self.clauses)
+        self.clauses.append(clause_to_add)
 
-        for cls_lit in cls:
-            self.occurrence_count[cls_lit] += 1
+        for clause_lit in clause_to_add:
+            self.occurrence_count[clause_lit] += 1
 
         # Only a literal that is not already false can be a sentinel. With
         # fewer than two of those the clause is satisfied, unit, or false, and
         # none of those needs to be watched.
-        unassigned = [cls_lit for cls_lit in cls
-                      if not self.variable_set[abs(cls_lit)]]
+        unassigned = [clause_lit for clause_lit in clause_to_add
+                      if not self.variable_set[abs(clause_lit)]]
 
         if len(unassigned) > 1:
-            self.sentinels[unassigned[0]].add(cls_num)
-            self.sentinels[unassigned[-1]].add(cls_num)
-        elif not any(cls_lit in self.var_settings for cls_lit in cls):
+            self.sentinels[unassigned[0]].add(clause_num)
+            self.sentinels[unassigned[-1]].add(clause_num)
+        elif not any(clause_lit in self.var_settings
+                     for clause_lit in clause_to_add):
             if unassigned:
                 self._unit_prop_queue.append(unassigned[0])
             else:

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from copy import deepcopy
+from enum import Enum
 from heapq import heappush, heappop
 
 from sympy.core.sorting import ordered
@@ -22,11 +23,12 @@ from sympy.assumptions.cnf import EncodedCNF
 from sympy.logic.algorithms.lra_theory import LRASolver
 
 
-# Status codes used by the IPASIR style interface of SATSolver. The values are
-# the ones mandated by the IPASIR standard for ``ipasir_solve``.
-UNKNOWN = 0
-SATISFIABLE = 10
-UNSATISFIABLE = 20
+class IpasirStatus(Enum):
+    # Status codes used by the IPASIR style interface of SATSolver. The values are
+    # the ones mandated by the IPASIR standard for ``ipasir_solve``.
+    UNKNOWN = 0
+    SATISFIABLE = 10
+    UNSATISFIABLE = 20
 
 
 def dpll_satisfiable(expr, all_models=False, use_lra_theory=False):
@@ -151,7 +153,7 @@ class SATSolver:
         self.lra = lra_theory
 
         # State of the IPASIR style interface
-        self._status = UNKNOWN
+        self._status = IpasirStatus.UNKNOWN
         self._models = None
         self._clause_buffer = []
 
@@ -328,31 +330,30 @@ class SATSolver:
         inspected with ``fixed()``, and ``solve()`` may be called
         afterwards to continue with a full search.
 
-        Returns ``UNSATISFIABLE`` if propagation runs into a conflict and
-        ``SATISFIABLE`` if it leaves no variable unassigned, as no decision
-        is needed to satisfy the clauses then and ``val()`` can read the
-        model. Otherwise ``UNKNOWN`` is returned.
+        Returns ``IpasirStatus.UNSATISFIABLE`` if propagation runs into a
+        conflict and ``IpasirStatus.SATISFIABLE`` if it leaves no variable
+        unassigned, as no decision is needed to satisfy the clauses then and
+        ``val()`` can read the model. Otherwise ``IpasirStatus.UNKNOWN`` is
+        returned.
 
         TODO: in IPASIR this propagates at whatever decision level the solver
         is on, which is not implemented here yet, so a ``ValueError`` is
         raised away from the root level rather than propagating there.
 
         TODO: an assignment also has to hold in the LRA theory to be a model,
-        so ``UNKNOWN`` is returned for a solver that has one and the theory
-        is left for ``solve()`` to check.
+        so ``IpasirStatus.UNKNOWN`` is returned for a solver that has one and
+        the theory is left for ``solve()`` to check.
 
         Examples
         ========
 
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver
-        >>> from sympy.logic.algorithms.dpll2 import UNKNOWN
-        >>> from sympy.logic.algorithms.dpll2 import SATISFIABLE, UNSATISFIABLE
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
 
         Propagating ``{1}`` through ``{-1, 2}`` implies the literal ``2``,
         which leaves ``3`` for the search to decide on:
 
         >>> l = SATSolver([{1}, {-1, 2}, {3, -3}], {1, 2, 3}, set())
-        >>> l.propagate() == UNKNOWN
+        >>> l.propagate() == IpasirStatus.UNKNOWN
         True
         >>> l.fixed(2)
         1
@@ -361,7 +362,7 @@ class SATSolver:
         are satisfied without any search:
 
         >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
-        >>> l.propagate() == SATISFIABLE
+        >>> l.propagate() == IpasirStatus.SATISFIABLE
         True
         >>> l.val(2)
         2
@@ -369,7 +370,7 @@ class SATSolver:
         A conflict at the root level means the clauses are unsatisfiable:
 
         >>> l = SATSolver([{1}, {-1}], {1}, set())
-        >>> l.propagate() == UNSATISFIABLE
+        >>> l.propagate() == IpasirStatus.UNSATISFIABLE
         True
 
         """
@@ -378,10 +379,10 @@ class SATSolver:
 
         self._simplify()
         if self.is_unsatisfied:
-            self._status = UNSATISFIABLE
+            self._status = IpasirStatus.UNSATISFIABLE
         elif self.lra is None and all(self.variable_set[1:]):
             # Nothing is left to decide on, so the assignments are a model.
-            self._status = SATISFIABLE
+            self._status = IpasirStatus.SATISFIABLE
 
         return self._status
 
@@ -402,10 +403,10 @@ class SATSolver:
         Examples
         ========
 
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
         >>> l = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
-        >>> l.propagate()
-        0
+        >>> l.propagate() == IpasirStatus.UNKNOWN
+        True
         >>> l.fixed(1), l.fixed(2), l.fixed(-2)
         (1, 1, -1)
 
@@ -428,20 +429,20 @@ class SATSolver:
     def solve(self):
         """Search for a model of the clauses.
 
-        Returns ``SATISFIABLE`` or ``UNSATISFIABLE``. When ``propagate()``
-        has already been called, the work it did at the root level is reused
-        rather than repeated. Use ``val()`` to read the model afterwards.
+        Returns ``IpasirStatus.SATISFIABLE`` or
+        ``IpasirStatus.UNSATISFIABLE``. When ``propagate()`` has already been
+        called, the work it did at the root level is reused rather than
+        repeated. Use ``val()`` to read the model afterwards.
 
         Examples
         ========
 
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver
-        >>> from sympy.logic.algorithms.dpll2 import SATISFIABLE
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
 
         >>> l = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
-        >>> l.propagate()
-        0
-        >>> l.solve() == SATISFIABLE
+        >>> l.propagate() == IpasirStatus.UNKNOWN
+        True
+        >>> l.solve() == IpasirStatus.SATISFIABLE
         True
         >>> l.val(2)
         2
@@ -454,9 +455,9 @@ class SATSolver:
 
         self._models = self._find_model()
         if next(self._models, None) is None:
-            self._status = UNSATISFIABLE
+            self._status = IpasirStatus.UNSATISFIABLE
         else:
-            self._status = SATISFIABLE
+            self._status = IpasirStatus.SATISFIABLE
 
         return self._status
 
@@ -467,15 +468,15 @@ class SATSolver:
         Examples
         ========
 
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
         >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
-        >>> l.solve()
-        10
+        >>> l.solve() == IpasirStatus.SATISFIABLE
+        True
         >>> l.val(1), l.val(2)
         (1, 2)
 
         """
-        if self._status != SATISFIABLE:
+        if self._status != IpasirStatus.SATISFIABLE:
             raise ValueError("val() is only defined once solve() has returned "
                 "SATISFIABLE.")
 
@@ -496,8 +497,7 @@ class SATSolver:
         Examples
         ========
 
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver
-        >>> from sympy.logic.algorithms.dpll2 import SATISFIABLE, UNSATISFIABLE
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
 
         A clause added one literal at a time:
 
@@ -505,7 +505,7 @@ class SATSolver:
         >>> l.add(-1)
         >>> l.add(2)
         >>> l.add(0)
-        >>> l.propagate() == SATISFIABLE
+        >>> l.propagate() == IpasirStatus.SATISFIABLE
         True
         >>> l.fixed(2)
         1
@@ -513,11 +513,11 @@ class SATSolver:
         Clauses may be added to a solver that has already been used:
 
         >>> l = SATSolver([{1, 2}], {1, 2}, set())
-        >>> l.solve() == SATISFIABLE
+        >>> l.solve() == IpasirStatus.SATISFIABLE
         True
         >>> l.clause(-1)
         >>> l.clause(-2)
-        >>> l.solve() == UNSATISFIABLE
+        >>> l.solve() == IpasirStatus.UNSATISFIABLE
         True
 
         """
@@ -537,8 +537,8 @@ class SATSolver:
             self._undo()
 
         self._models = None
-        if self._status == SATISFIABLE:
-            self._status = UNKNOWN
+        if self._status == IpasirStatus.SATISFIABLE:
+            self._status = IpasirStatus.UNKNOWN
 
         cls_num = len(self.clauses)
         self.clauses.append(cls)
@@ -560,7 +560,7 @@ class SATSolver:
                 self._unit_prop_queue.append(unassigned[0])
             else:
                 self.is_unsatisfied = True
-                self._status = UNSATISFIABLE
+                self._status = IpasirStatus.UNSATISFIABLE
 
     def clause(self, *lits):
         """Add the clause made up of *lits* to the solver.
@@ -574,15 +574,14 @@ class SATSolver:
         Examples
         ========
 
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver
-        >>> from sympy.logic.algorithms.dpll2 import UNSATISFIABLE
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
 
         >>> l = SATSolver([{1, 2}], {1, 2}, set())
         >>> l.clause(-1, 2)
-        >>> l.propagate()
-        0
+        >>> l.propagate() == IpasirStatus.UNKNOWN
+        True
         >>> l.clause([-2])
-        >>> l.propagate() == UNSATISFIABLE
+        >>> l.propagate() == IpasirStatus.UNSATISFIABLE
         True
 
         """
@@ -609,19 +608,18 @@ class SATSolver:
         Examples
         ========
 
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver
-        >>> from sympy.logic.algorithms.dpll2 import SATISFIABLE, UNSATISFIABLE
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
 
         Trying ``-2`` without giving up the work already done:
 
         >>> l = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
-        >>> l.propagate()
-        0
+        >>> l.propagate() == IpasirStatus.UNKNOWN
+        True
         >>> temporary = l.copy()
         >>> temporary.clause(-2)
-        >>> temporary.solve() == UNSATISFIABLE
+        >>> temporary.solve() == IpasirStatus.UNSATISFIABLE
         True
-        >>> l.solve() == SATISFIABLE
+        >>> l.solve() == IpasirStatus.SATISFIABLE
         True
 
         """

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -13,6 +13,7 @@ References:
 from __future__ import annotations
 
 from collections import defaultdict
+from copy import deepcopy
 from heapq import heappush, heappop
 
 from sympy.core.sorting import ordered
@@ -152,6 +153,7 @@ class SATSolver:
         # State of the IPASIR style interface
         self._status = UNKNOWN
         self._models = None
+        self._clause_buffer = []
 
     def _initialize_variables(self, variables):
         """Set up the variable data structures needed."""
@@ -312,8 +314,8 @@ class SATSolver:
     """
     A subset of the IPASIR standard for incremental SAT solving, using the
     names that CaDiCaL gives them in its C++ API. Only the parts needed to
-    inspect the root level before searching are implemented so far; adding
-    clauses to a solver that has already been used, assumptions and
+    inspect the root level before searching and to keep solving after new
+    clauses have been added are implemented so far; assumptions and
     ``failed`` are not supported yet.
 
     # https://github.com/arminbiere/cadical/blob/master/src/cadical.hpp
@@ -446,8 +448,9 @@ class SATSolver:
 
         """
         if self._models is not None:
-            raise ValueError("solve() can only be called once, as restarting "
-                "the search is not implemented yet.")
+            raise ValueError("solve() can only be called again once new "
+                "clauses have been added with add() or clause(), as "
+                "restarting the same search is not implemented yet.")
 
         self._models = self._find_model()
         if next(self._models, None) is None:
@@ -481,6 +484,159 @@ class SATSolver:
         if -lit in self.var_settings:
             return -lit
         return 0
+
+    def add(self, lit):
+        """Add *lit* to the clause that is being built, or add that clause to
+        the solver when *lit* is 0.
+
+        Adding a clause backtracks to the root level, keeping the literals
+        implied there, so ``solve()`` may be called again afterwards. An
+        unsatisfiable solver stays unsatisfiable.
+
+        Examples
+        ========
+
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver
+        >>> from sympy.logic.algorithms.dpll2 import SATISFIABLE, UNSATISFIABLE
+
+        A clause added one literal at a time:
+
+        >>> l = SATSolver([{1}], {1, 2}, set())
+        >>> l.add(-1)
+        >>> l.add(2)
+        >>> l.add(0)
+        >>> l.propagate() == SATISFIABLE
+        True
+        >>> l.fixed(2)
+        1
+
+        Clauses may be added to a solver that has already been used:
+
+        >>> l = SATSolver([{1, 2}], {1, 2}, set())
+        >>> l.solve() == SATISFIABLE
+        True
+        >>> l.clause(-1)
+        >>> l.clause(-2)
+        >>> l.solve() == UNSATISFIABLE
+        True
+
+        """
+        if lit != 0:
+            if abs(lit) >= len(self.variable_set):
+                raise ValueError("%s is not a literal of one of the variables "
+                    "the solver was created with." % lit)
+
+            self._clause_buffer.append(lit)
+            return
+
+        cls = self._clause_buffer
+        self._clause_buffer = []
+
+        # The decisions were made without this clause, so the search restarts.
+        while len(self.levels) > 1:
+            self._undo()
+
+        self._models = None
+        if self._status == SATISFIABLE:
+            self._status = UNKNOWN
+
+        cls_num = len(self.clauses)
+        self.clauses.append(cls)
+
+        for cls_lit in cls:
+            self.occurrence_count[cls_lit] += 1
+
+        # Only a literal that is not already false can be a sentinel. With
+        # fewer than two of those the clause is satisfied, unit, or false, and
+        # none of those needs to be watched.
+        unassigned = [cls_lit for cls_lit in cls
+                      if not self.variable_set[abs(cls_lit)]]
+
+        if len(unassigned) > 1:
+            self.sentinels[unassigned[0]].add(cls_num)
+            self.sentinels[unassigned[-1]].add(cls_num)
+        elif not any(cls_lit in self.var_settings for cls_lit in cls):
+            if unassigned:
+                self._unit_prop_queue.append(unassigned[0])
+            else:
+                self.is_unsatisfied = True
+                self._status = UNSATISFIABLE
+
+    def clause(self, *lits):
+        """Add the clause made up of *lits* to the solver.
+
+        The literals are given either one by one or as a single iterable of
+        them, covering the ``clause(int, ...)`` and ``clause(const
+        std::vector<int> &)`` overloads of CaDiCaL. This is ``add()`` called
+        on each of them and then on 0, so the remarks made there apply here as
+        well. Without any literal it adds the empty clause, which is false.
+
+        Examples
+        ========
+
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver
+        >>> from sympy.logic.algorithms.dpll2 import UNSATISFIABLE
+
+        >>> l = SATSolver([{1, 2}], {1, 2}, set())
+        >>> l.clause(-1, 2)
+        >>> l.propagate()
+        0
+        >>> l.clause([-2])
+        >>> l.propagate() == UNSATISFIABLE
+        True
+
+        """
+        if len(lits) == 1 and not isinstance(lits[0], int):
+            lits = lits[0]
+
+        for lit in lits:
+            self.add(lit)
+
+        self.add(0)
+
+    def copy(self):
+        """Return a solver with the same clauses and the same state as this
+        one, but independent of it.
+
+        Adding clauses to the copy or searching with it leaves this solver
+        untouched. The model of a previous ``solve()`` is not carried over,
+        so the copy is free to search again.
+
+        Unlike ``copy`` in CaDiCaL, which copies the formula into a solver
+        given to it, this returns a new solver and copies the state of the
+        search along with the formula.
+
+        Examples
+        ========
+
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver
+        >>> from sympy.logic.algorithms.dpll2 import SATISFIABLE, UNSATISFIABLE
+
+        Trying ``-2`` without giving up the work already done:
+
+        >>> l = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
+        >>> l.propagate()
+        0
+        >>> temporary = l.copy()
+        >>> temporary.clause(-2)
+        >>> temporary.solve() == UNSATISFIABLE
+        True
+        >>> l.solve() == SATISFIABLE
+        True
+
+        """
+        # A generator cannot be copied, and the symbols are only ever read.
+        models, symbols = self._models, self.symbols
+        self._models, self.symbols = None, None
+
+        try:
+            other = deepcopy(self)
+        finally:
+            self._models, self.symbols = models, symbols
+
+        other.symbols = symbols
+
+        return other
 
     ########################
     #    Helper Methods    #

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -4,9 +4,11 @@ Features:
   - Clause learning
   - Watch literal scheme
   - VSIDS heuristic
+  - IPASIR style interface for incremental solving
 
 References:
   - https://en.wikipedia.org/wiki/DPLL_algorithm
+  - https://satcompetition.github.io/2020/track_incremental.html
 """
 from __future__ import annotations
 
@@ -17,6 +19,13 @@ from sympy.core.sorting import ordered
 from sympy.assumptions.cnf import EncodedCNF
 
 from sympy.logic.algorithms.lra_theory import LRASolver
+
+
+# Status codes used by the IPASIR style interface of SATSolver. The values are
+# the ones mandated by the IPASIR standard for ``ipasir_solve``.
+UNKNOWN = 0
+SATISFIABLE = 10
+UNSATISFIABLE = 20
 
 
 def dpll_satisfiable(expr, all_models=False, use_lra_theory=False):
@@ -139,6 +148,10 @@ class SATSolver:
         self.original_num_clauses = len(self.clauses)
 
         self.lra = lra_theory
+
+        # State of the IPASIR style interface
+        self._status = UNKNOWN
+        self._models = None
 
     def _initialize_variables(self, variables):
         """Set up the variable data structures needed."""
@@ -292,6 +305,153 @@ class SATSolver:
                 self._undo()
                 self.levels.append(Level(flip_lit, flipped=True))
                 flip_var = True
+
+    ###############################
+    #    IPASIR Style Interface   #
+    ###############################
+    """
+    A subset of the IPASIR standard for incremental SAT solving, using the
+    names that CaDiCaL gives them in its C++ API. Only the parts needed to
+    inspect the root level before searching are implemented so far; adding
+    clauses to a solver that has already been used, assumptions and
+    ``failed`` are not supported yet.
+    """
+    def propagate(self):
+        """Propagate the unit clauses at the root decision level.
+
+        No decision is made here, so every literal that gets assigned is
+        implied by the clauses of the solver. The assignments can be
+        inspected with :meth:`fixed`, and :meth:`solve` may be called
+        afterwards to continue with a full search.
+
+        Returns ``UNSATISFIABLE`` if propagation runs into a conflict and
+        ``UNKNOWN`` otherwise, since propagation on its own cannot show
+        that the clauses are satisfiable.
+
+        Examples
+        ========
+
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver
+        >>> from sympy.logic.algorithms.dpll2 import UNKNOWN, UNSATISFIABLE
+
+        Propagating ``{1}`` through ``{-1, 2}`` implies the literal ``2``:
+
+        >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+        >>> l.propagate() == UNKNOWN
+        True
+        >>> l.fixed(2)
+        1
+
+        A conflict at the root level means the clauses are unsatisfiable:
+
+        >>> l = SATSolver([{1}, {-1}], {1}, set())
+        >>> l.propagate() == UNSATISFIABLE
+        True
+
+        """
+        if len(self.levels) > 1:
+            raise ValueError("propagate() can only be used at the root level.")
+
+        self._simplify()
+        if self.is_unsatisfied:
+            self._status = UNSATISFIABLE
+
+        return self._status
+
+    def fixed(self, lit):
+        """Return 1 if *lit* is implied by the clauses, -1 if ``-lit`` is
+        implied by them, and 0 if neither is known at this point.
+
+        This is only defined at the root level, where no decision has been
+        made and therefore every assignment is implied by the clauses. Note
+        that the literals found by :meth:`propagate` are implied but are not
+        necessarily all of the implied literals, so 0 means "not known"
+        rather than "not implied".
+
+        Examples
+        ========
+
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver
+        >>> l = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
+        >>> l.propagate()
+        0
+        >>> l.fixed(1), l.fixed(2), l.fixed(-2)
+        (1, 1, -1)
+
+        Nothing is implied about ``3``, as it only occurs in a clause that
+        propagation cannot resolve:
+
+        >>> l.fixed(3)
+        0
+
+        """
+        if len(self.levels) > 1:
+            raise ValueError("fixed() is only defined at the root level.")
+
+        if lit in self.var_settings:
+            return 1
+        if -lit in self.var_settings:
+            return -1
+        return 0
+
+    def solve(self):
+        """Search for a model of the clauses.
+
+        Returns ``SATISFIABLE`` or ``UNSATISFIABLE``. When :meth:`propagate`
+        has already been called, the work it did at the root level is reused
+        rather than repeated. Use :meth:`val` to read the model afterwards.
+
+        Examples
+        ========
+
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver
+        >>> from sympy.logic.algorithms.dpll2 import SATISFIABLE
+
+        >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+        >>> l.propagate()
+        0
+        >>> l.solve() == SATISFIABLE
+        True
+        >>> l.val(2)
+        2
+
+        """
+        if self._models is not None:
+            raise ValueError("solve() can only be called once, as restarting "
+                "the search is not implemented yet.")
+
+        self._models = self._find_model()
+        if next(self._models, None) is None:
+            self._status = UNSATISFIABLE
+        else:
+            self._status = SATISFIABLE
+
+        return self._status
+
+    def val(self, lit):
+        """Return *lit* if it is true in the model found by :meth:`solve`,
+        ``-lit`` if it is false there, and 0 if the model does not assign it.
+
+        Examples
+        ========
+
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver
+        >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+        >>> l.solve()
+        10
+        >>> l.val(1), l.val(2)
+        (1, 2)
+
+        """
+        if self._status != SATISFIABLE:
+            raise ValueError("val() is only defined once solve() has returned "
+                "SATISFIABLE.")
+
+        if lit in self.var_settings:
+            return lit
+        if -lit in self.var_settings:
+            return -lit
+        return 0
 
     ########################
     #    Helper Methods    #

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -315,32 +315,54 @@ class SATSolver:
     inspect the root level before searching are implemented so far; adding
     clauses to a solver that has already been used, assumptions and
     ``failed`` are not supported yet.
+
+    # https://github.com/arminbiere/cadical/blob/master/src/cadical.hpp
     """
     def propagate(self):
         """Propagate the unit clauses at the root decision level.
 
         No decision is made here, so every literal that gets assigned is
         implied by the clauses of the solver. The assignments can be
-        inspected with :meth:`fixed`, and :meth:`solve` may be called
+        inspected with ``fixed()``, and ``solve()`` may be called
         afterwards to continue with a full search.
 
         Returns ``UNSATISFIABLE`` if propagation runs into a conflict and
-        ``UNKNOWN`` otherwise, since propagation on its own cannot show
-        that the clauses are satisfiable.
+        ``SATISFIABLE`` if it leaves no variable unassigned, as no decision
+        is needed to satisfy the clauses then and ``val()`` can read the
+        model. Otherwise ``UNKNOWN`` is returned.
+
+        TODO: in IPASIR this propagates at whatever decision level the solver
+        is on, which is not implemented here yet, so a ``ValueError`` is
+        raised away from the root level rather than propagating there.
+
+        TODO: an assignment also has to hold in the LRA theory to be a model,
+        so ``UNKNOWN`` is returned for a solver that has one and the theory
+        is left for ``solve()`` to check.
 
         Examples
         ========
 
         >>> from sympy.logic.algorithms.dpll2 import SATSolver
-        >>> from sympy.logic.algorithms.dpll2 import UNKNOWN, UNSATISFIABLE
+        >>> from sympy.logic.algorithms.dpll2 import UNKNOWN
+        >>> from sympy.logic.algorithms.dpll2 import SATISFIABLE, UNSATISFIABLE
 
-        Propagating ``{1}`` through ``{-1, 2}`` implies the literal ``2``:
+        Propagating ``{1}`` through ``{-1, 2}`` implies the literal ``2``,
+        which leaves ``3`` for the search to decide on:
 
-        >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+        >>> l = SATSolver([{1}, {-1, 2}, {3, -3}], {1, 2, 3}, set())
         >>> l.propagate() == UNKNOWN
         True
         >>> l.fixed(2)
         1
+
+        With ``3`` gone, propagation assigns every variable and the clauses
+        are satisfied without any search:
+
+        >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+        >>> l.propagate() == SATISFIABLE
+        True
+        >>> l.val(2)
+        2
 
         A conflict at the root level means the clauses are unsatisfiable:
 
@@ -355,6 +377,9 @@ class SATSolver:
         self._simplify()
         if self.is_unsatisfied:
             self._status = UNSATISFIABLE
+        elif self.lra is None and all(self.variable_set[1:]):
+            # Nothing is left to decide on, so the assignments are a model.
+            self._status = SATISFIABLE
 
         return self._status
 
@@ -364,9 +389,13 @@ class SATSolver:
 
         This is only defined at the root level, where no decision has been
         made and therefore every assignment is implied by the clauses. Note
-        that the literals found by :meth:`propagate` are implied but are not
+        that the literals found by ``propagate()`` are implied but are not
         necessarily all of the implied literals, so 0 means "not known"
         rather than "not implied".
+
+        TODO: in IPASIR this can be asked at any decision level, which needs
+        the assignments made at the root level to be kept apart from the ones
+        that follow from a decision.
 
         Examples
         ========
@@ -397,9 +426,9 @@ class SATSolver:
     def solve(self):
         """Search for a model of the clauses.
 
-        Returns ``SATISFIABLE`` or ``UNSATISFIABLE``. When :meth:`propagate`
+        Returns ``SATISFIABLE`` or ``UNSATISFIABLE``. When ``propagate()``
         has already been called, the work it did at the root level is reused
-        rather than repeated. Use :meth:`val` to read the model afterwards.
+        rather than repeated. Use ``val()`` to read the model afterwards.
 
         Examples
         ========
@@ -407,7 +436,7 @@ class SATSolver:
         >>> from sympy.logic.algorithms.dpll2 import SATSolver
         >>> from sympy.logic.algorithms.dpll2 import SATISFIABLE
 
-        >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+        >>> l = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
         >>> l.propagate()
         0
         >>> l.solve() == SATISFIABLE
@@ -429,7 +458,7 @@ class SATSolver:
         return self._status
 
     def val(self, lit):
-        """Return *lit* if it is true in the model found by :meth:`solve`,
+        """Return *lit* if it is true in the model found by ``solve()``,
         ``-lit`` if it is false there, and 0 if the model does not assign it.
 
         Examples

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -328,55 +328,24 @@ class SATSolver:
     # https://github.com/arminbiere/cadical/blob/master/src/cadical.hpp
     """
     def propagate(self):
-        """Propagate the unit clauses at the root decision level.
+        """Propagate the unit clauses at the root level, deciding nothing.
 
-        No decision is made here, so every literal that gets assigned is
-        implied by the clauses of the solver. The assignments can be
-        inspected with ``fixed()``, and ``solve()`` may be called
-        afterwards to continue with a full search.
+        Returns ``UNSATISFIABLE`` on a conflict, ``SATISFIABLE`` if it leaves
+        no variable unassigned, and ``UNKNOWN`` otherwise.
 
-        Returns ``IpasirStatus.UNSATISFIABLE`` if propagation runs into a
-        conflict and ``IpasirStatus.SATISFIABLE`` if it leaves no variable
-        unassigned, as no decision is needed to satisfy the clauses then and
-        ``val()`` can read the model. Otherwise ``IpasirStatus.UNKNOWN`` is
-        returned.
-
-        TODO: in IPASIR this propagates at whatever decision level the solver
-        is on, which is not implemented here yet, so a ``ValueError`` is
-        raised away from the root level rather than propagating there.
-
-        TODO: an assignment also has to hold in the LRA theory to be a model,
-        so ``IpasirStatus.UNKNOWN`` is returned for a solver that has one and
-        the theory is left for ``solve()`` to check.
+        TODO: IPASIR propagates at any decision level, while this is limited
+        to the root, and a solver with an LRA theory always gets ``UNKNOWN``
+        since the theory is only checked by ``solve()``.
 
         Examples
         ========
 
         >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
-
-        Propagating ``{1}`` through ``{-1, 2}`` implies the literal ``2``,
-        which leaves ``3`` for the search to decide on:
-
-        >>> l = SATSolver([{1}, {-1, 2}, {3, -3}], {1, 2, 3}, set())
-        >>> l.propagate() == IpasirStatus.UNKNOWN
-        True
-        >>> l.fixed(2)
-        1
-
-        With ``3`` gone, propagation assigns every variable and the clauses
-        are satisfied without any search:
-
         >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
         >>> l.propagate() == IpasirStatus.SATISFIABLE
         True
-        >>> l.val(2)
-        2
-
-        A conflict at the root level means the clauses are unsatisfiable:
-
-        >>> l = SATSolver([{1}, {-1}], {1}, set())
-        >>> l.propagate() == IpasirStatus.UNSATISFIABLE
-        True
+        >>> l.fixed(2)
+        1
 
         """
         if len(self.levels) > 1:
@@ -393,33 +362,10 @@ class SATSolver:
 
     def fixed(self, lit):
         """Return 1 if *lit* is implied by the clauses, -1 if ``-lit`` is
-        implied by them, and 0 if neither is known at this point.
+        implied, and 0 if neither is known yet.
 
-        This is only defined at the root level, where no decision has been
-        made and therefore every assignment is implied by the clauses. Note
-        that the literals found by ``propagate()`` are implied but are not
-        necessarily all of the implied literals, so 0 means "not known"
-        rather than "not implied".
-
-        TODO: in IPASIR this can be asked at any decision level, which needs
-        the assignments made at the root level to be kept apart from the ones
-        that follow from a decision.
-
-        Examples
-        ========
-
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
-        >>> l = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
-        >>> l.propagate() == IpasirStatus.UNKNOWN
-        True
-        >>> l.fixed(1), l.fixed(2), l.fixed(-2)
-        (1, 1, -1)
-
-        Nothing is implied about ``3``, as it only occurs in a clause that
-        propagation cannot resolve:
-
-        >>> l.fixed(3)
-        0
+        TODO: IPASIR answers this at any decision level, which needs the root
+        level assignments to be kept apart from those a decision implies.
 
         """
         if len(self.levels) > 1:
@@ -432,25 +378,8 @@ class SATSolver:
         return 0
 
     def solve(self):
-        """Search for a model of the clauses.
-
-        Returns ``IpasirStatus.SATISFIABLE`` or
-        ``IpasirStatus.UNSATISFIABLE``. When ``propagate()`` has already been
-        called, the work it did at the root level is reused rather than
-        repeated. Use ``val()`` to read the model afterwards.
-
-        Examples
-        ========
-
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
-
-        >>> l = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
-        >>> l.propagate() == IpasirStatus.UNKNOWN
-        True
-        >>> l.solve() == IpasirStatus.SATISFIABLE
-        True
-        >>> l.val(2)
-        2
+        """Search for a model, reusing the work ``propagate()`` already did,
+        and return ``SATISFIABLE`` or ``UNSATISFIABLE``.
 
         """
         if self._models is not None:
@@ -470,16 +399,6 @@ class SATSolver:
         """Return *lit* if it is true in the model found by ``solve()``,
         ``-lit`` if it is false there, and 0 if the model does not assign it.
 
-        Examples
-        ========
-
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
-        >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
-        >>> l.solve() == IpasirStatus.SATISFIABLE
-        True
-        >>> l.val(1), l.val(2)
-        (1, 2)
-
         """
         if self._status != IpasirStatus.SATISFIABLE:
             raise ValueError("val() is only defined once solve() has returned "
@@ -492,38 +411,28 @@ class SATSolver:
         return 0
 
     def add(self, lit):
-        """Add *lit* to the clause that is being built, or add that clause to
-        the solver when *lit* is 0.
+        """Add *lit* to the clause being built, or add that clause to the
+        solver when *lit* is 0.
 
-        Adding a clause backtracks to the root level, keeping the literals
-        implied there, so ``solve()`` may be called again afterwards. An
-        unsatisfiable solver stays unsatisfiable.
+        The search restarts from the root level, so ``solve()`` may be called
+        again, and an unsatisfiable solver stays unsatisfiable.
+
+        TODO: only literals of the variables the solver was created with can
+        be added, as there is no way to introduce a new variable yet.
 
         Examples
         ========
 
         >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
-
-        A clause added one literal at a time:
-
-        >>> l = SATSolver([{1}], {1, 2}, set())
-        >>> l.add(-1)
-        >>> l.add(2)
-        >>> l.add(0)
-        >>> l.propagate() == IpasirStatus.SATISFIABLE
-        True
-        >>> l.fixed(2)
-        1
-
-        Clauses may be added to a solver that has already been used:
-
         >>> l = SATSolver([{1, 2}], {1, 2}, set())
         >>> l.solve() == IpasirStatus.SATISFIABLE
         True
-        >>> l.clause(-1)
-        >>> l.clause(-2)
-        >>> l.solve() == IpasirStatus.UNSATISFIABLE
+        >>> l.add(-1)
+        >>> l.add(0)
+        >>> l.solve() == IpasirStatus.SATISFIABLE
         True
+        >>> l.val(1)
+        -1
 
         """
         if lit != 0:
@@ -569,26 +478,10 @@ class SATSolver:
                 self._status = IpasirStatus.UNSATISFIABLE
 
     def clause(self, *lits):
-        """Add the clause made up of *lits* to the solver.
+        """Add the clause made up of *lits*, given one by one or as a single
+        iterable, which covers the ``clause`` overloads of CaDiCaL.
 
-        The literals are given either one by one or as a single iterable of
-        them, covering the ``clause(int, ...)`` and ``clause(const
-        std::vector<int> &)`` overloads of CaDiCaL. This is ``add()`` called
-        on each of them and then on 0, so the remarks made there apply here as
-        well. Without any literal it adds the empty clause, which is false.
-
-        Examples
-        ========
-
-        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
-
-        >>> l = SATSolver([{1, 2}], {1, 2}, set())
-        >>> l.clause(-1, 2)
-        >>> l.propagate() == IpasirStatus.UNKNOWN
-        True
-        >>> l.clause([-2])
-        >>> l.propagate() == IpasirStatus.UNSATISFIABLE
-        True
+        Without any literal it adds the empty clause, which is false.
 
         """
         if len(lits) == 1 and not isinstance(lits[0], int):
@@ -597,30 +490,22 @@ class SATSolver:
         for lit in lits:
             self.add(lit)
 
+        # Zero is never a literal, which is why IPASIR uses it to mark the
+        # end of a clause rather than passing a length around.
         self.add(0)
 
     def copy(self):
-        """Return a solver with the same clauses and the same state as this
-        one, but independent of it.
+        """Return an independent solver with the same clauses and state, so
+        that adding clauses to it or searching with it changes nothing here.
 
-        Adding clauses to the copy or searching with it leaves this solver
-        untouched. The model of a previous ``solve()`` is not carried over,
-        so the copy is free to search again.
-
-        Unlike ``copy`` in CaDiCaL, which copies the formula into a solver
-        given to it, this returns a new solver and copies the state of the
-        search along with the formula.
+        Unlike ``copy`` in CaDiCaL this returns a new solver and copies the
+        state of the search along with the formula.
 
         Examples
         ========
 
         >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
-
-        Trying ``-2`` without giving up the work already done:
-
-        >>> l = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
-        >>> l.propagate() == IpasirStatus.UNKNOWN
-        True
+        >>> l = SATSolver([{1}, {-1, 2}], {1, 2}, set())
         >>> temporary = l.copy()
         >>> temporary.clause(-2)
         >>> temporary.solve() == IpasirStatus.UNSATISFIABLE

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -17,6 +17,7 @@ from sympy.logic.algorithms.dpll2 import SATSolver, UNKNOWN, SATISFIABLE, \
 
 from sympy.logic.algorithms.z3_wrapper import z3_satisfiable
 from sympy.assumptions.cnf import CNF, EncodedCNF
+from sympy.logic.algorithms.lra_theory import LRASolver
 from sympy.logic.tests.test_lra_theory import make_random_problem
 from sympy.core.random import randint
 
@@ -139,7 +140,7 @@ def test_dpll2_satisfiable():
 
 def test_satsolver_propagate():
     # Propagating {1} through {-1, 2} implies 2, which in turn implies 3.
-    s = SATSolver([{1}, {-1, 2}, {-2, 3}], {1, 2, 3}, set())
+    s = SATSolver([{1}, {-1, 2}, {-2, 3}, {4, -4}], {1, 2, 3, 4}, set())
     assert s.propagate() == UNKNOWN
     assert (s.fixed(1), s.fixed(2), s.fixed(3)) == (1, 1, 1)
     assert (s.fixed(-1), s.fixed(-2), s.fixed(-3)) == (-1, -1, -1)
@@ -158,8 +159,26 @@ def test_satsolver_propagate():
     s = SATSolver([{1}, {-1}], {1}, set())
     assert s.propagate() == UNSATISFIABLE
 
-    # Propagating is idempotent.
+    # Propagation leaving no variable unassigned is a model, so no decision
+    # has to be made and the clauses are satisfiable.
     s = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+    assert s.propagate() == SATISFIABLE
+    assert (s.val(1), s.val(2)) == (1, 2)
+    assert s.solve() == SATISFIABLE
+
+    # An assignment of every variable is only a model if it holds in the LRA
+    # theory as well, so propagating on its own cannot report satisfiable.
+    x = symbols('x')
+    enc = EncodedCNF()
+    enc.from_cnf(CNF.from_prop((x > 1) & (x < 0)))
+    lra, conflicts = LRASolver.from_encoded_cnf(enc)
+    s = SATSolver(enc.data + conflicts, enc.variables, set(), enc.symbols,
+                  lra_theory=lra)
+    assert s.propagate() == UNKNOWN
+    assert s.solve() == UNSATISFIABLE
+
+    # Propagating is idempotent.
+    s = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
     assert s.propagate() == UNKNOWN
     assert s.propagate() == UNKNOWN
     assert s.fixed(2) == 1

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -12,8 +12,7 @@ from sympy.logic.algorithms.dpll import dpll, dpll_satisfiable, \
     find_pure_symbol_int_repr, find_unit_clause_int_repr, \
     unit_propagate_int_repr
 from sympy.logic.algorithms.dpll2 import dpll_satisfiable as dpll2_satisfiable
-from sympy.logic.algorithms.dpll2 import SATSolver, UNKNOWN, SATISFIABLE, \
-    UNSATISFIABLE
+from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
 
 from sympy.logic.algorithms.z3_wrapper import z3_satisfiable
 from sympy.assumptions.cnf import CNF, EncodedCNF
@@ -141,30 +140,30 @@ def test_dpll2_satisfiable():
 def test_satsolver_propagate():
     # Propagating {1} through {-1, 2} implies 2, which in turn implies 3.
     s = SATSolver([{1}, {-1, 2}, {-2, 3}, {4, -4}], {1, 2, 3, 4}, set())
-    assert s.propagate() == UNKNOWN
+    assert s.propagate() == IpasirStatus.UNKNOWN
     assert (s.fixed(1), s.fixed(2), s.fixed(3)) == (1, 1, 1)
     assert (s.fixed(-1), s.fixed(-2), s.fixed(-3)) == (-1, -1, -1)
 
     # Nothing is implied when there is no unit clause to propagate from.
     s = SATSolver([{1, 2}, {-1, 2}], {1, 2}, set())
-    assert s.propagate() == UNKNOWN
+    assert s.propagate() == IpasirStatus.UNKNOWN
     assert (s.fixed(1), s.fixed(2)) == (0, 0)
 
     # Propagation is sound but not complete: 2 is implied by these clauses,
     # yet finding that out needs a case split rather than propagation.
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     assert s.val(2) == 2
 
     # A conflict while propagating means the clauses are unsatisfiable.
     s = SATSolver([{1}, {-1}], {1}, set())
-    assert s.propagate() == UNSATISFIABLE
+    assert s.propagate() == IpasirStatus.UNSATISFIABLE
 
     # Propagation leaving no variable unassigned is a model, so no decision
     # has to be made and the clauses are satisfiable.
     s = SATSolver([{1}, {-1, 2}], {1, 2}, set())
-    assert s.propagate() == SATISFIABLE
+    assert s.propagate() == IpasirStatus.SATISFIABLE
     assert (s.val(1), s.val(2)) == (1, 2)
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
 
     # An assignment of every variable is only a model if it holds in the LRA
     # theory as well, so propagating on its own cannot report satisfiable.
@@ -174,13 +173,13 @@ def test_satsolver_propagate():
     lra, conflicts = LRASolver.from_encoded_cnf(enc)
     s = SATSolver(enc.data + conflicts, enc.variables, set(), enc.symbols,
                   lra_theory=lra)
-    assert s.propagate() == UNKNOWN
-    assert s.solve() == UNSATISFIABLE
+    assert s.propagate() == IpasirStatus.UNKNOWN
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
 
     # Propagating is idempotent.
     s = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
-    assert s.propagate() == UNKNOWN
-    assert s.propagate() == UNKNOWN
+    assert s.propagate() == IpasirStatus.UNKNOWN
+    assert s.propagate() == IpasirStatus.UNKNOWN
     assert s.fixed(2) == 1
 
 
@@ -189,11 +188,11 @@ def test_satsolver_solve_after_propagate():
     # level, inspect what that implied, then run the full search.
     s = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
 
-    assert s.propagate() == UNKNOWN
+    assert s.propagate() == IpasirStatus.UNKNOWN
     assert s.fixed(2) == 1
     assert s.fixed(3) == 0
 
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     # The literals fixed at the root level still hold in the model.
     assert s.val(1) == 1
     assert s.val(2) == 2
@@ -201,37 +200,37 @@ def test_satsolver_solve_after_propagate():
 
     # Solving without propagating first gives the same answer.
     s = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     assert (s.val(1), s.val(2)) == (1, 2)
 
     # Unsatisfiable at the root level, both with and without propagating.
     for propagate_first in (True, False):
         s = SATSolver([{1}, {-1, 2}, {-2}], {1, 2}, set())
         if propagate_first:
-            assert s.propagate() == UNSATISFIABLE
-        assert s.solve() == UNSATISFIABLE
+            assert s.propagate() == IpasirStatus.UNSATISFIABLE
+        assert s.solve() == IpasirStatus.UNSATISFIABLE
 
     # Unsatisfiable, but only the full search can show it.
     s = SATSolver([{1, 2}, {1, -2}, {-1, 2}, {-1, -2}], {1, 2}, set())
-    assert s.propagate() == UNKNOWN
-    assert s.solve() == UNSATISFIABLE
+    assert s.propagate() == IpasirStatus.UNKNOWN
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
 
 
 def test_satsolver_interface_errors():
     # val() needs a model to read from.
     s = SATSolver([{1}, {-1, 2}], {1, 2}, set())
     raises(ValueError, lambda: s.val(1))
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     raises(ValueError, lambda: s.solve())
 
     s = SATSolver([{1}, {-1}], {1}, set())
-    assert s.solve() == UNSATISFIABLE
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
     raises(ValueError, lambda: s.val(1))
 
     # Away from the root level an assignment is a guess rather than something
     # the clauses imply, so fixed() and propagate() are not meaningful.
     s = SATSolver([{1, 2}], {1, 2}, set())
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     assert len(s.levels) > 1
     raises(ValueError, lambda: s.fixed(1))
     raises(ValueError, lambda: s.propagate())
@@ -248,87 +247,87 @@ def test_satsolver_add_clause():
     s.add(-1)
     s.add(2)
     s.add(0)
-    assert s.propagate() == SATISFIABLE
+    assert s.propagate() == IpasirStatus.SATISFIABLE
     assert (s.fixed(1), s.fixed(2)) == (1, 1)
 
     # clause() takes the literals one by one or as a single iterable.
     s = SATSolver([{1}], {1, 2}, set())
     s.clause(-1, 2)
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     assert (s.val(1), s.val(2)) == (1, 2)
 
     s = SATSolver([{1}], {1, 2}, set())
     s.clause({-1, 2})
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     assert (s.val(1), s.val(2)) == (1, 2)
 
     # A solver that already searched can be given clauses and search again.
     s = SATSolver([{1, 2}], {1, 2}, set())
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     s.clause(-1)
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     assert s.val(1) == -1
     assert s.val(2) == 2
 
     # An unsatisfiable solver stays unsatisfiable.
     s.clause(-2)
-    assert s.solve() == UNSATISFIABLE
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
     s.clause(1, 2)
-    assert s.solve() == UNSATISFIABLE
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
 
     # A clause falsified by the literals fixed at the root level conflicts,
     # and one with a single literal left over propagates it.
     s = SATSolver([{1}, {-1, 2}], {1, 2}, set())
-    assert s.propagate() == SATISFIABLE
+    assert s.propagate() == IpasirStatus.SATISFIABLE
     s.clause(-2)
-    assert s.propagate() == UNSATISFIABLE
+    assert s.propagate() == IpasirStatus.UNSATISFIABLE
 
     s = SATSolver([{1}], {1, 2, 3}, set())
-    assert s.propagate() == UNKNOWN
+    assert s.propagate() == IpasirStatus.UNKNOWN
     s.clause(-1, -2, 3)
     s.clause(2)
-    assert s.propagate() == SATISFIABLE
+    assert s.propagate() == IpasirStatus.SATISFIABLE
     assert s.fixed(3) == 1
 
     # The empty clause is false.
     s = SATSolver([{1, 2}], {1, 2}, set())
     s.clause()
-    assert s.solve() == UNSATISFIABLE
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
 
 
 def test_satsolver_copy():
     # The copy has the state of the original without sharing it.
     s = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
-    assert s.propagate() == UNKNOWN
+    assert s.propagate() == IpasirStatus.UNKNOWN
 
     temporary = s.copy()
     assert (temporary.fixed(1), temporary.fixed(2)) == (1, 1)
 
     # Clauses added to the copy say nothing about the original.
     temporary.clause(-2)
-    assert temporary.solve() == UNSATISFIABLE
+    assert temporary.solve() == IpasirStatus.UNSATISFIABLE
     assert s.fixed(2) == 1
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     assert s.val(2) == 2
 
     # The copy of a solved solver searches again, the original keeps its model.
     s = SATSolver([{1, 2}], {1, 2}, set())
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
     model = (s.val(1), s.val(2))
 
     temporary = s.copy()
     temporary.clause(-1)
     temporary.clause(-2)
-    assert temporary.solve() == UNSATISFIABLE
+    assert temporary.solve() == IpasirStatus.UNSATISFIABLE
     assert (s.val(1), s.val(2)) == model
 
     # The clauses of the original are left alone too.
     s = SATSolver([{1, 2}], {1, 2}, set())
     temporary = s.copy()
     temporary.clause(-1, -2)
-    assert temporary.solve() == SATISFIABLE
+    assert temporary.solve() == IpasirStatus.SATISFIABLE
     assert s.clauses == [[1, 2]]
-    assert s.solve() == SATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
 
 
 def test_minisat22_satisfiable():

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -12,6 +12,8 @@ from sympy.logic.algorithms.dpll import dpll, dpll_satisfiable, \
     find_pure_symbol_int_repr, find_unit_clause_int_repr, \
     unit_propagate_int_repr
 from sympy.logic.algorithms.dpll2 import dpll_satisfiable as dpll2_satisfiable
+from sympy.logic.algorithms.dpll2 import SATSolver, UNKNOWN, SATISFIABLE, \
+    UNSATISFIABLE
 
 from sympy.logic.algorithms.z3_wrapper import z3_satisfiable
 from sympy.assumptions.cnf import CNF, EncodedCNF
@@ -133,6 +135,87 @@ def test_dpll2_satisfiable():
         {B: True, A: True})
     assert dpll2_satisfiable( Equivalent(A, B) & A ) == {A: True, B: True}
     assert dpll2_satisfiable( Equivalent(A, B) & ~A ) == {A: False, B: False}
+
+
+def test_satsolver_propagate():
+    # Propagating {1} through {-1, 2} implies 2, which in turn implies 3.
+    s = SATSolver([{1}, {-1, 2}, {-2, 3}], {1, 2, 3}, set())
+    assert s.propagate() == UNKNOWN
+    assert (s.fixed(1), s.fixed(2), s.fixed(3)) == (1, 1, 1)
+    assert (s.fixed(-1), s.fixed(-2), s.fixed(-3)) == (-1, -1, -1)
+
+    # Nothing is implied when there is no unit clause to propagate from.
+    s = SATSolver([{1, 2}, {-1, 2}], {1, 2}, set())
+    assert s.propagate() == UNKNOWN
+    assert (s.fixed(1), s.fixed(2)) == (0, 0)
+
+    # Propagation is sound but not complete: 2 is implied by these clauses,
+    # yet finding that out needs a case split rather than propagation.
+    assert s.solve() == SATISFIABLE
+    assert s.val(2) == 2
+
+    # A conflict while propagating means the clauses are unsatisfiable.
+    s = SATSolver([{1}, {-1}], {1}, set())
+    assert s.propagate() == UNSATISFIABLE
+
+    # Propagating is idempotent.
+    s = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+    assert s.propagate() == UNKNOWN
+    assert s.propagate() == UNKNOWN
+    assert s.fixed(2) == 1
+
+
+def test_satsolver_solve_after_propagate():
+    # The three steps needed by the assumptions system: propagate at the root
+    # level, inspect what that implied, then run the full search.
+    s = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
+
+    assert s.propagate() == UNKNOWN
+    assert s.fixed(2) == 1
+    assert s.fixed(3) == 0
+
+    assert s.solve() == SATISFIABLE
+    # The literals fixed at the root level still hold in the model.
+    assert s.val(1) == 1
+    assert s.val(2) == 2
+    assert s.val(3) in (3, -3)
+
+    # Solving without propagating first gives the same answer.
+    s = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
+    assert s.solve() == SATISFIABLE
+    assert (s.val(1), s.val(2)) == (1, 2)
+
+    # Unsatisfiable at the root level, both with and without propagating.
+    for propagate_first in (True, False):
+        s = SATSolver([{1}, {-1, 2}, {-2}], {1, 2}, set())
+        if propagate_first:
+            assert s.propagate() == UNSATISFIABLE
+        assert s.solve() == UNSATISFIABLE
+
+    # Unsatisfiable, but only the full search can show it.
+    s = SATSolver([{1, 2}, {1, -2}, {-1, 2}, {-1, -2}], {1, 2}, set())
+    assert s.propagate() == UNKNOWN
+    assert s.solve() == UNSATISFIABLE
+
+
+def test_satsolver_interface_errors():
+    # val() needs a model to read from.
+    s = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+    raises(ValueError, lambda: s.val(1))
+    assert s.solve() == SATISFIABLE
+    raises(ValueError, lambda: s.solve())
+
+    s = SATSolver([{1}, {-1}], {1}, set())
+    assert s.solve() == UNSATISFIABLE
+    raises(ValueError, lambda: s.val(1))
+
+    # Away from the root level an assignment is a guess rather than something
+    # the clauses imply, so fixed() and propagate() are not meaningful.
+    s = SATSolver([{1, 2}], {1, 2}, set())
+    assert s.solve() == SATISFIABLE
+    assert len(s.levels) > 1
+    raises(ValueError, lambda: s.fixed(1))
+    raises(ValueError, lambda: s.propagate())
 
 
 def test_minisat22_satisfiable():

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -1,6 +1,8 @@
 """For more tests on satisfiability, see test_dimacs"""
 from __future__ import annotations
 
+from itertools import product
+
 from sympy.assumptions.ask import Q
 from sympy.core.symbol import symbols
 from sympy.core.relational import Ne, Eq, Unequality
@@ -18,7 +20,7 @@ from sympy.logic.algorithms.z3_wrapper import z3_satisfiable
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.logic.algorithms.lra_theory import LRASolver
 from sympy.logic.tests.test_lra_theory import make_random_problem
-from sympy.core.random import randint
+from sympy.core.random import randint, choice
 
 from sympy.testing.pytest import raises, skip
 from sympy.external import import_module
@@ -328,6 +330,40 @@ def test_satsolver_copy():
     assert temporary.solve() == IpasirStatus.SATISFIABLE
     assert s.clauses == [[1, 2]]
     assert s.solve() == IpasirStatus.SATISFIABLE
+
+
+def test_satsolver_add_clause_random():
+    # Adding clauses to a solver that has already searched and then searching
+    # again has to agree with checking every assignment by hand.
+    for _ in range(150):
+        num_vars = randint(2, 6)
+        variables = set(range(1, num_vars + 1))
+        clauses = [{randint(1, num_vars) * choice([-1, 1])
+                    for _ in range(randint(1, 3))}
+                   for _ in range(randint(1, 3))]
+
+        solver = SATSolver(clauses, variables, set())
+
+        for _ in range(12):
+            satisfiable = any(
+                all(any((lit > 0) == assignment[abs(lit) - 1] for lit in clause)
+                    for clause in clauses)
+                for assignment in product([False, True], repeat=num_vars))
+
+            assert (solver.solve() == IpasirStatus.SATISFIABLE) == satisfiable
+
+            if satisfiable:
+                # The model has to assign every variable and satisfy every
+                # clause the solver has been given so far.
+                for var in variables:
+                    assert solver.val(var) in (var, -var)
+                for clause in clauses:
+                    assert any(solver.val(lit) == lit for lit in clause)
+
+            new_clause = {randint(1, num_vars) * choice([-1, 1])
+                          for _ in range(randint(1, 3))}
+            clauses.append(new_clause)
+            solver.clause(new_clause)
 
 
 def test_minisat22_satisfiable():

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -236,6 +236,100 @@ def test_satsolver_interface_errors():
     raises(ValueError, lambda: s.fixed(1))
     raises(ValueError, lambda: s.propagate())
 
+    # A variable the solver does not have cannot be introduced.
+    s = SATSolver([{1, 2}], {1, 2}, set())
+    raises(ValueError, lambda: s.add(3))
+    raises(ValueError, lambda: s.clause(-1, 3))
+
+
+def test_satsolver_add_clause():
+    # A clause is built one literal at a time and added by a final 0.
+    s = SATSolver([{1}], {1, 2}, set())
+    s.add(-1)
+    s.add(2)
+    s.add(0)
+    assert s.propagate() == SATISFIABLE
+    assert (s.fixed(1), s.fixed(2)) == (1, 1)
+
+    # clause() takes the literals one by one or as a single iterable.
+    s = SATSolver([{1}], {1, 2}, set())
+    s.clause(-1, 2)
+    assert s.solve() == SATISFIABLE
+    assert (s.val(1), s.val(2)) == (1, 2)
+
+    s = SATSolver([{1}], {1, 2}, set())
+    s.clause({-1, 2})
+    assert s.solve() == SATISFIABLE
+    assert (s.val(1), s.val(2)) == (1, 2)
+
+    # A solver that already searched can be given clauses and search again.
+    s = SATSolver([{1, 2}], {1, 2}, set())
+    assert s.solve() == SATISFIABLE
+    s.clause(-1)
+    assert s.solve() == SATISFIABLE
+    assert s.val(1) == -1
+    assert s.val(2) == 2
+
+    # An unsatisfiable solver stays unsatisfiable.
+    s.clause(-2)
+    assert s.solve() == UNSATISFIABLE
+    s.clause(1, 2)
+    assert s.solve() == UNSATISFIABLE
+
+    # A clause falsified by the literals fixed at the root level conflicts,
+    # and one with a single literal left over propagates it.
+    s = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+    assert s.propagate() == SATISFIABLE
+    s.clause(-2)
+    assert s.propagate() == UNSATISFIABLE
+
+    s = SATSolver([{1}], {1, 2, 3}, set())
+    assert s.propagate() == UNKNOWN
+    s.clause(-1, -2, 3)
+    s.clause(2)
+    assert s.propagate() == SATISFIABLE
+    assert s.fixed(3) == 1
+
+    # The empty clause is false.
+    s = SATSolver([{1, 2}], {1, 2}, set())
+    s.clause()
+    assert s.solve() == UNSATISFIABLE
+
+
+def test_satsolver_copy():
+    # The copy has the state of the original without sharing it.
+    s = SATSolver([{1}, {-1, 2}, {3, 4}], {1, 2, 3, 4}, set())
+    assert s.propagate() == UNKNOWN
+
+    temporary = s.copy()
+    assert (temporary.fixed(1), temporary.fixed(2)) == (1, 1)
+
+    # Clauses added to the copy say nothing about the original.
+    temporary.clause(-2)
+    assert temporary.solve() == UNSATISFIABLE
+    assert s.fixed(2) == 1
+    assert s.solve() == SATISFIABLE
+    assert s.val(2) == 2
+
+    # The copy of a solved solver searches again, the original keeps its model.
+    s = SATSolver([{1, 2}], {1, 2}, set())
+    assert s.solve() == SATISFIABLE
+    model = (s.val(1), s.val(2))
+
+    temporary = s.copy()
+    temporary.clause(-1)
+    temporary.clause(-2)
+    assert temporary.solve() == UNSATISFIABLE
+    assert (s.val(1), s.val(2)) == model
+
+    # The clauses of the original are left alone too.
+    s = SATSolver([{1, 2}], {1, 2}, set())
+    temporary = s.copy()
+    temporary.clause(-1, -2)
+    assert temporary.solve() == SATISFIABLE
+    assert s.clauses == [[1, 2]]
+    assert s.solve() == SATISFIABLE
+
 
 def test_minisat22_satisfiable():
     A, B, C = symbols('A,B,C')


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes part 1 of https://github.com/sympy/sympy/issues/30157

#### Brief description of what is fixed or changed
Adds IPASIR style interface to `SATSolver`:

* `propagate()` does root level unit propagation without making any decisions
* `fixed(lit)` reports whether a literal is implied by the clauses at that point
* `solve()` continues with the full search, reusing the work `propagate()` already did
* `val(lit)` reads a literal's value out of the model

Tests are also added for the same. This is what #30121 needs in order to answer a query from the root level assignments before doing any search.

#### Other comments
Should be looked after #29906 is merged. This is a continuation of that PR and will cause conflicts once #29906 is in.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
The tests and documentation/comments were written down by Claude Code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
