### PR TITLE
Fix TypeError in construct_domain for non-finite complex coefficients

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -37,8 +37,13 @@ def _construct_simple(coeffs, opt):
         else:
             is_complex = pure_complex(coeff)
             if is_complex:
-                complexes = True
                 x, y = is_complex
+                if not (x.is_finite and y.is_finite):
+                    # A non-finite real or imaginary part (e.g. oo*I) cannot be
+                    # represented in ZZ_I/QQ_I/CC, so fall back to the expression
+                    # domain (EX) instead of raising while building the number.
+                    return False
+                complexes = True
                 if x.is_Rational and y.is_Rational:
                     if not (x.is_Integer and y.is_Integer):
                         rationals = True

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -252,3 +252,14 @@ def test_issue_25337():
 
     x_algebraic = Symbol('x', algebraic=True)
     assert construct_domain(x_algebraic)[0] == ZZ[x_algebraic]
+
+
+def test_issue_30061():
+    # A complex number with a non-finite real or imaginary part cannot be
+    # represented in ZZ_I/QQ_I/CC and must fall back to EX rather than raising.
+    assert construct_domain([S.Infinity*I]) == (EX, [EX(S.Infinity*I)])
+    assert construct_domain([S.NegativeInfinity*I]) == (EX, [EX(S.NegativeInfinity*I)])
+    assert construct_domain([2 + S.Infinity*I]) == (EX, [EX(2 + S.Infinity*I)])
+    # Ordinary finite complex coefficients are unaffected.
+    assert construct_domain([2 + 3*I]) == (ZZ_I, [ZZ_I(2, 3)])
+    assert construct_domain([Rational(1, 2) + I]) == (QQ_I, [QQ_I(Rational(1, 2), 1)])


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30061

#### Brief description of what is fixed or changed

`construct_domain([oo*I])` raised `TypeError: cannot create mpf from oo`:

```python
>>> from sympy import *
>>> construct_domain([oo*I])
TypeError: cannot create mpf from oo
```

`pure_complex(oo*I)` returns `(0, oo)`, so `_construct_simple` classified the coefficient as a floating complex number and tried to represent it in `CC`, where the non-finite imaginary part cannot be converted to an `mpf`.

The complex branch now checks that both the real and imaginary parts are finite. When they are not, it falls back to the expression domain `EX`, exactly how `oo`, `-oo`, `zoo` and `nan` are already handled (#25337):

```python
>>> construct_domain([oo*I])
(EX, [EX(oo*I)])
>>> construct_domain([-oo*I])
(EX, [EX(-oo*I)])
```

Finite complex coefficients are unaffected (`2 + 3*I` -> `ZZ_I`, `1/2 + I` -> `QQ_I`, `1.0*I` -> `CC`).

#### Other comments

Added `test_issue_30061` in `sympy/polys/tests/test_constructor.py`. The full `test_constructor.py` suite passes.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a `TypeError` in `construct_domain` when a coefficient had a non-finite real or imaginary part (e.g. `oo*I`); such inputs now fall back to the `EX` domain.
<!-- END RELEASE NOTES -->