### PR TITLE
fix: Use scipy sparse arrays instead of sparse matrices

### DIFF
--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -2807,7 +2807,8 @@ def test_17522_scipy():
     except ImportError:
         skip('SciPy must be available to test indexing matrixified SciPy sparse matrices')
 
-    m = _matrixify(csr_matrix([[1, 2], [3, 4]]))
+    with ignore_warnings(DeprecationWarning):
+        m = _matrixify(csr_matrix([[1, 2], [3, 4]]))
     assert m[3] == 4
     assert list(m) == [1, 2, 3, 4]
 

--- a/sympy/matrices/tests/test_matrixbase.py
+++ b/sympy/matrices/tests/test_matrixbase.py
@@ -3512,11 +3512,16 @@ def test_17522_mpmath():
 def test_17522_scipy():
     from sympy.matrices.common import _matrixify
     try:
-        from scipy.sparse import csr_matrix
+        from scipy.sparse import csr_array, csr_matrix
     except ImportError:
-        skip('SciPy must be available to test indexing matrixified SciPy sparse matrices')
+        skip('SciPy must be available to test indexing matrixified SciPy sparse arrays and matrices')
 
-    m = _matrixify(csr_matrix([[1, 2], [3, 4]]))
+    m = _matrixify(csr_array([[1, 2], [3, 4]]))
+    assert m[3] == 4
+    assert list(m) == [1, 2, 3, 4]
+
+    with ignore_warnings(DeprecationWarning):
+        m = _matrixify(csr_matrix([[1, 2], [3, 4]]))
     assert m[3] == 4
     assert list(m) == [1, 2, 3, 4]
 

--- a/sympy/physics/quantum/identitysearch.py
+++ b/sympy/physics/quantum/identitysearch.py
@@ -71,7 +71,7 @@ def is_scalar_sparse_matrix(circuit, nqubits, identity_only, eps=1e-11):
         # See parameter for default value.
 
         # Get the ndarray version of the dense matrix
-        dense_matrix = matrix.todense().getA()
+        dense_matrix = matrix.toarray()
         # Since complex values can't be compared, must split
         # the matrix into real and imaginary components
         # Find the real values in between -eps and eps

--- a/sympy/physics/quantum/matrixcache.py
+++ b/sympy/physics/quantum/matrixcache.py
@@ -16,8 +16,8 @@ class MatrixCache:
 
     This class takes small matrices in the standard ``sympy.Matrix`` format,
     and then converts these to both ``numpy.matrix`` and
-    ``scipy.sparse.csr_matrix`` matrices. These matrices are then stored for
-    future recovery.
+    ``scipy.sparse.csr_array`` arrays. These representations are then stored
+    for future recovery.
     """
 
     def __init__(self, dtype='complex'):

--- a/sympy/physics/quantum/matrixutils.py
+++ b/sympy/physics/quantum/matrixutils.py
@@ -1,6 +1,8 @@
 """Utilities to deal with sympy.Matrix, numpy and scipy.sparse."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sympy.core.expr import Expr
 from sympy.core.numbers import I
 from sympy.core.singleton import S
@@ -24,24 +26,36 @@ __all__ = [
     'matrix_zeros'
 ]
 
-# Conditionally define the base classes for numpy and scipy.sparse arrays
-# for use in isinstance tests.
+# Conditionally define the base classes for NumPy and SciPy sparse arrays and
+# matrices for use in isinstance tests.  Sparse matrices are included here so
+# that they continue to be accepted as inputs even though the functions in
+# this module create sparse arrays.
 
 np = import_module('numpy')
-if not np:
+if TYPE_CHECKING:
+    from numpy import ndarray as numpy_ndarray
+elif not np:
     class numpy_ndarray:
         pass
 else:
-    numpy_ndarray = np.ndarray  # type: ignore
+    numpy_ndarray = np.ndarray
 
 scipy = import_module('scipy', import_kwargs={'fromlist': ['sparse']})
-if not scipy:
+if TYPE_CHECKING:
+    from scipy import sparse
+    from scipy.sparse import sparray as scipy_sparse_matrix
+elif not scipy:
     class scipy_sparse_matrix:
         pass
     sparse = None
 else:
     sparse = scipy.sparse
