### PR TITLE
Clarify import path for plotting functions in docs

### DIFF
--- a/doc/src/modules/plotting.rst
+++ b/doc/src/modules/plotting.rst
@@ -25,6 +25,13 @@ The above functions are only for convenience and ease of use. It is possible to
 plot any plot by passing the corresponding ``Series`` class to :class:`~.Plot` as
 argument.
 
+.. note::
+
+   Import these functions directly from ``sympy.plotting``, e.g.
+   ``sympy.plotting.plot3d`` or ``from sympy.plotting import plot3d``.
+   ``sympy.plotting.plot`` (used above for autodoc purposes) is not
+   itself accessible as an attribute at runtime.
+
 Plot Class
 ----------
 


### PR DESCRIPTION
#### References to other Issues or PRs
Fixes #30171

#### Brief description of what is fixed or changed
sympy.plotting.plot.plot3d was failing with an AttributeError. There exist both a function and a submodule named plot. When sympy/plotting/__init__.py runs, it imports the plot function and assigns it the name plot, which overwrites the submodule of the same name. So sympy.plotting.plot refers to the function, and the function doesn't have plot3d on it — that's why it fails.

This isn't a code bug, it's expected Python behavior — but the docs make it look like sympy.plotting.plot.plot3d should work. As a fix, I updated the documentation to guide users to the correct way of calling these functions (e.g. sympy.plotting.plot3d instead of sympy.plotting.plot.plot3d).

#### Other comments

#### AI Generation Disclosure
I used Claude to help identify the root cause of the AttributeError and to draft the wording of the documentation note added in doc/src/modules/plotting.rst. I verified the root cause myself by running the reproduction steps in Python, and edited the note before finalizing it. The PR description was written by me.

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->