### PR TITLE
Risch: Implement most remaining exp-log cases from Bronstein

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2970,7 +2970,7 @@ def manualintegrate(f, var):
     >>> manualintegrate(exp(x) / (1 + exp(2 * x)), x)
     atan(exp(x))
     >>> integrate(exp(x) / (1 + exp(2 * x)))
-    RootSum(4*w**2 + 1, Lambda(w, w*log(2*w + exp(x))))
+    atan(exp(x))
     >>> manualintegrate(cos(x)**4 * sin(x), x)
     -cos(x)**5/5
     >>> integrate(cos(x)**4 * sin(x), x)

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -828,15 +828,17 @@ def _prde_normalized_solve(A, B, G, gamma, DE, n=None):
     # y = p/gamma of the initial equation with ci = Sum(dj*aji).
 
     if n is None:
-        try:
-            # We try n=5. At least for prde_spde, it will always
-            # terminate no matter what n is.
-            n = bound_degree(a, b, r, DE, parametric=True)
-        except NotImplementedError:
-            # A temporary bound is set. Eventually, it will be removed.
-            # the currently added test case takes large time
-            # even with n=5, and much longer with large n's.
-            n = 5
+        # bound_degree() raises NotImplementedError when it cannot decide
+        # one of its structure-theorem queries, and we let that propagate.
+        # Guessing a finite bound here instead (n = 5 from 2017 to 2026)
+        # is unsound: solutions of degree above the guess are silently
+        # lost, so a caller like is_deriv_in_field() can be tricked into
+        # a false proof that an elementary integral is nonelementary.
+        # Falling back to n == oo (as rischDE() does) is not an option
+        # either, since the parametric no-cancellation and cancellation
+        # algorithms iterate over range(n, ...), which requires a finite
+        # bound.
+        n = bound_degree(a, b, r, DE, parametric=True)
 
     h, B = param_poly_rischDE(a, b, r, n, DE)
 

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1134,7 +1134,7 @@ def is_deriv_k(fa, fd, DE):
     dfa, dfd = dfa.cancel(dfd, include=True)
 
     # Our assumption here is that each monomial is recursively transcendental
-    if len(DE.exts) != len(DE.D):
+    if len(DE.exts) != len(DE.D) - 1:
         if [i for i in DE.cases if i == 'tan'] or \
                 ({i for i, case in enumerate(DE.cases) if case == 'primitive'} -
                         set(DE.indices('log'))):
@@ -1169,12 +1169,12 @@ def is_deriv_k(fa, fd, DE):
             raise NotImplementedError("Cannot work with non-rational "
                 "coefficients in this case.")
         else:
-            terms = ([DE.extargs[i] for i in DE.indices('exp')] +
+            terms = ([DE.extargs[i - 1] for i in DE.indices('exp')] +
                     [DE.T[i] for i in DE.indices('log')])
             ans = list(zip(terms, u))
             result = Add(*[Mul(i, j) for i, j in ans])
             argterms = ([DE.T[i] for i in DE.indices('exp')] +
-                    [DE.extargs[i] for i in DE.indices('log')])
+                    [DE.extargs[i - 1] for i in DE.indices('log')])
             l = []
             ld = []
             for i, j in zip(argterms, u):
@@ -1261,7 +1261,7 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
         dfa, dfd = fa, fd
 
     # Our assumption here is that each monomial is recursively transcendental
-    if len(DE.exts) != len(DE.D):
+    if len(DE.exts) != len(DE.D) - 1:
         if [i for i in DE.cases if i == 'tan'] or \
                 ({i for i, case in enumerate(DE.cases) if case == 'primitive'} -
                         set(DE.indices('log'))):
@@ -1302,13 +1302,13 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
             n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u])
             u *= n
             terms = ([DE.T[i] for i in DE.indices('exp')] +
-                    [DE.extargs[i] for i in DE.indices('log')])
+                    [DE.extargs[i - 1] for i in DE.indices('log')])
             ans = list(zip(terms, u))
             result = Mul(*[Pow(i, j) for i, j in ans])
 
             # exp(f) will be the same as result up to a multiplicative
             # constant.  We now find the log of that constant.
-            argterms = ([DE.extargs[i] for i in DE.indices('exp')] +
+            argterms = ([DE.extargs[i - 1] for i in DE.indices('exp')] +
                     [DE.T[i] for i in DE.indices('log')])
             const = cancel(fa.as_expr()/fd.as_expr() -
                 Add(*[Mul(i, j/n) for i, j in zip(argterms, u)]))

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -271,21 +271,34 @@ def constant_system(A, u, DE):
 
     D = lambda x: derivation(x, DE, basic=True)
 
-    for j, i in itertools.product(range(A.cols), range(A.rows)):
-        if A[i, j].expr.has(*DE.T):
-            # This assumes that const(F(t0, ..., tn) == const(K) == F
-            Ri = A[i, :]
-            # Rm+1; m = A.rows
-            DAij = D(A[i, j])
-            Rm1 = Ri.applyfunc(lambda x: D(x) / DAij)
-            um1 = D(u[i]) / DAij
+    # Repeat until no entry of A is nonconstant, processing rows appended
+    # in earlier iterations as well ("while A is not constant do" in the
+    # book's ConstantSystem; iterating over a snapshot of the original
+    # rows would let nonconstant entries in the appended rows escape).
+    # The safety cap guards against nontermination in case cancel() fails
+    # to recognize an identically zero derivation (see the comment above).
+    for _ in range((Au.rows + 1)*(Au.cols + 1)*(len(DE.T) + 1) + 10):
+        for j, i in itertools.product(range(A.cols), range(A.rows)):
+            if A[i, j].expr.has(*DE.T):
+                break
+        else:
+            break
+        # This assumes that const(F(t0, ..., tn)) == const(K) == F
+        Ri = A[i, :]
+        # Rm+1; m = A.rows
+        DAij = D(A[i, j])
+        Rm1 = Ri.applyfunc(lambda x: D(x) / DAij)
+        um1 = D(u[i]) / DAij
 
-            Aj = A[:, j]
-            A = A - Aj * Rm1
-            u = u - Aj * um1
+        Aj = A[:, j]
+        A = A - Aj * Rm1
+        u = u - Aj * um1
 
-            A = A.col_join(Rm1)
-            u = u.col_join(Matrix([um1], u.gens))
+        A = A.col_join(Rm1)
+        u = u.col_join(Matrix([um1], u.gens))
+    else:
+        raise RuntimeError("constant_system() did not reach a constant "
+            "system; the constant field may not be computable by cancel().")
 
     return (A, u)
 
@@ -1323,6 +1336,51 @@ def parametric_log_deriv(fa, fd, wa, wd, DE):
     return A
 
 
+def _structure_system_solve(lhs, rhs, DE):
+    """
+    Find a constant solution x of the structure system lhs*x == rhs.
+
+    Explanation
+    ===========
+
+    lhs and rhs are matrices over K.  Returns a list of constant
+    solutions (free parameters set to zero), or None if there is no
+    constant solution.  constant_system() returns a reduced *system*,
+    not a solution, and treating its right hand side as a solution (as
+    this module once did) is only accidentally correct when the
+    reduction is identity-like, so the reduced system is solved
+    explicitly here and the solution is verified against the original
+    equation.
+
+    Raises NotImplementedError if the verification fails, which
+    indicates constants not computable by cancel() (see the comment in
+    constant_system()).
+    """
+    A, u = constant_system(lhs, rhs, DE)
+    if not A:
+        return None
+    um = u.to_Matrix()
+    if not all(derivation(i, DE, basic=True).is_zero for i in um):
+        # No constant solution
+        return None
+    from sympy.matrices import Matrix as EMatrix
+    try:
+        xs, params = EMatrix(A.to_Matrix()).gauss_jordan_solve(EMatrix(um))
+    except ValueError:
+        return None
+    xs = xs.subs(dict.fromkeys(params, S.Zero))
+    # Defensive verification against the original system
+    lhs_m = lhs.to_Matrix()
+    rhs_m = rhs.to_Matrix()
+    for i in range(lhs_m.rows):
+        if cancel(Add(*[lhs_m[i, j]*xs[j] for j in range(lhs_m.cols)])
+                - rhs_m[i]) != 0:
+            raise NotImplementedError("The candidate solution of the "
+                "structure system failed verification; the constant field "
+                "may not be computable by cancel().")
+    return list(xs)
+
+
 def is_deriv_k(fa, fd, DE):
     r"""
     Checks if Df/f is the derivative of an element of k(t).
@@ -1410,15 +1468,10 @@ def is_deriv_k(fa, fd, DE):
     lhs = Matrix([E_part + L_part], dum)
     rhs = Matrix([dfa.as_expr()/dfd.as_expr()], dum)
 
-    A, u = constant_system(lhs, rhs, DE)
+    u = _structure_system_solve(lhs, rhs, DE)
 
-    u = u.to_Matrix()  # Poly to Expr
-
-    if not A or not all(derivation(i, DE, basic=True).is_zero for i in u):
-        # If the elements of u are not all constant
-        # Note: See comment in constant_system
-
-        # Also note: derivation(basic=True) calls cancel()
+    if u is None:
+        # No constant solution
         return None
     else:
         if not all(i.is_Rational for i in u):
@@ -1537,15 +1590,10 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
     lhs = Matrix([E_part + L_part], dum)
     rhs = Matrix([dfa.as_expr()/dfd.as_expr()], dum)
 
-    A, u = constant_system(lhs, rhs, DE)
+    u = _structure_system_solve(lhs, rhs, DE)
 
-    u = u.to_Matrix()  # Poly to Expr
-
-    if not A or not all(derivation(i, DE, basic=True).is_zero for i in u):
-        # If the elements of u are not all constant
-        # Note: See comment in constant_system
-
-        # Also note: derivation(basic=True) calls cancel()
+    if u is None:
+        # No constant solution
         return None
     else:
         if not all(i.is_Rational for i in u):
@@ -1556,7 +1604,7 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
                 "coefficients in this case.")
         else:
             n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u])
-            u *= n
+            u = [n*i for i in u]
             terms = ([DE.T[i] for i in DE.indices('exp')] +
                     [DE.extargs[i - 1] for i in DE.indices('log')])
             ans = list(zip(terms, u))

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -888,6 +888,36 @@ def limited_integrate(fa, fd, G, DE):
         return Y, C
 
 
+def is_deriv_in_field(fa, fd, DE):
+    """
+    Checks if f can be written as the derivative of an element of k(t).
+
+    Explanation
+    ===========
+
+    f in k(t) is the derivative of an element of k(t) if there exists v in
+    k(t) such that f == Dv.  Either returns (va, vd), with va, vd in k[t]
+    such that f == D(va/vd), or None, which means that f is not the
+    derivative of an element of k(t).  Note that v is determined only up
+    to an additive constant.
+
+    This is the in-field integration problem from Section 5.12 of
+    Bronstein's book (the "Recognizing Derivatives" subsection; neither
+    edition gives it as named pseudocode).  It is solved here as the
+    special case of the limited integration problem (Section 7.2) with an
+    empty list of special elements.
+
+    See also
+    ========
+    limited_integrate, is_log_deriv_k_t_radical_in_field
+    """
+    A = limited_integrate(fa, fd, [], DE)
+    if A is None:
+        return None
+    (va, vd), _ = A
+    return (va, vd)
+
+
 def parametric_log_deriv_heu(fa, fd, wa, wd, DE, c1=None):
     """
     Parametric logarithmic derivative heuristic.

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -226,11 +226,12 @@ def constant_system(A, u, DE):
 
     Given a differential field (K, D) with constant field C = Const(K), a Matrix
     A, and a vector (Matrix) u with coefficients in K, returns the tuple
-    (B, v, s), where B is a Matrix with coefficients in C and v is a vector
-    (Matrix) such that either v has coefficients in C, in which case s is True
-    and the solutions in C of Ax == u are exactly all the solutions of Bx == v,
-    or v has a non-constant coefficient, in which case s is False Ax == u has no
-    constant solution.
+    (B, v), where B is a Matrix with coefficients in C and v is a vector
+    (Matrix) such that either v has coefficients in C, in which case the
+    solutions in C of Ax == u are exactly all the solutions of Bx == v, or v
+    has a non-constant coefficient, in which case Ax == u has no constant
+    solution.  Note that B and v are a reduced *system*, not a solution:
+    callers must check that v is constant and then solve Bx == v themselves.
 
     This algorithm is used both in solving parametric problems and in
     determining if an element a of K is a derivative of an element of K or the
@@ -541,6 +542,10 @@ def prde_cancel_liouvillian(b, Q, n, DE):
     from the discussion in Section 7.1 of Bronstein's book (neither edition
     gives it as named pseudocode).
     """
+    if DE.case not in ('primitive', 'exp'):
+        raise ValueError("case must be 'primitive' or 'exp', not %s." %
+            DE.case)
+
     H = []
 
     if DE.case == 'exp':
@@ -734,44 +739,24 @@ def param_poly_rischDE(a, b, q, n, DE):
     return h, A
 
 
-def param_rischDE(fa, fd, G, DE):
+def _prde_normalized_solve(A, B, G, gamma, DE, n=None):
     """
-    Solve a Parametric Risch Differential Equation: Dy + f*y == Sum(ci*Gi, (i, 1, m)).
+    Common tail of param_rischDE() and limited_integrate().
 
     Explanation
     ===========
 
-    Given a derivation D in k(t), f in k(t), and G
-    = [G1, ..., Gm] in k(t)^m, return h = [h1, ..., hr] in k(t)^r and
-    a matrix A with m + r columns and entries in Const(k) such that
-    Dy + f*y = Sum(ci*Gi, (i, 1, m)) has a solution y
-    in k(t) with c1, ..., cm in Const(k) if and only if y = Sum(dj*hj,
-    (j, 1, r)) where d1, ..., dr are in Const(k) and (c1, ..., cm,
-    d1, ..., dr) is a solution of Ax == 0.
-
-    Elements of k(t) are tuples (a, d) with a and d in k[t].
-
-    This chains together the parametric algorithms of Section 7.1 of
-    Bronstein's book; the book does not give it as a single named
-    pseudocode function.
+    Given A, B in k[t] and G = [G1, ..., Gm] in k(t)^m with the equation
+    A*Dp + B*p == Sum(ci*Gi, (i, 1, m)) already reduced (weakly
+    normalized, denominators cleared), return h = [h1, ..., hr] in
+    k(t)^r and a matrix C with entries in Const(k) such that solutions
+    of the original problem are y == Sum(dj*hj, (j, 1, r))/1 with
+    (c1, ..., cm, d1, ..., dr) in the nullspace of C, where the
+    returned hj have already been divided by gamma.  If ``n`` is None,
+    the degree bound is computed with bound_degree(); otherwise ``n``
+    is used as a proven degree bound, avoiding bound_degree() entirely.
     """
     m = len(G)
-    q, (fa, fd) = weak_normalizer(fa, fd, DE)
-    # Solutions of the weakly normalized equation Dz + f*z = q*Sum(ci*Gi)
-    # correspond to solutions y = z/q of the original equation.
-    gamma = q
-    G = [(q*ga).cancel(gd, include=True) for ga, gd in G]
-
-    a, (ba, bd), G, hn = prde_normal_denom(fa, fd, G, DE)
-    # Solutions q in k<t> of  a*Dq + b*q = Sum(ci*Gi) correspond
-    # to solutions z = q/hn of the weakly normalized equation.
-    gamma *= hn
-
-    A, B, G, hs = prde_special_denom(a, ba, bd, G, DE)
-    # Solutions p in k[t] of  A*Dp + B*p = Sum(ci*Gi) correspond
-    # to solutions q = p/hs of the previous equation.
-    gamma *= hs
-
     g = A.gcd(B)
     a, b, g = A.quo(g), B.quo(g), [gia.cancel(gid*g, include=True) for
         gia, gid in G]
@@ -815,15 +800,16 @@ def param_rischDE(fa, fd, G, DE):
     # Solutions of a*Dp + b*p = Sum(dj*rj) correspond to solutions
     # y = p/gamma of the initial equation with ci = Sum(dj*aji).
 
-    try:
-        # We try n=5. At least for prde_spde, it will always
-        # terminate no matter what n is.
-        n = bound_degree(a, b, r, DE, parametric=True)
-    except NotImplementedError:
-        # A temporary bound is set. Eventually, it will be removed.
-        # the currently added test case takes large time
-        # even with n=5, and much longer with large n's.
-        n = 5
+    if n is None:
+        try:
+            # We try n=5. At least for prde_spde, it will always
+            # terminate no matter what n is.
+            n = bound_degree(a, b, r, DE, parametric=True)
+        except NotImplementedError:
+            # A temporary bound is set. Eventually, it will be removed.
+            # the currently added test case takes large time
+            # even with n=5, and much longer with large n's.
+            n = 5
 
     h, B = param_poly_rischDE(a, b, r, n, DE)
 
@@ -872,6 +858,46 @@ def param_rischDE(fa, fd, G, DE):
     C = Matrix([ni[:] for ni in N], DE.t)  # rows n1, ..., ns.
 
     return [hk.cancel(gamma, include=True) for hk in h], C
+
+
+def param_rischDE(fa, fd, G, DE):
+    """
+    Solve a Parametric Risch Differential Equation: Dy + f*y == Sum(ci*Gi, (i, 1, m)).
+
+    Explanation
+    ===========
+
+    Given a derivation D in k(t), f in k(t), and G
+    = [G1, ..., Gm] in k(t)^m, return h = [h1, ..., hr] in k(t)^r and
+    a matrix A with m + r columns and entries in Const(k) such that
+    Dy + f*y = Sum(ci*Gi, (i, 1, m)) has a solution y
+    in k(t) with c1, ..., cm in Const(k) if and only if y = Sum(dj*hj,
+    (j, 1, r)) where d1, ..., dr are in Const(k) and (c1, ..., cm,
+    d1, ..., dr) is a solution of Ax == 0.
+
+    Elements of k(t) are tuples (a, d) with a and d in k[t].
+
+    This chains together the parametric algorithms of Section 7.1 of
+    Bronstein's book; the book does not give it as a single named
+    pseudocode function.
+    """
+    q, (fa, fd) = weak_normalizer(fa, fd, DE)
+    # Solutions of the weakly normalized equation Dz + f*z = q*Sum(ci*Gi)
+    # correspond to solutions y = z/q of the original equation.
+    gamma = q
+    G = [(q*ga).cancel(gd, include=True) for ga, gd in G]
+
+    a, (ba, bd), G, hn = prde_normal_denom(fa, fd, G, DE)
+    # Solutions q in k<t> of  a*Dq + b*q = Sum(ci*Gi) correspond
+    # to solutions z = q/hn of the weakly normalized equation.
+    gamma *= hn
+
+    A, B, G, hs = prde_special_denom(a, ba, bd, G, DE)
+    # Solutions p in k[t] of  A*Dp + B*p = Sum(ci*Gi) correspond
+    # to solutions q = p/hs of the previous equation.
+    gamma *= hs
+
+    return _prde_normalized_solve(A, B, G, gamma, DE)
 
 
 def limited_integrate_reduce(fa, fd, G, DE):
@@ -943,30 +969,33 @@ def limited_integrate(fa, fd, G, DE):
     function).
     """
     fa, fd = fa*Poly(1/fd.LC(), DE.t), fd.monic()
-    # interpreting limited integration problem as a
-    # parametric Risch DE problem
-    Fa = Poly(0, DE.t)
-    Fd = Poly(1, DE.t)
-    G = [(fa, fd)] + G
-    h, A = param_rischDE(Fa, Fd, G, DE)
-    V = A.nullspace()
-    V = [v for v in V if v[0] != 0]
-    if not V:
+    # Reduction to a polynomial problem (LimitedIntegrateReduce, Section
+    # 7.2): for any solution v in k(t), c1, ..., cm in Const(k) of
+    # f == Dv + Sum(ci*wi), p == v*h is in k[t] and satisfies
+    # A*Dp + b*p == g + Sum(ci*vi) with deg(p) <= N.
+    A, b, h, N, g, V = limited_integrate_reduce(fa, fd, G, DE)
+    # Solve the parametric problem with right hand sides [g] + V.
+    # Solutions of the original problem correspond to parametric
+    # solutions whose g-coefficient is 1.  N is a proven degree bound,
+    # so bound_degree() is not needed.
+    Q = [g] + V
+    hs, C = _prde_normalized_solve(A, b, Q, h, DE, n=N)
+    W = C.nullspace()
+    W = [w for w in W if w[0] != 0]
+    if not W:
         return None