-    scipy_sparse_matrix = sparse.spmatrix # type: ignore
+    if hasattr(sparse, 'sparray'):
+        # Since SciPy 1.11 sparse arrays and matrices have separate bases.
+        scipy_sparse_matrix = (sparse.sparray, sparse.spmatrix)
+    else:
+        # In SciPy 1.8-1.10 sparse arrays inherit from spmatrix.
+        scipy_sparse_matrix = sparse.spmatrix
 
 
 def sympy_to_numpy(m, **options):
@@ -58,12 +72,13 @@ def sympy_to_numpy(m, **options):
 
 
 def sympy_to_scipy_sparse(m, **options):
-    """Convert a SymPy Matrix/complex number to a numpy matrix or scalar."""
+    """Convert a SymPy Matrix/complex number to a SciPy sparse array or
+    scalar."""
     if not np or not sparse:
         raise ImportError
     dtype = options.get('dtype', 'complex')
     if isinstance(m, MatrixBase):
-        return sparse.csr_matrix(np.array(m.tolist(), dtype=dtype))
+        return sparse.csr_array(np.array(m.tolist(), dtype=dtype))
     elif isinstance(m, Expr):
         if m.is_Number or m.is_NumberSymbol or m == I:
             return complex(m)
@@ -71,7 +86,7 @@ def sympy_to_scipy_sparse(m, **options):
 
 
 def scipy_sparse_to_sympy(m, **options):
-    """Convert a scipy.sparse matrix to a SymPy matrix."""
+    """Convert a SciPy sparse array or matrix to a SymPy matrix."""
     return MatrixBase(m.todense())
 
 
@@ -106,14 +121,14 @@ def to_numpy(m, **options):
 
 
 def to_scipy_sparse(m, **options):
-    """Convert a sympy/numpy matrix to a scipy.sparse matrix."""
+    """Convert a SymPy/NumPy matrix to a SciPy sparse array."""
     dtype = options.get('dtype', 'complex')
     if isinstance(m, (MatrixBase, Expr)):
         return sympy_to_scipy_sparse(m, dtype=dtype)
     elif isinstance(m, numpy_ndarray):
         if not sparse:
             raise ImportError
-        return sparse.csr_matrix(m)
+        return sparse.csr_array(m)
     elif isinstance(m, scipy_sparse_matrix):
         return m
     raise TypeError('Expected sympy/numpy/scipy.sparse matrix, got: %r' % m)
@@ -167,7 +182,7 @@ def _scipy_sparse_tensor_product(*product):
         answer = sparse.kron(answer, item)
     # The final matrices will just be multiplied, so csr is a good final
     # sparse format.
-    return sparse.csr_matrix(answer)
+    return sparse.csr_array(answer)
 
 
 def matrix_tensor_product(*product):
@@ -191,7 +206,9 @@ def _scipy_sparse_eye(n):
     """scipy.sparse version of complex eye."""
     if not sparse:
         raise ImportError
-    return sparse.eye(n, n, dtype='complex')
+    indices = np.arange(n)
+    return sparse.csr_array(
+        (np.ones(n, dtype='complex'), (indices, indices)), shape=(n, n))
 
 
 def matrix_eye(n, **options):
@@ -221,9 +238,9 @@ def _scipy_sparse_zeros(m, n, **options):
     if not sparse:
         raise ImportError
     if spmatrix == 'lil':
-        return sparse.lil_matrix((m, n), dtype=dtype)
+        return sparse.lil_array((m, n), dtype=dtype)
     elif spmatrix == 'csr':
-        return sparse.csr_matrix((m, n), dtype=dtype)
+        return sparse.csr_array((m, n), dtype=dtype)
 
 
 def matrix_zeros(m, n, **options):

--- a/sympy/physics/quantum/qubit.py
+++ b/sympy/physics/quantum/qubit.py
@@ -212,7 +212,7 @@ class Qubit(QubitState, Ket):
             return np.array(result, dtype='complex').transpose()
         elif _format == 'scipy.sparse':
             from scipy import sparse
