### PR TITLE
stats: fix LogLogistic expectation ignoring its expression

### DIFF
--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -65,6 +65,7 @@ from sympy.functions.elementary.trigonometric import (atan, cos, sin, tan)
 from sympy.functions.special.bessel import (besseli, besselj, besselk)
 from sympy.functions.special.beta_functions import beta as beta_fn
 from sympy.concrete.summations import Sum
+from sympy.core.add import Add
 from sympy.core.basic import Basic
 from sympy.core.function import Lambda
 from sympy.core.numbers import (I, Rational, pi)
@@ -2631,9 +2632,35 @@ class LogLogisticDistribution(SingleContinuousDistribution):
         a, b = self.alpha, self.beta
         return a*((p/(1 - p))**(1/b))
 
-    def expectation(self, expr, var, **kwargs):
-        a, b = self.args
-        return Piecewise((S.NaN, b <= 1), (pi*a/(b*sin(pi/b)), True))
+    def _raw_moment(self, k):
+        """The k-th raw moment, which exists only for beta > k."""
+        a, b = self.alpha, self.beta
+        if k.is_zero:
+            return S.One
+        return Piecewise((S.NaN, b <= k), (a**k*(k*pi/b)/sin(k*pi/b), True))
+
+    def expectation(self, expr, var, evaluate=True, **kwargs):
+        if evaluate:
+            # There is no moment generating function for this distribution, so
+            # the generic implementation would integrate. Expand polynomials in
+            # `var` over the closed form for the raw moments instead. Anything
+            # else has no closed form here and is left to the generic path.
+            terms = []
+            for term in expr.expand().as_ordered_terms():
+                coeff, rest = term.as_independent(var, as_Add=False)
+                if rest is S.One:
+                    k = S.Zero
+                elif rest == var:
+                    k = S.One
+                elif rest.is_Pow and rest.base == var and rest.exp.is_positive:
+                    k = rest.exp
+                else:
+                    terms = None
+                    break
+                terms.append(coeff*self._raw_moment(k))
+            if terms is not None:
+                return Add(*terms)
+        return super().expectation(expr, var, evaluate, **kwargs)
 
 def LogLogistic(name, alpha, beta):
     r"""

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -907,6 +907,28 @@ def test_loglogistic():
     X = LogLogistic('x', 1, 2)
     assert median(X) == FiniteSet(1)
 
+    # Higher moments must use the k-th raw moment a**k*(k*pi/b)/sin(k*pi/b),
+    # not the mean. The expectation used to ignore the expression it was given
+    # and return the mean for every input, which silently made E(X**2),
+    # variance and every other moment wrong.
+    X = LogLogistic('x', 1, 3)
+    assert E(X) == pi/(3*sin(pi/3))
+    assert E(X**2) == 2*pi/(3*sin(2*pi/3))
+    assert E(2*X) == 2*pi/(3*sin(pi/3))
+    assert simplify(E(X**2 + X) - (2*pi/(3*sin(2*pi/3)) + pi/(3*sin(pi/3)))) == 0
+    assert simplify(variance(X) - (2*pi/(3*sin(2*pi/3)) - (pi/(3*sin(pi/3)))**2)) == 0
+
+    # The k-th moment only exists for beta > k.
+    assert E(X**3) is S.NaN
+    assert variance(LogLogistic('x', 1, 2)) is S.NaN
+
+    # The closed form has to agree with integrating the density directly.
+    z = Symbol('z', positive=True)
+    X = LogLogistic('x', 2, 5)
+    for k in (1, 2, 3, 4):
+        direct = Integral(z**k*density(X)(z), (z, 0, oo)).doit()
+        assert simplify(E(X**k) - direct) == 0
+
 def test_logitnormal():
     mu = Symbol('mu', real=True)
     s = Symbol('s', positive=True)


### PR DESCRIPTION
`LogLogisticDistribution.expectation` discarded the `expr` it was given and
returned the mean for every input:

    def expectation(self, expr, var, **kwargs):
        a, b = self.args
        return Piecewise((S.NaN, b <= 1), (pi*a/(b*sin(pi/b)), True))

So E(X) was right by luck and every other expectation was silently wrong. For
LogLogistic('X', 1, 3) the second moment is 4*pi/(3*sqrt(3)) = 2.4184, but
E(X**2) returned the mean 2*sqrt(3)*pi/9 = 1.2092, and variance returned the
mean as well instead of 0.9562. E(X**3) is divergent for beta = 3 and also came
back as the mean. Integrating the density directly confirms the correct values.

The k-th raw moment is a**k*(k*pi/b)/sin(k*pi/b), and it exists only for
beta > k. Expectations of polynomials in the variable are now summed term by
term over that closed form, which is what the generic implementation does via
the moment generating function for distributions that have one; this one does
not, so it would otherwise integrate, and that integration fails for
`variance`. Everything that is not a polynomial in the variable is delegated to
the generic implementation, matching how `PoissonDistribution.expectation`
guards its own special cases before calling `super()`.

E(X) is unchanged, including its symbolic form, so the existing assertions
still hold exactly.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
