### PR TITLE
fix(physics.quantum): support scipy.sparse array API and avoid csr_matrix deprecation warnings

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1459,6 +1459,7 @@ Sai Udayagiri <saibabu.udayagiri@gmail.com> Sai Udayagiri <saibabu.udayagiri@ema
 Saicharan <62512681+saicharan2804@users.noreply.github.com>
 Saicharan <saicharanhahaha@gmail.com>
 Saikat Das <saikatdchhe@gmail.com>
+Sajal Kumar Mishra <sajalmishra0906@gmail.com> snipy09 <sajalmishra0906@gmail.com>
 Saket Kumar Singh <saketkumar1202@gmail.com>
 Saketh <alurusaisaketh@gmail.com>
 Sakirul Alam <binarysakir@gmail.com>

--- a/sympy/physics/quantum/identitysearch.py
+++ b/sympy/physics/quantum/identitysearch.py
@@ -71,7 +71,7 @@ def is_scalar_sparse_matrix(circuit, nqubits, identity_only, eps=1e-11):
         # See parameter for default value.
 
         # Get the ndarray version of the dense matrix
-        dense_matrix = matrix.todense().getA()
+        dense_matrix = np.asarray(matrix.todense())
         # Since complex values can't be compared, must split
         # the matrix into real and imaginary components
         # Find the real values in between -eps and eps

--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -41,7 +41,10 @@ if not scipy:
     sparse = None
 else:
     sparse = scipy.sparse
-    scipy_sparse_matrix = sparse.spmatrix # type: ignore
+    if hasattr(sparse, 'sparray'):
+        scipy_sparse_matrix = (sparse.spmatrix, sparse.sparray)  # type: ignore
+    else:
+        scipy_sparse_matrix = sparse.spmatrix  # type: ignore
 
 
 def sympy_to_numpy(m, **options):
@@ -63,6 +66,8 @@ def sympy_to_scipy_sparse(m, **options):
         raise ImportError
     dtype = options.get('dtype', 'complex')
     if isinstance(m, MatrixBase):
+        if hasattr(sparse, 'csr_array'):
+            return sparse.csr_array(np.array(m.tolist(), dtype=dtype))
         return sparse.csr_matrix(np.array(m.tolist(), dtype=dtype))
     elif isinstance(m, Expr):
         if m.is_Number or m.is_NumberSymbol or m == I:
@@ -72,7 +77,8 @@ def sympy_to_scipy_sparse(m, **options):
 
 def scipy_sparse_to_sympy(m, **options):
     """Convert a scipy.sparse matrix to a SymPy matrix."""
-    return MatrixBase(m.todense())
+    from sympy.matrices.dense import Matrix
+    return Matrix(m.todense())
 
 
 def numpy_to_sympy(m, **options):
@@ -113,6 +119,8 @@ def to_scipy_sparse(m, **options):
     elif isinstance(m, numpy_ndarray):
         if not sparse:
             raise ImportError
+        if hasattr(sparse, 'csr_array'):
+            return sparse.csr_array(m)
         return sparse.csr_matrix(m)
     elif isinstance(m, scipy_sparse_matrix):
         return m
@@ -167,6 +175,8 @@ def _scipy_sparse_tensor_product(*product):
         answer = sparse.kron(answer, item)
     # The final matrices will just be multiplied, so csr is a good final
     # sparse format.
+    if hasattr(sparse, 'csr_array'):
+        return sparse.csr_array(answer)
     return sparse.csr_matrix(answer)
 
 
@@ -221,8 +231,12 @@ def _scipy_sparse_zeros(m, n, **options):
     if not sparse:
         raise ImportError
     if spmatrix == 'lil':
+        if hasattr(sparse, 'lil_array'):
+            return sparse.lil_array((m, n), dtype=dtype)
         return sparse.lil_matrix((m, n), dtype=dtype)
     elif spmatrix == 'csr':
+        if hasattr(sparse, 'csr_array'):
+            return sparse.csr_array((m, n), dtype=dtype)
         return sparse.csr_matrix((m, n), dtype=dtype)
 
 

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -212,6 +212,8 @@ class Qubit(QubitState, Ket):
             return np.array(result, dtype='complex').transpose()
         elif _format == 'scipy.sparse':
             from scipy import sparse
+            if hasattr(sparse, 'csr_array'):
+                return sparse.csr_array(result, dtype='complex').transpose()
             return sparse.csr_matrix(result, dtype='complex').transpose()
 
     def _eval_trace(self, bra, **kwargs):

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -182,6 +182,11 @@ def represent(expr, **options):
             base = inv(base.tocsc()).tocsr()
         if format == 'numpy':
             return np.linalg.matrix_power(base, exp)
+        if format == 'scipy.sparse':
+            from scipy import sparse
+            if hasattr(sparse, 'sparray') and isinstance(base, sparse.sparray):
+                from scipy.sparse.linalg import matrix_power
+                return matrix_power(base, exp)
         return base ** exp
     elif isinstance(expr, TensorProduct):
         new_args = [represent(arg, **options) for arg in expr.args]
@@ -231,8 +236,14 @@ def represent(expr, **options):
 
         next_arg = represent(arg, **options)
         if format == 'numpy' and isinstance(next_arg, np.ndarray):
-            # Must use np.matmult to "matrix multiply" two np.ndarray
+            # Must use np.matmul to "matrix multiply" two np.ndarray
             result = np.matmul(next_arg, result)
+        elif format == 'scipy.sparse':
+            from scipy import sparse
+            if hasattr(sparse, 'sparray') and isinstance(next_arg, sparse.sparray):
+                result = next_arg @ result
+            else:
+                result = next_arg*result
         else:
             result = next_arg*result
         last_arg = arg

--- a/sympy/physics/quantum/tests/test_matrixutils.py
+++ b/sympy/physics/quantum/tests/test_matrixutils.py
@@ -135,3 +135,16 @@ def test_matrix_zeros_scipy():
 
     sci = matrix_zeros(4, 4, format='scipy.sparse')
     assert isinstance(sci, scipy_sparse_matrix)
+
+
+def test_scipy_sparse_array_support():
+    if not np or not scipy:
+        skip("numpy or scipy not installed.")
+
+    sparse = scipy.sparse
+    if hasattr(sparse, 'csr_array'):
+        arr = sparse.csr_array([[1, 2], [3, 4]])
+        assert isinstance(arr, scipy_sparse_matrix)
+        sym_mat = to_sympy(arr)
+        assert sym_mat == Matrix([[1, 2], [3, 4]])
+


### PR DESCRIPTION
## Summary
- Update `sympy.physics.quantum.matrixutils` and related modules (`qubit`, `represent`, `identitysearch`) to support modern SciPy sparse arrays (`csr_array`, `sparray`) in addition to legacy `csr_matrix`/`spmatrix`.
- Prevents `DeprecationWarning` when using modern SciPy versions where `csr_matrix` is deprecated in favor of `csr_array`.
- Handles matrix multiplication (`@`) and matrix power (`matrix_power`) for `sparray` objects in `represent()`.
- Adds test coverage for `csr_array` conversion in `test_matrixutils.py`.

Fixes #30198

<!-- BEGIN RELEASE NOTES -->
- physics.quantum
  - Supported SciPy sparse arrays (`csr_array`, `sparray`) in `matrixutils` and related quantum modules to prevent `DeprecationWarning`s in modern SciPy versions.
<!-- END RELEASE NOTES -->