-            return sparse.csr_matrix(result, dtype='complex').transpose()
+            return sparse.csr_array(result, dtype='complex').transpose()
 
     def _eval_trace(self, bra, **kwargs):
         indices = kwargs.get('indices', [])

--- a/sympy/physics/quantum/represent.py
+++ b/sympy/physics/quantum/represent.py
@@ -19,7 +19,9 @@ from sympy.physics.quantum.anticommutator import AntiCommutator
 from sympy.physics.quantum.innerproduct import InnerProduct
 from sympy.physics.quantum.qexpr import QExpr
 from sympy.physics.quantum.tensorproduct import TensorProduct
-from sympy.physics.quantum.matrixutils import flatten_scalar
+from sympy.physics.quantum.matrixutils import (
+    flatten_scalar, matrix_eye, scipy_sparse_matrix,
+)
 from sympy.physics.quantum.state import KetBase, BraBase, StateBase
 from sympy.physics.quantum.operator import Operator, OuterProduct
 from sympy.physics.quantum.qapply import qapply
@@ -50,6 +52,23 @@ def _sympy_to_scalar(e):
         elif e.is_Number or e.is_NumberSymbol or e == I:
             return complex(e)
     raise TypeError('Expected number, got: %r' % e)
+
+
+try:
+    from scipy.sparse.linalg import matrix_power as _scipy_sparse_matrix_power
+except ImportError:
+    # Compatibility fallback for SciPy < 1.12, which does not provide
+    # scipy.sparse.linalg.matrix_power.
+    def _scipy_sparse_matrix_power(base, exp):
+        """Raise a SciPy sparse array to a nonnegative integer power."""
+        result = matrix_eye(base.shape[0], format='scipy.sparse')
+        while exp:
+            if exp % 2:
+                result = result @ base
+            exp //= 2
+            if exp:
+                base = base @ base
+        return result
 
 
 def represent(expr, **options):
@@ -182,6 +201,8 @@ def represent(expr, **options):
             base = inv(base.tocsc()).tocsr()
         if format == 'numpy':
             return np.linalg.matrix_power(base, exp)
+        if format == 'scipy.sparse':
+            return _scipy_sparse_matrix_power(base, exp)
         return base ** exp
     elif isinstance(expr, TensorProduct):
         new_args = [represent(arg, **options) for arg in expr.args]
@@ -231,8 +252,12 @@ def represent(expr, **options):
 
         next_arg = represent(arg, **options)
         if format == 'numpy' and isinstance(next_arg, np.ndarray):
-            # Must use np.matmult to "matrix multiply" two np.ndarray
+            # Must use np.matmul to matrix multiply two NumPy arrays.
             result = np.matmul(next_arg, result)
+        elif (format == 'scipy.sparse' and
+              isinstance(next_arg, scipy_sparse_matrix) and
+              isinstance(result, scipy_sparse_matrix)):
+            result = next_arg @ result
         else:
             result = next_arg*result
         last_arg = arg

--- a/sympy/physics/quantum/tests/test_dagger.py
+++ b/sympy/physics/quantum/tests/test_dagger.py
@@ -80,7 +80,7 @@ def test_scipy_sparse_dagger():
     else:
         sparse = scipy.sparse
 
-    a = sparse.csr_matrix([[1.0 + 0.0j, 2.0j], [-1.0j, 2.0 + 0.0j]])
+    a = sparse.csr_array([[1.0 + 0.0j, 2.0j], [-1.0j, 2.0 + 0.0j]])
     adag = a.copy().transpose().conjugate()
     assert np.linalg.norm((Dagger(a) - adag).todense()) == 0.0
 

--- a/sympy/physics/quantum/tests/test_matrixutils.py
+++ b/sympy/physics/quantum/tests/test_matrixutils.py
@@ -6,11 +6,11 @@ from sympy.matrices.dense import (Matrix, ones, zeros)
 
 from sympy.physics.quantum.matrixutils import (
     to_sympy, to_numpy, to_scipy_sparse, matrix_tensor_product,
-    matrix_to_zero, matrix_zeros, numpy_ndarray, scipy_sparse_matrix
+    matrix_to_zero, matrix_zeros, numpy_ndarray
 )
 
 from sympy.external import import_module