-    else:
-        # we can take any vector from V, we take V[0]
-        c0 = V[0][0]
-        # v = [-1, c1, ..., cm, d1, ..., dr]
-        v = V[0]/(-c0)
-        r = len(h)
-        m = len(v) - r - 1
-        C = list(v[1: m + 1])
-        y = -sum((v[m + 1 + i]*h[i][0].as_expr()/h[i][1].as_expr()
-                for i in range(r)), S.Zero)
-        y_num, y_den = y.as_numer_denom()
-        Ya, Yd = Poly(y_num, DE.t), Poly(y_den, DE.t)
-        Y = Ya*Poly(1/Yd.LC(), DE.t), Yd.monic()
-        return Y, C
+    # we can take any vector from W; take W[0], scaled so that the
+    # g-coefficient is 1
+    w = W[0]/W[0][0]
+    r = len(hs)
+    m = len(w) - r - 1
+    C = list(w[1: m + 1])
+    y = sum((w[m + 1 + i]*hs[i][0].as_expr()/hs[i][1].as_expr()
+            for i in range(r)), S.Zero)
+    y_num, y_den = y.as_numer_denom()
+    Ya, Yd = Poly(y_num, DE.t), Poly(y_den, DE.t)
+    Y = Ya*Poly(1/Yd.LC(), DE.t), Yd.monic()
+    return Y, C
 
 
 def is_deriv_in_field(fa, fd, DE):

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -615,11 +615,6 @@ def prde_cancel_liouvillian(b, Q, n, DE):
         # D(q_rest) + b*q_rest == Sum(ci*qi) - d*(D(h) + b*h)
         # (see the equation following (7.17) in Section 7.1; the sign of
         # the b*h term is misprinted as a minus in the 1st edition).
-        # Note that only the t**(i-1)-coefficient of Fi[j] is ever
-        # consumed (the loop descends strictly through the degrees), and
-        # the b*hji term contributes only to the t**i-coefficient, so
-        # the sign of b*hji cannot affect the result; it is written in
-        # the book's (2nd edition) form for clarity.
         for j in range(ri):
             hji = fi[j] * (DE.t**i).as_poly(fi[j].gens)
             hi[j] = hji
@@ -1761,12 +1756,6 @@ def is_log_deriv_k_t_radical_in_field(fa, fd, DE, case='auto', z=None):
         if A is None:
             return None
         n, e, u = A
-        # parametric_log_deriv() may return v as a Poly (e.g. the
-        # rational shortcut returns Poly(1, t)); keep u an Expr
-        # throughout.  Mixing Poly with Expr here built malformed Polys
-        # like Poly(t, x, domain='ZZ[t]') (with the tower generator in
-        # the coefficient domain) -- deprecated since SymPy 1.6, and
-        # only working downstream by accident of as_expr() round-trips.
         if isinstance(u, Poly):
             u = u.as_expr()
         u *= DE.t**e

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -284,6 +284,12 @@ def constant_system(A, u, DE):
         else:
             break
         # This assumes that const(F(t0, ..., tn)) == const(K) == F
+        # TODO: If A[i, j] contains symbolic constants, D(A[i, j]) can
+        # vanish for special values of them (e.g. an entry y*t is
+        # nonconstant except at y == 0), and dividing by it makes the
+        # reduced system valid only generically.  The correct result
+        # would be a Piecewise over the (solve()-generated) vanishing
+        # conditions of each pivot.
         Ri = A[i, :]
         # Rm+1; m = A.rows
         DAij = D(A[i, j])
@@ -499,7 +505,15 @@ def prde_no_cancel_b_equal(b, Q, n, DE):
     delta = DE.d.degree(DE.t)
     lam = DE.d.LC()
 
-    # The degree at which cancellation could occur
+    # The degree at which cancellation could occur.
+    # TODO: If b or Dt contains symbolic constants, Mc may be an integer
+    # only for special values of them (e.g. b == -y*t gives Mc == y), and
+    # the divisions by u below then produce a result that is valid only
+    # generically: e.g. H == [-t**3/(y - 3) - 3*t/(y**2 - 4*y + 3)] is
+    # undefined at y == 3 and y == 1.  The correct result would be a
+    # Piecewise with one condition per loop iteration where
+    # solve(N*lam + lc(b), y) is nonempty, with the cancellation
+    # algorithms handling those special values.
     Mc = cancel(-b.LC()/lam)
     if Mc.is_Integer and Mc > 0:
         M = int(Mc)
@@ -999,6 +1013,11 @@ def limited_integrate(fa, fd, G, DE):
         return None
     # we can take any vector from W; take W[0], scaled so that the
     # g-coefficient is 1
+    # TODO: If W[0][0] contains symbolic constants, it can vanish for
+    # special values of them, making the result valid only generically;
+    # a different nullspace vector may serve those special values, and
+    # the correct result would be a Piecewise over the corresponding
+    # conditions.
     w = W[0]/W[0][0]
     r = len(hs)
     m = len(w) - r - 1
@@ -1165,6 +1184,14 @@ def parametric_log_deriv_heu(fa, fd, wa, wd, DE, c1=None):
                     return None
                 cc = cancel(p.LC()/q.LC())
                 if not cc.is_Rational:
+                    # If cc contains symbolic constants, it may be
+                    # rational only for special values of them (a
+                    # condition like "y in QQ" that is not expressible
+                    # as a Piecewise relational); None here is correct
+                    # generically and at worst yields a false
+                    # nonelementary proof at those values, never a
+                    # wrong antiderivative, so no Piecewise handling is
+                    # needed.
                     return None
             M, N = cc.as_numer_denom()
 
@@ -1289,6 +1316,11 @@ def parametric_log_deriv_structure(fa, fd, wa, wd, DE):
     except ValueError:
         # Inconsistent system: f - (m/n)*w is not a combination of the
         # available logarithmic derivatives for any m/n.
+        # With symbolic constants, inconsistency is decided only
+        # generically; at special values of the constants a solution may
+        # exist.  The wrapper then raises NotImplementedError, which is
+        # sound (an honest error, never a wrong answer), so no Piecewise
+        # handling is needed here.
         return None
     xs = xs.subs(dict.fromkeys(params, S.Zero))
 
@@ -1367,6 +1399,13 @@ def _structure_system_solve(lhs, rhs, DE):
     try:
         xs, params = EMatrix(A.to_Matrix()).gauss_jordan_solve(EMatrix(um))
     except ValueError:
+        # With symbolic constants in the system, inconsistency (and
+        # the pivoting above) is decided only generically; at special
+        # values of the constants a solution may exist.  Returning None
+        # here errs on the incomplete-but-sound side (a spurious
+        # "not a derivative"/"not a radical" answer, at worst a false
+        # nonelementary proof, never a wrong antiderivative), so no
+        # Piecewise handling is needed here.
         return None
     xs = xs.subs(dict.fromkeys(params, S.Zero))
     # Defensive verification against the original system

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -83,14 +83,14 @@ def real_imag(ba, bd, gen):
     ba = ba.as_poly(gen).as_dict()
     denom_real = [value if key[0] % 4 == 0 else -value if key[0] % 4 == 2 else 0 for key, value in bd.items()]
     denom_imag = [value if key[0] % 4 == 1 else -value if key[0] % 4 == 3 else 0 for key, value in bd.items()]
-    bd_real = sum(r for r in denom_real)
-    bd_imag = sum(r for r in denom_imag)
+    bd_real = sum(denom_real, S.Zero)
+    bd_imag = sum(denom_imag, S.Zero)
     num_real = [value if key[0] % 4 == 0 else -value if key[0] % 4 == 2 else 0 for key, value in ba.items()]
     num_imag = [value if key[0] % 4 == 1 else -value if key[0] % 4 == 3 else 0 for key, value in ba.items()]
-    ba_real = sum(r for r in num_real)
-    ba_imag = sum(r for r in num_imag)
-    ba = ((ba_real*bd_real + ba_imag*bd_imag).as_poly(gen), (ba_imag*bd_real - ba_real*bd_imag).as_poly(gen))
-    bd = (bd_real*bd_real + bd_imag*bd_imag).as_poly(gen)
+    ba_real = sum(num_real, S.Zero)
+    ba_imag = sum(num_imag, S.Zero)
+    ba = (Poly(ba_real*bd_real + ba_imag*bd_imag, gen), Poly(ba_imag*bd_real - ba_real*bd_imag, gen))
+    bd = Poly(bd_real*bd_real + bd_imag*bd_imag, gen)
     return (ba[0], ba[1], bd)
 
 
@@ -871,8 +871,8 @@ def limited_integrate(fa, fd, G, DE):
         r = len(h)
         m = len(v) - r - 1
         C = list(v[1: m + 1])
-        y = -sum(v[m + 1 + i]*h[i][0].as_expr()/h[i][1].as_expr() \
-                for i in range(r))
+        y = -sum((v[m + 1 + i]*h[i][0].as_expr()/h[i][1].as_expr()
+                for i in range(r)), S.Zero)
         y_num, y_den = y.as_numer_denom()
         Ya, Yd = Poly(y_num, DE.t), Poly(y_den, DE.t)
         Y = Ya*Poly(1/Yd.LC(), DE.t), Yd.monic()

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -458,6 +458,81 @@ def prde_no_cancel_b_small(b, Q, n, DE):
     return f + H, A.col_join(B).col_join(C)
 
 
+def prde_no_cancel_b_equal(b, Q, n, DE):
+    """
+    Parametric Poly Risch Differential Equation - No cancellation: deg(b) == delta(t) - 1
+
+    Explanation
+    ===========
+
+    Given a derivation D on k[t] with delta(t) >= 2, n in ZZ, and
+    b, q1, ..., qm in k[t] with deg(b) == delta(t) - 1 and
+    n > -lc(b)/lc(Dt), returns h1, ..., hr in k[t] and a matrix A with
+    coefficients in Const(k) such that if c1, ..., cm in Const(k) and
+    q in k[t] satisfy deg(q) <= n and Dq + b*q == Sum(ci*qi, (i, 1, m)),
+    then q == Sum(dj*hj, (j, 1, r)), where d1, ..., dr in Const(k) and
+    A*Matrix([c1, ..., cm, d1, ..., dr]).T == 0.
+
+    This implements the "When delta(t) >= 2 and deg(b) == delta(t) - 1"
+    discussion of Section 7.1 of Bronstein's book (neither edition gives
+    it as named pseudocode).  If the possible-cancellation degree
+    -lc(b)/lc(Dt) is a positive integer at most n, the remaining problem
+    is delegated to the cancellation algorithms via param_poly_rischDE(),
+    which for delta(t) >= 2 are not yet implemented, so this case
+    currently raises NotImplementedError.
+    """
+    m = len(Q)
+    delta = DE.d.degree(DE.t)
+    lam = DE.d.LC()
+
+    # The degree at which cancellation could occur
+    Mc = cancel(-b.LC()/lam)
+    if Mc.is_Integer and Mc > 0:
+        M = int(Mc)
+    else:
+        M = -1
+
+    H = [Poly(0, DE.t)]*m
+
+    for N in range(n, M, -1):  # [n, ..., M + 1]
+        u = cancel(N*lam + b.LC())  # nonzero, since N != -lc(b)/lam
+        for i in range(m):
+            si = Q[i].nth(N + delta - 1)/u
+            sitn = Poly(si*DE.t**N, DE.t)
+            H[i] = H[i] + sitn
+            Q[i] = Q[i] - derivation(sitn, DE) - b*sitn
+
+    if M == -1:
+        # The loop ran through N == 0, so as in prde_no_cancel_b_large()
+        # any solution is q == Sum(ci*hi) and the (updated) right hand
+        # sides must satisfy Sum(ci*qi) == 0.
+        if all(qi.is_zero for qi in Q):
+            dc = -1
+        else:
+            dc = max(qi.degree(DE.t) for qi in Q)
+        Mmat = Matrix(dc + 1, m, lambda i, j: Q[j].nth(i), DE.t)
+        A, _ = constant_system(Mmat, zeros(dc + 1, 1, DE.t), DE)
+        c = eye(m, DE.t)
+        A = A.row_join(zeros(A.rows, m, DE.t)).col_join(c.row_join(-c))
+        return (H, A)
+
+    # We reached the possible-cancellation degree M > 0.  Solve the
+    # remaining problem, with the updated right hand sides and degree
+    # bound M, by the cancellation algorithms.
+    f, B = param_poly_rischDE(Poly(1, DE.t), b, Q, M, DE)
+    # Any solution is q == Sum(ci*hi) + Sum(dj*fj), where the fj and the
+    # matrix B constrain (c1, ..., cm, d1, ..., dr).  Combine into a
+    # relation matrix over the columns
+    # (c1, ..., cm, d_h1, ..., d_hm, d_f1, ..., d_fr), where the first
+    # block of rows enforces d_hi == ci.
+    r = len(f)
+    Bc = Matrix(B.rows, m, lambda i, j: B[i, j], DE.t)
+    Bd = Matrix(B.rows, r, lambda i, j: B[i, m + j], DE.t)
+    top = eye(m, DE.t).row_join(-eye(m, DE.t)).row_join(zeros(m, r, DE.t))
+    bottom = Bc.row_join(zeros(B.rows, m, DE.t)).row_join(Bd)
+    return (H + f, top.col_join(bottom))
+
+
 def prde_cancel_liouvillian(b, Q, n, DE):
     """
     Parametric Poly Risch Differential Equation - Cancellation: Liouvillian case.
@@ -566,8 +641,7 @@ def param_poly_rischDE(a, b, q, n, DE):
         elif (DE.d.degree() >= 2 and
               b.degree() == DE.d.degree() - 1 and
               n > -b.as_poly().LC()/DE.d.as_poly().LC()):
-            raise NotImplementedError("prde_no_cancel_b_equal() is "
-                "not yet implemented.")
+            return prde_no_cancel_b_equal(b, q, n, DE)
 
         else:
             # Liouvillian cases

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1218,20 +1218,42 @@ def parametric_log_deriv_structure(fa, fd, wa, wd, DE):
     rhs = Matrix([f], dum)
 
     A, u = constant_system(lhs, rhs, DE)
-    u = u.to_Matrix()
 
-    if not A or not all(derivation(i, DE, basic=True).is_zero for i in u):
-        return None
-    if not all(i.is_Rational for i in u):
+    # A*x == u is now a linear system with constant coefficients for the
+    # rational unknowns x == (m/n, r1, ..., rk).  Note that u is the
+    # reduced right hand side, not a solution: the system may be
+    # underdetermined (e.g. when w is a combination of the generators),
+    # so solve it explicitly, setting any free parameters to zero.
+    Am = A.to_Matrix()
+    um = u.to_Matrix()
+    if not (all(i.is_Rational for i in Am) and
+            all(i.is_Rational for i in um)):
+        if not all(derivation(i, DE, basic=True).is_zero for i in Am.vec()) \
+                or not all(derivation(i, DE, basic=True).is_zero for i in um):
+            # The system could not be reduced to one over the constants
+            return None
         raise NotImplementedError("Cannot work with non-rational "
             "coefficients in this case.")
+    from sympy.matrices import Matrix as _Matrix
+    try:
+        xs, params = _Matrix(Am).gauss_jordan_solve(_Matrix(um))
+    except ValueError:
+        # Inconsistent system: f - (m/n)*w is not a combination of the
+        # available logarithmic derivatives for any m/n.
+        return None
+    xs = xs.subs(dict.fromkeys(params, S.Zero))
 
-    n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u], S.One)
-    u *= n  # now integers: [m, n*r1, ..., n*rk]
-    m = u[0]
+    n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in xs], S.One)
+    xs *= n  # now integers: [m, n*r1, ..., n*rk]
+    m = xs[0]
     terms = ([DE.T[i] for i in E_indices] + [DE.extargs[i - 1] for i in L_indices])
-    v = Mul(*[Pow(i, j) for i, j in zip(terms, u[1:])])
+    v = Mul(*[Pow(i, j) for i, j in zip(terms, xs[1:])])
     if n == 0:
+        return None
+    # Defensive check of n*f == Dv/v + m*w (Dv/v is the same QQ-linear
+    # combination of the generator logarithmic derivatives by construction)
+    lhs_check = Add(*[Mul(j, i) for i, j in zip(E_part + L_part, xs[1:])])
+    if cancel(n*f - m*w - lhs_check) != 0:
         return None
     if n < 0:
         n, m, v = -n, -m, 1/v

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1761,6 +1761,14 @@ def is_log_deriv_k_t_radical_in_field(fa, fd, DE, case='auto', z=None):
         if A is None:
             return None
         n, e, u = A
+        # parametric_log_deriv() may return v as a Poly (e.g. the
+        # rational shortcut returns Poly(1, t)); keep u an Expr
+        # throughout.  Mixing Poly with Expr here built malformed Polys
+        # like Poly(t, x, domain='ZZ[t]') (with the tower generator in
+        # the coefficient domain) -- deprecated since SymPy 1.6, and
+        # only working downstream by accident of as_expr() round-trips.
+        if isinstance(u, Poly):
+            u = u.as_expr()
         u *= DE.t**e
 
     elif case == 'primitive':

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -900,7 +900,7 @@ def limited_integrate_reduce(fa, fd, G, DE):
     """
     dn, ds = splitfactor(fd, DE)
     E = [splitfactor(gd, DE) for _, gd in G]
-    En, Es = list(zip(*E))
+    En, Es = list(zip(*E)) if E else ((), ())
     c = reduce(lambda i, j: i.lcm(j), (dn,) + En)  # lcm(dn, en1, ..., enm)
     hn = c.gcd(c.diff(DE.t))
     a = hn
@@ -913,8 +913,8 @@ def limited_integrate_reduce(fa, fd, G, DE):
         hs = reduce(lambda i, j: i.lcm(j), (ds,) + Es)  # lcm(ds, es1, ..., esm)
         a = hn*hs
         b -= (hn*derivation(hs, DE)).quo(hs)
-        mu = min(order_at_oo(fa, fd, DE.t), min(order_at_oo(ga, gd, DE.t) for
-            ga, gd in G))
+        mu = min([order_at_oo(fa, fd, DE.t)] + [order_at_oo(ga, gd, DE.t) for
+            ga, gd in G])
         # So far, all the above are also nonlinear or Liouvillian, but if this
         # changes, then this will need to be updated to call bound_degree()
         # as per the docstring of this function (DE.case == 'other_linear').
@@ -924,7 +924,14 @@ def limited_integrate_reduce(fa, fd, G, DE):
         raise NotImplementedError
 
     V = [(-a*hn*ga).cancel(gd, include=True) for ga, gd in G]
-    return (a, b, a, N, (a*hn*fa).cancel(fd, include=True), V)
+    # Note: the first component is hn, not a.  Both editions of the book
+    # return a here, but that does not satisfy the stated contract when
+    # hs != 1: from v == p/a, the original equation multiplied by a**2
+    # gives a*Dp - Da*p == a**2*f - Sum(ci*a**2*wi), and dividing through
+    # by hs (which divides Da exactly, since hs is special) gives
+    # hn*Dp + b*p == a*hn*f - Sum(ci*a*hn*wi) with the b and right hand
+    # sides constructed above.
+    return (hn, b, a, N, (a*hn*fa).cancel(fd, include=True), V)
 
 
 def limited_integrate(fa, fd, G, DE):

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -287,9 +287,11 @@ def constant_system(A, u, DE):
         # TODO: If A[i, j] contains symbolic constants, D(A[i, j]) can
         # vanish for special values of them (e.g. an entry y*t is
         # nonconstant except at y == 0), and dividing by it makes the
-        # reduced system valid only generically.  The correct result
-        # would be a Piecewise over the (solve()-generated) vanishing
-        # conditions of each pivot.
+        # reduced system valid only generically.  The same applies to
+        # the pivots of the rref() calls, which also divide by
+        # parameter-dependent entries.  The correct result would be a
+        # Piecewise over the (solve()-generated) vanishing conditions of
+        # each pivot.
         Ri = A[i, :]
         # Rm+1; m = A.rows
         DAij = D(A[i, j])
@@ -611,7 +613,13 @@ def prde_cancel_liouvillian(b, Q, n, DE):
         # Substituting q == d*h + q_rest into Dq + b*q == Sum(ci*qi)
         # leaves the residual equation
         # D(q_rest) + b*q_rest == Sum(ci*qi) - d*(D(h) + b*h)
-        # (see the equation following (7.17) in Section 7.1).
+        # (see the equation following (7.17) in Section 7.1; the sign of
+        # the b*h term is misprinted as a minus in the 1st edition).
+        # Note that only the t**(i-1)-coefficient of Fi[j] is ever
+        # consumed (the loop descends strictly through the degrees), and
+        # the b*hji term contributes only to the t**i-coefficient, so
+        # the sign of b*hji cannot affect the result; it is written in
+        # the book's (2nd edition) form for clarity.
         for j in range(ri):
             hji = fi[j] * (DE.t**i).as_poly(fi[j].gens)
             hi[j] = hji
@@ -1409,6 +1417,12 @@ def _structure_system_solve(lhs, rhs, DE):
         # nonelementary proof, never a wrong antiderivative), so no
         # Piecewise handling is needed here.
         return None
