### PR TITLE
[GsOC] Prs methods refactoring

### DIFF
--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -48,7 +48,7 @@ from sympy.polys.polyutils import (
     _dict_reorder,
     _parallel_dict_from_expr,
 )
-from sympy.polys.sparseprs import smp_pdiv, smp_pexquo, smp_pquo, smp_prem
+from sympy.polys.sparseprs import smp_pdiv, smp_pexquo, smp_pquo, smp_prem, smp_subresultants
 from sympy.printing.defaults import DefaultPrinting
 from sympy.polys.sparsetools import (
     _smp_iadd,
@@ -2097,8 +2097,10 @@ class PolyElement(
         [x**2*y + x*y, x + y, x**3 + x**2]
 
         """
-        x_index = self.ring.index(x)
-        return self._subresultants(g, x_index)
+        ring = self.ring
+        x_index = ring.index(x)
+        return [self.new(el) for el in
+        smp_subresultants(self, g, x_index, ring.ngens, ring.domain)]
 
     def symmetrize(
         self,
@@ -2996,64 +2998,6 @@ class PolyElement(
     # The following _p* and _subresultants methods can just be converted to pure python
     # methods in case of python-flint since their speeds don't exactly matter wrt the
     # flint version.
-
-
-    def _subresultants(self, g: PolyElement[Er], x: int):
-        f = self
-
-        n = f._degree_int(x)
-        m = g._degree_int(x)
-
-        if n < m:
-            f, g = g, f
-            n, m = m, n
-
-        if f == 0:
-            return [0, 0]
-
-        if g == 0:
-            return [f, 1]
-
-        R = [f, g]
-
-        d = n - m
-        b = (-1) ** (d + 1)
-
-        # Compute the pseudo-remainder for f and g
-        h = f.prem(g, x)
-        h = h * b
-
-        # Compute the coefficient of g with respect to x**m
-        lc = g.coeff_wrt(x, m)
-
-        c = lc**d
-
-        S = [1, c]
-
-        c = -c
-
-        while h:
-            k = h.degree(x)
-
-            R.append(h)
-            f, g, m, d = g, h, k, m - k
-
-            b = -lc * c**d
-            h = f.prem(g, x)
-            h = h.exquo(b)
-
-            lc = g.coeff_wrt(x, k)
-
-            if d > 1:
-                p = (-lc) ** d
-                q = c ** (d - 1)
-                c = p.exquo(q)
-            else:
-                c = -lc
-
-            S.append(-c)
-
-        return R
 
     def _subs(self, subs_dict: Mapping[int, Er]) -> PolyElement[Er]:
         ring = self.ring

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -48,6 +48,7 @@ from sympy.polys.polyutils import (
     _dict_reorder,
     _parallel_dict_from_expr,
 )
+from sympy.polys.sparseprs import smp_pdiv, smp_prem
 from sympy.printing.defaults import DefaultPrinting
 from sympy.polys.sparsetools import (
     _smp_iadd,
@@ -1906,8 +1907,9 @@ class PolyElement(
         pdiv, pquo, pexquo, sympy.polys.domains.ring.Ring.rem
 
         """
-        x_index = self.ring.index(x)
-        return self._prem(g, x_index)
+        ring = self.ring
+        x_index = ring.index(x)
+        return self.new(smp_prem(self, g, x_index, ring.ngens, ring.domain))
 
     def pdiv(
         self, g: PolyElement[Er], x: PolyElement[Er] | int | None = None
@@ -1972,10 +1974,10 @@ class PolyElement(
         (2*x + 2*y - 2, -4*y + 4)
         >>> f.div(g) # shows the difference between pdiv and div
         (0, x**2 + x*y)
-        >>> f.pdiv(g, y) # generator is given
-        (2*x**3 + 2*x**2*y + 6*x**2 + 2*x*y + 8*x + 4, 0)
-        >>> f.pdiv(g, 1) # generator index is given
-        (2*x**3 + 2*x**2*y + 6*x**2 + 2*x*y + 8*x + 4, 0)
+        >>> f.pdiv(g, y)  # generator is given
+        (2*x**3 + 2*x**2*y + 2*x**2 + 2*x*y, 0)
+        >>> f.pdiv(g, 1)  # generator index is given
+        (2*x**3 + 2*x**2*y + 2*x**2 + 2*x*y, 0)
 
         See Also
         ========
@@ -1992,7 +1994,8 @@ class PolyElement(
 
         """
         x_index = self.ring.index(x)
-        return self._pdiv(g, x_index)
+        q, r = smp_pdiv(self, g, x_index, self.ring.ngens, self.ring.domain)
+        return self.new(q), self.new(r)
 
     def pquo(self, g: PolyElement[Er], x: PolyElement[Er] | int | None = None):
         """
@@ -2989,89 +2992,6 @@ class PolyElement(
     # The following _p* and _subresultants methods can just be converted to pure python
     # methods in case of python-flint since their speeds don't exactly matter wrt the
     # flint version.
-    def _prem(self, g: PolyElement[Er], x: int) -> PolyElement[Er]:
-        f = self
-
-        df = f._degree_int(x)
-        dg = g._degree_int(x)
-
-        if dg < 0:
-            raise ZeroDivisionError("polynomial division")
-
-        r, dr = f, df
-
-        if df < dg:
-            return r
-
-        N = df - dg + 1
-
-        lc_g = g.coeff_wrt(x, dg)
-
-        xp = f.ring.gens[x]
-
-        while True:
-            lc_r = r.coeff_wrt(x, dr)
-            j, N = dr - dg, N - 1
-
-            R = r * lc_g
-            G = g * lc_r * xp**j
-            r = R - G
-
-            dr = r._degree_int(x)
-
-            if dr < dg:
-                break
-
-        c = lc_g**N
-
-        return r * c
-
-    def _pdiv(
-        self, g: PolyElement[Er], x: int
-    ) -> tuple[PolyElement[Er], PolyElement[Er]]:
-        f = self
-
-        df = f._degree_int(x)
-        dg = g._degree_int(x)
-
-        if dg < 0:
-            raise ZeroDivisionError("polynomial division")
-
-        q, r, dr = self.ring(x), f, df
-
-        if df < dg:
-            return q, r
-
-        N = df - dg + 1
-        lc_g = g.coeff_wrt(x, dg)
-
-        xp = f.ring.gens[x]
-
-        while True:
-            lc_r = r.coeff_wrt(x, dr)
-            j, N = dr - dg, N - 1
-
-            Q = q * lc_g
-
-            q = Q + (lc_r) * xp**j
-
-            R = r * lc_g
-
-            G = g * lc_r * xp**j
-
-            r = R - G
-
-            dr = r._degree_int(x)
-
-            if dr < dg:
-                break
-
-        c = lc_g**N
-
-        q = q * c
-        r = r * c
-
-        return q, r
 
     def _pquo(self, g: PolyElement[Er], x: int) -> PolyElement[Er]:
         f = self

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -48,7 +48,7 @@ from sympy.polys.polyutils import (
     _dict_reorder,
     _parallel_dict_from_expr,
 )
-from sympy.polys.sparseprs import smp_pdiv, smp_prem
+from sympy.polys.sparseprs import smp_pdiv, smp_pexquo, smp_pquo, smp_prem
 from sympy.printing.defaults import DefaultPrinting
 from sympy.polys.sparsetools import (
     _smp_iadd,
@@ -2024,8 +2024,10 @@ class PolyElement(
         prem, pdiv, pexquo, sympy.polys.domains.ring.Ring.quo
 
         """
-        x_index = self.ring.index(x)
-        return self._pquo(g, x_index)
+        ring = self.ring
+        x_index = ring.index(x)
+        q = smp_pquo(self, g, x_index, ring.ngens, ring.domain)
+        return self.new(q)
 
     def pexquo(self, g: PolyElement[Er], x: PolyElement[Er] | int | None = None):
         """
@@ -2056,8 +2058,10 @@ class PolyElement(
         prem, pdiv, pquo, sympy.polys.domains.ring.Ring.exquo
 
         """
-        x_index = self.ring.index(x)
-        return self._pexquo(g, x_index)
+        ring = self.ring
+        x_index = ring.index(x)
+        q = smp_pexquo(self, g, x_index, ring.ngens, ring.domain)
+        return self.new(q)
 
     def subresultants(self, g: PolyElement[Er], x: PolyElement[Er] | int | None = None):
         """
@@ -2993,18 +2997,6 @@ class PolyElement(
     # methods in case of python-flint since their speeds don't exactly matter wrt the
     # flint version.
 
-    def _pquo(self, g: PolyElement[Er], x: int) -> PolyElement[Er]:
-        f = self
-        return f.pdiv(g, x)[0]
-
-    def _pexquo(self, g: PolyElement[Er], x: int):
-        f = self
-        q, r = f.pdiv(g, x)
-
-        if r.is_zero:
-            return q
-        else:
-            raise ExactQuotientFailed(f, g)
 
     def _subresultants(self, g: PolyElement[Er], x: int):
         f = self

--- a/sympy/polys/sparseprs.py
+++ b/sympy/polys/sparseprs.py
@@ -4,10 +4,13 @@ from typing import TYPE_CHECKING
 
 from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.sparsetools import (
+    _smp_imul_ground,
     smp_add,
     smp_coeff_wrt,
     smp_degree,
+    smp_div_list,
     smp_mul,
+    smp_neg,
     smp_pow_generic,
     smp_sub,
 )
@@ -115,3 +118,63 @@ def smp_pexquo(f: smp[Er], g: smp[Er], i: int, n: int, dom: Domain[Er]) -> smp[E
         return q
     else:
         raise ExactQuotientFailed(f, g)
+
+
+def smp_subresultants(f: smp[Er], g: smp[Er], i: int, n: int, dom: Domain[Er]) -> list[smp[Er]]:
+
+        l = smp_degree(f, i, n, dom)
+        m = smp_degree(g, i, n, dom)
+
+        if l < m:
+            f, g = g, f
+            l, m = m, l
+
+        if not f:
+            return [{}, {}]
+
+        if not g:
+            zm = (0,) * n
+            return [f, {zm: dom.one}]
+
+        R = [f, g]
+
+        d = l - m
+        b = dom((-1) ** (d + 1))
+
+        # Compute the pseudo-remainder for f and g
+        h = smp_prem(f, g, i, n, dom)
+
+        _smp_imul_ground(h, b, n, dom)
+
+        # Compute the coefficient of g with respect to x**m
+        lc = smp_coeff_wrt(g, i, m, n, dom)
+
+        c = smp_pow_generic(lc, d, dom, n)
+
+        c = smp_neg(c, n, dom)
+        while h:
+
+            k = smp_degree(h, i, n, dom)
+
+            R.append(h)
+            f, g, m, d = g, h, k, m - k
+
+            b = smp_mul(smp_neg(lc, n, dom), smp_pow_generic(c, d, dom, n), dom, n)
+
+            h = smp_prem(f, g, i, n, dom)
+
+            [h], _ = smp_div_list(h, [b], n, dom)
+            lc = smp_coeff_wrt(g, i, k, n, dom)
+
+            if d > 1:
+
+                p = smp_pow_generic(smp_neg(lc, n, dom), d, dom, n)
+
+                q = smp_pow_generic(c, (d - 1), dom, n)
+
+                [c], _ = smp_div_list(p, [q], n, dom)
+            else:
+
+                c = smp_neg(lc, n, dom)
+
+        return R

--- a/sympy/polys/sparseprs.py
+++ b/sympy/polys/sparseprs.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sympy.polys.sparsetools import (
+    smp_add,
+    smp_coeff_wrt,
+    smp_degree,
+    smp_mul,
+    smp_pow_generic,
+    smp_sub,
+)
+
+if TYPE_CHECKING:
+    from sympy.polys.domains.domain import Domain, Er
+    from sympy.polys.sparsetools import smp
+
+
+def smp_prem(f: smp[Er], g: smp[Er], i: int, n: int, dom: Domain[Er]) -> smp[Er]:
+
+    df = smp_degree(f, i, n, dom)
+    dg = smp_degree(g, i, n, dom)
+    if dg < 0:
+        raise ZeroDivisionError("polynomial division")
+
+    r, dr = f, df
+
+    if df < dg:
+        return r
+
+    N = df - dg + 1
+
+    lc_g = smp_coeff_wrt(g, i, dg, n, dom)
+
+    while True:
+        lc_r = smp_coeff_wrt(r, i, dr, n, dom)
+        j, N = dr - dg, N - 1
+
+        R = smp_mul(r, lc_g, dom, n)
+
+        xp = {(0,) * i + (j,) + (0,) * (n - i - 1): dom.one}
+
+        G = smp_mul(smp_mul(g, lc_r, dom, n), xp, dom, n)
+
+        r = smp_sub(R, G, dom, n)
+
+        dr = smp_degree(r, i, n, dom)
+        # dr = r._degree_int(x)
+
+        if dr < dg:
+            break
+
+    # c = lc_g**N
+    c = smp_pow_generic(lc_g, N, dom, n)
+
+    return smp_mul(c, r, dom, n)
+
+
+def smp_pdiv(
+    f: smp[Er], g: smp[Er], i: int, n: int, dom: Domain[Er]
+) -> tuple[smp[Er], smp[Er]]:
+    df = smp_degree(f, i, n, dom)
+    dg = smp_degree(g, i, n, dom)
+
+    if dg < 0:
+        raise ZeroDivisionError("polynomial division")
+
+    q: smp[Er] = {}
+    r, dr = f, df
+
+    if df < dg:
+        return q, r
+
+    N = df - dg + 1
+    lc_g = smp_coeff_wrt(g, i, dg, n, dom)
+
+    while True:
+        lc_r = smp_coeff_wrt(r, i, dr, n, dom)
+        j, N = dr - dg, N - 1
+
+        Q = smp_mul(q, lc_g, dom, n)
+
+        xp = {(0,) * i + (j,) + (0,) * (n - i - 1): dom.one}
+
+        q = smp_add(Q, smp_mul(lc_r, xp, dom, n), dom, n)
+
+        R = smp_mul(r, lc_g, dom, n)
+
+        G = smp_mul(smp_mul(g, lc_r, dom, n), xp, dom, n)
+
+        r = smp_sub(R, G, dom, n)
+
+        dr = smp_degree(r, i, n, dom)
+
+        if dr < dg:
+            break
+
+    c = smp_pow_generic(lc_g, N, dom, n)
+
+    q = smp_mul(q, c, dom, n)
+    r = smp_mul(r, c, dom, n)
+
+    return q, r

--- a/sympy/polys/sparseprs.py
+++ b/sympy/polys/sparseprs.py
@@ -141,12 +141,12 @@ def smp_subresultants(
     R = [f, g]
 
     d = l - m
-    b = dom((-1) ** (d + 1))
+    v = dom((-1) ** (d + 1))
 
     # Compute the pseudo-remainder for f and g
     h = smp_prem(f, g, i, n, dom)
 
-    _smp_imul_ground(h, b, n, dom)
+    _smp_imul_ground(h, v, n, dom)
 
     # Compute the coefficient of g with respect to x**m
     lc = smp_coeff_wrt(g, i, m, n, dom)

--- a/sympy/polys/sparseprs.py
+++ b/sympy/polys/sparseprs.py
@@ -120,61 +120,60 @@ def smp_pexquo(f: smp[Er], g: smp[Er], i: int, n: int, dom: Domain[Er]) -> smp[E
         raise ExactQuotientFailed(f, g)
 
 
-def smp_subresultants(f: smp[Er], g: smp[Er], i: int, n: int, dom: Domain[Er]) -> list[smp[Er]]:
+def smp_subresultants(
+    f: smp[Er], g: smp[Er], i: int, n: int, dom: Domain[Er]
+) -> list[smp[Er]]:
 
-        l = smp_degree(f, i, n, dom)
-        m = smp_degree(g, i, n, dom)
+    l = smp_degree(f, i, n, dom)
+    m = smp_degree(g, i, n, dom)
 
-        if l < m:
-            f, g = g, f
-            l, m = m, l
+    if l < m:
+        f, g = g, f
+        l, m = m, l
 
-        if not f:
-            return [{}, {}]
+    if not f:
+        return [{}, {}]
 
-        if not g:
-            zm = (0,) * n
-            return [f, {zm: dom.one}]
+    if not g:
+        zm = (0,) * n
+        return [f, {zm: dom.one}]
 
-        R = [f, g]
+    R = [f, g]
 
-        d = l - m
-        b = dom((-1) ** (d + 1))
+    d = l - m
+    b = dom((-1) ** (d + 1))
 
-        # Compute the pseudo-remainder for f and g
+    # Compute the pseudo-remainder for f and g
+    h = smp_prem(f, g, i, n, dom)
+
+    _smp_imul_ground(h, b, n, dom)
+
+    # Compute the coefficient of g with respect to x**m
+    lc = smp_coeff_wrt(g, i, m, n, dom)
+
+    c = smp_pow_generic(lc, d, dom, n)
+
+    c = smp_neg(c, n, dom)
+    while h:
+        k = smp_degree(h, i, n, dom)
+
+        R.append(h)
+        f, g, m, d = g, h, k, m - k
+
+        b = smp_mul(smp_neg(lc, n, dom), smp_pow_generic(c, d, dom, n), dom, n)
+
         h = smp_prem(f, g, i, n, dom)
 
-        _smp_imul_ground(h, b, n, dom)
+        [h], _ = smp_div_list(h, [b], n, dom)
+        lc = smp_coeff_wrt(g, i, k, n, dom)
 
-        # Compute the coefficient of g with respect to x**m
-        lc = smp_coeff_wrt(g, i, m, n, dom)
+        if d > 1:
+            p = smp_pow_generic(smp_neg(lc, n, dom), d, dom, n)
 
-        c = smp_pow_generic(lc, d, dom, n)
+            q = smp_pow_generic(c, (d - 1), dom, n)
 
-        c = smp_neg(c, n, dom)
-        while h:
+            [c], _ = smp_div_list(p, [q], n, dom)
+        else:
+            c = smp_neg(lc, n, dom)
 
-            k = smp_degree(h, i, n, dom)
-
-            R.append(h)
-            f, g, m, d = g, h, k, m - k
-
-            b = smp_mul(smp_neg(lc, n, dom), smp_pow_generic(c, d, dom, n), dom, n)
-
-            h = smp_prem(f, g, i, n, dom)
-
-            [h], _ = smp_div_list(h, [b], n, dom)
-            lc = smp_coeff_wrt(g, i, k, n, dom)
-
-            if d > 1:
-
-                p = smp_pow_generic(smp_neg(lc, n, dom), d, dom, n)
-
-                q = smp_pow_generic(c, (d - 1), dom, n)
-
-                [c], _ = smp_div_list(p, [q], n, dom)
-            else:
-
-                c = smp_neg(lc, n, dom)
-
-        return R
+    return R

--- a/sympy/polys/sparseprs.py
+++ b/sympy/polys/sparseprs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from sympy.polys.polyerrors import ExactQuotientFailed
 from sympy.polys.sparsetools import (
     smp_add,
     smp_coeff_wrt,
@@ -101,3 +102,16 @@ def smp_pdiv(
     r = smp_mul(r, c, dom, n)
 
     return q, r
+
+
+def smp_pquo(f: smp[Er], g: smp[Er], i: int, n: int, dom: Domain[Er]) -> smp[Er]:
+    return smp_pdiv(f, g, i, n, dom)[0]
+
+
+def smp_pexquo(f: smp[Er], g: smp[Er], i: int, n: int, dom: Domain[Er]) -> smp[Er]:
+    q, r = smp_pdiv(f, g, i, n, dom)
+
+    if r == {}:
+        return q
+    else:
+        raise ExactQuotientFailed(f, g)

--- a/sympy/polys/sparsetools.py
+++ b/sympy/polys/sparsetools.py
@@ -398,6 +398,11 @@ def smp_sub_ground(d: smp[Er], c: Er, n: int, domain: Domain[Er]) -> smp[Er]:
     return h
 
 
+def smp_neg(f: smp[Er], n: int, domain: Domain[Er]) -> smp[Er]:
+    # Return the opposite of a sparse polynomial.
+    return {mon: -coeff for mon, coeff in f.items() if coeff}
+
+
 def _smp_isub_ground(d: smp[Er], c: Er, n: int, domain: Domain[Er]) -> None:
     # Subtract a ground coefficient from a sparse polynomial in place.
     if not c:

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -1923,7 +1923,7 @@ def test_PolyElement_pdiv():
 
     f, g = x*y + 2*x + 1, x + y
     assert f.pdiv(g) == (y + 2, -y**2 - 2*y + 1)
-    assert f.pdiv(g, y) == f.pdiv(g, 1) == (x + 1, -x**2 + 2*x + 1)
+    assert f.pdiv(g, y) == f.pdiv(g, 1) == (x, -x**2 + 2*x + 1)
 
     assert R(0).pdiv(g) == (0, 0)
     raises(ZeroDivisionError, lambda: f.prem(R(0)))
@@ -1936,7 +1936,7 @@ def test_PolyElement_pquo():
 
     f, g = x**4 - 4*x**2*y + 4*y**2, x**2 - 2*y
     assert f.pquo(g) == f.pquo(g, x) == x**2 - 2*y
-    assert f.pquo(g, y) == 4*x**2 - 8*y + 4
+    assert f.pquo(g, y) == 4*x**2 - 8*y
 
     f, g = x**4 - y**4, x**2 - y**2
     assert f.pquo(g) == f.pquo(g, 0) == x**2 + y**2
@@ -1947,7 +1947,7 @@ def test_PolyElement_pexquo():
 
     f, g = x**2 - y**2, x - y
     assert f.pexquo(g) == f.pexquo(g, x) == x + y
-    assert f.pexquo(g, y) == f.pexquo(g, 1) == x + y + 1
+    assert f.pexquo(g, y) == f.pexquo(g, 1) == x + y
 
     f, g = x**2 + 3*x + 6, x + 2
     raises(ExactQuotientFailed, lambda: f.pexquo(g))


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
This PR fefactors the PRS methods in rings.py to rely on functions working on raw dictionaries representing polynomials, instead  of PolyElements.

#### Other comments
The logic here follows the logic of PR #30049 . It creates a new file sparseprs to include the prs functions. 
While working on the refactoring I also discovered a bug in the implementation of the method `_pdiv` : 
`pdiv` initialized the pseudo-quotient with `self.ring(x),` where `x` is the generator index. For generators other than the first, this produced a nonzero constant initial quotient, so the result did not satisfy the pseudo-division identity documented in the docstring. The affected examples and tests were updated accordingly.
I'm not very expert of the math of these functions, and I relied on AI to identify the bug. However it definitely was a bug, since the docstring wasn't coeherent with the doctest.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * Refactor the prs related methods in rings.py to work on dictionaries rather than on PolyElement objects
<!-- END RELEASE NOTES -->
