### PR TITLE
printing: fix crash in `pretty(Add(S.NaN, x, evaluate=False))`

### DIFF
--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -2014,7 +2014,7 @@ class PrettyPrinter(Printer):
             elif term.is_Rational and term.q > 1:
                 pforms.append(None)
                 indices.append(i)
-            elif term.is_Number and term < 0:
+            elif term.is_Number and term.is_extended_negative:
                 pform = self._print(-term)
                 pforms.append(pretty_negative(pform, i))
             elif (

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -7008,6 +7008,12 @@ def test_pretty_Add():
     eq = Mul(-2, x - 2, evaluate=False) + 5
     assert pretty(eq) == '5 - 2*(x - 2)'
 
+    assert pretty(Add(S.NaN, x, evaluate=False)) == 'x + nan'
+
+    assert pretty(Add(S.NaN, 3*I, evaluate=False)) == 'nan + 3*I'
+
+    assert pretty(Add(S.NaN, x, -oo, evaluate=False)) == 'x - oo + nan'
+
 
 def test_issue_7179():
     assert upretty(Not(Equivalent(x, y))) == 'x ⇎ y'


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None.

#### Brief description of what is fixed or changed
Before the fix, `pretty(Add(S.NaN, x, evaluate=False))` crashes.

The traceback is:

```markdown
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File ".../sympy/printing/printer.py", line 408, in __call__
    return self.__wrapped__(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../sympy/printing/pretty/pretty.py", line 2927, in pretty
    return pp.doprint(expr)
           ^^^^^^^^^^^^^^^^
  File ".../sympy/printing/pretty/pretty.py", line 67, in doprint
    return self._print(expr).render(**self._settings)
           ^^^^^^^^^^^^^^^^^
  File ".../sympy/printing/printer.py", line 332, in _print
    return printmethod(expr, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../sympy/printing/pretty/pretty.py", line 1979, in _print_Add
    elif term.is_Number and term < 0:
                            ^^^^^^^^
  File ".../sympy/core/decorators.py", line 249, in _func
    return func(self, other)
           ^^^^^^^^^^^^^^^^^
  File ".../sympy/core/expr.py", line 417, in __lt__
    return StrictLessThan(self, other)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../sympy/core/relational.py", line 881, in __new__
    raise TypeError("Invalid NaN comparison")
TypeError: Invalid NaN comparison
```

After the fix, 

```python
>>> from sympy import symbols, Add, S, pretty
>>> x = symbols('x')
>>> pretty(Add(S.NaN, x, evaluate=False))
'x + nan'
```

#### Other comments
The symbol `x` is already defined in line 92 of `sympy/printing/pretty/tests/test_pretty.py`.
https://github.com/sympy/sympy/blob/c0a595d78fb2a2c4b0dfa7f2ee720fde84918c6c/sympy/printing/pretty/tests/test_pretty.py#L88-L92

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
DeepSeek suggested adding the regression tests `assert pretty(Add(S.NaN, 3*I, evaluate=False)) == 'nan + 3*I'` and `assert pretty(Add(S.NaN, x, -oo, evaluate=False)) == 'x - oo + nan'`.
Other code was written manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed crash in `pretty(Add(S.NaN, x, evaluate=False))`.
<!-- END RELEASE NOTES -->