+    # TODO: Zeroing the free parameters can miss a rational solution when
+    # a pivot divided by a symbolic constant: e.g. y*x1 + x2 == 1 gives
+    # xs == [(1 - tau)/y, tau], which is non-rational at tau == 0 but
+    # rational at tau == 1.  Choosing a rational point of the affine
+    # solution space (when one exists) would decide more towers; failing
+    # that only causes an honest NotImplementedError downstream.
     xs = xs.subs(dict.fromkeys(params, S.Zero))
     # Defensive verification against the original system
     lhs_m = lhs.to_Matrix()

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -468,6 +468,13 @@ def prde_cancel_liouvillian(b, Q, n, DE):
     """
     H = []
 
+    if DE.case == 'exp':
+        # The coefficient of t**i satisfies the equation
+        # D(q_i) + (b + i*eta)*q_i == rhs_i over k, where eta == Dt/t.
+        # eta must be computed at the current level, before DecrementLevel
+        # is entered below.
+        eta = DE.d.quo(Poly(DE.t, DE.t)).as_expr()
+
     # Why use DecrementLevel? Below line answers that:
     # Assuming that we can solve such problems over 'k' (not k[t])
     if DE.case == 'primitive':
@@ -477,8 +484,7 @@ def prde_cancel_liouvillian(b, Q, n, DE):
     for i in range(n, -1, -1):
         if DE.case == 'exp': # this re-checking can be avoided
             with DecrementLevel(DE):
-                ba, bd = frac_in(b + (i*(derivation(DE.t, DE)/DE.t)).as_poly(b.gens),
-                                DE.t, field=True)
+                ba, bd = frac_in(b.as_expr() + i*eta, DE.t, field=True)
         with DecrementLevel(DE):
             Qy = [frac_in(q.nth(i), DE.t, field=True) for q in Q]
             fi, Ai = param_rischDE(ba, bd, Qy, DE)
@@ -495,12 +501,15 @@ def prde_cancel_liouvillian(b, Q, n, DE):
 
         Fi, hi = [None]*ri, [None]*ri
 
-        # from eq. on top of p.238 (unnumbered)
+        # Substituting q == d*h + q_rest into Dq + b*q == Sum(ci*qi)
+        # leaves the residual equation
+        # D(q_rest) + b*q_rest == Sum(ci*qi) - d*(D(h) + b*h)
+        # (see the equation following (7.17) in Section 7.1).
         for j in range(ri):
             hji = fi[j] * (DE.t**i).as_poly(fi[j].gens)
             hi[j] = hji
-            # building up Sum(djn*(D(fjn*t^n) - b*fjnt^n))
-            Fi[j] = -(derivation(hji, DE) - b*hji)
+            # building up Sum(dji*(D(fji*t^i) + b*fji*t^i))
+            Fi[j] = -(derivation(hji, DE) + b*hji)
 
         H += hi
         # in the next loop instead of Q it has

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1164,19 +1164,104 @@ def parametric_log_deriv_heu(fa, fd, wa, wd, DE, c1=None):
     return (Q*N, Q*M, v)
 
 
+def parametric_log_deriv_structure(fa, fd, wa, wd, DE):
+    """
+    Parametric logarithmic derivative problem via the structure theorems.
+
+    Explanation
+    ===========
+
+    Tries to solve n*f == Dv/v + m*w for n, m in ZZ, n != 0, and v in
+    k(t)*, by solving the structure equation
+
+        f == (m/n)*w + Sum(ri*Dti/ti, i in E) + Sum(ri*Dti, i in L)
+
+    for rational (m/n, r1, ..., rk), where E and L are the
+    hyperexponential and logarithmic monomials of the current tower (up
+    to the current level), as in equation (7.44) of Section 7.3 of
+    Bronstein's book, with theta adjoined as an extra hyperexponential
+    generator.  A solution yields (n, m, v) with
+    v == Product(termi**(n*ri)) directly.
+
+    Either returns (n, m, v), or None, which means that f - (m/n)*w is
+    not a QQ-linear combination of the logarithmic derivatives available
+    from the current tower for any m/n in QQ.  Note that None does NOT
+    prove that no solution exists: a solution whose v requires monomials
+    not in the tower (e.g. new logarithms) is not found by this method.
+    Callers must treat None as inconclusive.
+    """
+    # The same assumptions as in is_log_deriv_k_t_radical()
+    if len(DE.exts) != len(DE.D) - 1:
+        if [i for i in DE.cases if i == 'tan'] or \
+                ({i for i, case in enumerate(DE.cases) if case == 'primitive'} -
+                        set(DE.indices('log'))):
+            raise NotImplementedError("Real version of the structure "
+                "theorems with hypertangent support is not yet implemented.")
+        raise NotImplementedError("Nonelementary extensions not supported "
+            "in the structure theorems.")
+
+    # Use only the part of the tower visible at the current level: the
+    # callers pose this problem inside DecrementLevel, and v must lie in
+    # the current field (w itself is usually the log derivative of the
+    # monomial one level up, which must not appear in v).
+    top = len(DE.T) + DE.level
+    E_indices = [i for i in DE.indices('exp') if i <= top]
+    L_indices = [i for i in DE.indices('log') if i <= top]
+    E_part = [DE.D[i].quo(Poly(DE.T[i], DE.T[i])).as_expr() for i in E_indices]
+    L_part = [DE.D[i].as_expr() for i in L_indices]
+
+    w = wa.as_expr()/wd.as_expr()
+    f = fa.as_expr()/fd.as_expr()
+
+    dum = Dummy()
+    lhs = Matrix([[w] + E_part + L_part], dum)
+    rhs = Matrix([f], dum)
+
+    A, u = constant_system(lhs, rhs, DE)
+    u = u.to_Matrix()
+
+    if not A or not all(derivation(i, DE, basic=True).is_zero for i in u):
+        return None
+    if not all(i.is_Rational for i in u):
+        raise NotImplementedError("Cannot work with non-rational "
+            "coefficients in this case.")
+
+    n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u], S.One)
+    u *= n  # now integers: [m, n*r1, ..., n*rk]
+    m = u[0]
+    terms = ([DE.T[i] for i in E_indices] + [DE.extargs[i - 1] for i in L_indices])
+    v = Mul(*[Pow(i, j) for i, j in zip(terms, u[1:])])
+    if n == 0:
+        return None
+    if n < 0:
+        n, m, v = -n, -m, 1/v
+    return (n, m, v)
+
+
 def parametric_log_deriv(fa, fd, wa, wd, DE):
     """
     Solves the parametric logarithmic derivative problem.
 
     This is the parametric logarithmic derivative problem from Section 7.3
-    of Bronstein's book; currently only the heuristic
-    (``ParametricLogarithmicDerivative``) is implemented.
+    of Bronstein's book: n*f == Dv/v + m*w for n, m in ZZ, n != 0, and
+    v in k(t)*.  The heuristic (``ParametricLogarithmicDerivative``) is
+    tried first; if it cannot decide, the structure theorem method of the
+    same section is tried.
     """
-    # TODO: Write the full algorithm using the structure theorems.  Until
-    # then, this propagates NotImplementedError when the heuristic cannot
-    # decide (it must not be caught and treated as "no solution", since a
-    # solution may exist; see parametric_log_deriv_heu()).
-    A = parametric_log_deriv_heu(fa, fd, wa, wd, DE)
+    try:
+        A = parametric_log_deriv_heu(fa, fd, wa, wd, DE)
+    except NotImplementedError:
+        A = parametric_log_deriv_structure(fa, fd, wa, wd, DE)
+        if A is None:
+            # The structure method proves nonexistence only when the
+            # elementary extension containing Integral(f) needs no
+            # monomials outside the current tower, which we cannot check
+            # here, so an inconclusive result must not be reported as
+            # "no solution".
+            raise NotImplementedError("parametric_log_deriv() could not "
+                "decide: the heuristic failed and f - (m/n)*w is not a "
+                "combination of logarithmic derivatives from the current "
+                "tower for any m/n in QQ.")
     return A
 
 

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -229,7 +229,15 @@ def ratint_logpart(f, g, x, t=None):
     a, b = g, f - g.diff()*Poly(t, x)
 
     res, R = resultant(a, b, includePRS=True)
-    res = Poly(res, t, composite=False)
+    res = cancel(res, extension=True)
+    p, q = res.as_numer_denom()
+    if q.has(t):
+        # The subresultant PRS over a coefficient ring with radicals can
+        # return the resultant as an unreduced quotient that cancel()
+        # cannot always clear; the division is exact, so do it in t.
+        res = Poly(p, t, composite=False).exquo(Poly(q, t, composite=False))
+    else:
+        res = Poly(res, t, composite=False)
 
     assert res, "BUG: resultant(%s, %s) cannot be zero" % (a, b)
 

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -367,7 +367,7 @@ def _roots_real_complex(poly):
     return reals, complexes
 
 
-def log_to_real(h, q, x, t):
+def log_to_real(h, q, x, t, complex_only=False):
     r"""
     Convert complex logarithms to real functions.
 
@@ -381,6 +381,12 @@ def log_to_real(h, q, x, t):
                   -- = --  )  a log(h(a, x))
                   dx   dx /__,
                          a | q(a) = 0
+
+    None is returned when the roots of q cannot all be computed
+    explicitly, and, if ``complex_only=True``, when no roots of q come
+    in complex-conjugate pairs (so the caller can keep the sum of
+    logarithms in unevaluated form unless rewriting it removes complex
+    logarithms).
 
     Examples
     ========
@@ -408,6 +414,9 @@ def log_to_real(h, q, x, t):
 
     reals, complexes = rs
 
+    if complex_only and not complexes:
+        return None
+
     u = Dummy('u')
     v = Dummy('v')
 
@@ -426,7 +435,10 @@ def log_to_real(h, q, x, t):
 
         AB = (A**2 + B**2).as_expr()
 
-        result += r_u*log(AB) + r_v*log_to_atan(A, B)
+        result += r_u*log(AB)
+        if not (A.is_zero or B.is_zero):
+            # If A or B is zero, the arc-tangent term is a constant
+            result += r_v*log_to_atan(A, B)
 
     for r in reals:
         result += r*log(h.as_expr().subs(t, r))

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -398,7 +398,7 @@ def bound_degree(a, b, cQ, DE, case='auto', parametric=False):
                 if A is not None:
                     aa, z = A
                     if aa == 1:
