### PR TITLE
Fix nsimplify returning a different value for exact Rational

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -913,6 +913,7 @@ Juan Barbosa <js.barbosa10@uniandes.edu.co>
 Juan Felipe Osorio <jfosorio@gmail.com>
 Juan Luis Cano Rodríguez <juanlu001@gmail.com>
 Juha Remes <jremes@outlook.com>
+Julian Lim <244760094+seedaylight@users.noreply.github.com>
 Julien Palard <julien@palard.fr>
 Julien Rioux <julien.rioux@gmail.com>
 Julio Idichekop Filho <idichekop@yahoo.com.br>

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -13,7 +13,7 @@ from sympy.core.exprtools import factor_nc
 from sympy.core.parameters import global_parameters
 from sympy.core.function import (expand_log, count_ops, _mexpand,
     nfloat, expand_mul, expand)
-from sympy.core.numbers import Float, I, Integer, pi, Rational, equal_valued
+from sympy.core.numbers import Float, I, pi, Rational, equal_valued
 from sympy.core.relational import Relational
 from sympy.core.rules import Transform
 from sympy.core.sorting import default_sort_key, ordered

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -1456,7 +1456,9 @@ def nsimplify(expr, constants=(), tolerance=None, full=False, rational=None,
 
     """
     expr = sympify(expr)
-    if isinstance(expr, Integer):
+    # exact rationals are already exact: return them unchanged rather than
+    # risking a spurious, float-indistinguishable replacement (see gh-30210)
+    if isinstance(expr, Rational):
         return expr
     expr = expr.xreplace({
         Float('inf'): S.Infinity,

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -410,6 +410,12 @@ def test_nsimplify():
     e = x**0.0
     assert e.is_Pow and nsimplify(x**0.0) == 1
     assert nsimplify(3.333333, tolerance=0.1, rational=True) == Rational(10, 3)
+
+    # exact rationals must not be converted to a different exact value
+    # https://github.com/sympy/sympy/issues/30210
+    assert nsimplify(Rational(-9072, 12245)) == Rational(-9072, 12245)
+    assert nsimplify(S.Half) == S.Half
+    assert nsimplify(Rational(1, 3)) == Rational(1, 3)
     assert nsimplify(3.333333, tolerance=0.01, rational=True) == Rational(10, 3)
     assert nsimplify(3.666666, tolerance=0.1, rational=True) == Rational(11, 3)
     assert nsimplify(3.666666, tolerance=0.01, rational=True) == Rational(11, 3)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30210

#### Brief description of what is fixed or changed

`nsimplify` treats its input as a number whose "simple form" should be guessed, which is fine for floats but wrong for an exact rational: for example, `nsimplify(Rational(-9072, 12245))` used to return a different exact expression that only matched the input to about 17 significant digits, silently breaking exact comparisons. This PR makes `nsimplify` return bare exact `Rational` (and `Integer`) inputs unchanged, skipping numeric identification entirely. Exact composite inputs like `sqrt(8)` are not affected and still go through identification, so valid exact simplifications are preserved. Regression tests were added and the full simplify test module passes.

#### Other comments

The change is intentionally small: it only affects bare `Rational`/`Integer` inputs. A possible follow-up is the same class of issue for exact algebraic expressions with rational coefficients (e.g. `sqrt(2)*Rational(9072, 12245)` is also replaced by a spurious value), but that needs more care to avoid breaking legitimate exact simplifications.

#### AI Generation Disclosure

This patch was developed with assistance from an AI coding agent (OpenAI Codex). AI-assisted portions:
- `sympy/simplify/simplify.py` lines 1459-1461 (early return for exact `Rational`)
- `sympy/simplify/tests/test_simplify.py` lines 414-418 (regression tests)

I reviewed the change, understand the root cause (exact rationals should not go through numeric identification), and verified the tests pass.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* simplify
  * `nsimplify` no longer returns a different exact value for `Rational` input.

<!-- END RELEASE NOTES -->