-from sympy.testing.pytest import skip
+from sympy.testing.pytest import ignore_warnings, skip
 
 m = Matrix([[1, 2], [3, 4]])
 
@@ -110,8 +110,15 @@ def test_to_scipy_sparse():
     else:
         sparse = scipy.sparse
 
-    result = sparse.csr_matrix([[1, 2], [3, 4]], dtype='complex')
-    assert np.linalg.norm((to_scipy_sparse(m) - result).todense()) == 0.0
+    result = sparse.csr_array([[1, 2], [3, 4]], dtype='complex')
+    converted = to_scipy_sparse(m)
+    assert isinstance(converted, sparse.csr_array)
+    assert np.linalg.norm((converted - result).todense()) == 0.0
+
+    # Legacy sparse matrices remain accepted as inputs.
+    with ignore_warnings(DeprecationWarning):
+        legacy = sparse.csr_matrix([[1, 2], [3, 4]], dtype='complex')
+    assert to_scipy_sparse(legacy) is legacy
 
 epsilon = .000001
 
@@ -134,4 +141,4 @@ def test_matrix_zeros_scipy():
         skip("scipy not installed.")
 
     sci = matrix_zeros(4, 4, format='scipy.sparse')
-    assert isinstance(sci, scipy_sparse_matrix)
+    assert isinstance(sci, scipy.sparse.csr_array)

--- a/sympy/printing/numpy.py
+++ b/sympy/printing/numpy.py
@@ -369,7 +369,7 @@ class SciPyPrinter(NumPyPrinter):
             data.append(v)
 
         return "{name}(({data}, ({i}, {j})), shape={shape})".format(
-            name=self._module_format('scipy.sparse.coo_matrix'),
+            name=self._module_format('scipy.sparse.coo_array'),
             data=data, i=i, j=j, shape=expr.shape
         )
 

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -224,7 +224,7 @@ def test_SciPyPrinter():
     assert not any(m.startswith('scipy') for m in p.module_imports)
     smat = SparseMatrix(2, 5, {(0, 1): 3})
     assert p.doprint(smat) == \
-        'scipy.sparse.coo_matrix(([3], ([0], [1])), shape=(2, 5))'
+        'scipy.sparse.coo_array(([3], ([0], [1])), shape=(2, 5))'
     assert 'scipy.sparse' in p.module_imports
 
     assert p.doprint(S.GoldenRatio) == 'scipy.constants.golden_ratio'

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -722,13 +722,13 @@ def test_numpy_old_matrix():
         assert isinstance(f(1, 2, 3), numpy.matrix)
 
 
-def test_scipy_sparse_matrix():
+def test_scipy_sparse_array():
     if not scipy:
         skip("scipy not installed.")
     A = SparseMatrix([[x, 0], [0, y]])
     f = lambdify((x, y), A, modules="scipy")
     B = f(1, 2)
-    assert isinstance(B, scipy.sparse.coo_matrix)
+    assert isinstance(B, scipy.sparse.coo_array)
 
 
 


### PR DESCRIPTION
SciPy has deprecated the sparse matrix types and will remove them in a future version. The sparse array types should be used instead. This commit changes sympy's quantum module to use sparse array types instead of sparse matrix types. This is not a backwards-comptaible change but is ultimately necessary since SciPy is going to remove the sparse matrix types altogether.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes gh-30198
Closes gh-30202 (this PR is a better fix)

#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Most code written by codex.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.quantum
    * BREAKING: Operations in physics.quantum that previously returned SciPy sparse matrices now return SciPy sparse arrays. 

* utilities
  * BREAKING: `lambdify(..., modules="scipy")` now returns a SciPy sparse array instead of a sparse matrix when lambdifying a SymPy SparseMatrix or ImmutableSparseMatrix. This follows SciPy’s deprecation of sparse matrix classes in favor of sparse arrays.
<!-- END RELEASE NOTES -->