-                        beta = -(a*derivation(z, DE).as_poly(t1) +
+                        beta = -(a*derivation(z, DE, basic=True).as_poly(t1) +
                             b*z.as_poly(t1)).LC()/(z.as_expr()*a.LC())
                         betaa, betad = frac_in(beta, DE.t)
                         from .prde import limited_integrate

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -852,8 +852,8 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
             raise TypeError("Result should be a number")
 
         if parametric:
-            raise NotImplementedError("prde_no_cancel_b_equal() is not yet "
-                "implemented.")
+            from .prde import prde_no_cancel_b_equal
+            return prde_no_cancel_b_equal(b, cQ, n, DE)
 
         R = no_cancel_equal(b, cQ, n, DE)
 

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -481,7 +481,9 @@ def spde(a, b, c, n, DE):
     while True:
         if c.is_zero:
             return (zero, zero, 0, zero, beta)  # -1 is more to the point
-        if (n < 0) is True:
+        # == True so a SymPy Integer n works too ((S(-1) < 0) is
+        # BooleanTrue), while a symbolic n still falls through
+        if (n < 0) == True:
             raise NonElementaryIntegralException("n became negative in "
                 "spde().")
 

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -492,6 +492,16 @@ def spde(a, b, c, n, DE):
             c = c.to_field().quo(a)
             return (b, c, n, alpha, beta)
 
+        if n is oo:
+            # Each pass through the reduction below decreases n by
+            # deg(a) > 0 and "no solution" is detected by n < 0, so with
+            # no degree bound the loop can run forever when there is no
+            # solution (e.g. a == t, b == 1, c == x over t == exp(x):
+            # gcd(a, b) == 1 stays trivial and no other exit is ever
+            # taken).  Raise rather than loop.
+            raise NotImplementedError("spde() with an infinite degree bound "
+                "terminates only when deg(a) becomes 0.")
+
         r, z = gcdex_diophantine(b, a, c)
         b += derivation(a, DE)
         c = z - derivation(r, DE)
@@ -911,18 +921,15 @@ def rischDE(fa, fd, ga, gd, DE):
     a, (ba, bd), (ca, cd), hn = normal_denom(fa, fd, ga, gd, DE)
     A, B, C, hs = special_denom(a, ba, bd, ca, cd, DE)
     try:
-        # Until this is fully implemented, use oo.  Note that this will almost
-        # certainly cause non-termination in spde() (unless A == 1), and
-        # *might* lead to non-termination in the next step for a nonelementary
-        # integral (I don't know for certain yet).  Fortunately, spde() is
-        # currently written recursively, so this will just give
-        # RuntimeError: maximum recursion depth exceeded.
         n = bound_degree(A, B, C, DE)
     except NotImplementedError:
-        # Useful for debugging:
-        # import warnings
-        # warnings.warn("rischDE: Proceeding with n = oo; may cause "
-        #     "non-termination.")
+        # bound_degree() could not decide one of its structure-theorem
+        # queries.  Proceeding with n == oo is sound: no bound is needed
+        # to accept a solution, and the no-cancellation and cancellation
+        # algorithms all terminate by descending on deg(c).  The only
+        # step that needs a finite bound to terminate is the deg(a) > 0
+        # reduction in spde(), which raises NotImplementedError instead
+        # of looping forever when it would need one.
         n = oo
 
     B, C, m, alpha, beta = spde(A, B, C, n, DE)

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -473,6 +473,11 @@ def spde(a, b, c, n, DE):
     alpha = Poly(1, DE.t)
     beta = Poly(0, DE.t)
 
+    # Generous pass allowance for n == oo (see below); any solution of
+    # degree d is found within about d/deg(a) passes, so this only
+    # defers solutions of very high degree to an honest error.
+    oo_passes = 4*(a.degree(DE.t) + b.degree(DE.t) + c.degree(DE.t) + 4)
+
     while True:
         if c.is_zero:
             return (zero, zero, 0, zero, beta)  # -1 is more to the point
@@ -497,10 +502,16 @@ def spde(a, b, c, n, DE):
             # deg(a) > 0 and "no solution" is detected by n < 0, so with
             # no degree bound the loop can run forever when there is no
             # solution (e.g. a == t, b == 1, c == x over t == exp(x):
-            # gcd(a, b) == 1 stays trivial and no other exit is ever
-            # taken).  Raise rather than loop.
-            raise NotImplementedError("spde() with an infinite degree bound "
-                "terminates only when deg(a) becomes 0.")
+            # gcd(a, b) == 1 stays trivial, c cycles through nonzero
+            # constants, and no other exit is ever taken).  Allow a
+            # generous number of passes (solvable cases terminate
+            # quickly, with c becoming zero), then give up with an
+            # honest error -- NotImplementedError, not a nonexistence
+            # claim.
+            oo_passes -= 1
+            if oo_passes < 0:
+                raise NotImplementedError("spde() ran out of passes with "
+                    "an infinite degree bound; cannot decide solvability.")
 
         r, z = gcdex_diophantine(b, a, c)
         b += derivation(a, DE)

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -481,8 +481,6 @@ def spde(a, b, c, n, DE):
     while True:
         if c.is_zero:
             return (zero, zero, 0, zero, beta)  # -1 is more to the point
-        # == True so a SymPy Integer n works too ((S(-1) < 0) is
-        # BooleanTrue), while a symbolic n still falls through
         if (n < 0) == True:
             raise NonElementaryIntegralException("n became negative in "
                 "spde().")
@@ -786,11 +784,7 @@ def cancel_exp(b, c, n, DE):
                     # The homogeneous solutions are C*t**(-m)/z for
                     # constants C, so the t**(-m) coefficient of q is
                     # adjustable by the constant of integration exactly
-                    # when it is C/z for a constant C; in that case,
-                    # remove that term.  (A non-constant coefficient
-                    # cannot be removed by any choice of the constant,
-                    # and stripping it anyway would return a q that does
-                    # not solve the equation.)
+                    # when it is C/z for a constant C.
                     q = q - Poly(q.nth(-m)*DE.t**(-m), DE.t)
                 if q.degree(DE.t) > n:
                     raise NonElementaryIntegralException("deg(p/(z*t**m)) "

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -797,37 +797,26 @@ def cancel_exp(b, c, n, DE):
     return q
 
 
-def solve_poly_rde(b, cQ, n, DE, parametric=False):
+def solve_poly_rde(b, c, n, DE):
     """
     Solve a Polynomial Risch Differential Equation with degree bound ``n``.
 
     This constitutes step 4 of the outline given in the rde.py docstring.
 
-    For parametric=False, cQ is c, a Poly; for parametric=True, cQ is Q ==
-    [q1, ..., qm], a list of Polys.
-
     This dispatches among the algorithms of Sections 6.5 and 6.6 of
-    Bronstein's book (and their parametric analogues from Section 7.1); it
-    has no single named counterpart.
+    Bronstein's book; it has no single named counterpart.  The parametric
+    analogue of this dispatch is param_poly_rischDE() in prde.py.
     """
     # No cancellation
     if not b.is_zero and (DE.case == 'base' or
             b.degree(DE.t) > max(0, DE.d.degree(DE.t) - 1)):
 
-        if parametric:
-            # Delayed imports
-            from .prde import prde_no_cancel_b_large
-            return prde_no_cancel_b_large(b, cQ, n, DE)
-        return no_cancel_b_large(b, cQ, n, DE)
+        return no_cancel_b_large(b, c, n, DE)
 
     elif (b.is_zero or b.degree(DE.t) < DE.d.degree(DE.t) - 1) and \
             (DE.case == 'base' or DE.d.degree(DE.t) >= 2):
 
-        if parametric:
-            from .prde import prde_no_cancel_b_small
-            return prde_no_cancel_b_small(b, cQ, n, DE)
-
-        R = no_cancel_b_small(b, cQ, n, DE)
+        R = no_cancel_b_small(b, c, n, DE)
 
         if isinstance(R, Poly):
             return R
@@ -851,11 +840,7 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
         if not b.as_poly(DE.t).LC().is_number:
             raise TypeError("Result should be a number")
 
-        if parametric:
-            from .prde import prde_no_cancel_b_equal
-            return prde_no_cancel_b_equal(b, cQ, n, DE)
-
-        R = no_cancel_equal(b, cQ, n, DE)
+        R = no_cancel_equal(b, c, n, DE)
 
         if isinstance(R, Poly):
             return R
@@ -868,12 +853,9 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
     else:
         # Cancellation
         if b.is_zero:
-            if parametric:
-                raise NotImplementedError("Parametric cancellation with "
-                    "b == 0 is not yet implemented.")
             # Dq == c: in-field integration (Section 6.6)
             from .prde import is_deriv_in_field
-            B = is_deriv_in_field(cQ, Poly(1, DE.t), DE)
+            B = is_deriv_in_field(c, Poly(1, DE.t), DE)
             if B is None:
                 raise NonElementaryIntegralException("c is not the "
                     "derivative of an element of k(t) in solve_poly_rde().")
@@ -892,16 +874,10 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
             return q
         else:
             if DE.case == 'exp':
-                if parametric:
-                    raise NotImplementedError("Parametric RDE cancellation "
-                        "hyperexponential case is not yet implemented.")
-                return cancel_exp(b, cQ, n, DE)
+                return cancel_exp(b, c, n, DE)
 
             elif DE.case == 'primitive':
-                if parametric:
-                    raise NotImplementedError("Parametric RDE cancellation "
-                        "primitive case is not yet implemented.")
-                return cancel_primitive(b, cQ, n, DE)
+                return cancel_primitive(b, c, n, DE)
 
             else:
                 raise NotImplementedError("Other Poly (P)RDE cancellation "

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -768,9 +768,16 @@ def cancel_exp(b, c, n, DE):
                 raise NonElementaryIntegralException("p/(z*t**m) is not in "
                     "k[t] in cancel_exp().")
             if q.degree(DE.t) > n:
-                if m < 0 and q.degree(DE.t) == -m:
-                    # The coefficient of t**(-m) is adjustable by the
-                    # constant of integration; remove that term.
+                if m < 0 and q.degree(DE.t) == -m and \
+                        not cancel(z*q.nth(-m)).has(*DE.T):
+                    # The homogeneous solutions are C*t**(-m)/z for
+                    # constants C, so the t**(-m) coefficient of q is
+                    # adjustable by the constant of integration exactly
+                    # when it is C/z for a constant C; in that case,
+                    # remove that term.  (A non-constant coefficient
+                    # cannot be removed by any choice of the constant,
+                    # and stripping it anyway would return a q that does
+                    # not solve the equation.)
                     q = q - Poly(q.nth(-m)*DE.t**(-m), DE.t)
                 if q.degree(DE.t) > n:
                     raise NonElementaryIntegralException("deg(p/(z*t**m)) "

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -652,19 +652,35 @@ def cancel_primitive(b, c, n, DE):
     This is ``PolyRischDECancelPrim`` from Section 6.6 of Bronstein's book.
     """
     # Delayed imports
-    from .prde import is_log_deriv_k_t_radical_in_field
+    from .prde import is_log_deriv_k_t_radical_in_field, is_deriv_in_field
     with DecrementLevel(DE):
         ba, bd = frac_in(b, DE.t)
         A = is_log_deriv_k_t_radical_in_field(ba, bd, DE)
-        if A is not None:
-            m, z = A
-            if m == 1:  # b == Dz/z
-                raise NotImplementedError("is_deriv_in_field() is required to "
-                    " solve this problem.")
-                # if z*c == Dp for p in k[t] and deg(p) <= n:
-                #     return p/z
-                # else:
-                #     raise NonElementaryIntegralException
+
+    if A is not None:
+        m, z = A
+        if m == 1:  # b == Dz/z
+            # D(z*q) == z*(Dq + b*q), so q solves Dq + b*q == c iff
+            # p == z*q satisfies Dp == z*c.  So find an antiderivative
+            # p in k[t] of z*c with deg(p) <= n, and return q == p/z.
+            zca, zcd = frac_in(z*c.as_expr(), DE.t, cancel=True)
+            B = is_deriv_in_field(zca, zcd, DE)
+            if B is None:
+                raise NonElementaryIntegralException("z*c is not the "
+                    "derivative of an element of k(t) in cancel_primitive().")
+            pa, pd = B
+            # For a primitive t, an antiderivative in k(t) of an element
+            # of k[t] is itself in k[t] (it can have no poles), and any
+            # additive constant keeps q == p/z in k[t], so any choice of
+            # p will do.
+            q = cancel(pa.as_expr()/(pd.as_expr()*z)).as_poly(DE.t)
+            if q is None:
+                raise NonElementaryIntegralException("p/z is not in k[t] "
+                    "in cancel_primitive().")
+            if q.degree(DE.t) > n:
+                raise NonElementaryIntegralException("deg(p/z) > n in "
+                    "cancel_primitive().")
+            return q
 
     if c.is_zero:
         return c  # return 0
@@ -705,23 +721,51 @@ def cancel_exp(b, c, n, DE):
 
     This is ``PolyRischDECancelExp`` from Section 6.6 of Bronstein's book.
     """
-    from .prde import parametric_log_deriv
+    from .prde import parametric_log_deriv, is_deriv_in_field
     eta = DE.d.quo(Poly(DE.t, DE.t)).as_expr()
 
     with DecrementLevel(DE):
         etaa, etad = frac_in(eta, DE.t)
         ba, bd = frac_in(b, DE.t)
         A = parametric_log_deriv(ba, bd, etaa, etad, DE)
-        if A is not None:
-            a, m, z = A
-            if a == 1:
-                raise NotImplementedError("is_deriv_in_field() is required to "
-                    "solve this problem.")
-                # if c*z*t**m == Dp for p in k<t> and q = p/(z*t**m) in k[t] and
-                # deg(q) <= n:
-                #     return q
-                # else:
-                #     raise NonElementaryIntegralException
+
+    if A is not None:
+        a, m, z = A
+        if a == 1:
+            # b == Dz/z + m*Dt/t, so D(z*t**m*q) == z*t**m*(Dq + b*q).
+            # Hence q solves Dq + b*q == c iff p == z*t**m*q satisfies
+            # Dp == z*t**m*c.  So find an antiderivative p in k<t> of
+            # z*t**m*c; then q == p/(z*t**m) must be in k[t] with
+            # deg(q) <= n.
+            pa, pd = frac_in(z*DE.t**m*c.as_expr(), DE.t, cancel=True)
+            B = is_deriv_in_field(pa, pd, DE)
+            if B is None:
+                raise NonElementaryIntegralException("z*t**m*c is not the "
+                    "derivative of an element of k(t) in cancel_exp().")
+            va, vd = B
+            p = cancel(va.as_expr()/vd.as_expr())
+            if m > 0:
+                # p is determined only up to an additive constant.  For
+                # m > 0 the true p == z*t**m*q has no t-free term (all its
+                # monomials have degree >= m), while a constant term would
+                # make p/(z*t**m) non-polynomial, so remove it.
+                p -= p.subs(DE.t, 0)
+            # For m <= 0 any additive constant C leaves q in k[t]
+            # (C/(z*t**m) == C*t**(-m)/z), and q + C*t**(-m)/z is still a
+            # solution, since t**(-m)/z solves the homogeneous equation.
+            q = cancel(p/(z*DE.t**m)).as_poly(DE.t)
+            if q is None:
+                raise NonElementaryIntegralException("p/(z*t**m) is not in "
+                    "k[t] in cancel_exp().")
+            if q.degree(DE.t) > n:
+                if m < 0 and q.degree(DE.t) == -m:
+                    # The coefficient of t**(-m) is adjustable by the
+                    # constant of integration; remove that term.
+                    q = q - Poly(q.nth(-m)*DE.t**(-m), DE.t)
+                if q.degree(DE.t) > n:
+                    raise NonElementaryIntegralException("deg(p/(z*t**m)) "
+                        "> n in cancel_exp().")
+            return q
 
     if c.is_zero:
         return c  # return 0
@@ -824,8 +868,28 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
     else:
         # Cancellation
         if b.is_zero:
-            raise NotImplementedError("Remaining cases for Poly (P)RDE are "
-            "not yet implemented (is_deriv_in_field() required).")
+            if parametric:
+                raise NotImplementedError("Parametric cancellation with "
+                    "b == 0 is not yet implemented.")
+            # Dq == c: in-field integration (Section 6.6)
+            from .prde import is_deriv_in_field
+            B = is_deriv_in_field(cQ, Poly(1, DE.t), DE)
+            if B is None:
+                raise NonElementaryIntegralException("c is not the "
+                    "derivative of an element of k(t) in solve_poly_rde().")
+            va, vd = B
+            # For a primitive or hyperexponential t, an antiderivative in
+            # k(t) of an element of k[t] is itself in k[t], and any
+            # additive constant is also in k[t], so any choice of the
+            # antiderivative will do.
+            q = cancel(va.as_expr()/vd.as_expr()).as_poly(DE.t)
+            if q is None:
+                raise NonElementaryIntegralException("The antiderivative "
+                    "of c is not in k[t] in solve_poly_rde().")
+            if q.degree(DE.t) > n:
+                raise NonElementaryIntegralException("The antiderivative "
+                    "of c has degree > n in solve_poly_rde().")
+            return q
         else:
             if DE.case == 'exp':
                 if parametric:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -335,20 +335,29 @@ class DifferentialExtension:
         # fractional q the left side is a principal root that differs
         # from exp(q*u) by a locally constant root of unity off the real
         # line.  Radicals of exponentials also arise internally (the
-        # radical case of _exp_part substitutes t**(p/n) and restarts),
-        # and rewriting those into the answer turned correctly
+        # radical case of _exp_part substitutes t**(p/n) and restarts);
+        # those denote a root the construction is free to choose, so
+        # folding them to exp(q*u) is exact, and rewriting the answer
+        # back into principal-root notation is what turned correctly
         # integrated results into non-antiderivatives at complex points.
-        # So the notation is only restored where it is the user's own:
-        # a fractional power is put back only if it appears in the
-        # original integrand -- and not when the integrand also contains
-        # the folded exponential form itself, since a global
-        # substitution would then rewrite genuine exp(q*u) occurrences
-        # into the principal root as well.
-        self.backsubs += [(j, i) for i, j in ratpows_repl
-                          if i.exp.is_Integer or
-                          (self.origf is not None and self.origf.has(i)
-                           and not self.origf.has(j))]
-        self.newf = self.newf.xreplace(dict(ratpows_repl))
+        # A fractional power the user wrote, however, means the
+        # principal root specifically: fold it as ratio*exp(q*u) with an
+        # opaque locally constant ratio (a root of unity on each
+        # component), restored exactly on backsubstitution -- which also
+        # keeps integrands mixing exp(u)**q with exp(q*u) itself
+        # pointwise correct.
+        subs_map = {}
+        for i, j in ratpows_repl:
+            if i.exp.is_Integer:
+                self.backsubs.append((j, i))
+                subs_map[i] = j
+            elif self.origf is not None and self.origf.has(i):
+                ratio = Dummy('exp_branch')
+                self.backsubs.append((ratio, i/j))
+                subs_map[i] = ratio*j
+            else:
+                subs_map[i] = j
+        self.newf = self.newf.xreplace(subs_map)
 
         # To make the process deterministic, the args are sorted
         # so that functions with smaller op-counts are processed first.

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -871,7 +871,7 @@ def as_poly_1t(p, t, z):
 
     t_part, remainder = pa.div(pd)
 
-    ans = t_part.as_poly(t, z, expand=False)
+    ans = Poly(t_part, t, z, expand=False)
 
     if remainder:
         one = remainder.one
@@ -879,7 +879,7 @@ def as_poly_1t(p, t, z):
         r = pd.degree() - remainder.degree()
         z_part = remainder.transform(one, tp) * tp**r
         z_part = z_part.replace(t, z).to_field().quo_ground(pd.LC())
-        ans += z_part.as_poly(t, z, expand=False)
+        ans += Poly(z_part, t, z, expand=False)
 
     return ans
 
@@ -1093,7 +1093,7 @@ def hermite_reduce(a, d, DE):
     gd = Poly(1, DE.t)
 
     dd = derivation(d, DE)
-    dm = gcd(d.to_field(), dd.to_field()).as_poly(DE.t)
+    dm = Poly(gcd(d.to_field(), dd.to_field()), DE.t)
     ds, _ = d.div(dm)
 
     while dm.degree(DE.t) > 0:
@@ -1104,13 +1104,13 @@ def hermite_reduce(a, d, DE):
         ds_ddm = ds.mul(ddm)
         ds_ddm_dm, _ = ds_ddm.div(dm)
 
-        b, c = gcdex_diophantine(-ds_ddm_dm.as_poly(DE.t),
-            dms.as_poly(DE.t), a.as_poly(DE.t))
-        b, c = b.as_poly(DE.t), c.as_poly(DE.t)
+        b, c = gcdex_diophantine(-Poly(ds_ddm_dm, DE.t),
+            Poly(dms, DE.t), Poly(a, DE.t))
+        b, c = Poly(b, DE.t), Poly(c, DE.t)
 
-        db = derivation(b, DE).as_poly(DE.t)
+        db = Poly(derivation(b, DE), DE.t)
         ds_dms, _ = ds.div(dms)
-        a = c.as_poly(DE.t) - db.mul(ds_dms).as_poly(DE.t)
+        a = Poly(c, DE.t) - Poly(db.mul(ds_dms), DE.t)
 
         ga = ga*dm + b*gd
         gd = gd*dm
@@ -1185,7 +1185,7 @@ def laurent_series(a, d, F, n, DE):
     """
     if F.degree() == 0:
         return (Poly(0, DE.t), Poly(1, DE.t), [])
-    Z = _symbols('z', n)
+    Z: list[Symbol] = [*_symbols('z', n)]
     z = Symbol('z')
     Z.insert(0, z)
     delta_a = Poly(0, DE.t)
@@ -1317,7 +1317,7 @@ def recognize_log_derivative(a, d, DE, z=None):
     r = Poly(r, z)
     Np, Sp = splitfactor_sqf(r, DE, coefficientD=True, z=z)
 
-    if any(s.as_poly(z).degree() > 0 for s, _ in Np):
+    if any(Poly(s, z).degree() > 0 for s, _ in Np):
         # The normal part of the splitting factorization contains the
         # factors of the resultant whose roots are not constants; such
         # roots cannot be integers, so f is not the logarithmic derivative
@@ -1413,8 +1413,9 @@ def residue_reduce(a, d, DE, z=None, invert=True):
             s = Poly(s, z).monic()
 
             if invert:
-                h_lc = Poly(h.as_poly(DE.t).LC(), DE.t, field=True, expand=False)
-                inv, coeffs = h_lc.as_poly(z, field=True).invert(s), [S.One]
+                h_lc = Poly(Poly(h, DE.t).LC(), DE.t, field=True, expand=False)
+                inv = Poly(h_lc, z, field=True).invert(s)
+                coeffs = [S.One]
 
                 for coeff in h.coeffs()[1:]:
                     L = reduced(inv*coeff.as_poly(inv.gens), [s])[1]
@@ -1952,8 +1953,8 @@ def risch_integrate(f, x, extension=None, handle_first='log',
             fa, fd = frac_in(i, DE.t)
         else:
             result = result.subs(DE.backsubs)
-            if not i.is_zero:
-                i = NonElementaryIntegral(i.function.subs(DE.backsubs),i.limits)
+            if isinstance(i, Integral):
+                i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)
             if not separate_integral:
                 result += i
                 return result

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -590,8 +590,35 @@ class DifferentialExtension:
             A = is_deriv_k(arga, argd, self)
             if A is not None:
                 ans, u, const = A
-                newterm = log(const) + u
-                self.newf = self.newf.xreplace({log(arg): newterm})
+                # u + log(const) equals log(arg) only up to a locally
+                # constant branch term: log(const) is the principal-branch
+                # choice, valid where every argument involved is positive
+                # (e.g. log(-x**2) == 2*log(x) + I*pi only holds for
+                # x > 0).  The one case where it is exact everywhere is a
+                # single tower logarithm with coefficient one and a
+                # positive constant: log(c*w) == log(c) + log(w) for
+                # c > 0 on the whole complex plane.
+                if (u is not self.x and u in self.T and const.is_positive and
+                        self.exts[self.T.index(u) - 1] == 'log'):
+                    self.newf = self.newf.xreplace({log(arg): log(const) + u})
+                    continue
+                # Otherwise the difference log(arg) - u is locally
+                # constant wherever the functions are defined, so
+                # integrating with an opaque constant in its place and
+                # restoring the exact difference on backsubstitution keeps
+                # the answer, now expressed through the original
+                # logarithm, correct on every connected component.
+                branch_const = Dummy('log_branch')
+                # arg and u may involve tower symbols; express the
+                # difference through the concrete functions (and through
+                # any originals recorded in backsubs so far, so that
+                # e.g. x**x reappears as x**x rather than exp(x*log(x))).
+                concrete = list(zip(reversed(self.T),
+                    reversed([f(self.x) for f in self.Tfuncs])))
+                diff_expr = (log(arg.subs(concrete)) -
+                    u.subs(concrete)).subs(self.backsubs)
+                self.backsubs.append((branch_const, diff_expr))
+                self.newf = self.newf.xreplace({log(arg): branch_const + u})
                 continue
 
             else:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -280,7 +280,14 @@ class DifferentialExtension:
             if handle_first == 'exp' or not log_new_extension:
                 exp_new_extension = self._exp_part(exps)
                 if exp_new_extension is None:
-                    # reset and restart
+                    # Reset and restart.  reset() clears backsubs, so any
+                    # rewrite recorded there -- a branch-constant Dummy
+                    # from _log_part(), a user radical's notation -- must
+                    # first be folded back into newf, or the Dummy leaks
+                    # into the final result as a free symbol and the
+                    # original notation is never re-encountered by the
+                    # rebuild.
+                    self.newf = self.newf.subs(self.backsubs)
                     self.f = self.newf
                     self.reset()
                     exp_new_extension = True
@@ -333,10 +340,14 @@ class DifferentialExtension:
         # integrated results into non-antiderivatives at complex points.
         # So the notation is only restored where it is the user's own:
         # a fractional power is put back only if it appears in the
-        # original integrand.
+        # original integrand -- and not when the integrand also contains
+        # the folded exponential form itself, since a global
+        # substitution would then rewrite genuine exp(q*u) occurrences
+        # into the principal root as well.
         self.backsubs += [(j, i) for i, j in ratpows_repl
                           if i.exp.is_Integer or
-                          (self.origf is not None and self.origf.has(i))]
+                          (self.origf is not None and self.origf.has(i)
+                           and not self.origf.has(j))]
         self.newf = self.newf.xreplace(dict(ratpows_repl))
 
         # To make the process deterministic, the args are sorted

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1408,7 +1408,6 @@ def residue_reduce(a, d, DE, z=None, invert=True):
     z = z or Dummy('z')
     a, d = a.cancel(d, include=True)
     a, d = a.to_field().mul_ground(1/d.LC()), d.to_field().mul_ground(1/d.LC())
-    kkinv = [1/x for x in DE.T[:DE.level]] + DE.T[:DE.level]
 
     if a.is_zero:
         return ([], True)
@@ -1439,15 +1438,14 @@ def residue_reduce(a, d, DE, z=None, invert=True):
             h = R_map.get(i)
             if h is None:
                 continue
-            h_lc = Poly(h.as_poly(DE.t).LC(), DE.t, field=True)
+            s = Poly(s, z).monic()
+            h_lc = Poly(h.as_poly(DE.t).LC(), z, field=True)
 
             h_lc_sqf = h_lc.sqf_list_include(all=True)
 
             for a, j in h_lc_sqf:
-                h = Poly(h, DE.t, field=True).exquo(Poly(gcd(a, s**j, *kkinv),
-                    DE.t))
-
-            s = Poly(s, z).monic()
+                g = a.gcd(s)
+                h = Poly(h, DE.t, field=True).exquo(Poly(g.as_expr()**j, DE.t))
 
             if invert:
                 h_lc = Poly(Poly(h, DE.t).LC(), DE.t, field=True, expand=False)

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -137,8 +137,10 @@ class DifferentialExtension:
       For back-substitution after integration.
     - backsubs: A (possibly empty) list of further substitutions to be made on
       the final integral to make it look more like the integrand.
-    - exts:
-    - extargs:
+    - exts: The type ('exp' or 'log') of each extension; exts[i]
+      describes T[i + 1] (T[0] == x is not an extension).
+    - extargs: The argument of the exp or log of each extension, indexed
+      like exts.
     - cases: List of string representations of the cases of T.
     - t: The top level extension variable, as defined by the current level
       (see level below).
@@ -663,8 +665,8 @@ class DifferentialExtension:
         self.T = [self.x]
         self.D = [Poly(1, self.x)]
         self.level = -1
-        self.exts = [None]
-        self.extargs = [None]
+        self.exts = []
+        self.extargs = []
         if self.dummy:
             self.ts = numbered_symbols('t', cls=Dummy)
         else:
@@ -687,8 +689,9 @@ class DifferentialExtension:
         Returns
         =======
 
-        list: A list of indices of 'exts' where extension of
-            type 'extension' is present.
+        list: A list of indices into T (and D) of the extensions of
+            type 'extension'.  Note that self.exts[i] describes the
+            extension T[i + 1], since T[0] == x is not an extension.
 
         Examples
         ========
@@ -703,7 +706,7 @@ class DifferentialExtension:
         [1]
 
         """
-        return [i for i, ext in enumerate(self.exts) if ext == extension]
+        return [i for i, ext in enumerate(self.exts, 1) if ext == extension]
 
     def increment_level(self):
         """

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -44,6 +44,7 @@ from sympy.functions.elementary.trigonometric import (atan, sin, cos,
     tan, acot, cot, asin, acos)
 from .integrals import integrate, Integral
 from .heurisch import _symbols
+from .rationaltools import log_to_atan, _roots_real_complex
 from sympy.polys.polyerrors import PolynomialError
 from sympy.polys.polytools import (real_roots, cancel, Poly, gcd,
     reduced)
@@ -1363,11 +1364,6 @@ def residue_reduce(a, d, DE, z=None, invert=True):
     This is ``ResidueReduce`` (the Lazard-Rioboo-Trager version) from
     Section 5.6 of Bronstein's book.
     """
-    # TODO: Use log_to_atan() from rationaltools.py
-    # If r = residue_reduce(...), then the logarithmic part is given by:
-    # sum([RootSum(a[0].as_poly(z), lambda i: i*log(a[1].as_expr()).subs(z,
-    # i)).subs(t, log(x)) for a in r[0]])
-
     z = z or Dummy('z')
     a, d = a.cancel(d, include=True)
     a, d = a.to_field().mul_ground(1/d.LC()), d.to_field().mul_ground(1/d.LC())
@@ -1430,16 +1426,82 @@ def residue_reduce(a, d, DE, z=None, invert=True):
     return (H, b)
 
 
+def residue_reduce_log_to_real(s, h, DE, z):
+    """
+    Try to express a term returned by residue_reduce() using real functions.
+
+    Explanation
+    ===========
+
+    Given a pair ``(s, h)`` from the tuple returned by residue_reduce(),
+    return a sum of real logarithms and arc-tangents of polynomials in
+    ``DE.t`` whose derivative equals that of RootSum(s, Lambda(z,
+    z*log(h))), or None if s has no complex roots or if its roots cannot
+    all be computed explicitly.  The rewriting is only valid when the
+    generators of the differential extension represent real functions.
+
+    This is Rioboo's ``LogToReal`` from Section 2.8 of Bronstein's book,
+    applied to the output of ``ResidueReduce``: the roots of s are the
+    residues, playing the part of the roots of the Rothstein-Trager
+    resultant in Chapter 2, and h plays the part of the resultant's
+    remainder.
+    """
+    from sympy.simplify.radsimp import collect
+
+    if s.as_expr().has(I) or h.as_expr().has(I) or any(
+            f(DE.x).has(I) for f in DE.Tfuncs):
+        return None
+
+    rs = _roots_real_complex(s)
+    if rs is None:
+        return None
+    reals, complexes = rs
+    if not complexes:
+        return None
+
+    u, v = Dummy('u'), Dummy('v')
+    H = h.as_expr().xreplace({z: u + I*v}).expand()
+    H_map = collect(H, I, evaluate=False)
+    a, b = H_map.get(S.One, S.Zero), H_map.get(I, S.Zero)
+
+    result = S.Zero
+    for r_u, r_v in complexes:
+        A = Poly(a.xreplace({u: r_u, v: r_v}), DE.t)
+        B = Poly(b.xreplace({u: r_u, v: r_v}), DE.t)
+
+        result += r_u*log((A**2 + B**2).as_expr())
+        if not (A.is_zero or B.is_zero):
+            # If A or B is zero, this term is a constant.
+            result += r_v*log_to_atan(A, B)
+
+    for r in reals:
+        result += r*log(h.as_expr().xreplace({z: r}))
+
+    return result
+
+
 def residue_reduce_to_basic(H, DE, z):
     """
     Converts the tuple returned by residue_reduce() into a Basic expression.
+
+    Terms whose residues come in complex-conjugate pairs are rewritten as
+    real logarithms and arc-tangents using residue_reduce_log_to_real();
+    the remaining terms are returned as RootSums.
     """
     # TODO: check what Lambda does with RootOf
     i = Dummy('i')
     s = list(zip(reversed(DE.T), reversed([f(DE.x) for f in DE.Tfuncs])))
 
-    return sum(RootSum(a[0].as_poly(z), Lambda(i, i*log(a[1].as_expr()).subs(
-        {z: i}).subs(s))) for a in H)
+    result = S.Zero
+    for a in H:
+        real = residue_reduce_log_to_real(a[0].as_poly(z), a[1], DE, z)
+        if real is not None:
+            result += real.subs(s)
+        else:
+            result += RootSum(a[0].as_poly(z), Lambda(i, i*log(
+                a[1].as_expr()).subs({z: i}).subs(s)))
+
+    return result
 
 
 def residue_reduce_derivation(H, DE, z):

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -44,7 +44,7 @@ from sympy.functions.elementary.trigonometric import (atan, sin, cos,
     tan, acot, cot, asin, acos)
 from .integrals import integrate, Integral
 from .heurisch import _symbols
-from .rationaltools import log_to_atan, _roots_real_complex
+from .rationaltools import log_to_real
 from sympy.polys.polyerrors import PolynomialError
 from sympy.polys.polytools import (real_roots, cancel, Poly, gcd,
     reduced)
@@ -1426,75 +1426,28 @@ def residue_reduce(a, d, DE, z=None, invert=True):
     return (H, b)
 
 
-def residue_reduce_log_to_real(s, h, DE, z):
-    """
-    Try to express a term returned by residue_reduce() using real functions.
-
-    Explanation
-    ===========
-
-    Given a pair ``(s, h)`` from the tuple returned by residue_reduce(),
-    return a sum of real logarithms and arc-tangents of polynomials in
-    ``DE.t`` whose derivative equals that of RootSum(s, Lambda(z,
-    z*log(h))), or None if s has no complex roots or if its roots cannot
-    all be computed explicitly.  The rewriting is only valid when the
-    generators of the differential extension represent real functions.
-
-    This is Rioboo's ``LogToReal`` from Section 2.8 of Bronstein's book,
-    applied to the output of ``ResidueReduce``: the roots of s are the
-    residues, playing the part of the roots of the Rothstein-Trager
-    resultant in Chapter 2, and h plays the part of the resultant's
-    remainder.
-    """
-    from sympy.simplify.radsimp import collect
-
-    if s.as_expr().has(I) or h.as_expr().has(I) or any(
-            f(DE.x).has(I) for f in DE.Tfuncs):
-        return None
-
-    rs = _roots_real_complex(s)
-    if rs is None:
-        return None
-    reals, complexes = rs
-    if not complexes:
-        return None
-
-    u, v = Dummy('u'), Dummy('v')
-    H = h.as_expr().xreplace({z: u + I*v}).expand()
-    H_map = collect(H, I, evaluate=False)
-    a, b = H_map.get(S.One, S.Zero), H_map.get(I, S.Zero)
-
-    result = S.Zero
-    for r_u, r_v in complexes:
-        A = Poly(a.xreplace({u: r_u, v: r_v}), DE.t)
-        B = Poly(b.xreplace({u: r_u, v: r_v}), DE.t)
-
-        result += r_u*log((A**2 + B**2).as_expr())
-        if not (A.is_zero or B.is_zero):
-            # If A or B is zero, this term is a constant.
-            result += r_v*log_to_atan(A, B)
-
-    for r in reals:
-        result += r*log(h.as_expr().xreplace({z: r}))
-
-    return result
-
-
 def residue_reduce_to_basic(H, DE, z):
     """
     Converts the tuple returned by residue_reduce() into a Basic expression.
 
-    Terms whose residues come in complex-conjugate pairs are rewritten as
-    real logarithms and arc-tangents using residue_reduce_log_to_real();
-    the remaining terms are returned as RootSums.
+    Terms whose residues can all be computed explicitly are rewritten as
+    real logarithms and arc-tangents using log_to_real() (Rioboo's
+    algorithm from Section 2.8 of Bronstein's book, with the roots of
+    each s_i as the residues and S_i in place of the Rothstein-Trager
+    resultant's remainder); the remaining terms are returned as RootSums.
+    log_to_real() is only valid over a real field, so it is not used when
+    I appears in a term or in the extension tower.
     """
     # TODO: check what Lambda does with RootOf
     i = Dummy('i')
     s = list(zip(reversed(DE.T), reversed([f(DE.x) for f in DE.Tfuncs])))
+    real_tower = not any(f(DE.x).has(I) for f in DE.Tfuncs)
 
     result = S.Zero
     for a in H:
-        real = residue_reduce_log_to_real(a[0].as_poly(z), a[1], DE, z)
+        real = None
+        if real_tower and not (a[0].as_expr().has(I) or a[1].as_expr().has(I)):
+            real = log_to_real(a[1], a[0].as_poly(z), DE.t, z)
         if real is not None:
             result += real.subs(s)
         else:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -167,9 +167,9 @@ class DifferentialExtension:
     # of the class easily (the memory use doesn't matter too much, since we
     # only create one DifferentialExtension per integration).  Also, it's nice
     # to have a safeguard when debugging.
-    __slots__ = ('f', 'x', 'T', 'D', 'fa', 'fd', 'Tfuncs', 'backsubs',
-        'exts', 'extargs', 'cases', 'case', 't', 'd', 'newf', 'level',
-        'ts', 'dummy')
+    __slots__ = ('f', 'origf', 'x', 'T', 'D', 'fa', 'fd', 'Tfuncs',
+        'backsubs', 'exts', 'extargs', 'cases', 'case', 't', 'd', 'newf',
+        'level', 'ts', 'dummy')
 
     def __init__(self, f=None, x=None, handle_first='log', dummy=False, extension=None, rewrite_complex=None):
         """
@@ -224,8 +224,10 @@ class DifferentialExtension:
                 str(handle_first))
 
         # f will be the original function, self.f might change if we reset
-        # (e.g., we pull out a constant from an exponential)
+        # (e.g., we pull out a constant from an exponential); origf always
+        # stays the expression the user handed in
         self.f = f
+        self.origf = f
         self.x = x
         # setting the default value 'dummy'
         self.dummy = dummy
@@ -322,7 +324,19 @@ class DifferentialExtension:
 
         ratpows_repl = [
             (i, i.base.base**(i.exp*i.base.exp)) for i in ratpows]
-        self.backsubs += [(j, i) for i, j in ratpows_repl]
+        # exp(u)**q == exp(q*u) is exact for integer q, but for
+        # fractional q the left side is a principal root that differs
+        # from exp(q*u) by a locally constant root of unity off the real
+        # line.  Radicals of exponentials also arise internally (the
+        # radical case of _exp_part substitutes t**(p/n) and restarts),
+        # and rewriting those into the answer turned correctly
+        # integrated results into non-antiderivatives at complex points.
+        # So the notation is only restored where it is the user's own:
+        # a fractional power is put back only if it appears in the
+        # original integrand.
+        self.backsubs += [(j, i) for i, j in ratpows_repl
+                          if i.exp.is_Integer or
+                          (self.origf is not None and self.origf.has(i))]
         self.newf = self.newf.xreplace(dict(ratpows_repl))
 
         # To make the process deterministic, the args are sorted

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -15,14 +15,15 @@ from sympy.polys.polymatrix import PolyMatrix as Matrix
 
 from sympy.testing.pytest import raises
 
-from sympy.core import Add
+from sympy.core import Add, Dummy
+from sympy.matrices import MutableDenseMatrix
 from sympy.core.numbers import Rational
 from sympy.functions.elementary.exponential import exp
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.polys.domains.rationalfield import QQ
 from sympy.polys.polytools import Poly, cancel
-from sympy.abc import x, t, n
+from sympy.abc import x, t, n, y
 
 t0, t1, t2, t3, k = symbols('t:4 k')
 
@@ -113,6 +114,29 @@ def test_constant_system():
                  [0, 1, 0],
                  [0, 0, 0],
                  [0, 0, 1]], ring=R), Matrix([0, 1, 0, 0], ring=R))
+
+    # Multiple rows with symbolic constants: pivoting on y is sound, since
+    # y is a nonzero element of the constant field QQ(y)
+    dum = Dummy()
+    A = Matrix([[y, 1, x], [0, y, 1 + x]], dum)
+    u = Matrix([[x + y], [x + 2]], dum)
+    B, v = constant_system(A, u, DE)
+    assert (B.to_Matrix(), v.to_Matrix()) == \
+        (MutableDenseMatrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+         MutableDenseMatrix([[(y**2 - 1)/y**2], [1/y], [1]]))
+
+    # An entry whose derivation-quotient rows still contain tower
+    # variables, requiring more than one pass of the elimination loop
+    # ("while A is not constant" in the book's ConstantSystem); the
+    # output must be fully constant
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t0, t0),
+        Poly((t0 + x*t0)*t1, t1)], 'exts': ['exp', 'exp'],
+        'extargs': [x, x*t0]})
+    A = Matrix([[t1, t0]], dum)
+    u = Matrix([[0]], dum)
+    B, v = constant_system(A, u, DE)
+    assert not any(B.to_Matrix()[i, j].has(t0, t1)
+        for i in range(B.rows) for j in range(B.cols))
 
 
 def test_prde_spde():
@@ -333,6 +357,9 @@ def test_limited_integrate():
     # An empty list of special elements (the is_deriv_in_field() case)
     assert limited_integrate(Poly(2*x, x), Poly(1, x), [], DE) == \
         ((Poly(x**2, x), Poly(1, x, domain='QQ')), [])
+    # ... and with a symbolic constant coefficient
+    assert limited_integrate(Poly(2*y*x, x), Poly(1, x), [], DE) == \
+        ((Poly(y*x**2, x), Poly(1, x, domain='QQ')), [])
 
 
 def test_is_log_deriv_k_t_radical():
@@ -350,6 +377,15 @@ def test_is_log_deriv_k_t_radical():
         'exts': ['exp', 'log'], 'extargs': [x, x]})
     assert is_log_deriv_k_t_radical(Poly(x + t/2 + 3, t), Poly(1, t), DE) == \
         ([(t0, 2), (x, 1)], x*t0**2, 2, 3)
+
+
+    # A tower with a symbolic constant parameter: t0 == exp(y*x).
+    # exp(2*y*x) == t0**2 is a K-radical; the structure coefficients are
+    # rational even though the constant field is QQ(y)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(y*t0, t0)],
+        'exts': ['exp'], 'extargs': [y*x]})
+    assert is_log_deriv_k_t_radical(Poly(2*y*x, t0), Poly(1, t0), DE) == \
+        ([(t0, 2)], t0**2, 1, 0)
 
 
 def test_structure_theorem_guards():
@@ -408,6 +444,21 @@ def test_is_deriv_k():
         'exts': ['log'], 'extargs': [1/x]})
     assert is_deriv_k(Poly(1, t), Poly(x, t), DE) == ([(t, 1)], t, 1)
 
+
+    # Linearly dependent tower generators (log(x) and log(x**2)) make the
+    # structure system underdetermined; the solution must still be a
+    # correct full-length coefficient vector (the reduced system used to
+    # be misread as a solution vector and silently zip-truncated)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t0),
+        Poly(2/x, t1)], 'exts': ['log', 'log'],
+        'extargs': [x, x**2]})
+    assert is_deriv_k(Poly(x, t0), Poly(1, t0), DE) == \
+        ([(t0, 1), (t1, 0)], t0, 1)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(2/x, t0),
+        Poly(1/x, t1)], 'exts': ['log', 'log'],
+        'extargs': [x**2, x]})
+    assert is_deriv_k(Poly(x, t0), Poly(1, t0), DE) == \
+        ([(t0, S.Half), (t1, 0)], t0/2, 1)
 
 def test_is_log_deriv_k_t_radical_in_field():
     # NOTE: any potential constant factor in the second element of the result

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -478,6 +478,18 @@ def test_is_log_deriv_k_t_radical_in_field():
     assert is_log_deriv_k_t_radical_in_field(Poly(1, t), Poly(2*x**2, t), DE) == \
         (2, 1/t)
 
+    # exp case: u must come back as an Expr, never as a malformed Poly
+    # with the tower generator inside the coefficient domain (this used
+    # to return Poly(t, x, domain='ZZ[t]')-shaped results, and issued
+    # the deprecated Poly/Expr mixing warning when residue terms were
+    # present)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    assert is_log_deriv_k_t_radical_in_field(Poly(1, t), Poly(1, t), DE) == \
+        (1, t)
+    # f == Dt/t + Dt/(t + 1): the log-derivative of t*(t + 1)
+    assert is_log_deriv_k_t_radical_in_field(Poly(2*t + 1, t),
+        Poly(t + 1, t), DE) == (1, t**2 + t)
+
 
 def test_parametric_log_deriv_structure():
     # The heuristic fails on all of these (z in k at a primitive level);

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from sympy.integrals.risch import DifferentialExtension, derivation
 from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
     prde_linear_constraints, constant_system, prde_spde, prde_no_cancel_b_large,
-    prde_no_cancel_b_small, limited_integrate_reduce, limited_integrate,
+    prde_no_cancel_b_small, prde_no_cancel_b_equal, limited_integrate_reduce,
+    limited_integrate,
     is_deriv_k, is_log_deriv_k_t_radical, parametric_log_deriv_heu,
     is_log_deriv_k_t_radical_in_field, param_poly_rischDE, param_rischDE,
     is_deriv_in_field,
@@ -168,6 +169,36 @@ def test_prde_no_cancel():
     assert V[0] == Matrix([Rational(-1, 2), 0, 0, 1, 0, 0]*3, ring=R)
     assert (Matrix([h])*V[0][6:, :])[0] == Poly(x**2/2, t, domain='QQ(x)')
     assert (Matrix([q])*V[0][:6, :])[0] == Poly(x - S.Half, t, domain='QQ(x)')
+
+
+def test_prde_no_cancel_b_equal():
+    # deg(b) == delta(t) - 1, with t == tan-like (Dt == t**2 + 1)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
+    # -lc(b)/lc(Dt) == -1 is not a positive integer, so the loop runs to
+    # N == 0: Dq + t*q == 2*t**2 + 1 has the solution q == t
+    assert prde_no_cancel_b_equal(Poly(t, t), [Poly(2*t**2 + 1, t)], 1, DE) == \
+        ([Poly(t, t)], Matrix([[1, -1]], DE.t))
+    # A solution with a nonconstant coefficient and two right hand sides:
+    # q == t**2 solves Dq + t*q == c1 for c == D(t**2) + t*t**2
+    b = Poly(t, t)
+    q = Poly(t**2, t)
+    c = derivation(q, DE) + b*q
+    h, A = prde_no_cancel_b_equal(b, [c, Poly(0, t)], 2, DE)
+    V = A.nullspace()
+    sols = 0
+    for v in V:
+        if v[0] != 0:
+            y = Add(*[(v[2 + j]*h[j]).as_expr() for j in range(len(h))])
+            yp = Poly(y/v[0].as_expr(), t, field=True)
+            if cancel(derivation(yp, DE).as_expr() + (b*yp).as_expr()
+                    - c.as_expr()) == 0:
+                sols += 1
+    assert sols >= 1
+    # When the possible-cancellation degree -lc(b)/lc(Dt) is reached, the
+    # rest is delegated to the cancellation algorithms, which are not yet
+    # implemented for delta(t) >= 2
+    raises(NotImplementedError, lambda: prde_no_cancel_b_equal(
+        Poly(-2*t, t), [Poly(t**4 + 3*t**2, t)], 3, DE))
 
 
 def test_prde_cancel_liouvillian():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -6,6 +6,7 @@ from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
     prde_no_cancel_b_small, prde_no_cancel_b_equal, limited_integrate_reduce,
     limited_integrate,
     is_deriv_k, is_log_deriv_k_t_radical, parametric_log_deriv_heu,
+    parametric_log_deriv, parametric_log_deriv_structure,
     is_log_deriv_k_t_radical_in_field, param_poly_rischDE, param_rischDE,
     is_deriv_in_field,
     prde_cancel_liouvillian)
@@ -405,6 +406,27 @@ def test_is_log_deriv_k_t_radical_in_field():
         (1, t)
     assert is_log_deriv_k_t_radical_in_field(Poly(1, t), Poly(2*x**2, t), DE) == \
         (2, 1/t)
+
+
+def test_parametric_log_deriv_structure():
+    # The heuristic fails on all of these (z in k at a primitive level);
+    # the structure-theorem method (equation (7.44)) decides them.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)],
+        'exts': ['log'], 'extargs': [x]})
+    # f == 1/x == Dx/x, w == 1: 1*f == Dx/x + 0*w
+    assert parametric_log_deriv_structure(Poly(1, t), Poly(x, t),
+        Poly(1, t), Poly(1, t), DE) == (1, 0, x)
+    # f == 1 + 1/(2*x), w == 1: 2*f == Dx/x + 2*w  (through the wrapper,
+    # exercising the heuristic -> structure fallback)
+    assert parametric_log_deriv(Poly(2*x + 1, t), Poly(2*x, t),
+        Poly(1, t), Poly(1, t), DE) == (2, 2, x)
+    # f == 1/(x + 1), w == 1 has the solution (1, 0, x + 1), but x + 1 is
+    # not in the tower, so the structure method is inconclusive (None) and
+    # the wrapper must raise rather than claim no solution exists.
+    assert parametric_log_deriv_structure(Poly(1, t), Poly(x + 1, t),
+        Poly(1, t), Poly(1, t), DE) is None
+    raises(NotImplementedError, lambda: parametric_log_deriv(
+        Poly(1, t), Poly(x + 1, t), Poly(1, t), Poly(1, t), DE))
 
 
 def test_is_deriv_in_field():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -330,6 +330,9 @@ def test_limited_integrate():
     G = [(Poly(1, x), Poly(x, x))]
     assert limited_integrate(Poly(5*x**2, x), Poly(3, x), G, DE) == \
         ((Poly(5*x**3/9, x), Poly(1, x, domain='QQ')), [0])
+    # An empty list of special elements (the is_deriv_in_field() case)
+    assert limited_integrate(Poly(2*x, x), Poly(1, x), [], DE) == \
+        ((Poly(x**2, x), Poly(1, x, domain='QQ')), [])
 
 
 def test_is_log_deriv_k_t_radical():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -12,11 +12,12 @@ from sympy.polys.polymatrix import PolyMatrix as Matrix
 
 from sympy.testing.pytest import raises
 
+from sympy.core import Add
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.polys.domains.rationalfield import QQ
-from sympy.polys.polytools import Poly
+from sympy.polys.polytools import Poly, cancel
 from sympy.abc import x, t, n
 
 t0, t1, t2, t3, k = symbols('t:4 k')
@@ -189,6 +190,26 @@ def test_prde_cancel_liouvillian():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-t, t)]})
     assert prde_cancel_liouvillian(Poly(0, t, domain='QQ[x]'), [Poly(1, t, domain='QQ(x)')], 0, DE) == \
             ([Poly(1, t, domain='QQ'), Poly(x, t, domain='ZZ(x)')], Matrix([[-1, 0, 1]], DE.t))
+
+    ### 3. case == 'exp' with b != 0 and n > 0.  This exercises the level at
+    ### which eta == Dt/t is computed and the sign of the residual update
+    ### Fi == -(D(h) + b*h), both of which used to be wrong.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    b = Poly(1/x, t, field=True)
+    Q = [Poly((x + 1)*t/x, t, field=True)]
+    h, A = prde_cancel_liouvillian(b, Q, 1, DE)
+    V = A.nullspace()
+    # Dy + y/x == c1*(x + 1)*t/x must have the solution y == t (c1 == 1)
+    found = False
+    for v in V:
+        if v[0] == 0:
+            continue
+        y = Add(*[(v[1 + j]*h[j]).as_expr() for j in range(len(h))])/v[0].as_expr()
+        yp = Poly(y, t, field=True)
+        if cancel(derivation(yp, DE).as_expr() + b.as_expr()*y
+                - Q[0].as_expr()) == 0:
+            found = True
+    assert found
 
 
 def test_param_poly_rischDE():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -1,6 +1,6 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from __future__ import annotations
-from sympy.integrals.risch import DifferentialExtension, derivation
+from sympy.integrals.risch import DifferentialExtension, derivation, frac_in
 from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
     prde_linear_constraints, constant_system, prde_spde, prde_no_cancel_b_large,
     prde_no_cancel_b_small, prde_no_cancel_b_equal, limited_integrate_reduce,
@@ -17,6 +17,7 @@ from sympy.testing.pytest import raises
 
 from sympy.core import Add
 from sympy.core.numbers import Rational
+from sympy.functions.elementary.exponential import exp
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.polys.domains.rationalfield import QQ
@@ -427,6 +428,27 @@ def test_parametric_log_deriv_structure():
         Poly(1, t), Poly(1, t), DE) is None
     raises(NotImplementedError, lambda: parametric_log_deriv(
         Poly(1, t), Poly(x + 1, t), Poly(1, t), Poly(1, t), DE))
+
+    # Nontrivial n and m: f == 1/(2*x) + 3, w == 2:
+    # 2*f == Dx/x + 3*w
+    assert parametric_log_deriv_structure(Poly(6*x + 1, t), Poly(2*x, t),
+        Poly(2, t), Poly(1, t), DE) == (2, 3, x)
+
+    # Underdetermined system (w lies in the span of the generators) and a
+    # w == 0 query.  Which solution is returned depends on the free
+    # parameter choice, so check the defining equation n*f == Dv/v + m*w
+    # instead of an exact tuple.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t),
+        Poly(t1, t1)], 'exts': ['log', 'exp'], 'extargs': [x, x]})
+    for f, w in [(1/x + 2, S(3)), (1/x + 5, S.Zero)]:
+        fa, fd = frac_in(f, t1)
+        wa, wd = frac_in(w, t1)
+        A = parametric_log_deriv_structure(fa, fd, wa, wd, DE)
+        assert A is not None
+        n, m, v = A
+        assert n > 0 and n.is_Integer and m.is_Integer
+        vv = v.subs(t1, exp(x))  # t1 == exp(x) in this extension
+        assert cancel(n*f - m*w - vv.diff(x)/vv) == 0
 
 
 def test_is_deriv_in_field():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -262,18 +262,18 @@ def test_limited_integrate():
 
 
 def test_is_log_deriv_k_t_radical():
-    DE = DifferentialExtension(extension={'D': [Poly(1, x)], 'exts': [None],
-        'extargs': [None]})
+    DE = DifferentialExtension(extension={'D': [Poly(1, x)], 'exts': [],
+        'extargs': []})
     assert is_log_deriv_k_t_radical(Poly(2*x, x), Poly(1, x), DE) is None
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(2*t1, t1), Poly(1/x, t2)],
-        'exts': [None, 'exp', 'log'], 'extargs': [None, 2*x, x]})
+        'exts': ['exp', 'log'], 'extargs': [2*x, x]})
     assert is_log_deriv_k_t_radical(Poly(x + t2/2, t2), Poly(1, t2), DE) == \
         ([(t1, 1), (x, 1)], t1*x, 2, 0)
     # TODO: Add more tests
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t0, t0), Poly(1/x, t)],
-        'exts': [None, 'exp', 'log'], 'extargs': [None, x, x]})
+        'exts': ['exp', 'log'], 'extargs': [x, x]})
     assert is_log_deriv_k_t_radical(Poly(x + t/2 + 3, t), Poly(1, t), DE) == \
         ([(t0, 2), (x, 1)], x*t0**2, 2, 3)
 
@@ -283,7 +283,7 @@ def test_structure_theorem_guards():
     # supported by the structure theorems.  When every primitive monomial
     # in it is a logarithm, it is reported as a nonelementary tower.
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t1),
-        Poly(t2, t2)], 'exts': [None, 'log'], 'extargs': [None, x]})
+        Poly(t2, t2)], 'exts': ['log'], 'extargs': [x]})
     for func in (is_deriv_k, is_log_deriv_k_t_radical):
         try:
             func(Poly(t2, t2), Poly(1, t2), DE)
@@ -296,7 +296,7 @@ def test_structure_theorem_guards():
     # arctangent-like monomial) needs the real version of the structure
     # theorems instead.
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t1),
-        Poly(1/(x**2 + 1), t2)], 'exts': [None, 'log'], 'extargs': [None, x]})
+        Poly(1/(x**2 + 1), t2)], 'exts': ['log'], 'extargs': [x]})
     for func in (is_deriv_k, is_log_deriv_k_t_radical):
         try:
             func(Poly(t2, t2), Poly(1, t2), DE)
@@ -308,30 +308,30 @@ def test_structure_theorem_guards():
 
 def test_is_deriv_k():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t1), Poly(1/(x + 1), t2)],
-        'exts': [None, 'log', 'log'], 'extargs': [None, x, x + 1]})
+        'exts': ['log', 'log'], 'extargs': [x, x + 1]})
     assert is_deriv_k(Poly(2*x**2 + 2*x, t2), Poly(1, t2), DE) == \
         ([(t1, 1), (t2, 1)], t1 + t2, 2)
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t1), Poly(t2, t2)],
-        'exts': [None, 'log', 'exp'], 'extargs': [None, x, x]})
+        'exts': ['log', 'exp'], 'extargs': [x, x]})
     assert is_deriv_k(Poly(x**2*t2**3, t2), Poly(1, t2), DE) == \
         ([(x, 3), (t1, 2)], 2*t1 + 3*x, 1)
     # TODO: Add more tests, including ones with exponentials
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(2/x, t1)],
-        'exts': [None, 'log'], 'extargs': [None, x**2]})
+        'exts': ['log'], 'extargs': [x**2]})
     assert is_deriv_k(Poly(x, t1), Poly(1, t1), DE) == \
         ([(t1, S.Half)], t1/2, 1)
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(2/(1 + x), t0)],
-        'exts': [None, 'log'], 'extargs': [None, x**2 + 2*x + 1]})
+        'exts': ['log'], 'extargs': [x**2 + 2*x + 1]})
     assert is_deriv_k(Poly(1 + x, t0), Poly(1, t0), DE) == \
         ([(t0, S.Half)], t0/2, 1)
 
     # Issue 10798
     # DE = DifferentialExtension(log(1/x), x)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-1/x, t)],
-        'exts': [None, 'log'], 'extargs': [None, 1/x]})
+        'exts': ['log'], 'extargs': [1/x]})
     assert is_deriv_k(Poly(1, t), Poly(x, t), DE) == ([(t, 1)], t, 1)
 
 

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -6,6 +6,7 @@ from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
     prde_no_cancel_b_small, limited_integrate_reduce, limited_integrate,
     is_deriv_k, is_log_deriv_k_t_radical, parametric_log_deriv_heu,
     is_log_deriv_k_t_radical_in_field, param_poly_rischDE, param_rischDE,
+    is_deriv_in_field,
     prde_cancel_liouvillian)
 
 from sympy.polys.polymatrix import PolyMatrix as Matrix
@@ -373,6 +374,28 @@ def test_is_log_deriv_k_t_radical_in_field():
         (1, t)
     assert is_log_deriv_k_t_radical_in_field(Poly(1, t), Poly(2*x**2, t), DE) == \
         (2, 1/t)
+
+
+def test_is_deriv_in_field():
+    DE = DifferentialExtension(extension={'D': [Poly(1, x)]})
+    assert is_deriv_in_field(Poly(2*x, x), Poly(1, x), DE) == \
+        (Poly(x**2, x), Poly(1, x, domain='QQ'))
+    assert is_deriv_in_field(Poly(1, x), Poly(x, x), DE) is None
+    # t == log(x): D(x*t) == t + 1; 1/(x*t) == D(log(log(x))) is not in the field
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
+    A = is_deriv_in_field(Poly(t + 1, t), Poly(1, t), DE)
+    assert A is not None
+    va, vd = A
+    vp = Poly(cancel(va.as_expr()/vd.as_expr()), t, field=True)
+    assert cancel(derivation(vp, DE).as_expr() - (t + 1)) == 0
+    assert is_deriv_in_field(Poly(1, t), Poly(x*t, t), DE) is None
+    # t == exp(x): D(x*t**2) == (2*x + 1)*t**2; t is not a derivative
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    A = is_deriv_in_field(Poly((2*x + 1)*t**2, t), Poly(1, t), DE)
+    assert A is not None
+    va, vd = A
+    vp = Poly(cancel(va.as_expr()/vd.as_expr()), t, field=True)
+    assert cancel(derivation(vp, DE).as_expr() - (2*x + 1)*t**2) == 0
 
 
 def test_parametric_log_deriv():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -304,6 +304,22 @@ def test_limited_integrate_reduce():
         (Poly(t, t), Poly(-1/x, t), Poly(t, t), 1, (Poly(x, t), Poly(1, t, domain='ZZ[x]')),
         [(Poly(-x*t, t), Poly(1, t, domain='ZZ[x]'))])
 
+    # An exp case with a nontrivial special part (hs != 1).  This
+    # distinguishes the first return component, which must be hn rather
+    # than a == hn*hs (the book returns a, which does not satisfy the
+    # stated contract): check the contract directly for the known
+    # solution v == 1/(t*x), c1 == 3 of f == Dv + c1*w1.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    fa, fd = frac_in((3*x**2*t - x - 1)/(x**2*t), t)
+    G = [(Poly(1, t), Poly(1, t))]
+    A, b, h, N, g, V = limited_integrate_reduce(fa, fd, G, DE)
+    p = Poly(cancel(h.as_expr()/(t*x)), t, field=True)  # p == v*h
+    assert p.degree(t) <= N
+    lhs = (A*derivation(p, DE) + b*p).as_expr()
+    rhs = cancel(g[0].as_expr()/g[1].as_expr() +
+        3*V[0][0].as_expr()/V[0][1].as_expr())
+    assert cancel(lhs - rhs) == 0
+
 
 def test_limited_integrate():
     DE = DifferentialExtension(extension={'D': [Poly(1, x)]})

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -9,9 +9,10 @@ from sympy.integrals.integrals import integrate
 from sympy.polys.polytools import Poly, cancel
 from sympy.simplify.simplify import simplify
 
-from sympy.integrals.rationaltools import ratint, ratint_logpart, log_to_atan
+from sympy.integrals.rationaltools import (ratint, ratint_logpart,
+    log_to_atan, log_to_real)
 
-from sympy.abc import a, b, x, t
+from sympy.abc import a, b, x, t, y
 
 half = S.Half
 
@@ -180,6 +181,19 @@ def test_log_to_atan():
     fg_ans = 2*atan(2*sqrt(3)*x/3 + sqrt(3)/3)
     assert log_to_atan(f, g) == fg_ans
     assert log_to_atan(g, f) == -fg_ans
+
+
+def test_log_to_real_complex_only():
+    h = Poly(x + 3*y/2 + S.Half, x, domain='QQ[y]')
+    q = Poly(3*y**2 + 1, y, domain='ZZ')
+    ans = 2*sqrt(3)*atan(2*sqrt(3)*x/3 + sqrt(3)/3)/3
+    assert log_to_real(h, q, x, y) == ans
+    assert log_to_real(h, q, x, y, complex_only=True) == ans
+    # With complex_only=True, a q with only real roots is not converted
+    h = Poly(x**2 - 1, x, domain='ZZ')
+    q = Poly(-2*y + 1, y, domain='ZZ')
+    assert log_to_real(h, q, x, y) == log(x**2 - 1)/2
+    assert log_to_real(h, q, x, y, complex_only=True) is None
 
 
 def test_issue_25896():

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -6,7 +6,7 @@ from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import atan
 from sympy.integrals.integrals import integrate
-from sympy.polys.polytools import Poly
+from sympy.polys.polytools import Poly, cancel
 from sympy.simplify.simplify import simplify
 
 from sympy.integrals.rationaltools import ratint, ratint_logpart, log_to_atan
@@ -136,6 +136,15 @@ def test_issue_5817():
     assert simplify(ratint(a/(b*c*x**2 + a**2 + b*a), x)) == \
         sqrt(a)*atan(sqrt(
             b)*sqrt(c)*x/(sqrt(a)*sqrt(a + b)))/(sqrt(b)*sqrt(c)*sqrt(a + b))
+
+
+def test_ratint_radical_coefficients():
+    # issue 26502
+    a = symbols('a', positive=True)
+    f = (-x**2 + sqrt(2))/(x**4 - sqrt(2)*x**2 + 1)
+    assert cancel((ratint(f, x).diff(x) - f).together()) == 0
+    g = (2*sqrt(a) - x**2)/(-sqrt(a)*x**2 + a + x**4)
+    assert cancel((ratint(g, x).diff(x) - g).together()) == 0
 
 
 def test_issue_5981():

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -166,6 +166,25 @@ def test_bound_degree():
     assert bound_degree(Poly(t, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), DE) == 0
 
 
+def test_bound_degree_rational_z():
+    # Primitive case with deg(a) == deg(b) and alpha == 1/(x*(x + 1)) ==
+    # Dz/z for z == x/(x + 1) -- a proper ratio in k*, so derivation(z, DE)
+    # inside bound_degree() needs basic=True (z is not polynomial in the
+    # tower generators; this used to crash with SympifyError).
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)],
+        'exts': ['log'], 'extargs': [x]})
+    assert bound_degree(Poly(t, t, field=True),
+        Poly(-t/(x*(x + 1)), t, field=True), Poly(1, t, field=True), DE) == 0
+    # The same alpha end-to-end: Dy - y/(x*(x + 1)) == (x + 1 - t)/(x*(x + 1))
+    # has the solution y == t (plus c*x/(x + 1) for any constant c, so check
+    # the defining equation rather than the exact result).
+    ya, yd = rischDE(Poly(-1, t, field=True), Poly(x*(x + 1), t, field=True),
+        Poly(x + 1 - t, t, field=True), Poly(x*(x + 1), t, field=True), DE)
+    y = ya.as_expr()/yd.as_expr()
+    assert cancel(derivation(Poly(y, t, field=True), DE).as_expr() -
+        y/(x*(x + 1)) - (x + 1 - t)/(x*(x + 1))) == 0
+
+
 def test_bound_degree_undecidable():
     # Exp case with deg(a) == deg(b) and alpha == -lc(b)/lc(a) == 1/(x + 1):
     # deciding whether alpha == m*Dt/t + Dz/z requires log(x + 1), which is

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -208,6 +208,17 @@ def test_spde():
         (Poly(0, x, domain='ZZ'), Poly(0, x), 0, Poly(0, x), Poly(3*x**3 - 2*x**2, x, domain='QQ'))
     assert spde(Poly(x**2 - x, x), Poly(x**2 - 5*x + 3, x), Poly(x**7 - x**6 - 2*x**4 + 3*x**3 - x**2, x), 5, DE) == \
         (Poly(1, x, domain='QQ'), Poly(x + 1, x, domain='QQ'), 1, Poly(x**4 - x**3, x), Poly(x**3 - x**2, x, domain='QQ'))
+    # n == oo (from rischDE() when bound_degree() cannot decide) must not
+    # loop forever when deg(a) > 0: a == t, b == 1, c == x has no
+    # solution and gcd(a, b) == 1 stays trivial, so no other exit is
+    # ever taken.  This used to spin indefinitely.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    raises(NotImplementedError, lambda: spde(Poly(t, t), Poly(1, t),
+        Poly(x, t, domain='ZZ[x]'), oo, DE))
+    # ...but with deg(a) == 0 it returns immediately, so n == oo is fine.
+    assert spde(Poly(2, t), Poly(t, t), Poly(t, t), oo, DE) == \
+        (Poly(t/2, t, domain='QQ'), Poly(t/2, t, domain='QQ'), oo,
+         Poly(1, t, domain='ZZ'), Poly(0, t, domain='ZZ'))
 
 def test_solve_poly_rde_no_cancel():
     # deg(b) large

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -234,7 +234,11 @@ def test_spde():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
     raises(NotImplementedError, lambda: spde(Poly(t, t), Poly(1, t),
         Poly(x, t, domain='ZZ[x]'), oo, DE))
-    # ...but with deg(a) == 0 it returns immediately, so n == oo is fine.
+    # ...while a solvable positive-degree case with n == oo still reduces
+    # and returns (q == 1 here; c becomes zero after one pass)...
+    assert spde(Poly(t, t), Poly(1, t), Poly(1, t), oo, DE) == \
+        (Poly(0, t), Poly(0, t), 0, Poly(0, t), Poly(1, t, domain='QQ'))
+    # ...and with deg(a) == 0 it returns immediately, so n == oo is fine.
     assert spde(Poly(2, t), Poly(t, t), Poly(t, t), oo, DE) == \
         (Poly(t/2, t, domain='QQ'), Poly(t/2, t, domain='QQ'), oo,
          Poly(1, t, domain='ZZ'), Poly(0, t, domain='ZZ'))

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -166,6 +166,22 @@ def test_bound_degree():
     assert bound_degree(Poly(t, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), DE) == 0
 
 
+def test_bound_degree_undecidable():
+    # Exp case with deg(a) == deg(b) and alpha == -lc(b)/lc(a) == 1/(x + 1):
+    # deciding whether alpha == m*Dt/t + Dz/z requires log(x + 1), which is
+    # not in the tower, so parametric_log_deriv() cannot decide and
+    # bound_degree() must raise rather than return an unsound bound.
+    # param_rischDE() propagates this (it used to guess n = 5 instead,
+    # which could truncate the parametric solution basis and turn into a
+    # false proof of nonelementarity downstream in is_deriv_in_field()).
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t0),
+        Poly(t1, t1)], 'exts': ['log', 'exp'], 'extargs': [x, x]})
+    raises(NotImplementedError, lambda: bound_degree(Poly(t1, t1),
+        Poly(-t1/(x + 1), t1, field=True), Poly(1, t1), DE))
+    raises(NotImplementedError, lambda: bound_degree(Poly(t1, t1),
+        Poly(-t1/(x + 1), t1, field=True), [Poly(1, t1)], DE, parametric=True))
+
+
 def test_spde():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
     raises(NonElementaryIntegralException, lambda: spde(Poly(t, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), 0, DE))

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -213,6 +213,10 @@ def test_solve_poly_rde_no_cancel():
     # The m == 0 branch: Dq + t*q == t has the solution q == 1 (this used
     # to return an Expr instead of a Poly)
     assert no_cancel_equal(Poly(t, t), Poly(t, t), 5, DE) == Poly(1, t)
+    # Immediate u == 0 return: -lc(b)/lc(Dt) == 3 is hit on the first
+    # iteration, reducing to a smaller problem of degree at most 3
+    assert no_cancel_equal(Poly(-3*t, t), Poly(t**2 + 1, t), oo, DE) == \
+        (Poly(0, t), 3, Poly(t**2 + 1, t))
 
 
 def test_solve_poly_rde_cancel():

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -240,7 +240,6 @@ def test_spde():
     assert spde(Poly(t, t), Poly(1, t), Poly(1, t), oo, DE) == \
         (Poly(0, t), Poly(0, t), 0, Poly(0, t), Poly(1, t, domain='QQ'))
     # A SymPy Integer bound must behave like the equal plain int
-    # (this used to loop forever: (S(-1) < 0) is not the True singleton)
     raises(NonElementaryIntegralException, lambda: spde(Poly(t, t),
         Poly(1, t), Poly(x, t, domain='ZZ[x]'), S(1), DE))
     # ...and with deg(a) == 0 it returns immediately, so n == oo is fine.
@@ -300,8 +299,7 @@ def test_solve_poly_rde_cancel():
     # D(x)/x - 2*Dt/t (z == x, m == -2), and the candidate q == 1 + t**2
     # has t**2-coefficient 1, with z*1 == x nonconstant, so no choice of
     # the integration constant removes the term: there is no solution
-    # with n == 0.  (Unconditional stripping used to return q == 1, which
-    # does not solve the equation.)
+    # with n == 0.
     raises(NonElementaryIntegralException, lambda: cancel_exp(
         Poly(1/x - 2, t, field=True),
         Poly(1/x - 2 + t**2/x, t, field=True), 0, DE))

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -1,6 +1,7 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from __future__ import annotations
 from sympy.core.numbers import (I, Rational, oo)
+from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.polys.polytools import Poly, cancel
 from sympy.integrals.risch import (DifferentialExtension, derivation,
@@ -238,6 +239,10 @@ def test_spde():
     # and returns (q == 1 here; c becomes zero after one pass)...
     assert spde(Poly(t, t), Poly(1, t), Poly(1, t), oo, DE) == \
         (Poly(0, t), Poly(0, t), 0, Poly(0, t), Poly(1, t, domain='QQ'))
+    # A SymPy Integer bound must behave like the equal plain int
+    # (this used to loop forever: (S(-1) < 0) is not the True singleton)
+    raises(NonElementaryIntegralException, lambda: spde(Poly(t, t),
+        Poly(1, t), Poly(x, t, domain='ZZ[x]'), S(1), DE))
     # ...and with deg(a) == 0 it returns immediately, so n == oo is fine.
     assert spde(Poly(2, t), Poly(t, t), Poly(t, t), oo, DE) == \
         (Poly(t/2, t, domain='QQ'), Poly(t/2, t, domain='QQ'), oo,

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -286,6 +286,20 @@ def test_solve_poly_rde_cancel():
     raises(NonElementaryIntegralException, lambda: cancel_exp(
         Poly((2*x + 1)/x, t), Poly(1/x**2, t), 0, DE))
 
+    # The t**(-m) stripping in the m < 0 branch is only valid when the
+    # stripped coefficient is C/z for a constant C.  Here b == 1/x - 2 ==
+    # D(x)/x - 2*Dt/t (z == x, m == -2), and the candidate q == 1 + t**2
+    # has t**2-coefficient 1, with z*1 == x nonconstant, so no choice of
+    # the integration constant removes the term: there is no solution
+    # with n == 0.  (Unconditional stripping used to return q == 1, which
+    # does not solve the equation.)
+    raises(NonElementaryIntegralException, lambda: cancel_exp(
+        Poly(1/x - 2, t, field=True),
+        Poly(1/x - 2 + t**2/x, t, field=True), 0, DE))
+    # ...while the same b with c == b has the genuine solution q == 1.
+    assert cancel_exp(Poly(1/x - 2, t, field=True),
+        Poly(1/x - 2, t, field=True), 0, DE) == Poly(1, t)
+
     # primitive
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
 

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -222,7 +222,19 @@ def test_solve_poly_rde_cancel():
         Poly(1, t)
     assert cancel_exp(Poly(2*x, t), Poly((1 + 2*x)*t, t), 1, DE) == \
         Poly(t, t)
-    # TODO: Add more exp tests, including tests that require is_deriv_in_field()
+    # The is_deriv_in_field() branch: b == (2*x + 1)/x == D(x)/x + 2*Dt/t
+    # (parametric_log_deriv() gives (1, 2, x)), and Dq + b*q == c has the
+    # solution q == 1 for c == (2*x + 1)/x.
+    assert cancel_exp(Poly((2*x + 1)/x, t), Poly((2*x + 1)/x, t), 0, DE) == \
+        Poly(1, t)
+    # ... but 1/(2*x) also works for c == 1/x (the code finds solutions
+    # with denominators via p/(z*t**m)):
+    assert cancel_exp(Poly((2*x + 1)/x, t), Poly(1/x, t), 0, DE) == \
+        Poly(1/(2*x), t)
+    # c == 1/x**2 requires a' + 2*a == 1/x over QQ(x), which has no
+    # rational solution (pole order mismatch at 0), so no solution exists
+    raises(NonElementaryIntegralException, lambda: cancel_exp(
+        Poly((2*x + 1)/x, t), Poly(1/x**2, t), 0, DE))
 
     # primitive
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
@@ -246,6 +258,16 @@ def test_solve_poly_rde_cancel():
     assert cancel_primitive(Poly(4*x, t), Poly(4*x*t**2 + 2*t/x, t), 3, DE) == \
         Poly(t**2, t)
 
+    # The is_deriv_in_field() branch: b == 1/x == D(x)/x
+    # (is_log_deriv_k_t_radical_in_field() gives (1, x)), and
+    # Dq + b*q == c has the solution q == t for c == (t + 1)/x.
+    assert cancel_primitive(Poly(1/x, t), Poly((t + 1)/x, t), 1, DE) == \
+        Poly(t, t)
+    # z*c == t/(x + 1) has antiderivative t*log(x + 1) - log(x + 1) + x,
+    # which is not in QQ(x, log(x)), so no solution exists
+    raises(NonElementaryIntegralException, lambda: cancel_primitive(
+        Poly(1/x, t), Poly(t/(x*(x + 1)), t), 1, DE))
+
     # The degree bound n must not be clobbered by the index returned from
     # is_log_deriv_k_t_radical_in_field(): b == 1/(2*x) has index 2
     # (2*b == D(x)/x), which used to replace n == 3 and wrongly reject
@@ -255,7 +277,20 @@ def test_solve_poly_rde_cancel():
     c = derivation(q, DE) + b*q
     assert cancel_primitive(b, c, 3, DE) == q
 
-    # TODO: Add more primitive tests, including tests that require is_deriv_in_field()
+    # The b == 0 cancellation case (Dq == c by in-field integration):
+    # primitive (t == log(x)): D(t**2) == 2*t/x
+    assert solve_poly_rde(Poly(0, t), Poly(2*t/x, t), 2, DE) == Poly(t**2, t)
+    # (note Dq == 1/x has the in-field solution q == t == log(x); use an
+    # integrand whose antiderivative needs log(x + 1), which is not in
+    # the field)
+    raises(NonElementaryIntegralException, lambda: solve_poly_rde(
+        Poly(0, t), Poly(t/(x + 1), t), 2, DE))
+    # exp (t == exp(x)): D(x*t) == (x + 1)*t
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    assert solve_poly_rde(Poly(0, t), Poly((x + 1)*t, t), 1, DE) == \
+        Poly(x*t, t)
+    raises(NonElementaryIntegralException, lambda: solve_poly_rde(
+        Poly(0, t), Poly(t/x, t), 1, DE))
 
 
 def test_rischDE():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -793,6 +793,22 @@ def test_risch_integrate():
     assert risch_integrate(log(x**y), x) == x*log(x**y) - x*y
     assert risch_integrate(log(sqrt(x)), x) == x*log(sqrt(x)) - x/2
 
+    # A restart (from the exponential radical path) clears backsubs, so
+    # the branch-constant Dummy recorded by _log_part() must be folded
+    # back into newf first, or it leaks into the result as a free symbol.
+    ans = risch_integrate(log(x) + log(x**2) + exp(x) + exp(x/2 + 1), x)
+    assert ans.free_symbols == {x}
+    assert cancel(diff(ans, x) - (log(x) + log(x**2) + exp(x) +
+        exp(x/2 + 1))) == 0
+
+    # Mixed notation: when the integrand contains both sqrt(exp(x)) and
+    # its folded form exp(x/2), restoring the radical globally would
+    # also rewrite the genuine exp(x/2), so the answer stays in the
+    # exact exponential form.
+    assert risch_integrate(sqrt(exp(x)) + exp(x/2), x) == 4*exp(x/2)
+    # A pure user radical keeps its notation.
+    assert risch_integrate(sqrt(exp(x)), x) == 2*sqrt(exp(x))
+
     # Example 6.2.1
     expr = (exp(x) - x**2 + 2*x)/((exp(x) + x)**2*x**2)*exp((x**2 - 1)/x + 1/(exp(x) + x))
     assert risch_integrate(expr, x) == exp(-x)*exp(1/(x + exp(x)) + (x**2 - 1)/x)

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -530,11 +530,18 @@ def test_DifferentialExtension_exp():
 
 
 def test_DifferentialExtension_log():
-    assert DifferentialExtension(log(x)*log(x + 1)*log(2*x**2 + 2*x), x)._important_attrs == \
-        (Poly(t0*t1**2 + (t0*log(2) + t0**2)*t1, t1), Poly(1, t1),
+    # log(2*x**2 + 2*x) is rewritten in terms of the other two logarithms
+    # plus an opaque locally-constant branch term (restored by backsubs),
+    # not the principal-branch constant log(2), which is only valid where
+    # the arguments are all positive.
+    DE = DifferentialExtension(log(x)*log(x + 1)*log(2*x**2 + 2*x), x)
+    c = DE.backsubs[-1][0]
+    assert DE._important_attrs == \
+        (Poly(t0*t1**2 + (c*t0 + t0**2)*t1, t1), Poly(1, t1),
         [Poly(1, x), Poly(1/x, t0),
         Poly(1/(x + 1), t1, expand=False)], [x, t0, t1],
-        [Lambda(i, log(i)), Lambda(i, log(i + 1))], [], ['log', 'log'],
+        [Lambda(i, log(i)), Lambda(i, log(i + 1))],
+        [(c, log(2*x**2 + 2*x) - log(x) - log(x + 1))], ['log', 'log'],
         [x, x + 1])
     assert DifferentialExtension(x**x*log(x), x)._important_attrs == \
         (Poly(t0*t1, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0),
@@ -545,10 +552,13 @@ def test_DifferentialExtension_log():
 
 def test_DifferentialExtension_symlog():
     # See comment on test_risch_integrate below
-    assert DifferentialExtension(log(x**x), x)._important_attrs == \
-        (Poly(t0*x, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0), Poly((t0 +
+    DE = DifferentialExtension(log(x**x), x)
+    c = DE.backsubs[-1][0]
+    assert DE._important_attrs == \
+        (Poly(t0*x + c, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0), Poly((t0 +
             1)*t1, t1)], [x, t0, t1], [Lambda(i, log(i)), Lambda(i, exp(i*t0))],
-            [(exp(x*log(x)), x**x)], ['log', 'exp'], [x, t0*x])
+            [(exp(x*log(x)), x**x), (c, log(x**x) - x*log(x))],
+            ['log', 'exp'], [x, t0*x])
     assert DifferentialExtension(log(x**y), x)._important_attrs == \
         (Poly(y*t0, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
         [Lambda(i, log(i))], [(y*log(x), log(x**y))], ['log'],
@@ -658,9 +668,11 @@ def test_DifferentialExtension_misc():
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(log(10)*t0, t0)], [x, t0],
         [Lambda(i, exp(i*log(10)))], [(exp(x*log(10)), 10**x)], ['exp'],
         [x*log(10)])
-    assert DifferentialExtension(log(x) + log(x**2), x)._important_attrs == \
-        (Poly(3*t0, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
-        [Lambda(i, log(i))], [], ['log'], [x])
+    DE = DifferentialExtension(log(x) + log(x**2), x)
+    c = DE.backsubs[-1][0]
+    assert DE._important_attrs == \
+        (Poly(3*t0 + c, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
+        [Lambda(i, log(i))], [(c, log(x**2) - 2*log(x))], ['log'], [x])
     assert DifferentialExtension(S.Zero, x)._important_attrs == \
         (Poly(0, x), Poly(1, x), [Poly(1, x)], [x], [], [], [], [])
     assert DifferentialExtension(tan(atan(x).rewrite(log)), x)._important_attrs == \
@@ -751,19 +763,20 @@ def test_risch_integrate():
     e2 = (log(-1/y)/2 - log(1/y)/2)/y - (log(1 - 1/y)/2 - log(1 + 1/y)/2)/y
     ans2 = risch_integrate(e2, y)
     assert ans2 == log(1/y)*log(1 - 1/y)/2 - log(1/y)*log(1 + 1/y)/2 + \
-            NonElementaryIntegral((I*pi*y**2 - 2*y*log(1/y) - I*pi)/(2*y**3 - 2*y), y)
+            NonElementaryIntegral((y**2*(log(-1/y) - log(1/y)) - 2*y*log(1/y)
+                - log(-1/y) + log(1/y))/(2*y**3 - 2*y), y)
     assert expand_log(cancel(diff(ans2, y) - e2), force=True) == 0
 
     # These are tested here in addition to in test_DifferentialExtension above
     # (symlogs) to test that backsubs works correctly.  The integrals should be
     # written in terms of the original logarithms in the integrands.
 
-    # XXX: Unfortunately, making backsubs work on this one is a little
-    # trickier, because x**x is converted to exp(x*log(x)), and so log(x**x)
-    # is converted to x*log(x). (x**2*log(x)).subs(x*log(x), log(x**x)) is
-    # smart enough, the issue is that these splits happen at different places
-    # in the algorithm.  Maybe a heuristic is in order
-    assert risch_integrate(log(x**x), x) == x**2*log(x)/2 - x**2/4
+    # The answer carries the locally-constant difference
+    # log(x**x) - x*log(x) explicitly (it vanishes on the domain where
+    # x**x is real, but not identically), so the original log(x**x)
+    # notation reappears through it.
+    assert risch_integrate(log(x**x), x) == \
+        x**2*log(x)/2 - x**2/4 + x*(log(x**x) - x*log(x))
 
     assert risch_integrate(log(x**y), x) == x*log(x**y) - x*y
     assert risch_integrate(log(sqrt(x)), x) == x*log(sqrt(x)) - x/2

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -532,9 +532,13 @@ def test_DifferentialExtension_exp():
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i/2)),
         Lambda(i, exp(i**2))], [], ['exp', 'exp'],
         [x/2, x**2])
-    assert DifferentialExtension(sqrt(exp(x)), x)._important_attrs == \
-        (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
-        [Lambda(i, exp(i/2))], [(exp(x/2), sqrt(exp(x)))], ['exp'], [x/2])
+    # A user-written radical of an exponential folds to an opaque
+    # locally constant ratio times exp(x/2); backsubs restores it exactly.
+    DE = DifferentialExtension(sqrt(exp(x)), x)
+    c = DE.backsubs[-1][0]
+    assert DE._important_attrs == \
+        (Poly(c*t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
+        [Lambda(i, exp(i/2))], [(c, exp(-x/2)*sqrt(exp(x)))], ['exp'], [x/2])
 
     assert DifferentialExtension(exp(x/2), x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
@@ -801,11 +805,13 @@ def test_risch_integrate():
     assert cancel(diff(ans, x) - (log(x) + log(x**2) + exp(x) +
         exp(x/2 + 1))) == 0
 
-    # Mixed notation: when the integrand contains both sqrt(exp(x)) and
-    # its folded form exp(x/2), restoring the radical globally would
-    # also rewrite the genuine exp(x/2), so the answer stays in the
-    # exact exponential form.
-    assert risch_integrate(sqrt(exp(x)) + exp(x/2), x) == 4*exp(x/2)
+    # Mixed notation: sqrt(exp(x)) and exp(x/2) are different functions
+    # off the real line (a locally constant sign apart), and both keep
+    # their identity: the radical is folded with an opaque ratio that is
+    # restored exactly, so the answer differentiates back to the mixed
+    # integrand on every component.
+    ans = risch_integrate(sqrt(exp(x)) + exp(x/2), x)
+    assert cancel((ans - 2*sqrt(exp(x)) - 2*exp(x/2)).expand()) == 0
     # A pure user radical keeps its notation.
     assert risch_integrate(sqrt(exp(x)), x) == 2*sqrt(exp(x))
 

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -510,15 +510,20 @@ def test_DifferentialExtension_exp():
         (Poly((1 + S.Exp1*t0)*t1 + t0, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i)),
         Lambda(i, exp(i**2))], [], ['exp', 'exp'], [x, x**2])
+    # exp(x/2 + x**2) makes the tower use exp(x/2) internally; the answer
+    # must stay in that exact form, not be rewritten into the principal
+    # root sqrt(exp(x)) the user never wrote (which differs from exp(x/2)
+    # by a locally constant sign off the real line), so no backsubs pair
+    # is recorded.
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x/2 + x**2), x)._important_attrs == \
         (Poly((t0 + 1)*t1 + t0**2, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1],
         [Lambda(i, exp(i/2)), Lambda(i, exp(i**2))],
-        [(exp(x/2), sqrt(exp(x)))], ['exp', 'exp'], [x/2, x**2])
+        [], ['exp', 'exp'], [x/2, x**2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x/2 + x**2 + 3), x)._important_attrs == \
         (Poly((t0*exp(3) + 1)*t1 + t0**2, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i/2)),
-        Lambda(i, exp(i**2))], [(exp(x/2), sqrt(exp(x)))], ['exp', 'exp'],
+        Lambda(i, exp(i**2))], [], ['exp', 'exp'],
         [x/2, x**2])
     assert DifferentialExtension(sqrt(exp(x)), x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
@@ -923,6 +928,7 @@ def test_DifferentialExtension_equality():
 def test_DifferentialExtension_printing():
     DE = DifferentialExtension(exp(2*x**2) + log(exp(x**2) + 1), x)
     assert repr(DE) == ("DifferentialExtension(dict([('f', exp(2*x**2) + log(exp(x**2) + 1)), "
+        "('origf', exp(2*x**2) + log(exp(x**2) + 1)), "
         "('x', x), ('T', [x, t0, t1]), ('D', [Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
         "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]), ('fa', Poly(t1 + t0**2, t1, domain='ZZ[t0]')), "
         "('fd', Poly(1, t1, domain='ZZ')), ('Tfuncs', [Lambda(i, exp(i**2)), Lambda(i, log(t0 + 1))]), "

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -801,6 +801,16 @@ def test_integrate_primitive_nonelementary_residual():
         assert cancel(together(diff(g, x) + i.function - f)) == 0
 
 
+def test_risch_integrate_cancellation():
+    # Requires the parametric Liouvillian cancellation case at the
+    # exponential level (prde_cancel_liouvillian() via limited_integrate());
+    # this used to hang because the coefficient shift i*Dt/t was computed
+    # at the wrong level.
+    e = exp(x)*log(exp(x) + 1)
+    assert risch_integrate(e, x) == \
+        exp(x)*log(exp(x) + 1) - exp(x) + log(exp(x) + 1)
+
+
 def test_bound_degree_limited_integrate():
     # bound_degree() used to raise "TypeError: '>' not supported between
     # instances of 'Poly' and 'int'" on these when the sharp primitive-case

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -491,38 +491,38 @@ def test_DifferentialExtension_exp():
     assert DifferentialExtension(exp(x) + exp(x**2), x)._important_attrs == \
         (Poly(t1 + t0, t1), Poly(1, t1), [Poly(1, x,), Poly(t0, t0),
         Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i)),
-        Lambda(i, exp(i**2))], [], [None, 'exp', 'exp'], [None, x, x**2])
+        Lambda(i, exp(i**2))], [], ['exp', 'exp'], [x, x**2])
     assert DifferentialExtension(exp(x) + exp(2*x), x)._important_attrs == \
         (Poly(t0**2 + t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0, t0)], [x, t0],
-        [Lambda(i, exp(i))], [], [None, 'exp'], [None, x])
+        [Lambda(i, exp(i))], [], ['exp'], [x])
     assert DifferentialExtension(exp(x) + exp(x/2), x)._important_attrs == \
         (Poly(t0**2 + t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)],
-        [x, t0], [Lambda(i, exp(i/2))], [], [None, 'exp'], [None, x/2])
+        [x, t0], [Lambda(i, exp(i/2))], [], ['exp'], [x/2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x + x**2), x)._important_attrs == \
         (Poly((1 + t0)*t1 + t0, t1), Poly(1, t1), [Poly(1, x), Poly(t0, t0),
         Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i)),
-        Lambda(i, exp(i**2))], [], [None, 'exp', 'exp'], [None, x, x**2])
+        Lambda(i, exp(i**2))], [], ['exp', 'exp'], [x, x**2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x + x**2 + 1), x)._important_attrs == \
         (Poly((1 + S.Exp1*t0)*t1 + t0, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i)),
-        Lambda(i, exp(i**2))], [], [None, 'exp', 'exp'], [None, x, x**2])
+        Lambda(i, exp(i**2))], [], ['exp', 'exp'], [x, x**2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x/2 + x**2), x)._important_attrs == \
         (Poly((t0 + 1)*t1 + t0**2, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1],
         [Lambda(i, exp(i/2)), Lambda(i, exp(i**2))],
-        [(exp(x/2), sqrt(exp(x)))], [None, 'exp', 'exp'], [None, x/2, x**2])
+        [(exp(x/2), sqrt(exp(x)))], ['exp', 'exp'], [x/2, x**2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x/2 + x**2 + 3), x)._important_attrs == \
         (Poly((t0*exp(3) + 1)*t1 + t0**2, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i/2)),
-        Lambda(i, exp(i**2))], [(exp(x/2), sqrt(exp(x)))], [None, 'exp', 'exp'],
-        [None, x/2, x**2])
+        Lambda(i, exp(i**2))], [(exp(x/2), sqrt(exp(x)))], ['exp', 'exp'],
+        [x/2, x**2])
     assert DifferentialExtension(sqrt(exp(x)), x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
-        [Lambda(i, exp(i/2))], [(exp(x/2), sqrt(exp(x)))], [None, 'exp'], [None, x/2])
+        [Lambda(i, exp(i/2))], [(exp(x/2), sqrt(exp(x)))], ['exp'], [x/2])
 
     assert DifferentialExtension(exp(x/2), x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
-        [Lambda(i, exp(i/2))], [], [None, 'exp'], [None, x/2])
+        [Lambda(i, exp(i/2))], [], ['exp'], [x/2])
 
 
 def test_DifferentialExtension_log():
@@ -530,13 +530,13 @@ def test_DifferentialExtension_log():
         (Poly(t0*t1**2 + (t0*log(2) + t0**2)*t1, t1), Poly(1, t1),
         [Poly(1, x), Poly(1/x, t0),
         Poly(1/(x + 1), t1, expand=False)], [x, t0, t1],
-        [Lambda(i, log(i)), Lambda(i, log(i + 1))], [], [None, 'log', 'log'],
-        [None, x, x + 1])
+        [Lambda(i, log(i)), Lambda(i, log(i + 1))], [], ['log', 'log'],
+        [x, x + 1])
     assert DifferentialExtension(x**x*log(x), x)._important_attrs == \
         (Poly(t0*t1, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0),
         Poly((1 + t0)*t1, t1)], [x, t0, t1], [Lambda(i, log(i)),
-        Lambda(i, exp(t0*i))], [(exp(x*log(x)), x**x)], [None, 'log', 'exp'],
-        [None, x, t0*x])
+        Lambda(i, exp(t0*i))], [(exp(x*log(x)), x**x)], ['log', 'exp'],
+        [x, t0*x])
 
 
 def test_DifferentialExtension_symlog():
@@ -544,26 +544,26 @@ def test_DifferentialExtension_symlog():
     assert DifferentialExtension(log(x**x), x)._important_attrs == \
         (Poly(t0*x, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0), Poly((t0 +
             1)*t1, t1)], [x, t0, t1], [Lambda(i, log(i)), Lambda(i, exp(i*t0))],
-            [(exp(x*log(x)), x**x)], [None, 'log', 'exp'], [None, x, t0*x])
+            [(exp(x*log(x)), x**x)], ['log', 'exp'], [x, t0*x])
     assert DifferentialExtension(log(x**y), x)._important_attrs == \
         (Poly(y*t0, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
-        [Lambda(i, log(i))], [(y*log(x), log(x**y))], [None, 'log'],
-        [None, x])
+        [Lambda(i, log(i))], [(y*log(x), log(x**y))], ['log'],
+        [x])
     assert DifferentialExtension(log(sqrt(x)), x)._important_attrs == \
         (Poly(t0, t0), Poly(2, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
-        [Lambda(i, log(i))], [(log(x)/2, log(sqrt(x)))], [None, 'log'],
-        [None, x])
+        [Lambda(i, log(i))], [(log(x)/2, log(sqrt(x)))], ['log'],
+        [x])
 
 
 def test_DifferentialExtension_handle_first():
     assert DifferentialExtension(exp(x)*log(x), x, handle_first='log')._important_attrs == \
         (Poly(t0*t1, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0),
         Poly(t1, t1)], [x, t0, t1], [Lambda(i, log(i)), Lambda(i, exp(i))],
-        [], [None, 'log', 'exp'], [None, x, x])
+        [], ['log', 'exp'], [x, x])
     assert DifferentialExtension(exp(x)*log(x), x, handle_first='exp')._important_attrs == \
         (Poly(t0*t1, t1), Poly(1, t1), [Poly(1, x), Poly(t0, t0),
         Poly(1/x, t1)], [x, t0, t1], [Lambda(i, exp(i)), Lambda(i, log(i))],
-        [], [None, 'exp', 'log'], [None, x, x])
+        [], ['exp', 'log'], [x, x])
 
     # This one must have the log first, regardless of what we set it to
     # (because the log is inside of the exponential: x**x == exp(x*log(x)))
@@ -574,7 +574,7 @@ def test_DifferentialExtension_handle_first():
         (Poly((-1 + x - x*t0**2)*t1, t1), Poly(x, t1),
             [Poly(1, x), Poly(1/x, t0), Poly((1 + t0)*t1, t1)], [x, t0, t1],
             [Lambda(i, log(i)), Lambda(i, exp(t0*i))], [(exp(x*log(x)), x**x)],
-            [None, 'log', 'exp'], [None, x, t0*x])
+            ['log', 'exp'], [x, t0*x])
 
 
 def test_DifferentialExtension_all_attrs():
@@ -626,9 +626,9 @@ def test_DifferentialExtension_extension_flag():
     assert DE.case == 'exp'
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)],
-        'exts': [None, 'exp'], 'extargs': [None, x]})
+        'exts': ['exp'], 'extargs': [x]})
     assert DE._important_attrs == (None, None, [Poly(1, x), Poly(t, t)], [x, t],
-        None, None, [None, 'exp'], [None, x])
+        None, None, ['exp'], [x])
     raises(ValueError, lambda: DifferentialExtension())
 
 
@@ -637,7 +637,7 @@ def test_DifferentialExtension_misc():
     assert DifferentialExtension(sin(y)*exp(x), x)._important_attrs == \
         (Poly(sin(y)*t0, t0, domain='ZZ[sin(y)]'), Poly(1, t0, domain='ZZ'),
         [Poly(1, x, domain='ZZ'), Poly(t0, t0, domain='ZZ')], [x, t0],
-        [Lambda(i, exp(i))], [], [None, 'exp'], [None, x])
+        [Lambda(i, exp(i))], [], ['exp'], [x])
     raises(NotImplementedError, lambda: DifferentialExtension(sin(x), x))
     # cot, acot, and the hyperbolic functions used to fall through to the
     # generic "Couldn't find an elementary transcendental extension" error
@@ -652,15 +652,15 @@ def test_DifferentialExtension_misc():
         assert "Trigonometric and hyperbolic" in str(e)
     assert DifferentialExtension(10**x, x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(log(10)*t0, t0)], [x, t0],
-        [Lambda(i, exp(i*log(10)))], [(exp(x*log(10)), 10**x)], [None, 'exp'],
-        [None, x*log(10)])
+        [Lambda(i, exp(i*log(10)))], [(exp(x*log(10)), 10**x)], ['exp'],
+        [x*log(10)])
     assert DifferentialExtension(log(x) + log(x**2), x)._important_attrs == \
         (Poly(3*t0, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
-        [Lambda(i, log(i))], [], [None, 'log'], [None, x])
+        [Lambda(i, log(i))], [], ['log'], [x])
     assert DifferentialExtension(S.Zero, x)._important_attrs == \
-        (Poly(0, x), Poly(1, x), [Poly(1, x)], [x], [], [], [None], [None])
+        (Poly(0, x), Poly(1, x), [Poly(1, x)], [x], [], [], [], [])
     assert DifferentialExtension(tan(atan(x).rewrite(log)), x)._important_attrs == \
-        (Poly(x, x), Poly(1, x), [Poly(1, x)], [x], [], [], [None], [None])
+        (Poly(x, x), Poly(1, x), [Poly(1, x)], [x], [], [], [], [])
 
 
 def test_DifferentialExtension_Rothstein():
@@ -673,7 +673,7 @@ def test_DifferentialExtension_Rothstein():
         [Poly(1, x), Poly(t0, t0), Poly(-(10 + 21*t0 + 10*t0**2)/(1 + 2*t0 +
         t0**2)*t1, t1, domain='ZZ(t0)')], [x, t0, t1],
         [Lambda(i, exp(i)), Lambda(i, exp(1/(t0 + 1) - 10*i))], [],
-        [None, 'exp', 'exp'], [None, x, 1/(t0 + 1) - 10*x])
+        ['exp', 'exp'], [x, 1/(t0 + 1) - 10*x])
 
 
 class _TestingException(Exception):
@@ -838,7 +838,7 @@ def test_DifferentialExtension_printing():
         "('x', x), ('T', [x, t0, t1]), ('D', [Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
         "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]), ('fa', Poly(t1 + t0**2, t1, domain='ZZ[t0]')), "
         "('fd', Poly(1, t1, domain='ZZ')), ('Tfuncs', [Lambda(i, exp(i**2)), Lambda(i, log(t0 + 1))]), "
-        "('backsubs', []), ('exts', [None, 'exp', 'log']), ('extargs', [None, x**2, t0 + 1]), "
+        "('backsubs', []), ('exts', ['exp', 'log']), ('extargs', [x**2, t0 + 1]), "
         "('cases', ['base', 'exp', 'primitive']), ('case', 'primitive'), ('t', t1), "
         "('d', Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')), ('newf', t0**2 + t1), ('level', -1), "
         "('dummy', False)]))")

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -301,6 +301,13 @@ def test_residue_reduce():
     assert residue_reduce(Poly(t, t), Poly(t + sqrt(2), t), DE, z) == \
         ([(Poly(z - 1, z, domain='QQ'), Poly(t + sqrt(2), t))], True)
 
+    # issue 26502: the leading coefficient of the subresultant remainder has
+    # a non-monomial denominator in x
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)], 'Tfuncs': [log]})
+    assert residue_reduce(Poly(-2*x*t - 2*x - 2, t),
+        Poly((x**3 + 2*x**2 + x)*t**2 - x, t), DE, z) == \
+        ([(Poly(z**2 - 1, z, domain='QQ'), Poly(t + z/(x + 1), t, domain='ZZ(x,z)'))], True)
+
 
 def test_integrate_hyperexponential():
     # TODO: Add tests for integrate_hyperexponential() from the book
@@ -806,6 +813,12 @@ def test_risch_integrate():
     # sin(x).rewrite(exp)
     expr = -I*(exp(I*x) - exp(-I*x))/2
     assert risch_integrate(expr, x) == -exp(I*x)/2 - exp(-I*x)/2
+
+    # issue 26502
+    expr = (-2*x*log(x) - 2*x - 2)/(x**3*log(x)**2 + 2*x**2*log(x)**2 +
+        x*log(x)**2 - x)
+    assert risch_integrate(expr, x) == \
+        log(log(x) + 1/(x + 1)) - log(log(x) - 1/(x + 1))
 
 def test_risch_integrate_symbolic_constant():
     # A symbolic constant in the exponential argument; the generic answer

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -825,9 +825,18 @@ def test_risch_integrate_log_to_atan():
     assert ans == log(exp(2*x) + 2*exp(x) + 2)/2 + 3*atan(exp(x) + 1)
     assert cancel(diff(ans, x) - e) == 0
 
-    # Residues that are real but irrational are still returned as a RootSum
+    # Real irrational residues also give explicit logarithms when the
+    # roots can be computed
     assert risch_integrate(exp(x)/(exp(2*x) - 2), x) == \
-        RootSum(Poly(8*z**2 - 1, z), Lambda(z, z*log(-4*z + exp(x))))
+        sqrt(2)*log(exp(x) - sqrt(2))/4 - sqrt(2)*log(exp(x) + sqrt(2))/4
+
+    # Terms whose residues cannot all be computed explicitly fall back
+    # to a RootSum
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)],
+        'Tfuncs': [log]})
+    H = [(Poly(z**5 - z - 1, z), Poly(t + z, t))]
+    assert residue_reduce_to_basic(H, DE, z) == \
+        RootSum(Poly(z**5 - z - 1, z), Lambda(z, z*log(z + log(x))))
 
 
 def test_integrate_primitive_nonelementary_residual():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -818,6 +818,13 @@ def test_risch_integrate_log_to_atan():
     assert ans == log(exp(x) + 3)/2 + atan(exp(x))
     assert cancel(diff(ans, x) - e) == 0
 
+    # Complex residues with a nonzero real part give both a log and an
+    # atan term
+    e = (exp(x) + 4)*exp(x)/((exp(x) + 1)**2 + 1)
+    ans = risch_integrate(e, x)
+    assert ans == log(exp(2*x) + 2*exp(x) + 2)/2 + 3*atan(exp(x) + 1)
+    assert cancel(diff(ans, x) - e) == 0
+
     # Residues that are real but irrational are still returned as a RootSum
     assert risch_integrate(exp(x)/(exp(2*x) - 2), x) == \
         RootSum(Poly(8*z**2 - 1, z), Lambda(z, z*log(-4*z + exp(x))))

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -810,6 +810,13 @@ def test_risch_integrate_cancellation():
     assert risch_integrate(e, x) == \
         exp(x)*log(exp(x) + 1) - exp(x) + log(exp(x) + 1)
 
+    # Requires the structure-theorem fallback of parametric_log_deriv()
+    # (the heuristic alone raises NotImplementedError on this one)
+    e = log(exp(x) + log(x))
+    g, i = risch_integrate(e, x, separate_integral=True)
+    assert isinstance(i, NonElementaryIntegral)
+    assert cancel(together(diff(g, x) + i.function - e)) == 0
+
 
 def test_bound_degree_limited_integrate():
     # bound_degree() used to raise "TypeError: '>' not supported between

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -817,6 +817,14 @@ def test_risch_integrate_cancellation():
     assert isinstance(i, NonElementaryIntegral)
     assert cancel(together(diff(g, x) + i.function - e)) == 0
 
+    # Purely elementary results through the same fallback (these raised
+    # NotImplementedError before)
+    for F in [(x - 1)*log(exp(x) + log(x)), exp(x)*log(exp(x) + log(x))]:
+        e = cancel(diff(F, x))
+        ans = risch_integrate(e, x)
+        assert not ans.has(NonElementaryIntegral)
+        assert cancel(together(diff(ans, x) - e)) == 0
+
 
 def test_bound_degree_limited_integrate():
     # bound_degree() used to raise "TypeError: '>' not supported between

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -12,6 +12,7 @@ from sympy.functions.elementary.hyperbolic import tanh
 from sympy.functions.elementary.trigonometric import (atan, cot, sin, tan)
 from sympy.polys.polytools import (Poly, cancel, factor)
 from sympy.polys.rationaltools import together
+from sympy.polys.rootoftools import RootSum
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     derivation, splitfactor, splitfactor_sqf, canonical_representation,
     hermite_reduce, polynomial_reduce, residue_reduce, residue_reduce_to_basic,
@@ -797,6 +798,29 @@ def test_risch_integrate_symbolic_constant():
 
 def test_risch_integrate_float():
     assert risch_integrate((-60*exp(x) - 19.2*exp(4*x))*exp(4*x), x) == -2.4*exp(8*x) - 12.0*exp(5*x)
+
+
+def test_risch_integrate_log_to_atan():
+    # Residues that come in complex-conjugate pairs give real arc-tangents
+    # instead of complex logarithms (Bronstein, Section 2.8).
+    e = exp(x)/((exp(x) + 1)**2 + 1)
+    ans = risch_integrate(e, x)
+    assert ans == atan(exp(x) + 1)
+    assert cancel(diff(ans, x) - e) == 0
+
+    assert risch_integrate(exp(x)/(exp(2*x) + 1), x) == atan(exp(x))
+    assert risch_integrate(1/(x*(log(x)**2 + 1)), x) == atan(log(x))
+    assert risch_integrate(1/(x**2 + 1), x) == atan(x)
+
+    # Real and complex residues in a single term
+    e = (exp(2*x) + 2*exp(x) + 7)*exp(x)/(2*(exp(x) + 3)*(exp(2*x) + 1))
+    ans = risch_integrate(e, x)
+    assert ans == log(exp(x) + 3)/2 + atan(exp(x))
+    assert cancel(diff(ans, x) - e) == 0
+
+    # Residues that are real but irrational are still returned as a RootSum
+    assert risch_integrate(exp(x)/(exp(2*x) - 2), x) == \
+        RootSum(Poly(8*z**2 - 1, z), Lambda(z, z*log(-4*z + exp(x))))
 
 
 def test_integrate_primitive_nonelementary_residual():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -221,6 +221,9 @@ def test_recognize_derivative():
     assert recognize_derivative(Poly(x, x), Poly((x**2 + 1)**2, x), DE) == True
     assert recognize_derivative(Poly(1, x), Poly((x**2 + 1)**2, x), DE) == False
     assert recognize_derivative(Poly(-2*x, x), Poly((x**2 - 1)**2, x), DE) == True
+    # Multiplicity 3: D(1/(x**2 + 1)**2) == -4*x/(x**2 + 1)**3
+    assert recognize_derivative(Poly(-4*x, x), Poly((x**2 + 1)**3, x), DE) == True
+    assert recognize_derivative(Poly(1, x), Poly((x**2 + 1)**3, x), DE) == False
     # Poles at nonconstant normal primes used to be ignored entirely,
     # giving false positives.  A simple such pole always has a nonzero
     # residue: 1/(t + x) with t = log(x) is not a derivative.
@@ -784,6 +787,13 @@ def test_risch_integrate():
     # sin(x).rewrite(exp)
     expr = -I*(exp(I*x) - exp(-I*x))/2
     assert risch_integrate(expr, x) == -exp(I*x)/2 - exp(-I*x)/2
+
+def test_risch_integrate_symbolic_constant():
+    # A symbolic constant in the exponential argument; the generic answer
+    # holds for y != 0 and the degenerate case is handled by conds
+    assert risch_integrate(exp(x*y), x) == \
+        Piecewise((exp(x*y)/y, Ne(y, 0)), (x, True))
+
 
 def test_risch_integrate_float():
     assert risch_integrate((-60*exp(x) - 19.2*exp(4*x))*exp(4*x), x) == -2.4*exp(8*x) - 12.0*exp(5*x)

--- a/sympy/polys/polymatrix.py
+++ b/sympy/polys/polymatrix.py
@@ -214,7 +214,13 @@ class MutablePolyDenseMatrix:
                 other_ds = DomainScalar(Kx.from_sympy(other), Kx)
             except (CoercionFailed, ValueError):
                 other_ds = DomainScalar.from_sympy(other)
-            return self.from_dm(self._dm * other_ds)
+            dm = self._dm * other_ds
+            if not dm.domain.is_PolynomialRing:
+                # a fallback scalar over a ground domain (e.g. EX) can
+                # drag the product's domain below a polynomial ring,
+                # which from_dm cannot represent
+                dm = dm.convert_to(dm.domain[self.gens])
+            return self.from_dm(dm)
         return NotImplemented
 
     def __rmul__(self, other):
@@ -222,7 +228,10 @@ class MutablePolyDenseMatrix:
             other = _sympify(other)
         if isinstance(other, Expr):
             other_ds = DomainScalar.from_sympy(other)
-            return self.from_dm(other_ds * self._dm)
+            dm = other_ds * self._dm
+            if not dm.domain.is_PolynomialRing:
+                dm = dm.convert_to(dm.domain[self.gens])
+            return self.from_dm(dm)
         return NotImplemented
 
     def __truediv__(self, other):

--- a/sympy/polys/tests/test_polymatrix.py
+++ b/sympy/polys/tests/test_polymatrix.py
@@ -5,11 +5,12 @@ from sympy.polys.polymatrix import PolyMatrix
 from sympy.polys import Poly
 
 from sympy.core.singleton import S
+from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.matrices.dense import Matrix
 from sympy.polys.domains.integerring import ZZ
 from sympy.polys.domains.rationalfield import QQ
 
-from sympy.abc import x, y
+from sympy.abc import t, x, y
 
 
 def _test_polymatrix():
@@ -184,3 +185,10 @@ def test_polymatrix_nullspace():
     raises(ValueError, lambda: PolyMatrix([1, 2], ring=ZZ[x]).nullspace())
     raises(ValueError, lambda: PolyMatrix([1, x], ring=QQ[x]).nullspace())
     assert M.rank() == 1
+
+
+def test_polymatrix_scalar_mul_ground_fallback():
+    M = PolyMatrix([[Poly(x*t, t)]], t)
+    expected = PolyMatrix([[Poly(x*(y + sqrt(y))*t, t, domain='EX')]], t)
+    assert M*(y + sqrt(y)) == expected
+    assert (y + sqrt(y))*M == expected


### PR DESCRIPTION
This implements phase 1 of Claude Fable's plan to implement the remainder of the transcendental Risch algorithm.

This is built on top of https://github.com/sympy/sympy/pull/30180, and should only be reviewed commit by commit. 

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


All code here was generated by Claude Fable. 


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- integrals
  - Implement more cases in the Risch algorithm. `integrate(exp(x)*log(exp(x) + 1), x)` no longer hangs. 

<!-- END RELEASE NOTES -->
