### PR TITLE
[DON'T MERGE] polys: fix crash in `construct_domain([oo * I])`

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -37,8 +37,10 @@ def _construct_simple(coeffs, opt):
         else:
             is_complex = pure_complex(coeff)
             if is_complex:
-                complexes = True
                 x, y = is_complex
+                if x.is_finite is not True or y.is_finite is not True:
+                    return None
+                complexes = True
                 if x.is_Rational and y.is_Rational:
                     if not (x.is_Integer and y.is_Integer):
                         rationals = True

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -252,3 +252,13 @@ def test_issue_25337():
 
     x_algebraic = Symbol('x', algebraic=True)
     assert construct_domain(x_algebraic)[0] == ZZ[x_algebraic]
+
+
+def test_issue_30061():
+    assert construct_domain([S.Infinity*I]) == (EX, [EX(S.Infinity*I)])
+    assert construct_domain([-S.Infinity*I]) == (EX, [EX(-S.Infinity*I)])
+    assert construct_domain([1 + S.Infinity*I]) == (EX, [EX(1 + S.Infinity*I)])
+    assert construct_domain([S.Infinity + I]) == (EX, [EX(S.Infinity + I)])
+    assert construct_domain([-S.Infinity + 2*I]) == (EX, [EX(-S.Infinity + 2*I)])
+
+    assert construct_domain(S.Infinity*I) == (EX, EX(S.Infinity*I))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
gh-30061


#### Brief description of what is fixed or changed

Before the fix, `construct_domain` showed the following behavior.

```python
In [1]: construct_domain([S.Infinity*I])
TypeError: cannot create mpf from oo
expected result = (EX, [EX(oo*I)])

In [2]: construct_domain([-S.Infinity*I])
TypeError: cannot create mpf from -oo
expected result = (EX, [EX(-oo*I)])

In [3]: construct_domain([1 + S.Infinity*I])
TypeError: cannot create mpf from oo
expected result = (EX, [EX(1 + oo*I)])

In [4]: construct_domain([S.Infinity + I])
TypeError: cannot create mpf from oo
expected result = (EX, [EX(oo + I)])

In [5]: construct_domain([-S.Infinity + 2*I])
TypeError: cannot create mpf from -oo
expected result = (EX, [EX(-oo + 2*I)])

In [6]: construct_domain(S.Infinity*I)
TypeError: cannot create mpf from oo
expected result = (EX, EX(oo*I))
```

After the fix, all the code snippets above produce the expected results.

#### Other comments
I added regression tests for all the cases above.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
DeepSeek assisted in finding the cause.
All code was written manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed crash in `construct_domain([oo * I])`.
<!-- END RELEASE NOTES -->