### PR TITLE
Using transcendental Risch to compute some algebraic integrals 

### DIFF
--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -971,13 +971,20 @@ class Integral(AddWithLimits):
                 pass
             else:
                 if i:
-                    # There was a nonelementary integral. Try integrating it.
+                    # There was a leftover integral. Try integrating it.
 
-                    # if no part of the NonElementaryIntegral is integrated by
-                    # the Risch algorithm, then use the original function to
-                    # integrate, instead of re-written one
+                    # if no part of the integral was computed by the
+                    # Risch algorithm, then use the original function to
+                    # integrate, instead of re-written one.  The leftover
+                    # is only provably nonelementary if risch_integrate()
+                    # said so: over a non-transcendental tower it returns
+                    # a plain Integral, and stamping that as
+                    # NonElementaryIntegral here would assert a proof
+                    # that was never made.
                     if result == 0:
-                        return NonElementaryIntegral(f, x).doit(risch=False)
+                        if isinstance(i, NonElementaryIntegral):
+                            return NonElementaryIntegral(f, x).doit(risch=False)
+                        return Integral(f, x).doit(risch=False)
                     else:
                         return result + i.doit(risch=False)
                 else:
@@ -1539,9 +1546,9 @@ def integrate(function, *symbols: SymbolLimits, meijerg=None, conds='piecewise',
 
     >>> from sympy import sqrt
     >>> integrate(sqrt(1 + x), (x, 0, x))
-    2*(x + 1)**(3/2)/3 - 2/3
+    sqrt(x + 1)*(2*x + 2)/3 - 2/3
     >>> integrate(sqrt(1 + x), x)
-    2*(x + 1)**(3/2)/3
+    sqrt(x + 1)*(2*x + 2)/3
 
     >>> integrate(x*y)
     Traceback (most recent call last):

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2970,7 +2970,7 @@ def manualintegrate(f, var):
     >>> manualintegrate(exp(x) / (1 + exp(2 * x)), x)
     atan(exp(x))
     >>> integrate(exp(x) / (1 + exp(2 * x)))
-    RootSum(4*w**2 + 1, Lambda(w, w*log(2*w + exp(x))))
+    atan(exp(x))
     >>> manualintegrate(cos(x)**4 * sin(x), x)
     -cos(x)**5/5
     >>> integrate(cos(x)**4 * sin(x), x)

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -828,15 +828,17 @@ def _prde_normalized_solve(A, B, G, gamma, DE, n=None):
     # y = p/gamma of the initial equation with ci = Sum(dj*aji).
 
     if n is None:
-        try:
-            # We try n=5. At least for prde_spde, it will always
-            # terminate no matter what n is.
-            n = bound_degree(a, b, r, DE, parametric=True)
-        except NotImplementedError:
-            # A temporary bound is set. Eventually, it will be removed.
-            # the currently added test case takes large time
-            # even with n=5, and much longer with large n's.
-            n = 5
+        # bound_degree() raises NotImplementedError when it cannot decide
+        # one of its structure-theorem queries, and we let that propagate.
+        # Guessing a finite bound here instead (n = 5 from 2017 to 2026)
+        # is unsound: solutions of degree above the guess are silently
+        # lost, so a caller like is_deriv_in_field() can be tricked into
+        # a false proof that an elementary integral is nonelementary.
+        # Falling back to n == oo (as rischDE() does) is not an option
+        # either, since the parametric no-cancellation and cancellation
+        # algorithms iterate over range(n, ...), which requires a finite
+        # bound.
+        n = bound_degree(a, b, r, DE, parametric=True)
 
     h, B = param_poly_rischDE(a, b, r, n, DE)
 

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1134,7 +1134,7 @@ def is_deriv_k(fa, fd, DE):
     dfa, dfd = dfa.cancel(dfd, include=True)
 
     # Our assumption here is that each monomial is recursively transcendental
-    if len(DE.exts) != len(DE.D):
+    if len(DE.exts) != len(DE.D) - 1:
         if [i for i in DE.cases if i == 'tan'] or \
                 ({i for i, case in enumerate(DE.cases) if case == 'primitive'} -
                         set(DE.indices('log'))):
@@ -1169,12 +1169,12 @@ def is_deriv_k(fa, fd, DE):
             raise NotImplementedError("Cannot work with non-rational "
                 "coefficients in this case.")
         else:
-            terms = ([DE.extargs[i] for i in DE.indices('exp')] +
+            terms = ([DE.extargs[i - 1] for i in DE.indices('exp')] +
                     [DE.T[i] for i in DE.indices('log')])
             ans = list(zip(terms, u))
             result = Add(*[Mul(i, j) for i, j in ans])
             argterms = ([DE.T[i] for i in DE.indices('exp')] +
-                    [DE.extargs[i] for i in DE.indices('log')])
+                    [DE.extargs[i - 1] for i in DE.indices('log')])
             l = []
             ld = []
             for i, j in zip(argterms, u):
@@ -1261,7 +1261,7 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
         dfa, dfd = fa, fd
 
     # Our assumption here is that each monomial is recursively transcendental
-    if len(DE.exts) != len(DE.D):
+    if len(DE.exts) != len(DE.D) - 1:
         if [i for i in DE.cases if i == 'tan'] or \
                 ({i for i, case in enumerate(DE.cases) if case == 'primitive'} -
                         set(DE.indices('log'))):
@@ -1302,13 +1302,13 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
             n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u])
             u *= n
             terms = ([DE.T[i] for i in DE.indices('exp')] +
-                    [DE.extargs[i] for i in DE.indices('log')])
+                    [DE.extargs[i - 1] for i in DE.indices('log')])
             ans = list(zip(terms, u))
             result = Mul(*[Pow(i, j) for i, j in ans])
 
             # exp(f) will be the same as result up to a multiplicative
             # constant.  We now find the log of that constant.
-            argterms = ([DE.extargs[i] for i in DE.indices('exp')] +
+            argterms = ([DE.extargs[i - 1] for i in DE.indices('exp')] +
                     [DE.T[i] for i in DE.indices('log')])
             const = cancel(fa.as_expr()/fd.as_expr() -
                 Add(*[Mul(i, j/n) for i, j in zip(argterms, u)]))

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -271,21 +271,34 @@ def constant_system(A, u, DE):
 
     D = lambda x: derivation(x, DE, basic=True)
 
-    for j, i in itertools.product(range(A.cols), range(A.rows)):
-        if A[i, j].expr.has(*DE.T):
-            # This assumes that const(F(t0, ..., tn) == const(K) == F
-            Ri = A[i, :]
-            # Rm+1; m = A.rows
-            DAij = D(A[i, j])
-            Rm1 = Ri.applyfunc(lambda x: D(x) / DAij)
-            um1 = D(u[i]) / DAij
+    # Repeat until no entry of A is nonconstant, processing rows appended
+    # in earlier iterations as well ("while A is not constant do" in the
+    # book's ConstantSystem; iterating over a snapshot of the original
+    # rows would let nonconstant entries in the appended rows escape).
+    # The safety cap guards against nontermination in case cancel() fails
+    # to recognize an identically zero derivation (see the comment above).
+    for _ in range((Au.rows + 1)*(Au.cols + 1)*(len(DE.T) + 1) + 10):
+        for j, i in itertools.product(range(A.cols), range(A.rows)):
+            if A[i, j].expr.has(*DE.T):
+                break
+        else:
+            break
+        # This assumes that const(F(t0, ..., tn)) == const(K) == F
+        Ri = A[i, :]
+        # Rm+1; m = A.rows
+        DAij = D(A[i, j])
+        Rm1 = Ri.applyfunc(lambda x: D(x) / DAij)
+        um1 = D(u[i]) / DAij
 
-            Aj = A[:, j]
-            A = A - Aj * Rm1
-            u = u - Aj * um1
+        Aj = A[:, j]
+        A = A - Aj * Rm1
+        u = u - Aj * um1
 
-            A = A.col_join(Rm1)
-            u = u.col_join(Matrix([um1], u.gens))
+        A = A.col_join(Rm1)
+        u = u.col_join(Matrix([um1], u.gens))
+    else:
+        raise RuntimeError("constant_system() did not reach a constant "
+            "system; the constant field may not be computable by cancel().")
 
     return (A, u)
 
@@ -1323,6 +1336,51 @@ def parametric_log_deriv(fa, fd, wa, wd, DE):
     return A
 
 
+def _structure_system_solve(lhs, rhs, DE):
+    """
+    Find a constant solution x of the structure system lhs*x == rhs.
+
+    Explanation
+    ===========
+
+    lhs and rhs are matrices over K.  Returns a list of constant
+    solutions (free parameters set to zero), or None if there is no
+    constant solution.  constant_system() returns a reduced *system*,
+    not a solution, and treating its right hand side as a solution (as
+    this module once did) is only accidentally correct when the
+    reduction is identity-like, so the reduced system is solved
+    explicitly here and the solution is verified against the original
+    equation.
+
+    Raises NotImplementedError if the verification fails, which
+    indicates constants not computable by cancel() (see the comment in
+    constant_system()).
+    """
+    A, u = constant_system(lhs, rhs, DE)
+    if not A:
+        return None
+    um = u.to_Matrix()
+    if not all(derivation(i, DE, basic=True).is_zero for i in um):
+        # No constant solution
+        return None
+    from sympy.matrices import Matrix as EMatrix
+    try:
+        xs, params = EMatrix(A.to_Matrix()).gauss_jordan_solve(EMatrix(um))
+    except ValueError:
+        return None
+    xs = xs.subs(dict.fromkeys(params, S.Zero))
+    # Defensive verification against the original system
+    lhs_m = lhs.to_Matrix()
+    rhs_m = rhs.to_Matrix()
+    for i in range(lhs_m.rows):
+        if cancel(Add(*[lhs_m[i, j]*xs[j] for j in range(lhs_m.cols)])
+                - rhs_m[i]) != 0:
+            raise NotImplementedError("The candidate solution of the "
+                "structure system failed verification; the constant field "
+                "may not be computable by cancel().")
+    return list(xs)
+
+
 def is_deriv_k(fa, fd, DE):
     r"""
     Checks if Df/f is the derivative of an element of k(t).
@@ -1410,15 +1468,10 @@ def is_deriv_k(fa, fd, DE):
     lhs = Matrix([E_part + L_part], dum)
     rhs = Matrix([dfa.as_expr()/dfd.as_expr()], dum)
 
-    A, u = constant_system(lhs, rhs, DE)
+    u = _structure_system_solve(lhs, rhs, DE)
 
-    u = u.to_Matrix()  # Poly to Expr
-
-    if not A or not all(derivation(i, DE, basic=True).is_zero for i in u):
-        # If the elements of u are not all constant
-        # Note: See comment in constant_system
-
-        # Also note: derivation(basic=True) calls cancel()
+    if u is None:
+        # No constant solution
         return None
     else:
         if not all(i.is_Rational for i in u):
@@ -1537,15 +1590,10 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
     lhs = Matrix([E_part + L_part], dum)
     rhs = Matrix([dfa.as_expr()/dfd.as_expr()], dum)
 
-    A, u = constant_system(lhs, rhs, DE)
+    u = _structure_system_solve(lhs, rhs, DE)
 
-    u = u.to_Matrix()  # Poly to Expr
-
-    if not A or not all(derivation(i, DE, basic=True).is_zero for i in u):
-        # If the elements of u are not all constant
-        # Note: See comment in constant_system
-
-        # Also note: derivation(basic=True) calls cancel()
+    if u is None:
+        # No constant solution
         return None
     else:
         if not all(i.is_Rational for i in u):
@@ -1556,7 +1604,7 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
                 "coefficients in this case.")
         else:
             n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u])
-            u *= n
+            u = [n*i for i in u]
             terms = ([DE.T[i] for i in DE.indices('exp')] +
                     [DE.extargs[i - 1] for i in DE.indices('log')])
             ans = list(zip(terms, u))

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1313,6 +1313,15 @@ def parametric_log_deriv_structure(fa, fd, wa, wd, DE):
                 or not all(derivation(i, DE, basic=True).is_zero for i in um):
             # The system could not be reduced to one over the constants
             return None
+        if not DE.transcendental:
+            # The raise below refuses to decide rationality of the
+            # constants because a None return is a proof of
+            # nonexistence.  Over a non-transcendental tower every
+            # nonelementary conclusion downstream of that proof is
+            # degraded to an unevaluated Integral anyway, and solved
+            # results are vetted independently, so an inconclusive
+            # answer may as well be "no".
+            return None
         raise NotImplementedError("Cannot work with non-rational "
             "coefficients in this case.")
     from sympy.matrices import Matrix as _Matrix
@@ -1365,7 +1374,14 @@ def parametric_log_deriv(fa, fd, wa, wd, DE):
             # elementary extension containing Integral(f) needs no
             # monomials outside the current tower, which we cannot check
             # here, so an inconclusive result must not be reported as
-            # "no solution".
+            # "no solution" -- over a transcendental tower, where "no
+            # solution" feeds valid nonelementary proofs.  Over a
+            # non-transcendental tower those proofs are degraded to
+            # unevaluated Integrals and solved results are vetted
+            # independently, so "no" is a safe answer and much better
+            # than aborting the whole integration.
+            if not DE.transcendental:
+                return None
             raise NotImplementedError("parametric_log_deriv() could not "
                 "decide: the heuristic failed and f - (m/n)*w is not a "
                 "combination of logarithmic derivatives from the current "
@@ -1525,6 +1541,13 @@ def is_deriv_k(fa, fd, DE):
         return None
     else:
         if not all(i.is_Rational for i in u):
+            if not DE.transcendental:
+                # Undecidable rationality of the coefficients: treat as
+                # no relation.  This can only add a redundant generator
+                # or forgo a rewrite; over a non-transcendental tower
+                # nonelementary conclusions are degraded and solved
+                # results are vetted, so soundness is not affected.
+                return None
             raise NotImplementedError("Cannot work with non-rational "
                 "coefficients in this case.")
         else:
@@ -1647,6 +1670,11 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
         return None
     else:
         if not all(i.is_Rational for i in u):
+            if not DE.transcendental:
+                # As above: over a non-transcendental tower an
+                # undecided rationality question may be answered "no
+                # relation" without risking an invalid proof.
+                return None
             # TODO: But maybe we can tell if they're not rational, like
             # log(2)/log(3). Also, there should be an option to continue
             # anyway, even if the result might potentially be wrong.

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -888,6 +888,36 @@ def limited_integrate(fa, fd, G, DE):
         return Y, C
 
 
+def is_deriv_in_field(fa, fd, DE):
+    """
+    Checks if f can be written as the derivative of an element of k(t).
+
+    Explanation
+    ===========
+
+    f in k(t) is the derivative of an element of k(t) if there exists v in
+    k(t) such that f == Dv.  Either returns (va, vd), with va, vd in k[t]
+    such that f == D(va/vd), or None, which means that f is not the
+    derivative of an element of k(t).  Note that v is determined only up
+    to an additive constant.
+
+    This is the in-field integration problem from Section 5.12 of
+    Bronstein's book (the "Recognizing Derivatives" subsection; neither
+    edition gives it as named pseudocode).  It is solved here as the
+    special case of the limited integration problem (Section 7.2) with an
+    empty list of special elements.
+
+    See also
+    ========
+    limited_integrate, is_log_deriv_k_t_radical_in_field
+    """
+    A = limited_integrate(fa, fd, [], DE)
+    if A is None:
+        return None
+    (va, vd), _ = A
+    return (va, vd)
+
+
 def parametric_log_deriv_heu(fa, fd, wa, wd, DE, c1=None):
     """
     Parametric logarithmic derivative heuristic.

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -226,11 +226,12 @@ def constant_system(A, u, DE):
 
     Given a differential field (K, D) with constant field C = Const(K), a Matrix
     A, and a vector (Matrix) u with coefficients in K, returns the tuple
-    (B, v, s), where B is a Matrix with coefficients in C and v is a vector
-    (Matrix) such that either v has coefficients in C, in which case s is True
-    and the solutions in C of Ax == u are exactly all the solutions of Bx == v,
-    or v has a non-constant coefficient, in which case s is False Ax == u has no
-    constant solution.
+    (B, v), where B is a Matrix with coefficients in C and v is a vector
+    (Matrix) such that either v has coefficients in C, in which case the
+    solutions in C of Ax == u are exactly all the solutions of Bx == v, or v
+    has a non-constant coefficient, in which case Ax == u has no constant
+    solution.  Note that B and v are a reduced *system*, not a solution:
+    callers must check that v is constant and then solve Bx == v themselves.
 
     This algorithm is used both in solving parametric problems and in
     determining if an element a of K is a derivative of an element of K or the
@@ -541,6 +542,10 @@ def prde_cancel_liouvillian(b, Q, n, DE):
     from the discussion in Section 7.1 of Bronstein's book (neither edition
     gives it as named pseudocode).
     """
+    if DE.case not in ('primitive', 'exp'):
+        raise ValueError("case must be 'primitive' or 'exp', not %s." %
+            DE.case)
+
     H = []
 
     if DE.case == 'exp':
@@ -734,44 +739,24 @@ def param_poly_rischDE(a, b, q, n, DE):
     return h, A
 
 
-def param_rischDE(fa, fd, G, DE):
+def _prde_normalized_solve(A, B, G, gamma, DE, n=None):
     """
-    Solve a Parametric Risch Differential Equation: Dy + f*y == Sum(ci*Gi, (i, 1, m)).
+    Common tail of param_rischDE() and limited_integrate().
 
     Explanation
     ===========
 
-    Given a derivation D in k(t), f in k(t), and G
-    = [G1, ..., Gm] in k(t)^m, return h = [h1, ..., hr] in k(t)^r and
-    a matrix A with m + r columns and entries in Const(k) such that
-    Dy + f*y = Sum(ci*Gi, (i, 1, m)) has a solution y
-    in k(t) with c1, ..., cm in Const(k) if and only if y = Sum(dj*hj,
-    (j, 1, r)) where d1, ..., dr are in Const(k) and (c1, ..., cm,
-    d1, ..., dr) is a solution of Ax == 0.
-
-    Elements of k(t) are tuples (a, d) with a and d in k[t].
-
-    This chains together the parametric algorithms of Section 7.1 of
-    Bronstein's book; the book does not give it as a single named
-    pseudocode function.
+    Given A, B in k[t] and G = [G1, ..., Gm] in k(t)^m with the equation
+    A*Dp + B*p == Sum(ci*Gi, (i, 1, m)) already reduced (weakly
+    normalized, denominators cleared), return h = [h1, ..., hr] in
+    k(t)^r and a matrix C with entries in Const(k) such that solutions
+    of the original problem are y == Sum(dj*hj, (j, 1, r))/1 with
+    (c1, ..., cm, d1, ..., dr) in the nullspace of C, where the
+    returned hj have already been divided by gamma.  If ``n`` is None,
+    the degree bound is computed with bound_degree(); otherwise ``n``
+    is used as a proven degree bound, avoiding bound_degree() entirely.
     """
     m = len(G)
-    q, (fa, fd) = weak_normalizer(fa, fd, DE)
-    # Solutions of the weakly normalized equation Dz + f*z = q*Sum(ci*Gi)
-    # correspond to solutions y = z/q of the original equation.
-    gamma = q
-    G = [(q*ga).cancel(gd, include=True) for ga, gd in G]
-
-    a, (ba, bd), G, hn = prde_normal_denom(fa, fd, G, DE)
-    # Solutions q in k<t> of  a*Dq + b*q = Sum(ci*Gi) correspond
-    # to solutions z = q/hn of the weakly normalized equation.
-    gamma *= hn
-
-    A, B, G, hs = prde_special_denom(a, ba, bd, G, DE)
-    # Solutions p in k[t] of  A*Dp + B*p = Sum(ci*Gi) correspond
-    # to solutions q = p/hs of the previous equation.
-    gamma *= hs
-
     g = A.gcd(B)
     a, b, g = A.quo(g), B.quo(g), [gia.cancel(gid*g, include=True) for
         gia, gid in G]
@@ -815,15 +800,16 @@ def param_rischDE(fa, fd, G, DE):
     # Solutions of a*Dp + b*p = Sum(dj*rj) correspond to solutions
     # y = p/gamma of the initial equation with ci = Sum(dj*aji).
 
-    try:
-        # We try n=5. At least for prde_spde, it will always
-        # terminate no matter what n is.
-        n = bound_degree(a, b, r, DE, parametric=True)
-    except NotImplementedError:
-        # A temporary bound is set. Eventually, it will be removed.
-        # the currently added test case takes large time
-        # even with n=5, and much longer with large n's.
-        n = 5
+    if n is None:
+        try:
+            # We try n=5. At least for prde_spde, it will always
+            # terminate no matter what n is.
+            n = bound_degree(a, b, r, DE, parametric=True)
+        except NotImplementedError:
+            # A temporary bound is set. Eventually, it will be removed.
+            # the currently added test case takes large time
+            # even with n=5, and much longer with large n's.
+            n = 5
 
     h, B = param_poly_rischDE(a, b, r, n, DE)
 
@@ -872,6 +858,46 @@ def param_rischDE(fa, fd, G, DE):
     C = Matrix([ni[:] for ni in N], DE.t)  # rows n1, ..., ns.
 
     return [hk.cancel(gamma, include=True) for hk in h], C
+
+
+def param_rischDE(fa, fd, G, DE):
+    """
+    Solve a Parametric Risch Differential Equation: Dy + f*y == Sum(ci*Gi, (i, 1, m)).
+
+    Explanation
+    ===========
+
+    Given a derivation D in k(t), f in k(t), and G
+    = [G1, ..., Gm] in k(t)^m, return h = [h1, ..., hr] in k(t)^r and
+    a matrix A with m + r columns and entries in Const(k) such that
+    Dy + f*y = Sum(ci*Gi, (i, 1, m)) has a solution y
+    in k(t) with c1, ..., cm in Const(k) if and only if y = Sum(dj*hj,
+    (j, 1, r)) where d1, ..., dr are in Const(k) and (c1, ..., cm,
+    d1, ..., dr) is a solution of Ax == 0.
+
+    Elements of k(t) are tuples (a, d) with a and d in k[t].
+
+    This chains together the parametric algorithms of Section 7.1 of
+    Bronstein's book; the book does not give it as a single named
+    pseudocode function.
+    """
+    q, (fa, fd) = weak_normalizer(fa, fd, DE)
+    # Solutions of the weakly normalized equation Dz + f*z = q*Sum(ci*Gi)
+    # correspond to solutions y = z/q of the original equation.
+    gamma = q
+    G = [(q*ga).cancel(gd, include=True) for ga, gd in G]
+
+    a, (ba, bd), G, hn = prde_normal_denom(fa, fd, G, DE)
+    # Solutions q in k<t> of  a*Dq + b*q = Sum(ci*Gi) correspond
+    # to solutions z = q/hn of the weakly normalized equation.
+    gamma *= hn
+
+    A, B, G, hs = prde_special_denom(a, ba, bd, G, DE)
+    # Solutions p in k[t] of  A*Dp + B*p = Sum(ci*Gi) correspond
+    # to solutions q = p/hs of the previous equation.
+    gamma *= hs
+
+    return _prde_normalized_solve(A, B, G, gamma, DE)
 
 
 def limited_integrate_reduce(fa, fd, G, DE):
@@ -943,30 +969,33 @@ def limited_integrate(fa, fd, G, DE):
     function).
     """
     fa, fd = fa*Poly(1/fd.LC(), DE.t), fd.monic()
-    # interpreting limited integration problem as a
-    # parametric Risch DE problem
-    Fa = Poly(0, DE.t)
-    Fd = Poly(1, DE.t)
-    G = [(fa, fd)] + G
-    h, A = param_rischDE(Fa, Fd, G, DE)
-    V = A.nullspace()
-    V = [v for v in V if v[0] != 0]
-    if not V:
+    # Reduction to a polynomial problem (LimitedIntegrateReduce, Section
+    # 7.2): for any solution v in k(t), c1, ..., cm in Const(k) of
+    # f == Dv + Sum(ci*wi), p == v*h is in k[t] and satisfies
+    # A*Dp + b*p == g + Sum(ci*vi) with deg(p) <= N.
+    A, b, h, N, g, V = limited_integrate_reduce(fa, fd, G, DE)
+    # Solve the parametric problem with right hand sides [g] + V.
+    # Solutions of the original problem correspond to parametric
+    # solutions whose g-coefficient is 1.  N is a proven degree bound,
+    # so bound_degree() is not needed.
+    Q = [g] + V
+    hs, C = _prde_normalized_solve(A, b, Q, h, DE, n=N)
+    W = C.nullspace()
+    W = [w for w in W if w[0] != 0]
+    if not W:
         return None
-    else:
-        # we can take any vector from V, we take V[0]
-        c0 = V[0][0]
-        # v = [-1, c1, ..., cm, d1, ..., dr]
-        v = V[0]/(-c0)
-        r = len(h)
-        m = len(v) - r - 1
-        C = list(v[1: m + 1])
-        y = -sum((v[m + 1 + i]*h[i][0].as_expr()/h[i][1].as_expr()
-                for i in range(r)), S.Zero)
-        y_num, y_den = y.as_numer_denom()
-        Ya, Yd = Poly(y_num, DE.t), Poly(y_den, DE.t)
-        Y = Ya*Poly(1/Yd.LC(), DE.t), Yd.monic()
-        return Y, C
+    # we can take any vector from W; take W[0], scaled so that the
+    # g-coefficient is 1
+    w = W[0]/W[0][0]
+    r = len(hs)
+    m = len(w) - r - 1
+    C = list(w[1: m + 1])
+    y = sum((w[m + 1 + i]*hs[i][0].as_expr()/hs[i][1].as_expr()
+            for i in range(r)), S.Zero)
+    y_num, y_den = y.as_numer_denom()
+    Ya, Yd = Poly(y_num, DE.t), Poly(y_den, DE.t)
+    Y = Ya*Poly(1/Yd.LC(), DE.t), Yd.monic()
+    return Y, C
 
 
 def is_deriv_in_field(fa, fd, DE):

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -615,11 +615,6 @@ def prde_cancel_liouvillian(b, Q, n, DE):
         # D(q_rest) + b*q_rest == Sum(ci*qi) - d*(D(h) + b*h)
         # (see the equation following (7.17) in Section 7.1; the sign of
         # the b*h term is misprinted as a minus in the 1st edition).
-        # Note that only the t**(i-1)-coefficient of Fi[j] is ever
-        # consumed (the loop descends strictly through the degrees), and
-        # the b*hji term contributes only to the t**i-coefficient, so
-        # the sign of b*hji cannot affect the result; it is written in
-        # the book's (2nd edition) form for clarity.
         for j in range(ri):
             hji = fi[j] * (DE.t**i).as_poly(fi[j].gens)
             hi[j] = hji
@@ -1761,12 +1756,6 @@ def is_log_deriv_k_t_radical_in_field(fa, fd, DE, case='auto', z=None):
         if A is None:
             return None
         n, e, u = A
-        # parametric_log_deriv() may return v as a Poly (e.g. the
-        # rational shortcut returns Poly(1, t)); keep u an Expr
-        # throughout.  Mixing Poly with Expr here built malformed Polys
-        # like Poly(t, x, domain='ZZ[t]') (with the tower generator in
-        # the coefficient domain) -- deprecated since SymPy 1.6, and
-        # only working downstream by accident of as_expr() round-trips.
         if isinstance(u, Poly):
             u = u.as_expr()
         u *= DE.t**e

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -284,6 +284,12 @@ def constant_system(A, u, DE):
         else:
             break
         # This assumes that const(F(t0, ..., tn)) == const(K) == F
+        # TODO: If A[i, j] contains symbolic constants, D(A[i, j]) can
+        # vanish for special values of them (e.g. an entry y*t is
+        # nonconstant except at y == 0), and dividing by it makes the
+        # reduced system valid only generically.  The correct result
+        # would be a Piecewise over the (solve()-generated) vanishing
+        # conditions of each pivot.
         Ri = A[i, :]
         # Rm+1; m = A.rows
         DAij = D(A[i, j])
@@ -499,7 +505,15 @@ def prde_no_cancel_b_equal(b, Q, n, DE):
     delta = DE.d.degree(DE.t)
     lam = DE.d.LC()
 
-    # The degree at which cancellation could occur
+    # The degree at which cancellation could occur.
+    # TODO: If b or Dt contains symbolic constants, Mc may be an integer
+    # only for special values of them (e.g. b == -y*t gives Mc == y), and
+    # the divisions by u below then produce a result that is valid only
+    # generically: e.g. H == [-t**3/(y - 3) - 3*t/(y**2 - 4*y + 3)] is
+    # undefined at y == 3 and y == 1.  The correct result would be a
+    # Piecewise with one condition per loop iteration where
+    # solve(N*lam + lc(b), y) is nonempty, with the cancellation
+    # algorithms handling those special values.
     Mc = cancel(-b.LC()/lam)
     if Mc.is_Integer and Mc > 0:
         M = int(Mc)
@@ -999,6 +1013,11 @@ def limited_integrate(fa, fd, G, DE):
         return None
     # we can take any vector from W; take W[0], scaled so that the
     # g-coefficient is 1
+    # TODO: If W[0][0] contains symbolic constants, it can vanish for
+    # special values of them, making the result valid only generically;
+    # a different nullspace vector may serve those special values, and
+    # the correct result would be a Piecewise over the corresponding
+    # conditions.
     w = W[0]/W[0][0]
     r = len(hs)
     m = len(w) - r - 1
@@ -1165,6 +1184,14 @@ def parametric_log_deriv_heu(fa, fd, wa, wd, DE, c1=None):
                     return None
                 cc = cancel(p.LC()/q.LC())
                 if not cc.is_Rational:
+                    # If cc contains symbolic constants, it may be
+                    # rational only for special values of them (a
+                    # condition like "y in QQ" that is not expressible
+                    # as a Piecewise relational); None here is correct
+                    # generically and at worst yields a false
+                    # nonelementary proof at those values, never a
+                    # wrong antiderivative, so no Piecewise handling is
+                    # needed.
                     return None
             M, N = cc.as_numer_denom()
 
@@ -1289,6 +1316,11 @@ def parametric_log_deriv_structure(fa, fd, wa, wd, DE):
     except ValueError:
         # Inconsistent system: f - (m/n)*w is not a combination of the
         # available logarithmic derivatives for any m/n.
+        # With symbolic constants, inconsistency is decided only
+        # generically; at special values of the constants a solution may
+        # exist.  The wrapper then raises NotImplementedError, which is
+        # sound (an honest error, never a wrong answer), so no Piecewise
+        # handling is needed here.
         return None
     xs = xs.subs(dict.fromkeys(params, S.Zero))
 
@@ -1367,6 +1399,13 @@ def _structure_system_solve(lhs, rhs, DE):
     try:
         xs, params = EMatrix(A.to_Matrix()).gauss_jordan_solve(EMatrix(um))
     except ValueError:
+        # With symbolic constants in the system, inconsistency (and
+        # the pivoting above) is decided only generically; at special
+        # values of the constants a solution may exist.  Returning None
+        # here errs on the incomplete-but-sound side (a spurious
+        # "not a derivative"/"not a radical" answer, at worst a false
+        # nonelementary proof, never a wrong antiderivative), so no
+        # Piecewise handling is needed here.
         return None
     xs = xs.subs(dict.fromkeys(params, S.Zero))
     # Defensive verification against the original system

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -83,14 +83,14 @@ def real_imag(ba, bd, gen):
     ba = ba.as_poly(gen).as_dict()
     denom_real = [value if key[0] % 4 == 0 else -value if key[0] % 4 == 2 else 0 for key, value in bd.items()]
     denom_imag = [value if key[0] % 4 == 1 else -value if key[0] % 4 == 3 else 0 for key, value in bd.items()]
-    bd_real = sum(r for r in denom_real)
-    bd_imag = sum(r for r in denom_imag)
+    bd_real = sum(denom_real, S.Zero)
+    bd_imag = sum(denom_imag, S.Zero)
     num_real = [value if key[0] % 4 == 0 else -value if key[0] % 4 == 2 else 0 for key, value in ba.items()]
     num_imag = [value if key[0] % 4 == 1 else -value if key[0] % 4 == 3 else 0 for key, value in ba.items()]
-    ba_real = sum(r for r in num_real)
-    ba_imag = sum(r for r in num_imag)
-    ba = ((ba_real*bd_real + ba_imag*bd_imag).as_poly(gen), (ba_imag*bd_real - ba_real*bd_imag).as_poly(gen))
-    bd = (bd_real*bd_real + bd_imag*bd_imag).as_poly(gen)
+    ba_real = sum(num_real, S.Zero)
+    ba_imag = sum(num_imag, S.Zero)
+    ba = (Poly(ba_real*bd_real + ba_imag*bd_imag, gen), Poly(ba_imag*bd_real - ba_real*bd_imag, gen))
+    bd = Poly(bd_real*bd_real + bd_imag*bd_imag, gen)
     return (ba[0], ba[1], bd)
 
 
@@ -871,8 +871,8 @@ def limited_integrate(fa, fd, G, DE):
         r = len(h)
         m = len(v) - r - 1
         C = list(v[1: m + 1])
-        y = -sum(v[m + 1 + i]*h[i][0].as_expr()/h[i][1].as_expr() \
-                for i in range(r))
+        y = -sum((v[m + 1 + i]*h[i][0].as_expr()/h[i][1].as_expr()
+                for i in range(r)), S.Zero)
         y_num, y_den = y.as_numer_denom()
         Ya, Yd = Poly(y_num, DE.t), Poly(y_den, DE.t)
         Y = Ya*Poly(1/Yd.LC(), DE.t), Yd.monic()

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -458,6 +458,81 @@ def prde_no_cancel_b_small(b, Q, n, DE):
     return f + H, A.col_join(B).col_join(C)
 
 
+def prde_no_cancel_b_equal(b, Q, n, DE):
+    """
+    Parametric Poly Risch Differential Equation - No cancellation: deg(b) == delta(t) - 1
+
+    Explanation
+    ===========
+
+    Given a derivation D on k[t] with delta(t) >= 2, n in ZZ, and
+    b, q1, ..., qm in k[t] with deg(b) == delta(t) - 1 and
+    n > -lc(b)/lc(Dt), returns h1, ..., hr in k[t] and a matrix A with
+    coefficients in Const(k) such that if c1, ..., cm in Const(k) and
+    q in k[t] satisfy deg(q) <= n and Dq + b*q == Sum(ci*qi, (i, 1, m)),
+    then q == Sum(dj*hj, (j, 1, r)), where d1, ..., dr in Const(k) and
+    A*Matrix([c1, ..., cm, d1, ..., dr]).T == 0.
+
+    This implements the "When delta(t) >= 2 and deg(b) == delta(t) - 1"
+    discussion of Section 7.1 of Bronstein's book (neither edition gives
+    it as named pseudocode).  If the possible-cancellation degree
+    -lc(b)/lc(Dt) is a positive integer at most n, the remaining problem
+    is delegated to the cancellation algorithms via param_poly_rischDE(),
+    which for delta(t) >= 2 are not yet implemented, so this case
+    currently raises NotImplementedError.
+    """
+    m = len(Q)
+    delta = DE.d.degree(DE.t)
+    lam = DE.d.LC()
+
+    # The degree at which cancellation could occur
+    Mc = cancel(-b.LC()/lam)
+    if Mc.is_Integer and Mc > 0:
+        M = int(Mc)
+    else:
+        M = -1
+
+    H = [Poly(0, DE.t)]*m
+
+    for N in range(n, M, -1):  # [n, ..., M + 1]
+        u = cancel(N*lam + b.LC())  # nonzero, since N != -lc(b)/lam
+        for i in range(m):
+            si = Q[i].nth(N + delta - 1)/u
+            sitn = Poly(si*DE.t**N, DE.t)
+            H[i] = H[i] + sitn
+            Q[i] = Q[i] - derivation(sitn, DE) - b*sitn
+
+    if M == -1:
+        # The loop ran through N == 0, so as in prde_no_cancel_b_large()
+        # any solution is q == Sum(ci*hi) and the (updated) right hand
+        # sides must satisfy Sum(ci*qi) == 0.
+        if all(qi.is_zero for qi in Q):
+            dc = -1
+        else:
+            dc = max(qi.degree(DE.t) for qi in Q)
+        Mmat = Matrix(dc + 1, m, lambda i, j: Q[j].nth(i), DE.t)
+        A, _ = constant_system(Mmat, zeros(dc + 1, 1, DE.t), DE)
+        c = eye(m, DE.t)
+        A = A.row_join(zeros(A.rows, m, DE.t)).col_join(c.row_join(-c))
+        return (H, A)
+
+    # We reached the possible-cancellation degree M > 0.  Solve the
+    # remaining problem, with the updated right hand sides and degree
+    # bound M, by the cancellation algorithms.
+    f, B = param_poly_rischDE(Poly(1, DE.t), b, Q, M, DE)
+    # Any solution is q == Sum(ci*hi) + Sum(dj*fj), where the fj and the
+    # matrix B constrain (c1, ..., cm, d1, ..., dr).  Combine into a
+    # relation matrix over the columns
+    # (c1, ..., cm, d_h1, ..., d_hm, d_f1, ..., d_fr), where the first
+    # block of rows enforces d_hi == ci.
+    r = len(f)
+    Bc = Matrix(B.rows, m, lambda i, j: B[i, j], DE.t)
+    Bd = Matrix(B.rows, r, lambda i, j: B[i, m + j], DE.t)
+    top = eye(m, DE.t).row_join(-eye(m, DE.t)).row_join(zeros(m, r, DE.t))
+    bottom = Bc.row_join(zeros(B.rows, m, DE.t)).row_join(Bd)
+    return (H + f, top.col_join(bottom))
+
+
 def prde_cancel_liouvillian(b, Q, n, DE):
     """
     Parametric Poly Risch Differential Equation - Cancellation: Liouvillian case.
@@ -566,8 +641,7 @@ def param_poly_rischDE(a, b, q, n, DE):
         elif (DE.d.degree() >= 2 and
               b.degree() == DE.d.degree() - 1 and
               n > -b.as_poly().LC()/DE.d.as_poly().LC()):
-            raise NotImplementedError("prde_no_cancel_b_equal() is "
-                "not yet implemented.")
+            return prde_no_cancel_b_equal(b, q, n, DE)
 
         else:
             # Liouvillian cases

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1218,20 +1218,42 @@ def parametric_log_deriv_structure(fa, fd, wa, wd, DE):
     rhs = Matrix([f], dum)
 
     A, u = constant_system(lhs, rhs, DE)
-    u = u.to_Matrix()
 
-    if not A or not all(derivation(i, DE, basic=True).is_zero for i in u):
-        return None
-    if not all(i.is_Rational for i in u):
+    # A*x == u is now a linear system with constant coefficients for the
+    # rational unknowns x == (m/n, r1, ..., rk).  Note that u is the
+    # reduced right hand side, not a solution: the system may be
+    # underdetermined (e.g. when w is a combination of the generators),
+    # so solve it explicitly, setting any free parameters to zero.
+    Am = A.to_Matrix()
+    um = u.to_Matrix()
+    if not (all(i.is_Rational for i in Am) and
+            all(i.is_Rational for i in um)):
+        if not all(derivation(i, DE, basic=True).is_zero for i in Am.vec()) \
+                or not all(derivation(i, DE, basic=True).is_zero for i in um):
+            # The system could not be reduced to one over the constants
+            return None
         raise NotImplementedError("Cannot work with non-rational "
             "coefficients in this case.")
+    from sympy.matrices import Matrix as _Matrix
+    try:
+        xs, params = _Matrix(Am).gauss_jordan_solve(_Matrix(um))
+    except ValueError:
+        # Inconsistent system: f - (m/n)*w is not a combination of the
+        # available logarithmic derivatives for any m/n.
+        return None
+    xs = xs.subs(dict.fromkeys(params, S.Zero))
 
-    n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u], S.One)
-    u *= n  # now integers: [m, n*r1, ..., n*rk]
-    m = u[0]
+    n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in xs], S.One)
+    xs *= n  # now integers: [m, n*r1, ..., n*rk]
+    m = xs[0]
     terms = ([DE.T[i] for i in E_indices] + [DE.extargs[i - 1] for i in L_indices])
-    v = Mul(*[Pow(i, j) for i, j in zip(terms, u[1:])])
+    v = Mul(*[Pow(i, j) for i, j in zip(terms, xs[1:])])
     if n == 0:
+        return None
+    # Defensive check of n*f == Dv/v + m*w (Dv/v is the same QQ-linear
+    # combination of the generator logarithmic derivatives by construction)
+    lhs_check = Add(*[Mul(j, i) for i, j in zip(E_part + L_part, xs[1:])])
+    if cancel(n*f - m*w - lhs_check) != 0:
         return None
     if n < 0:
         n, m, v = -n, -m, 1/v

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1761,6 +1761,14 @@ def is_log_deriv_k_t_radical_in_field(fa, fd, DE, case='auto', z=None):
         if A is None:
             return None
         n, e, u = A
+        # parametric_log_deriv() may return v as a Poly (e.g. the
+        # rational shortcut returns Poly(1, t)); keep u an Expr
+        # throughout.  Mixing Poly with Expr here built malformed Polys
+        # like Poly(t, x, domain='ZZ[t]') (with the tower generator in
+        # the coefficient domain) -- deprecated since SymPy 1.6, and
+        # only working downstream by accident of as_expr() round-trips.
+        if isinstance(u, Poly):
+            u = u.as_expr()
         u *= DE.t**e
 
     elif case == 'primitive':

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -900,7 +900,7 @@ def limited_integrate_reduce(fa, fd, G, DE):
     """
     dn, ds = splitfactor(fd, DE)
     E = [splitfactor(gd, DE) for _, gd in G]
-    En, Es = list(zip(*E))
+    En, Es = list(zip(*E)) if E else ((), ())
     c = reduce(lambda i, j: i.lcm(j), (dn,) + En)  # lcm(dn, en1, ..., enm)
     hn = c.gcd(c.diff(DE.t))
     a = hn
@@ -913,8 +913,8 @@ def limited_integrate_reduce(fa, fd, G, DE):
         hs = reduce(lambda i, j: i.lcm(j), (ds,) + Es)  # lcm(ds, es1, ..., esm)
         a = hn*hs
         b -= (hn*derivation(hs, DE)).quo(hs)
-        mu = min(order_at_oo(fa, fd, DE.t), min(order_at_oo(ga, gd, DE.t) for
-            ga, gd in G))
+        mu = min([order_at_oo(fa, fd, DE.t)] + [order_at_oo(ga, gd, DE.t) for
+            ga, gd in G])
         # So far, all the above are also nonlinear or Liouvillian, but if this
         # changes, then this will need to be updated to call bound_degree()
         # as per the docstring of this function (DE.case == 'other_linear').
@@ -924,7 +924,14 @@ def limited_integrate_reduce(fa, fd, G, DE):
         raise NotImplementedError
 
     V = [(-a*hn*ga).cancel(gd, include=True) for ga, gd in G]
-    return (a, b, a, N, (a*hn*fa).cancel(fd, include=True), V)
+    # Note: the first component is hn, not a.  Both editions of the book
+    # return a here, but that does not satisfy the stated contract when
+    # hs != 1: from v == p/a, the original equation multiplied by a**2
+    # gives a*Dp - Da*p == a**2*f - Sum(ci*a**2*wi), and dividing through
+    # by hs (which divides Da exactly, since hs is special) gives
+    # hn*Dp + b*p == a*hn*f - Sum(ci*a*hn*wi) with the b and right hand
+    # sides constructed above.
+    return (hn, b, a, N, (a*hn*fa).cancel(fd, include=True), V)
 
 
 def limited_integrate(fa, fd, G, DE):

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -287,9 +287,11 @@ def constant_system(A, u, DE):
         # TODO: If A[i, j] contains symbolic constants, D(A[i, j]) can
         # vanish for special values of them (e.g. an entry y*t is
         # nonconstant except at y == 0), and dividing by it makes the
-        # reduced system valid only generically.  The correct result
-        # would be a Piecewise over the (solve()-generated) vanishing
-        # conditions of each pivot.
+        # reduced system valid only generically.  The same applies to
+        # the pivots of the rref() calls, which also divide by
+        # parameter-dependent entries.  The correct result would be a
+        # Piecewise over the (solve()-generated) vanishing conditions of
+        # each pivot.
         Ri = A[i, :]
         # Rm+1; m = A.rows
         DAij = D(A[i, j])
@@ -611,7 +613,13 @@ def prde_cancel_liouvillian(b, Q, n, DE):
         # Substituting q == d*h + q_rest into Dq + b*q == Sum(ci*qi)
         # leaves the residual equation
         # D(q_rest) + b*q_rest == Sum(ci*qi) - d*(D(h) + b*h)
-        # (see the equation following (7.17) in Section 7.1).
+        # (see the equation following (7.17) in Section 7.1; the sign of
+        # the b*h term is misprinted as a minus in the 1st edition).
+        # Note that only the t**(i-1)-coefficient of Fi[j] is ever
+        # consumed (the loop descends strictly through the degrees), and
+        # the b*hji term contributes only to the t**i-coefficient, so
+        # the sign of b*hji cannot affect the result; it is written in
+        # the book's (2nd edition) form for clarity.
         for j in range(ri):
             hji = fi[j] * (DE.t**i).as_poly(fi[j].gens)
             hi[j] = hji
@@ -1409,6 +1417,12 @@ def _structure_system_solve(lhs, rhs, DE):
         # nonelementary proof, never a wrong antiderivative), so no
         # Piecewise handling is needed here.
         return None
+    # TODO: Zeroing the free parameters can miss a rational solution when
+    # a pivot divided by a symbolic constant: e.g. y*x1 + x2 == 1 gives
+    # xs == [(1 - tau)/y, tau], which is non-rational at tau == 0 but
+    # rational at tau == 1.  Choosing a rational point of the affine
+    # solution space (when one exists) would decide more towers; failing
+    # that only causes an honest NotImplementedError downstream.
     xs = xs.subs(dict.fromkeys(params, S.Zero))
     # Defensive verification against the original system
     lhs_m = lhs.to_Matrix()

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1313,17 +1313,10 @@ def parametric_log_deriv_structure(fa, fd, wa, wd, DE):
                 or not all(derivation(i, DE, basic=True).is_zero for i in um):
             # The system could not be reduced to one over the constants
             return None
-        if not DE.transcendental:
-            # The raise below refuses to decide rationality of the
-            # constants because a None return is a proof of
-            # nonexistence.  Over a non-transcendental tower every
-            # nonelementary conclusion downstream of that proof is
-            # degraded to an unevaluated Integral anyway, and solved
-            # results are vetted independently, so an inconclusive
-            # answer may as well be "no".
-            return None
-        raise NotImplementedError("Cannot work with non-rational "
-            "coefficients in this case.")
+        # Constant but not provably rational entries: the rationality
+        # of any solution is undecided, and None is inconclusive by
+        # this function's contract, so no more needs deciding here.
+        return None
     from sympy.matrices import Matrix as _Matrix
     try:
         xs, params = _Matrix(Am).gauss_jordan_solve(_Matrix(um))
@@ -1363,7 +1356,10 @@ def parametric_log_deriv(fa, fd, wa, wd, DE):
     of Bronstein's book: n*f == Dv/v + m*w for n, m in ZZ, n != 0, and
     v in k(t)*.  The heuristic (``ParametricLogarithmicDerivative``) is
     tried first; if it cannot decide, the structure theorem method of the
-    same section is tried.
+    same section is tried.  If that is inconclusive too, None is returned
+    as an unproven "no solution" and DE.transcendental is set to False,
+    which degrades every downstream nonelementary conclusion to an
+    unevaluated Integral and subjects solved results to vetting.
     """
     try:
         A = parametric_log_deriv_heu(fa, fd, wa, wd, DE)
@@ -1373,19 +1369,12 @@ def parametric_log_deriv(fa, fd, wa, wd, DE):
             # The structure method proves nonexistence only when the
             # elementary extension containing Integral(f) needs no
             # monomials outside the current tower, which we cannot check
-            # here, so an inconclusive result must not be reported as
-            # "no solution" -- over a transcendental tower, where "no
-            # solution" feeds valid nonelementary proofs.  Over a
-            # non-transcendental tower those proofs are degraded to
-            # unevaluated Integrals and solved results are vetted
-            # independently, so "no" is a safe answer and much better
-            # than aborting the whole integration.
-            if not DE.transcendental:
-                return None
-            raise NotImplementedError("parametric_log_deriv() could not "
-                "decide: the heuristic failed and f - (m/n)*w is not a "
-                "combination of logarithmic derivatives from the current "
-                "tower for any m/n in QQ.")
+            # here, so this "no solution" answer is not a proof.  Record
+            # that the tower's nonexistence answers are no longer
+            # certain: nonelementary conclusions are then degraded to
+            # unevaluated Integrals and solved results are vetted, as
+            # for a tower with algebraic generators.
+            DE.transcendental = False
     return A
 
 
@@ -1396,14 +1385,17 @@ def _structure_system_solve(lhs, rhs, DE):
     Explanation
     ===========
 
-    lhs and rhs are matrices over K.  Returns a list of constant
-    solutions (free parameters set to zero), or None if there is no
-    constant solution.  constant_system() returns a reduced *system*,
-    not a solution, and treating its right hand side as a solution (as
-    this module once did) is only accidentally correct when the
-    reduction is identity-like, so the reduced system is solved
-    explicitly here and the solution is verified against the original
-    equation.
+    lhs and rhs are matrices over K.  Returns (solution, unique), where
+    solution is a list of constants (free parameters set to zero) and
+    unique is True when the system had no free parameters, or None if
+    there is no constant solution.  Callers may draw conclusions from
+    the individual entries (e.g. their irrationality) only when unique
+    is True: zeroing a free parameter picks an arbitrary point of the
+    solution space.  constant_system() returns a reduced *system*, not
+    a solution, and treating its right hand side as a solution (as this
+    module once did) is only accidentally correct when the reduction is
+    identity-like, so the reduced system is solved explicitly here and
+    the solution is verified against the original equation.
 
     Raises NotImplementedError if the verification fails, which
     indicates constants not computable by cancel() (see the comment in
@@ -1433,7 +1425,7 @@ def _structure_system_solve(lhs, rhs, DE):
     # xs == [(1 - tau)/y, tau], which is non-rational at tau == 0 but
     # rational at tau == 1.  Choosing a rational point of the affine
     # solution space (when one exists) would decide more towers; failing
-    # that only causes an honest NotImplementedError downstream.
+    # that only degrades the tower downstream (undecided rationality).
     xs = xs.subs(dict.fromkeys(params, S.Zero))
     # Defensive verification against the original system
     lhs_m = lhs.to_Matrix()
@@ -1444,7 +1436,7 @@ def _structure_system_solve(lhs, rhs, DE):
             raise NotImplementedError("The candidate solution of the "
                 "structure system failed verification; the constant field "
                 "may not be computable by cancel().")
-    return list(xs)
+    return list(xs), not params
 
 
 def is_deriv_k(fa, fd, DE):
@@ -1459,6 +1451,11 @@ def is_deriv_k(fa, fd, DE):
     which means that Df/f is not the derivative of an element of k(t).  ans is
     a list of tuples such that Add(*[i*j for i, j in ans]) == u.  This is useful
     for seeing exactly which elements of k(t) produce u.
+
+    When the rationality of the structure coefficients cannot be decided,
+    None is returned as an unproven "no" and DE.transcendental is set to
+    False, which degrades every downstream nonelementary conclusion to an
+    unevaluated Integral and subjects solved results to vetting.
 
     This function uses the structure theorem approach, which says that for any
     f in K, Df/f is the derivative of a element of K if and only if there are ri
@@ -1534,22 +1531,29 @@ def is_deriv_k(fa, fd, DE):
     lhs = Matrix([E_part + L_part], dum)
     rhs = Matrix([dfa.as_expr()/dfd.as_expr()], dum)
 
-    u = _structure_system_solve(lhs, rhs, DE)
+    sol = _structure_system_solve(lhs, rhs, DE)
 
-    if u is None:
+    if sol is None:
         # No constant solution
         return None
     else:
+        u, unique = sol
         if not all(i.is_Rational for i in u):
-            if not DE.transcendental:
-                # Undecidable rationality of the coefficients: treat as
-                # no relation.  This can only add a redundant generator
-                # or forgo a rewrite; over a non-transcendental tower
-                # nonelementary conclusions are degraded and solved
-                # results are vetted, so soundness is not affected.
+            if unique and any(i.is_rational is False for i in u):
+                # The unique solution has a provably irrational entry,
+                # so no rational solution exists: Df/f is not the
+                # derivative of an element of k(t).
                 return None
-            raise NotImplementedError("Cannot work with non-rational "
-                "coefficients in this case.")
+            # The rationality of the coefficients is undecided (or a
+            # zeroed free parameter may be hiding a rational solution).
+            # Answer "no relation" -- which can only add a redundant
+            # generator or forgo a rewrite -- and record that the
+            # tower's transcendence is no longer certain, so that
+            # nonelementary conclusions are degraded to unevaluated
+            # Integrals and solved results are vetted, as for a tower
+            # with algebraic generators.
+            DE.transcendental = False
+            return None
         else:
             terms = ([DE.extargs[i - 1] for i in DE.indices('exp')] +
                     [DE.T[i] for i in DE.indices('log')])
@@ -1586,6 +1590,11 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
     written as the logarithmic derivative of a k(t)-radical.  ans is a list of
     tuples such that Mul(*[i**j for i, j in ans]) == u.  This is useful for
     seeing exactly what elements of k(t) produce u.
+
+    When the rationality of the structure coefficients cannot be decided,
+    None is returned as an unproven "no" and DE.transcendental is set to
+    False, which degrades every downstream nonelementary conclusion to an
+    unevaluated Integral and subjects solved results to vetting.
 
     This function uses the structure theorem approach, which says that for any
     f in K, Df is the logarithmic derivative of a K-radical if and only if there
@@ -1663,23 +1672,28 @@ def is_log_deriv_k_t_radical(fa, fd, DE, Df=True):
     lhs = Matrix([E_part + L_part], dum)
     rhs = Matrix([dfa.as_expr()/dfd.as_expr()], dum)
 
-    u = _structure_system_solve(lhs, rhs, DE)
+    sol = _structure_system_solve(lhs, rhs, DE)
 
-    if u is None:
+    if sol is None:
         # No constant solution
         return None
     else:
+        u, unique = sol
         if not all(i.is_Rational for i in u):
-            if not DE.transcendental:
-                # As above: over a non-transcendental tower an
-                # undecided rationality question may be answered "no
-                # relation" without risking an invalid proof.
+            if unique and any(i.is_rational is False for i in u):
+                # The unique solution has a provably irrational entry
+                # (e.g. log(2) for exp(log(2)*log(x)) over QQ(x, log(x))),
+                # so no rational solution exists: Df is not the
+                # logarithmic derivative of a k(t)-radical.
                 return None
-            # TODO: But maybe we can tell if they're not rational, like
-            # log(2)/log(3). Also, there should be an option to continue
-            # anyway, even if the result might potentially be wrong.
-            raise NotImplementedError("Cannot work with non-rational "
-                "coefficients in this case.")
+            # Undecided rationality (e.g. log(2)/log(3), or a zeroed
+            # free parameter hiding a rational solution): answer "no
+            # relation" and record that the tower's transcendence is no
+            # longer certain, degrading nonelementary conclusions and
+            # vetting solved results as for a tower with algebraic
+            # generators.
+            DE.transcendental = False
+            return None
         else:
             n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u])
             u = [n*i for i in u]

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -468,6 +468,13 @@ def prde_cancel_liouvillian(b, Q, n, DE):
     """
     H = []
 
+    if DE.case == 'exp':
+        # The coefficient of t**i satisfies the equation
+        # D(q_i) + (b + i*eta)*q_i == rhs_i over k, where eta == Dt/t.
+        # eta must be computed at the current level, before DecrementLevel
+        # is entered below.
+        eta = DE.d.quo(Poly(DE.t, DE.t)).as_expr()
+
     # Why use DecrementLevel? Below line answers that:
     # Assuming that we can solve such problems over 'k' (not k[t])
     if DE.case == 'primitive':
@@ -477,8 +484,7 @@ def prde_cancel_liouvillian(b, Q, n, DE):
     for i in range(n, -1, -1):
         if DE.case == 'exp': # this re-checking can be avoided
             with DecrementLevel(DE):
-                ba, bd = frac_in(b + (i*(derivation(DE.t, DE)/DE.t)).as_poly(b.gens),
-                                DE.t, field=True)
+                ba, bd = frac_in(b.as_expr() + i*eta, DE.t, field=True)
         with DecrementLevel(DE):
             Qy = [frac_in(q.nth(i), DE.t, field=True) for q in Q]
             fi, Ai = param_rischDE(ba, bd, Qy, DE)
@@ -495,12 +501,15 @@ def prde_cancel_liouvillian(b, Q, n, DE):
 
         Fi, hi = [None]*ri, [None]*ri
 
-        # from eq. on top of p.238 (unnumbered)
+        # Substituting q == d*h + q_rest into Dq + b*q == Sum(ci*qi)
+        # leaves the residual equation
+        # D(q_rest) + b*q_rest == Sum(ci*qi) - d*(D(h) + b*h)
+        # (see the equation following (7.17) in Section 7.1).
         for j in range(ri):
             hji = fi[j] * (DE.t**i).as_poly(fi[j].gens)
             hi[j] = hji
-            # building up Sum(djn*(D(fjn*t^n) - b*fjnt^n))
-            Fi[j] = -(derivation(hji, DE) - b*hji)
+            # building up Sum(dji*(D(fji*t^i) + b*fji*t^i))
+            Fi[j] = -(derivation(hji, DE) + b*hji)
 
         H += hi
         # in the next loop instead of Q it has

--- a/sympy/integrals/prde.py
+++ b/sympy/integrals/prde.py
@@ -1164,19 +1164,104 @@ def parametric_log_deriv_heu(fa, fd, wa, wd, DE, c1=None):
     return (Q*N, Q*M, v)
 
 
+def parametric_log_deriv_structure(fa, fd, wa, wd, DE):
+    """
+    Parametric logarithmic derivative problem via the structure theorems.
+
+    Explanation
+    ===========
+
+    Tries to solve n*f == Dv/v + m*w for n, m in ZZ, n != 0, and v in
+    k(t)*, by solving the structure equation
+
+        f == (m/n)*w + Sum(ri*Dti/ti, i in E) + Sum(ri*Dti, i in L)
+
+    for rational (m/n, r1, ..., rk), where E and L are the
+    hyperexponential and logarithmic monomials of the current tower (up
+    to the current level), as in equation (7.44) of Section 7.3 of
+    Bronstein's book, with theta adjoined as an extra hyperexponential
+    generator.  A solution yields (n, m, v) with
+    v == Product(termi**(n*ri)) directly.
+
+    Either returns (n, m, v), or None, which means that f - (m/n)*w is
+    not a QQ-linear combination of the logarithmic derivatives available
+    from the current tower for any m/n in QQ.  Note that None does NOT
+    prove that no solution exists: a solution whose v requires monomials
+    not in the tower (e.g. new logarithms) is not found by this method.
+    Callers must treat None as inconclusive.
+    """
+    # The same assumptions as in is_log_deriv_k_t_radical()
+    if len(DE.exts) != len(DE.D) - 1:
+        if [i for i in DE.cases if i == 'tan'] or \
+                ({i for i, case in enumerate(DE.cases) if case == 'primitive'} -
+                        set(DE.indices('log'))):
+            raise NotImplementedError("Real version of the structure "
+                "theorems with hypertangent support is not yet implemented.")
+        raise NotImplementedError("Nonelementary extensions not supported "
+            "in the structure theorems.")
+
+    # Use only the part of the tower visible at the current level: the
+    # callers pose this problem inside DecrementLevel, and v must lie in
+    # the current field (w itself is usually the log derivative of the
+    # monomial one level up, which must not appear in v).
+    top = len(DE.T) + DE.level
+    E_indices = [i for i in DE.indices('exp') if i <= top]
+    L_indices = [i for i in DE.indices('log') if i <= top]
+    E_part = [DE.D[i].quo(Poly(DE.T[i], DE.T[i])).as_expr() for i in E_indices]
+    L_part = [DE.D[i].as_expr() for i in L_indices]
+
+    w = wa.as_expr()/wd.as_expr()
+    f = fa.as_expr()/fd.as_expr()
+
+    dum = Dummy()
+    lhs = Matrix([[w] + E_part + L_part], dum)
+    rhs = Matrix([f], dum)
+
+    A, u = constant_system(lhs, rhs, DE)
+    u = u.to_Matrix()
+
+    if not A or not all(derivation(i, DE, basic=True).is_zero for i in u):
+        return None
+    if not all(i.is_Rational for i in u):
+        raise NotImplementedError("Cannot work with non-rational "
+            "coefficients in this case.")
+
+    n = S.One*reduce(ilcm, [i.as_numer_denom()[1] for i in u], S.One)
+    u *= n  # now integers: [m, n*r1, ..., n*rk]
+    m = u[0]
+    terms = ([DE.T[i] for i in E_indices] + [DE.extargs[i - 1] for i in L_indices])
+    v = Mul(*[Pow(i, j) for i, j in zip(terms, u[1:])])
+    if n == 0:
+        return None
+    if n < 0:
+        n, m, v = -n, -m, 1/v
+    return (n, m, v)
+
+
 def parametric_log_deriv(fa, fd, wa, wd, DE):
     """
     Solves the parametric logarithmic derivative problem.
 
     This is the parametric logarithmic derivative problem from Section 7.3
-    of Bronstein's book; currently only the heuristic
-    (``ParametricLogarithmicDerivative``) is implemented.
+    of Bronstein's book: n*f == Dv/v + m*w for n, m in ZZ, n != 0, and
+    v in k(t)*.  The heuristic (``ParametricLogarithmicDerivative``) is
+    tried first; if it cannot decide, the structure theorem method of the
+    same section is tried.
     """
-    # TODO: Write the full algorithm using the structure theorems.  Until
-    # then, this propagates NotImplementedError when the heuristic cannot
-    # decide (it must not be caught and treated as "no solution", since a
-    # solution may exist; see parametric_log_deriv_heu()).
-    A = parametric_log_deriv_heu(fa, fd, wa, wd, DE)
+    try:
+        A = parametric_log_deriv_heu(fa, fd, wa, wd, DE)
+    except NotImplementedError:
+        A = parametric_log_deriv_structure(fa, fd, wa, wd, DE)
+        if A is None:
+            # The structure method proves nonexistence only when the
+            # elementary extension containing Integral(f) needs no
+            # monomials outside the current tower, which we cannot check
+            # here, so an inconclusive result must not be reported as
+            # "no solution".
+            raise NotImplementedError("parametric_log_deriv() could not "
+                "decide: the heuristic failed and f - (m/n)*w is not a "
+                "combination of logarithmic derivatives from the current "
+                "tower for any m/n in QQ.")
     return A
 
 

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -229,7 +229,15 @@ def ratint_logpart(f, g, x, t=None):
     a, b = g, f - g.diff()*Poly(t, x)
 
     res, R = resultant(a, b, includePRS=True)
-    res = Poly(res, t, composite=False)
+    res = cancel(res, extension=True)
+    p, q = res.as_numer_denom()
+    if q.has(t):
+        # The subresultant PRS over a coefficient ring with radicals can
+        # return the resultant as an unreduced quotient that cancel()
+        # cannot always clear; the division is exact, so do it in t.
+        res = Poly(p, t, composite=False).exquo(Poly(q, t, composite=False))
+    else:
+        res = Poly(res, t, composite=False)
 
     assert res, "BUG: resultant(%s, %s) cannot be zero" % (a, b)
 

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -367,7 +367,7 @@ def _roots_real_complex(poly):
     return reals, complexes
 
 
-def log_to_real(h, q, x, t):
+def log_to_real(h, q, x, t, complex_only=False):
     r"""
     Convert complex logarithms to real functions.
 
@@ -381,6 +381,12 @@ def log_to_real(h, q, x, t):
                   -- = --  )  a log(h(a, x))
                   dx   dx /__,
                          a | q(a) = 0
+
+    None is returned when the roots of q cannot all be computed
+    explicitly, and, if ``complex_only=True``, when no roots of q come
+    in complex-conjugate pairs (so the caller can keep the sum of
+    logarithms in unevaluated form unless rewriting it removes complex
+    logarithms).
 
     Examples
     ========
@@ -408,6 +414,9 @@ def log_to_real(h, q, x, t):
 
     reals, complexes = rs
 
+    if complex_only and not complexes:
+        return None
+
     u = Dummy('u')
     v = Dummy('v')
 
@@ -426,7 +435,10 @@ def log_to_real(h, q, x, t):
 
         AB = (A**2 + B**2).as_expr()
 
-        result += r_u*log(AB) + r_v*log_to_atan(A, B)
+        result += r_u*log(AB)
+        if not (A.is_zero or B.is_zero):
+            # If A or B is zero, the arc-tangent term is a constant
+            result += r_v*log_to_atan(A, B)
 
     for r in reals:
         result += r*log(h.as_expr().subs(t, r))

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -398,7 +398,7 @@ def bound_degree(a, b, cQ, DE, case='auto', parametric=False):
                 if A is not None:
                     aa, z = A
                     if aa == 1:
-                        beta = -(a*derivation(z, DE).as_poly(t1) +
+                        beta = -(a*derivation(z, DE, basic=True).as_poly(t1) +
                             b*z.as_poly(t1)).LC()/(z.as_expr()*a.LC())
                         betaa, betad = frac_in(beta, DE.t)
                         from .prde import limited_integrate

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -852,8 +852,8 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
             raise TypeError("Result should be a number")
 
         if parametric:
-            raise NotImplementedError("prde_no_cancel_b_equal() is not yet "
-                "implemented.")
+            from .prde import prde_no_cancel_b_equal
+            return prde_no_cancel_b_equal(b, cQ, n, DE)
 
         R = no_cancel_equal(b, cQ, n, DE)
 

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -481,7 +481,9 @@ def spde(a, b, c, n, DE):
     while True:
         if c.is_zero:
             return (zero, zero, 0, zero, beta)  # -1 is more to the point
-        if (n < 0) is True:
+        # == True so a SymPy Integer n works too ((S(-1) < 0) is
+        # BooleanTrue), while a symbolic n still falls through
+        if (n < 0) == True:
             raise NonElementaryIntegralException("n became negative in "
                 "spde().")
 

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -492,6 +492,16 @@ def spde(a, b, c, n, DE):
             c = c.to_field().quo(a)
             return (b, c, n, alpha, beta)
 
+        if n is oo:
+            # Each pass through the reduction below decreases n by
+            # deg(a) > 0 and "no solution" is detected by n < 0, so with
+            # no degree bound the loop can run forever when there is no
+            # solution (e.g. a == t, b == 1, c == x over t == exp(x):
+            # gcd(a, b) == 1 stays trivial and no other exit is ever
+            # taken).  Raise rather than loop.
+            raise NotImplementedError("spde() with an infinite degree bound "
+                "terminates only when deg(a) becomes 0.")
+
         r, z = gcdex_diophantine(b, a, c)
         b += derivation(a, DE)
         c = z - derivation(r, DE)
@@ -911,18 +921,15 @@ def rischDE(fa, fd, ga, gd, DE):
     a, (ba, bd), (ca, cd), hn = normal_denom(fa, fd, ga, gd, DE)
     A, B, C, hs = special_denom(a, ba, bd, ca, cd, DE)
     try:
-        # Until this is fully implemented, use oo.  Note that this will almost
-        # certainly cause non-termination in spde() (unless A == 1), and
-        # *might* lead to non-termination in the next step for a nonelementary
-        # integral (I don't know for certain yet).  Fortunately, spde() is
-        # currently written recursively, so this will just give
-        # RuntimeError: maximum recursion depth exceeded.
         n = bound_degree(A, B, C, DE)
     except NotImplementedError:
-        # Useful for debugging:
-        # import warnings
-        # warnings.warn("rischDE: Proceeding with n = oo; may cause "
-        #     "non-termination.")
+        # bound_degree() could not decide one of its structure-theorem
+        # queries.  Proceeding with n == oo is sound: no bound is needed
+        # to accept a solution, and the no-cancellation and cancellation
+        # algorithms all terminate by descending on deg(c).  The only
+        # step that needs a finite bound to terminate is the deg(a) > 0
+        # reduction in spde(), which raises NotImplementedError instead
+        # of looping forever when it would need one.
         n = oo
 
     B, C, m, alpha, beta = spde(A, B, C, n, DE)

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -473,6 +473,11 @@ def spde(a, b, c, n, DE):
     alpha = Poly(1, DE.t)
     beta = Poly(0, DE.t)
 
+    # Generous pass allowance for n == oo (see below); any solution of
+    # degree d is found within about d/deg(a) passes, so this only
+    # defers solutions of very high degree to an honest error.
+    oo_passes = 4*(a.degree(DE.t) + b.degree(DE.t) + c.degree(DE.t) + 4)
+
     while True:
         if c.is_zero:
             return (zero, zero, 0, zero, beta)  # -1 is more to the point
@@ -497,10 +502,16 @@ def spde(a, b, c, n, DE):
             # deg(a) > 0 and "no solution" is detected by n < 0, so with
             # no degree bound the loop can run forever when there is no
             # solution (e.g. a == t, b == 1, c == x over t == exp(x):
-            # gcd(a, b) == 1 stays trivial and no other exit is ever
-            # taken).  Raise rather than loop.
-            raise NotImplementedError("spde() with an infinite degree bound "
-                "terminates only when deg(a) becomes 0.")
+            # gcd(a, b) == 1 stays trivial, c cycles through nonzero
+            # constants, and no other exit is ever taken).  Allow a
+            # generous number of passes (solvable cases terminate
+            # quickly, with c becoming zero), then give up with an
+            # honest error -- NotImplementedError, not a nonexistence
+            # claim.
+            oo_passes -= 1
+            if oo_passes < 0:
+                raise NotImplementedError("spde() ran out of passes with "
+                    "an infinite degree bound; cannot decide solvability.")
 
         r, z = gcdex_diophantine(b, a, c)
         b += derivation(a, DE)

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -481,8 +481,6 @@ def spde(a, b, c, n, DE):
     while True:
         if c.is_zero:
             return (zero, zero, 0, zero, beta)  # -1 is more to the point
-        # == True so a SymPy Integer n works too ((S(-1) < 0) is
-        # BooleanTrue), while a symbolic n still falls through
         if (n < 0) == True:
             raise NonElementaryIntegralException("n became negative in "
                 "spde().")
@@ -786,11 +784,7 @@ def cancel_exp(b, c, n, DE):
                     # The homogeneous solutions are C*t**(-m)/z for
                     # constants C, so the t**(-m) coefficient of q is
                     # adjustable by the constant of integration exactly
-                    # when it is C/z for a constant C; in that case,
-                    # remove that term.  (A non-constant coefficient
-                    # cannot be removed by any choice of the constant,
-                    # and stripping it anyway would return a q that does
-                    # not solve the equation.)
+                    # when it is C/z for a constant C.
                     q = q - Poly(q.nth(-m)*DE.t**(-m), DE.t)
                 if q.degree(DE.t) > n:
                     raise NonElementaryIntegralException("deg(p/(z*t**m)) "

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -797,37 +797,26 @@ def cancel_exp(b, c, n, DE):
     return q
 
 
-def solve_poly_rde(b, cQ, n, DE, parametric=False):
+def solve_poly_rde(b, c, n, DE):
     """
     Solve a Polynomial Risch Differential Equation with degree bound ``n``.
 
     This constitutes step 4 of the outline given in the rde.py docstring.
 
-    For parametric=False, cQ is c, a Poly; for parametric=True, cQ is Q ==
-    [q1, ..., qm], a list of Polys.
-
     This dispatches among the algorithms of Sections 6.5 and 6.6 of
-    Bronstein's book (and their parametric analogues from Section 7.1); it
-    has no single named counterpart.
+    Bronstein's book; it has no single named counterpart.  The parametric
+    analogue of this dispatch is param_poly_rischDE() in prde.py.
     """
     # No cancellation
     if not b.is_zero and (DE.case == 'base' or
             b.degree(DE.t) > max(0, DE.d.degree(DE.t) - 1)):
 
-        if parametric:
-            # Delayed imports
-            from .prde import prde_no_cancel_b_large
-            return prde_no_cancel_b_large(b, cQ, n, DE)
-        return no_cancel_b_large(b, cQ, n, DE)
+        return no_cancel_b_large(b, c, n, DE)
 
     elif (b.is_zero or b.degree(DE.t) < DE.d.degree(DE.t) - 1) and \
             (DE.case == 'base' or DE.d.degree(DE.t) >= 2):
 
-        if parametric:
-            from .prde import prde_no_cancel_b_small
-            return prde_no_cancel_b_small(b, cQ, n, DE)
-
-        R = no_cancel_b_small(b, cQ, n, DE)
+        R = no_cancel_b_small(b, c, n, DE)
 
         if isinstance(R, Poly):
             return R
@@ -851,11 +840,7 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
         if not b.as_poly(DE.t).LC().is_number:
             raise TypeError("Result should be a number")
 
-        if parametric:
-            from .prde import prde_no_cancel_b_equal
-            return prde_no_cancel_b_equal(b, cQ, n, DE)
-
-        R = no_cancel_equal(b, cQ, n, DE)
+        R = no_cancel_equal(b, c, n, DE)
 
         if isinstance(R, Poly):
             return R
@@ -868,12 +853,9 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
     else:
         # Cancellation
         if b.is_zero:
-            if parametric:
-                raise NotImplementedError("Parametric cancellation with "
-                    "b == 0 is not yet implemented.")
             # Dq == c: in-field integration (Section 6.6)
             from .prde import is_deriv_in_field
-            B = is_deriv_in_field(cQ, Poly(1, DE.t), DE)
+            B = is_deriv_in_field(c, Poly(1, DE.t), DE)
             if B is None:
                 raise NonElementaryIntegralException("c is not the "
                     "derivative of an element of k(t) in solve_poly_rde().")
@@ -892,16 +874,10 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
             return q
         else:
             if DE.case == 'exp':
-                if parametric:
-                    raise NotImplementedError("Parametric RDE cancellation "
-                        "hyperexponential case is not yet implemented.")
-                return cancel_exp(b, cQ, n, DE)
+                return cancel_exp(b, c, n, DE)
 
             elif DE.case == 'primitive':
-                if parametric:
-                    raise NotImplementedError("Parametric RDE cancellation "
-                        "primitive case is not yet implemented.")
-                return cancel_primitive(b, cQ, n, DE)
+                return cancel_primitive(b, c, n, DE)
 
             else:
                 raise NotImplementedError("Other Poly (P)RDE cancellation "

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -768,9 +768,16 @@ def cancel_exp(b, c, n, DE):
                 raise NonElementaryIntegralException("p/(z*t**m) is not in "
                     "k[t] in cancel_exp().")
             if q.degree(DE.t) > n:
-                if m < 0 and q.degree(DE.t) == -m:
-                    # The coefficient of t**(-m) is adjustable by the
-                    # constant of integration; remove that term.
+                if m < 0 and q.degree(DE.t) == -m and \
+                        not cancel(z*q.nth(-m)).has(*DE.T):
+                    # The homogeneous solutions are C*t**(-m)/z for
+                    # constants C, so the t**(-m) coefficient of q is
+                    # adjustable by the constant of integration exactly
+                    # when it is C/z for a constant C; in that case,
+                    # remove that term.  (A non-constant coefficient
+                    # cannot be removed by any choice of the constant,
+                    # and stripping it anyway would return a q that does
+                    # not solve the equation.)
                     q = q - Poly(q.nth(-m)*DE.t**(-m), DE.t)
                 if q.degree(DE.t) > n:
                     raise NonElementaryIntegralException("deg(p/(z*t**m)) "

--- a/sympy/integrals/rde.py
+++ b/sympy/integrals/rde.py
@@ -652,19 +652,35 @@ def cancel_primitive(b, c, n, DE):
     This is ``PolyRischDECancelPrim`` from Section 6.6 of Bronstein's book.
     """
     # Delayed imports
-    from .prde import is_log_deriv_k_t_radical_in_field
+    from .prde import is_log_deriv_k_t_radical_in_field, is_deriv_in_field
     with DecrementLevel(DE):
         ba, bd = frac_in(b, DE.t)
         A = is_log_deriv_k_t_radical_in_field(ba, bd, DE)
-        if A is not None:
-            m, z = A
-            if m == 1:  # b == Dz/z
-                raise NotImplementedError("is_deriv_in_field() is required to "
-                    " solve this problem.")
-                # if z*c == Dp for p in k[t] and deg(p) <= n:
-                #     return p/z
-                # else:
-                #     raise NonElementaryIntegralException
+
+    if A is not None:
+        m, z = A
+        if m == 1:  # b == Dz/z
+            # D(z*q) == z*(Dq + b*q), so q solves Dq + b*q == c iff
+            # p == z*q satisfies Dp == z*c.  So find an antiderivative
+            # p in k[t] of z*c with deg(p) <= n, and return q == p/z.
+            zca, zcd = frac_in(z*c.as_expr(), DE.t, cancel=True)
+            B = is_deriv_in_field(zca, zcd, DE)
+            if B is None:
+                raise NonElementaryIntegralException("z*c is not the "
+                    "derivative of an element of k(t) in cancel_primitive().")
+            pa, pd = B
+            # For a primitive t, an antiderivative in k(t) of an element
+            # of k[t] is itself in k[t] (it can have no poles), and any
+            # additive constant keeps q == p/z in k[t], so any choice of
+            # p will do.
+            q = cancel(pa.as_expr()/(pd.as_expr()*z)).as_poly(DE.t)
+            if q is None:
+                raise NonElementaryIntegralException("p/z is not in k[t] "
+                    "in cancel_primitive().")
+            if q.degree(DE.t) > n:
+                raise NonElementaryIntegralException("deg(p/z) > n in "
+                    "cancel_primitive().")
+            return q
 
     if c.is_zero:
         return c  # return 0
@@ -705,23 +721,51 @@ def cancel_exp(b, c, n, DE):
 
     This is ``PolyRischDECancelExp`` from Section 6.6 of Bronstein's book.
     """
-    from .prde import parametric_log_deriv
+    from .prde import parametric_log_deriv, is_deriv_in_field
     eta = DE.d.quo(Poly(DE.t, DE.t)).as_expr()
 
     with DecrementLevel(DE):
         etaa, etad = frac_in(eta, DE.t)
         ba, bd = frac_in(b, DE.t)
         A = parametric_log_deriv(ba, bd, etaa, etad, DE)
-        if A is not None:
-            a, m, z = A
-            if a == 1:
-                raise NotImplementedError("is_deriv_in_field() is required to "
-                    "solve this problem.")
-                # if c*z*t**m == Dp for p in k<t> and q = p/(z*t**m) in k[t] and
-                # deg(q) <= n:
-                #     return q
-                # else:
-                #     raise NonElementaryIntegralException
+
+    if A is not None:
+        a, m, z = A
+        if a == 1:
+            # b == Dz/z + m*Dt/t, so D(z*t**m*q) == z*t**m*(Dq + b*q).
+            # Hence q solves Dq + b*q == c iff p == z*t**m*q satisfies
+            # Dp == z*t**m*c.  So find an antiderivative p in k<t> of
+            # z*t**m*c; then q == p/(z*t**m) must be in k[t] with
+            # deg(q) <= n.
+            pa, pd = frac_in(z*DE.t**m*c.as_expr(), DE.t, cancel=True)
+            B = is_deriv_in_field(pa, pd, DE)
+            if B is None:
+                raise NonElementaryIntegralException("z*t**m*c is not the "
+                    "derivative of an element of k(t) in cancel_exp().")
+            va, vd = B
+            p = cancel(va.as_expr()/vd.as_expr())
+            if m > 0:
+                # p is determined only up to an additive constant.  For
+                # m > 0 the true p == z*t**m*q has no t-free term (all its
+                # monomials have degree >= m), while a constant term would
+                # make p/(z*t**m) non-polynomial, so remove it.
+                p -= p.subs(DE.t, 0)
+            # For m <= 0 any additive constant C leaves q in k[t]
+            # (C/(z*t**m) == C*t**(-m)/z), and q + C*t**(-m)/z is still a
+            # solution, since t**(-m)/z solves the homogeneous equation.
+            q = cancel(p/(z*DE.t**m)).as_poly(DE.t)
+            if q is None:
+                raise NonElementaryIntegralException("p/(z*t**m) is not in "
+                    "k[t] in cancel_exp().")
+            if q.degree(DE.t) > n:
+                if m < 0 and q.degree(DE.t) == -m:
+                    # The coefficient of t**(-m) is adjustable by the
+                    # constant of integration; remove that term.
+                    q = q - Poly(q.nth(-m)*DE.t**(-m), DE.t)
+                if q.degree(DE.t) > n:
+                    raise NonElementaryIntegralException("deg(p/(z*t**m)) "
+                        "> n in cancel_exp().")
+            return q
 
     if c.is_zero:
         return c  # return 0
@@ -824,8 +868,28 @@ def solve_poly_rde(b, cQ, n, DE, parametric=False):
     else:
         # Cancellation
         if b.is_zero:
-            raise NotImplementedError("Remaining cases for Poly (P)RDE are "
-            "not yet implemented (is_deriv_in_field() required).")
+            if parametric:
+                raise NotImplementedError("Parametric cancellation with "
+                    "b == 0 is not yet implemented.")
+            # Dq == c: in-field integration (Section 6.6)
+            from .prde import is_deriv_in_field
+            B = is_deriv_in_field(cQ, Poly(1, DE.t), DE)
+            if B is None:
+                raise NonElementaryIntegralException("c is not the "
+                    "derivative of an element of k(t) in solve_poly_rde().")
+            va, vd = B
+            # For a primitive or hyperexponential t, an antiderivative in
+            # k(t) of an element of k[t] is itself in k[t], and any
+            # additive constant is also in k[t], so any choice of the
+            # antiderivative will do.
+            q = cancel(va.as_expr()/vd.as_expr()).as_poly(DE.t)
+            if q is None:
+                raise NonElementaryIntegralException("The antiderivative "
+                    "of c is not in k[t] in solve_poly_rde().")
+            if q.degree(DE.t) > n:
+                raise NonElementaryIntegralException("The antiderivative "
+                    "of c has degree > n in solve_poly_rde().")
+            return q
         else:
             if DE.case == 'exp':
                 if parametric:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -335,20 +335,29 @@ class DifferentialExtension:
         # fractional q the left side is a principal root that differs
         # from exp(q*u) by a locally constant root of unity off the real
         # line.  Radicals of exponentials also arise internally (the
-        # radical case of _exp_part substitutes t**(p/n) and restarts),
-        # and rewriting those into the answer turned correctly
+        # radical case of _exp_part substitutes t**(p/n) and restarts);
+        # those denote a root the construction is free to choose, so
+        # folding them to exp(q*u) is exact, and rewriting the answer
+        # back into principal-root notation is what turned correctly
         # integrated results into non-antiderivatives at complex points.
-        # So the notation is only restored where it is the user's own:
-        # a fractional power is put back only if it appears in the
-        # original integrand -- and not when the integrand also contains
-        # the folded exponential form itself, since a global
-        # substitution would then rewrite genuine exp(q*u) occurrences
-        # into the principal root as well.
-        self.backsubs += [(j, i) for i, j in ratpows_repl
-                          if i.exp.is_Integer or
-                          (self.origf is not None and self.origf.has(i)
-                           and not self.origf.has(j))]
-        self.newf = self.newf.xreplace(dict(ratpows_repl))
+        # A fractional power the user wrote, however, means the
+        # principal root specifically: fold it as ratio*exp(q*u) with an
+        # opaque locally constant ratio (a root of unity on each
+        # component), restored exactly on backsubstitution -- which also
+        # keeps integrands mixing exp(u)**q with exp(q*u) itself
+        # pointwise correct.
+        subs_map = {}
+        for i, j in ratpows_repl:
+            if i.exp.is_Integer:
+                self.backsubs.append((j, i))
+                subs_map[i] = j
+            elif self.origf is not None and self.origf.has(i):
+                ratio = Dummy('exp_branch')
+                self.backsubs.append((ratio, i/j))
+                subs_map[i] = ratio*j
+            else:
+                subs_map[i] = j
+        self.newf = self.newf.xreplace(subs_map)
 
         # To make the process deterministic, the args are sorted
         # so that functions with smaller op-counts are processed first.

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -499,10 +499,13 @@ class DifferentialExtension:
                     # the principal choice), so this rewrite needs the
                     # same branch-ratio correction as the radicand
                     # split: e.g. it maps sqrt(-w) to I*sqrt(w), which
-                    # has the wrong sign where w < 0
-                    images = dict(zip(reversed(self.T),
+                    # has the wrong sign where w < 0.  Both i and
+                    # newterm live in tower symbols here, and Tfuncs
+                    # images can reference lower generators, so the
+                    # substitutions must be sequential, highest first.
+                    tower_subs = list(zip(reversed(self.T),
                         reversed([f(self.x) for f in self.Tfuncs])))
-                    ratio = i/newterm.xreplace(images)
+                    ratio = (i/newterm).subs(tower_subs)
                     if ratio != 1:
                         s = Dummy('s%d' % len(self.sign_consts))
                         self.sign_consts.append((s, ratio, i.exp.q))
@@ -2522,6 +2525,14 @@ def risch_integrate(f, x, extension=None, handle_first='log',
                     i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)
                 else:
                     i = Integral(i.function.subs(DE.backsubs), *i.limits)
+            if not DE.transcendental and \
+                    result.free_symbols - f.free_symbols - {x}:
+                # an internal symbol survived the back-substitutions (a
+                # tower Dummy leaked into a residue term, say); the
+                # result is unusable and must not be returned
+                if not separate_integral:
+                    return Integral(f, x)
+                return (S.Zero, Integral(f, x))
             if not separate_integral:
                 result += i
                 return result

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -871,7 +871,7 @@ def as_poly_1t(p, t, z):
 
     t_part, remainder = pa.div(pd)
 
-    ans = t_part.as_poly(t, z, expand=False)
+    ans = Poly(t_part, t, z, expand=False)
 
     if remainder:
         one = remainder.one
@@ -879,7 +879,7 @@ def as_poly_1t(p, t, z):
         r = pd.degree() - remainder.degree()
         z_part = remainder.transform(one, tp) * tp**r
         z_part = z_part.replace(t, z).to_field().quo_ground(pd.LC())
-        ans += z_part.as_poly(t, z, expand=False)
+        ans += Poly(z_part, t, z, expand=False)
 
     return ans
 
@@ -1093,7 +1093,7 @@ def hermite_reduce(a, d, DE):
     gd = Poly(1, DE.t)
 
     dd = derivation(d, DE)
-    dm = gcd(d.to_field(), dd.to_field()).as_poly(DE.t)
+    dm = Poly(gcd(d.to_field(), dd.to_field()), DE.t)
     ds, _ = d.div(dm)
 
     while dm.degree(DE.t) > 0:
@@ -1104,13 +1104,13 @@ def hermite_reduce(a, d, DE):
         ds_ddm = ds.mul(ddm)
         ds_ddm_dm, _ = ds_ddm.div(dm)
 
-        b, c = gcdex_diophantine(-ds_ddm_dm.as_poly(DE.t),
-            dms.as_poly(DE.t), a.as_poly(DE.t))
-        b, c = b.as_poly(DE.t), c.as_poly(DE.t)
+        b, c = gcdex_diophantine(-Poly(ds_ddm_dm, DE.t),
+            Poly(dms, DE.t), Poly(a, DE.t))
+        b, c = Poly(b, DE.t), Poly(c, DE.t)
 
-        db = derivation(b, DE).as_poly(DE.t)
+        db = Poly(derivation(b, DE), DE.t)
         ds_dms, _ = ds.div(dms)
-        a = c.as_poly(DE.t) - db.mul(ds_dms).as_poly(DE.t)
+        a = Poly(c, DE.t) - Poly(db.mul(ds_dms), DE.t)
 
         ga = ga*dm + b*gd
         gd = gd*dm
@@ -1185,7 +1185,7 @@ def laurent_series(a, d, F, n, DE):
     """
     if F.degree() == 0:
         return (Poly(0, DE.t), Poly(1, DE.t), [])
-    Z = _symbols('z', n)
+    Z: list[Symbol] = [*_symbols('z', n)]
     z = Symbol('z')
     Z.insert(0, z)
     delta_a = Poly(0, DE.t)
@@ -1317,7 +1317,7 @@ def recognize_log_derivative(a, d, DE, z=None):
     r = Poly(r, z)
     Np, Sp = splitfactor_sqf(r, DE, coefficientD=True, z=z)
 
-    if any(s.as_poly(z).degree() > 0 for s, _ in Np):
+    if any(Poly(s, z).degree() > 0 for s, _ in Np):
         # The normal part of the splitting factorization contains the
         # factors of the resultant whose roots are not constants; such
         # roots cannot be integers, so f is not the logarithmic derivative
@@ -1413,8 +1413,9 @@ def residue_reduce(a, d, DE, z=None, invert=True):
             s = Poly(s, z).monic()
 
             if invert:
-                h_lc = Poly(h.as_poly(DE.t).LC(), DE.t, field=True, expand=False)
-                inv, coeffs = h_lc.as_poly(z, field=True).invert(s), [S.One]
+                h_lc = Poly(Poly(h, DE.t).LC(), DE.t, field=True, expand=False)
+                inv = Poly(h_lc, z, field=True).invert(s)
+                coeffs = [S.One]
 
                 for coeff in h.coeffs()[1:]:
                     L = reduced(inv*coeff.as_poly(inv.gens), [s])[1]
@@ -1952,8 +1953,8 @@ def risch_integrate(f, x, extension=None, handle_first='log',
             fa, fd = frac_in(i, DE.t)
         else:
             result = result.subs(DE.backsubs)
-            if not i.is_zero:
-                i = NonElementaryIntegral(i.function.subs(DE.backsubs),i.limits)
+            if isinstance(i, Integral):
+                i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)
             if not separate_integral:
                 result += i
                 return result

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -590,8 +590,35 @@ class DifferentialExtension:
             A = is_deriv_k(arga, argd, self)
             if A is not None:
                 ans, u, const = A
-                newterm = log(const) + u
-                self.newf = self.newf.xreplace({log(arg): newterm})
+                # u + log(const) equals log(arg) only up to a locally
+                # constant branch term: log(const) is the principal-branch
+                # choice, valid where every argument involved is positive
+                # (e.g. log(-x**2) == 2*log(x) + I*pi only holds for
+                # x > 0).  The one case where it is exact everywhere is a
+                # single tower logarithm with coefficient one and a
+                # positive constant: log(c*w) == log(c) + log(w) for
+                # c > 0 on the whole complex plane.
+                if (u is not self.x and u in self.T and const.is_positive and
+                        self.exts[self.T.index(u) - 1] == 'log'):
+                    self.newf = self.newf.xreplace({log(arg): log(const) + u})
+                    continue
+                # Otherwise the difference log(arg) - u is locally
+                # constant wherever the functions are defined, so
+                # integrating with an opaque constant in its place and
+                # restoring the exact difference on backsubstitution keeps
+                # the answer, now expressed through the original
+                # logarithm, correct on every connected component.
+                branch_const = Dummy('log_branch')
+                # arg and u may involve tower symbols; express the
+                # difference through the concrete functions (and through
+                # any originals recorded in backsubs so far, so that
+                # e.g. x**x reappears as x**x rather than exp(x*log(x))).
+                concrete = list(zip(reversed(self.T),
+                    reversed([f(self.x) for f in self.Tfuncs])))
+                diff_expr = (log(arg.subs(concrete)) -
+                    u.subs(concrete)).subs(self.backsubs)
+                self.backsubs.append((branch_const, diff_expr))
+                self.newf = self.newf.xreplace({log(arg): branch_const + u})
                 continue
 
             else:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -405,6 +405,29 @@ class DifferentialExtension:
                     bf = factor(i.base)
                     pd = bf.as_powers_dict()
                     if len(pd) > 1 or any(e != 1 for e in pd.values()):
+                        # factor() is not canonical about factor signs
+                        # (they can depend on the symbol names), which
+                        # would make structurally equal radicands split
+                        # differently; normalize each factor to a
+                        # positive leading coefficient in x.  The branch
+                        # ratio absorbs any sign choice, so this is
+                        # purely a canonicalization.
+                        norm = {}
+                        negexp = S.Zero
+                        for b, e in pd.items():
+                            if b.is_Add:
+                                try:
+                                    lc = Poly(b, self.x).LC()
+                                except PolynomialError:
+                                    lc = None
+                                if lc is not None and lc.is_negative:
+                                    b = -b
+                                    negexp += e
+                            norm[b] = norm.get(b, S.Zero) + e
+                        if negexp:
+                            norm[S.NegativeOne] = norm.get(S.NegativeOne,
+                                S.Zero) + negexp
+                        pd = norm
                         split = Mul(*[Pow(b, e*i.exp) for b, e in
                                       pd.items()])
                         if all(b.is_nonnegative for b in pd):
@@ -2363,7 +2386,7 @@ class NonElementaryIntegral(Integral):
 
 def risch_integrate(f, x, extension=None, handle_first='log',
                     separate_integral=False, rewrite_complex=None,
-                    conds='piecewise', algebraic=False):
+                    conds='piecewise', algebraic=True):
     r"""
     The Risch Integration Algorithm.
 
@@ -2394,12 +2417,13 @@ def risch_integrate(f, x, extension=None, handle_first='log',
     possibly get a solution in terms of special functions.  It is False by
     default.
 
-    If ``algebraic`` is ``True``, the transcendental machinery is used to
-    solve integrals involving radicals (internally, by representing `x**(1/n)`
-    as ``exp(log(x)/n)``). In this case, an unevaluated ``Integral`` result is
-    not a proof of nonelementaryness. It only means the transcendental
-    algorithms aren't able to handle the radical integrand, and the full
-    algebraic Risch algorithm may be required.
+    If ``algebraic`` is ``True`` (the default), the transcendental machinery
+    is used to solve integrals involving radicals (internally, by representing
+    `x**(1/n)` as ``exp(log(x)/n)``). In this case, an unevaluated
+    ``Integral`` result is not a proof of nonelementaryness. It only means the
+    transcendental algorithms aren't able to handle the radical integrand, and
+    the full algebraic Risch algorithm may be required.  With
+    ``algebraic=False``, radical integrands raise ``NotImplementedError``.
 
     Examples
     ========

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -280,7 +280,14 @@ class DifferentialExtension:
             if handle_first == 'exp' or not log_new_extension:
                 exp_new_extension = self._exp_part(exps)
                 if exp_new_extension is None:
-                    # reset and restart
+                    # Reset and restart.  reset() clears backsubs, so any
+                    # rewrite recorded there -- a branch-constant Dummy
+                    # from _log_part(), a user radical's notation -- must
+                    # first be folded back into newf, or the Dummy leaks
+                    # into the final result as a free symbol and the
+                    # original notation is never re-encountered by the
+                    # rebuild.
+                    self.newf = self.newf.subs(self.backsubs)
                     self.f = self.newf
                     self.reset()
                     exp_new_extension = True
@@ -333,10 +340,14 @@ class DifferentialExtension:
         # integrated results into non-antiderivatives at complex points.
         # So the notation is only restored where it is the user's own:
         # a fractional power is put back only if it appears in the
-        # original integrand.
+        # original integrand -- and not when the integrand also contains
+        # the folded exponential form itself, since a global
+        # substitution would then rewrite genuine exp(q*u) occurrences
+        # into the principal root as well.
         self.backsubs += [(j, i) for i, j in ratpows_repl
                           if i.exp.is_Integer or
-                          (self.origf is not None and self.origf.has(i))]
+                          (self.origf is not None and self.origf.has(i)
+                           and not self.origf.has(j))]
         self.newf = self.newf.xreplace(dict(ratpows_repl))
 
         # To make the process deterministic, the args are sorted

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -157,6 +157,14 @@ class DifferentialExtension:
       answered "no" without proof -- nonexistence answers cannot be
       trusted, so nonelementary conclusions are degraded to unevaluated
       Integrals and solved results are independently vetted.
+    - algebraic_gens: Whether the tower is deliberately erecting
+      algebraic (radical) generators.  Implies transcendental == False,
+      but not conversely: a tower whose transcendence is merely
+      unproven (an undecided structure question) has no algebraic
+      generators, and construction decisions that depend on the actual
+      tower contents -- like _exp_part()'s restart-versus-adjoin choice
+      for a proven radical relation -- must use this, not
+      transcendental.
     (Note that self.T and self.D will always contain the complete extension,
     regardless of the level.  Therefore, you should ALWAYS use DE.t and DE.d
     instead of DE.T[-1] and DE.D[-1].  If you want to have a list of the
@@ -179,7 +187,7 @@ class DifferentialExtension:
     __slots__ = ('f', 'origf', 'x', 'T', 'D', 'fa', 'fd', 'Tfuncs',
             'backsubs', 'exts', 'extargs', 'cases', 'case', 'transcendental',
             't', 'd', 'newf', 'level', 'ts', 'dummy', 'algebraic',
-            'sign_consts')
+            'sign_consts', 'algebraic_gens')
 
     def __init__(self, f=None, x=None, handle_first='log',
             dummy=False, extension=None, rewrite_complex=None,
@@ -231,6 +239,8 @@ class DifferentialExtension:
                 # as exp(log(x)/2)); nonelementary conclusions are then
                 # invalid and are degraded to unevaluated Integrals.
                 self.transcendental = True
+            if 'algebraic_gens' not in extension:
+                self.algebraic_gens = not self.transcendental
 
             self._auto_attrs()
 
@@ -321,6 +331,7 @@ class DifferentialExtension:
                     self.backsubs += [(s, R) for s, R, _ in sign_consts]
                     if sign_consts:
                         self.transcendental = False
+                        self.algebraic_gens = True
                     exp_new_extension = True
                     continue
 
@@ -451,6 +462,7 @@ class DifferentialExtension:
                             # acceptance filter and nonelementary
                             # conclusions are invalid
                             self.transcendental = False
+                            self.algebraic_gens = True
             if reps:
                 self.newf = self.newf.xreplace(reps)
 
@@ -496,6 +508,7 @@ class DifferentialExtension:
                             "to represent it as an exp-log tower "
                             "(experimental)." % str(i))
                     self.transcendental = False
+                    self.algebraic_gens = True
                 # We can add a**b only if log(a) in the extension, because
                 # a**b == exp(b*log(a)).
                 basea, based = frac_in(i.base, self.t)
@@ -540,6 +553,7 @@ class DifferentialExtension:
                         self.sign_consts.append((s, ratio, i.exp.q))
                         self.backsubs.append((s, ratio))
                         self.transcendental = False
+                        self.algebraic_gens = True
                         newterm = s*newterm
                 # Under the current implementation, exp kills terms
                 # only if they are of the form a*log(x), where a is a
@@ -690,10 +704,34 @@ class DifferentialExtension:
                     # handle exp(log(x)/2) because it equals sqrt(x).
 
                     if const or len(ans) > 1:
-                        # If we're building a non-transcendental extension,
-                        # don't restart - just continue to avoid infinite loops
-                        if self.transcendental:
-                            rad = Mul(*[term**(power/n) for term, power in ans])
+                        # If we're deliberately building an algebraic
+                        # extension, don't restart - just continue to avoid
+                        # infinite loops.  A tower whose transcendence is
+                        # merely unproven still restarts: the rewrite
+                        # records the (proven) radical relation in the
+                        # regrouped generators, where adjoining a new
+                        # generator would leave it invisible to the
+                        # kernel checks.
+                        if not self.algebraic_gens:
+                            # Fold exponential factors of the radical to
+                            # exp((power/n)*arg) directly -- exact, since an
+                            # internally generated root denotes a
+                            # construction-chosen branch.  Leaving them as
+                            # exp(arg)**(power/n) can deadlock the rebuild:
+                            # the backsubs fold on restart can turn the base
+                            # into a non-exp power (2**x), which the
+                            # exp(u)**q folding in _rewrite_exps_pows() no
+                            # longer recognizes, and each pass then
+                            # regenerates the unfolded radical.
+                            radfactors = []
+                            for term, power in ans:
+                                if term in self.T[1:] and self.exts[
+                                        self.T.index(term) - 1] == 'exp':
+                                    radfactors.append(exp(self.extargs[
+                                        self.T.index(term) - 1]*power/n))
+                                else:
+                                    radfactors.append(term**(power/n))
+                            rad = Mul(*radfactors)
                             self.newf = self.newf.xreplace({exp(p*exparg):
                                                             exp(const*p)*rad for exparg, p in others})
                             self.newf = self.newf.xreplace(dict(list(zip(reversed(self.T),
@@ -861,6 +899,7 @@ class DifferentialExtension:
         self.T = [self.x]
         self.D = [Poly(1, self.x)]
         self.transcendental = True
+        self.algebraic_gens = False
         self.level = -1
         self.exts = []
         self.extargs = []

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1408,7 +1408,6 @@ def residue_reduce(a, d, DE, z=None, invert=True):
     z = z or Dummy('z')
     a, d = a.cancel(d, include=True)
     a, d = a.to_field().mul_ground(1/d.LC()), d.to_field().mul_ground(1/d.LC())
-    kkinv = [1/x for x in DE.T[:DE.level]] + DE.T[:DE.level]
 
     if a.is_zero:
         return ([], True)
@@ -1439,15 +1438,14 @@ def residue_reduce(a, d, DE, z=None, invert=True):
             h = R_map.get(i)
             if h is None:
                 continue
-            h_lc = Poly(h.as_poly(DE.t).LC(), DE.t, field=True)
+            s = Poly(s, z).monic()
+            h_lc = Poly(h.as_poly(DE.t).LC(), z, field=True)
 
             h_lc_sqf = h_lc.sqf_list_include(all=True)
 
             for a, j in h_lc_sqf:
-                h = Poly(h, DE.t, field=True).exquo(Poly(gcd(a, s**j, *kkinv),
-                    DE.t))
-
-            s = Poly(s, z).monic()
+                g = a.gcd(s)
+                h = Poly(h, DE.t, field=True).exquo(Poly(g.as_expr()**j, DE.t))
 
             if invert:
                 h_lc = Poly(Poly(h, DE.t).LC(), DE.t, field=True, expand=False)

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -27,10 +27,11 @@ from __future__ import annotations
 from types import GeneratorType
 from functools import reduce
 
+from sympy.core.add import Add
 from sympy.core.function import Lambda
 from sympy.core.mul import Mul
 from sympy.core.intfunc import ilcm
-from sympy.core.numbers import I
+from sympy.core.numbers import Float, I, Rational
 from sympy.core.power import Pow
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
@@ -45,6 +46,7 @@ from sympy.functions.elementary.trigonometric import (atan, sin, cos,
 from .integrals import integrate, Integral
 from .heurisch import _symbols
 from .rationaltools import log_to_real
+from sympy.polys.rationaltools import together
 from sympy.polys.polyerrors import PolynomialError
 from sympy.polys.polytools import (real_roots, cancel, Poly, gcd, rem, factor,
     reduced)
@@ -390,11 +392,11 @@ class DifferentialExtension:
                 if (i.exp.is_Rational and not i.exp.is_Integer and
                         not i.base.is_Symbol and not isinstance(i.base, exp)):
                     bf = factor(i.base)
-                    if bf != i.base and isinstance(bf, (Mul, Pow)):
+                    pd = bf.as_powers_dict()
+                    if len(pd) > 1 or any(e != 1 for e in pd.values()):
                         split = Mul(*[Pow(b, e*i.exp) for b, e in
-                                      bf.as_powers_dict().items()])
-                        if all(b.is_nonnegative for b in
-                               bf.as_powers_dict()):
+                                      pd.items()])
+                        if all(b.is_nonnegative for b in pd):
                             self.backsubs.append((split, i))
                             reps[i] = split
                         else:
@@ -1631,6 +1633,102 @@ def _nontrans_power_relations(DE):
     return rels
 
 
+def _nontrans_branch_corrections(result, DE):
+    """
+    Substitute the branch-ratio constants back into ``result`` and
+    correct the jumps their substitution introduces.
+
+    The candidate was found with each ratio held as a formal constant
+    s, so ``result`` with s substituted is an antiderivative on every
+    connected region where the ratio really is constant, but it may
+    jump by a constant where the ratio changes value (the real roots
+    and poles of the radicand factors).  Following Jeffrey, Labahn,
+    von Mohrenschildt & Rich (Theorem 5), subtracting
+    J*sign(x - r) with J == (G(r+) - G(r-))/2 at each such breakpoint
+    r restores continuity, extending the answer to Jeffrey's domain of
+    maximum extent.  The corrections are locally constant, so they
+    never affect the derivative; every step here is therefore free to
+    give up (unlocatable breakpoints, an unrecognizable ratio value, a
+    singular or infinite jump), leaving the plain substitution, which
+    is already correct on each region.
+    """
+    from sympy.core.numbers import pi
+    from sympy.functions.elementary.complexes import sign
+    from sympy.polys.polyroots import roots
+
+    x = DE.x
+    sign_subs = {s: R for s, R, _ in DE.sign_consts}
+    subbed = result.subs(sign_subs)
+    if not any(result.has(s) for s in sign_subs):
+        return subbed
+
+    # Breakpoints: real roots of every factor under a ratio (numerator
+    # and denominator -- the ratios jump only where some factor crosses
+    # zero or infinity).  Only exactly-representable, provably-real
+    # roots are usable; others just leave their jump uncorrected.
+    pts = set()
+    for _, R, _ in DE.sign_consts:
+        for p in R.atoms(Pow):
+            for b in p.base.as_numer_denom():
+                if not b.has(x):
+                    continue
+                try:
+                    rs = roots(Poly(b, x))
+                except PolynomialError:
+                    continue
+                pts.update(r for r in rs
+                           if r.is_real is True and r.is_comparable)
+    if not pts:
+        return subbed
+    pts = sorted(pts, key=lambda r: float(r))
+
+    def ratio_at(R, q, pt):
+        # the ratio's value just left/right of a breakpoint, snapped to
+        # an exact q-th root of unity (None if it isn't recognizably one)
+        try:
+            v = complex(R.subs(x, Float(pt)).evalf(30))
+        except (TypeError, ValueError):
+            return None
+        best = None
+        for j in range(q):
+            w = exp(2*I*pi*Rational(j, q))
+            d = abs(v - complex(w.evalf(30)))
+            if d < 0.01 and (best is None or d < best[1]):
+                best = (w, d)
+        return best[0] if best else None
+
+    corrections = []
+    for r in pts:
+        gap = min([1.0] + [abs(float(r) - float(s2))
+                           for s2 in pts if s2 != r])
+        d = Rational(int(gap/4 * 2**20) or 1, 2**20)
+        left, right = {}, {}
+        ok = True
+        for s, R, q in DE.sign_consts:
+            vl = ratio_at(R, q, float(r) - d)
+            vr_ = ratio_at(R, q, float(r) + d)
+            if vl is None or vr_ is None:
+                ok = False
+                break
+            left[s], right[s] = vl, vr_
+        if not ok or left == right:
+            continue
+        # cancel before substituting the breakpoint: singularities of
+        # the candidate there are often removable, but only in the
+        # s-form (the cancellation needs s*w*sqrt(v) still split)
+        Gl = cancel(together(result.subs(left))).subs(x, r)
+        Gr = cancel(together(result.subs(right))).subs(x, r)
+        J = cancel(together((Gr - Gl)/2))
+        if J == 0 or J.free_symbols or J.is_real is not True:
+            # a complex jump would make the answer complex on whole
+            # regions where it is real now; an infinite or undecidable
+            # one cannot be corrected by a constant.  Leave the jump:
+            # the result is still an antiderivative on each region.
+            continue
+        corrections.append(J*sign(x - r))
+    return subbed - Add(*corrections)
+
+
 def _nontrans_is_kernel(e, DE):
     """
     Decide whether e, polynomial in the tower generators, evaluates to
@@ -2239,7 +2337,17 @@ def risch_integrate(f, x, extension=None, handle_first='log',
             DE.decrement_level()
             fa, fd = frac_in(i, DE.t)
         else:
-            result = result.subs(DE.backsubs)
+            sign_symbols = {s for s, _, _ in DE.sign_consts or []}
+            result = result.subs([(o, n) for o, n in DE.backsubs
+                                  if o not in sign_symbols])
+            if sign_symbols:
+                if i == 0:
+                    result = _nontrans_branch_corrections(result, DE)
+                else:
+                    # with a leftover integral the total antiderivative
+                    # is unknown, so its jumps cannot be corrected
+                    result = result.subs(
+                        {s: R for s, R, _ in DE.sign_consts})
             if isinstance(i, Integral):
                 if DE.transcendental:
                     i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -2394,6 +2394,13 @@ def risch_integrate(f, x, extension=None, handle_first='log',
     possibly get a solution in terms of special functions.  It is False by
     default.
 
+    If ``algebraic`` is ``True``, the transcendental machinery is used to
+    solve integrals involving radicals (internally, by representing `x**(1/n)`
+    as ``exp(log(x)/n)``). In this case, an unevaluated ``Integral`` result is
+    not a proof of nonelementaryness. It only means the transcendental
+    algorithms aren't able to handle the radical integrand, and the full
+    algebraic Risch algorithm may be required.
+
     Examples
     ========
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -2245,9 +2245,18 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
 
         # XXX: Does qd = 0 always necessarily correspond to the exponential
         # equaling 1?
+        if DE.transcendental:
+            fallback = integrate((p - i).subs(DE.t, 1).subs(s), DE.x)
+        else:
+            # t == 1 encodes "the exponential degenerates to 1", which
+            # has no meaning for an algebraic generator (t representing
+            # sqrt(u) does not become 1 when a parameter vanishes);
+            # leave the degenerate branch unevaluated
+            fallback = Integral(cancel(
+                (a.as_expr()/d.as_expr()).subs(s)), DE.x)
         ret += Piecewise(
                 (qas/qds, Ne(qds, 0)),
-                (integrate((p - i).subs(DE.t, 1).subs(s), DE.x), True)
+                (fallback, True)
             )
     else:
         ret += qas/qds
@@ -2395,12 +2404,15 @@ def risch_integrate(f, x, extension=None, handle_first='log',
 
     Only transcendental functions are supported.  Currently, only exponentials
     and logarithms are supported, but support for trigonometric functions is
-    forthcoming.
+    forthcoming.  Radicals are handled through the ``algebraic`` flag
+    described below.
 
-    If this function returns an unevaluated Integral in the result, it means
-    that it has proven that integral to be nonelementary.  Any errors will
-    result in raising NotImplementedError.  The unevaluated Integral will be
-    an instance of NonElementaryIntegral, a subclass of Integral.
+    If this function returns a NonElementaryIntegral (a subclass of Integral)
+    in the result, it means that it has proven that integral to be
+    nonelementary.  A plain unevaluated Integral carries no such proof: it is
+    returned for radical integrands (see ``algebraic`` below), where the
+    nonelementary conclusions of the transcendental machinery are not valid.
+    Any errors will result in raising NotImplementedError.
 
     handle_first may be either 'exp' or 'log'.  This changes the order in
     which the extension is built, and may result in a different (but
@@ -2411,11 +2423,12 @@ def risch_integrate(f, x, extension=None, handle_first='log',
     exponential case has been implemented.
 
     If ``separate_integral`` is ``True``, the result is returned as a tuple (ans, i),
-    where the integral is ans + i, ans is elementary, and i is either a
-    NonElementaryIntegral or 0.  This useful if you want to try further
-    integrating the NonElementaryIntegral part using other algorithms to
-    possibly get a solution in terms of special functions.  It is False by
-    default.
+    where the integral is ans + i, ans is elementary, and i is either 0, a
+    NonElementaryIntegral, or a plain unevaluated Integral (for radical
+    integrands, where nonelementaryness is not proven).  This is useful if
+    you want to try further integrating the leftover part using other
+    algorithms to possibly get a solution in terms of special functions.  It
+    is False by default.
 
     If ``algebraic`` is ``True`` (the default), the transcendental machinery
     is used to solve integrals involving radicals (internally, by representing

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -378,7 +378,7 @@ class DifferentialExtension:
                            i.exp.has(*self.T))
         pows = update_sets(pows, self.newf.atoms(Pow),
                            lambda i: i.exp.is_rational_function(*self.T) and
-                           i.exp.has(*self.T))
+                           (i.exp.has(*self.T) or (i.exp.is_Rational and not i.exp.is_Integer)))
         numpows = update_sets(numpows, set(pows),
                               lambda i: not i.base.has(*self.T))
         sympows = update_sets(sympows, set(pows) - set(numpows),
@@ -484,12 +484,11 @@ class DifferentialExtension:
             self.T = [i.gen for i in self.D]
         if not self.x:
             self.x = self.T[0]
-            self.cases = [get_case(d, t) for d, t in zip(self.D, self.T)]
-            self.level = -1
-            self.t = self.T[self.level]
-            self.d = self.D[self.level]
-            self.case = self.cases[self.level]
-            self.transcendental = False
+        self.cases = [get_case(d, t) for d, t in zip(self.D, self.T)]
+        self.level = -1
+        self.t = self.T[self.level]
+        self.d = self.D[self.level]
+        self.case = self.cases[self.level]
 
     def _exp_part(self, exps):
         """
@@ -562,18 +561,22 @@ class DifferentialExtension:
                     # handle exp(log(x)/2) because it equals sqrt(x).
 
                     if const or len(ans) > 1:
-                        rad = Mul(*[term**(power/n) for term, power in ans])
-                        self.newf = self.newf.xreplace({exp(p*exparg):
-                                                        exp(const*p)*rad for exparg, p in others})
-                        self.newf = self.newf.xreplace(dict(list(zip(reversed(self.T),
-                                                                     reversed([f(self.x) for f in self.Tfuncs])))))
-                        restart = True
-                        break
+                        # If we're building a non-transcendental extension,
+                        # don't restart - just continue to avoid infinite loops
+                        if self.transcendental:
+                            rad = Mul(*[term**(power/n) for term, power in ans])
+                            self.newf = self.newf.xreplace({exp(p*exparg):
+                                                            exp(const*p)*rad for exparg, p in others})
+                            self.newf = self.newf.xreplace(dict(list(zip(reversed(self.T),
+                                                                         reversed([f(self.x) for f in self.Tfuncs])))))
+                            restart = True
+                            break
+                        # else: fall through to add extension normally
                     else:
                         # TODO: give algebraic dependence in error string
                         # raise NotImplementedError("Cannot integrate over "
                         #     "algebraic extensions.")
-                        self.algebraic = False
+                        pass
 
             arga, argd = frac_in(arg, self.t)
             darga = (argd*derivation(Poly(arga, self.t), self) -
@@ -591,10 +594,10 @@ class DifferentialExtension:
                 i = Dummy("i")
             else:
                 i = Symbol('i')
-                self.Tfuncs += [Lambda(i, exp(arg.subs(self.x, i)))]
-                self.newf = self.newf.xreplace(
-                    {exp(exparg): self.t**p for exparg, p in others})
-                new_extension = True
+            self.Tfuncs += [Lambda(i, exp(arg.subs(self.x, i)))]
+            self.newf = self.newf.xreplace(
+                {exp(exparg): self.t**p for exparg, p in others})
+            new_extension = True
 
         if restart:
             return None
@@ -674,9 +677,9 @@ class DifferentialExtension:
                     i = Dummy("i")
                 else:
                     i = Symbol('i')
-                    self.Tfuncs += [Lambda(i, log(arg.subs(self.x, i)))]
-                    self.newf = self.newf.xreplace({log(arg): self.t})
-                    new_extension = True
+                self.Tfuncs += [Lambda(i, log(arg.subs(self.x, i)))]
+                self.newf = self.newf.xreplace({log(arg): self.t})
+                new_extension = True
 
         return new_extension
 
@@ -1611,7 +1614,10 @@ def integrate_primitive(a, d, DE, z=None):
         i = cancel(a.as_expr()/d.as_expr() - (g1[1]*derivation(g1[0], DE) -
             g1[0]*derivation(g1[1], DE)).as_expr()/(g1[1]**2).as_expr() -
             residue_reduce_derivation(g2, DE, z))
-        i = NonElementaryIntegral(cancel(i).subs(s), DE.x)
+        if DE.transcendental:
+            i = NonElementaryIntegral(cancel(i).subs(s), DE.x)
+        else:
+            i = Integral(cancel(i).subs(s), DE.x)
         return ((g1[0].as_expr()/g1[1].as_expr()).subs(s) +
             residue_reduce_to_basic(g2, DE, z), i, b)
 
@@ -1628,7 +1634,11 @@ def integrate_primitive(a, d, DE, z=None):
         # i == p - Dq from integrate_primitive_polynomial(), which has been
         # proven to have no elementary integral over k(t), and ret contains
         # the partial q, so f == D(ret) + i holds for the returned values.
-        i = NonElementaryIntegral(cancel(i.as_expr()).subs(s), DE.x)
+        # The nonelementary proof is only valid for transcendental towers.
+        if DE.transcendental:
+            i = NonElementaryIntegral(cancel(i.as_expr()).subs(s), DE.x)
+        else:
+            i = Integral(cancel(i.as_expr()).subs(s), DE.x)
     else:
         i = cancel(i.as_expr())
 
@@ -1726,7 +1736,10 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
         i = cancel(a.as_expr()/d.as_expr() - (g1[1]*derivation(g1[0], DE) -
             g1[0]*derivation(g1[1], DE)).as_expr()/(g1[1]**2).as_expr() -
             residue_reduce_derivation(g2, DE, z))
-        i = NonElementaryIntegral(cancel(i.subs(s)), DE.x)
+        if DE.transcendental:
+            i = NonElementaryIntegral(cancel(i.subs(s)), DE.x)
+        else:
+            i = Integral(cancel(i.subs(s)), DE.x)
         return ((g1[0].as_expr()/g1[1].as_expr()).subs(s) +
             residue_reduce_to_basic(g2, DE, z), i, b)
 
@@ -1760,7 +1773,10 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
     if not b:
         i = p - (qd*derivation(qa, DE) - qa*derivation(qd, DE)).as_expr()/\
             (qd**2).as_expr()
-        i = NonElementaryIntegral(cancel(i).subs(s), DE.x)
+        if DE.transcendental:
+            i = NonElementaryIntegral(cancel(i).subs(s), DE.x)
+        else:
+            i = Integral(cancel(i).subs(s), DE.x)
     return (ret, i, b)
 
 
@@ -2032,13 +2048,12 @@ def risch_integrate(f, x, extension=None, handle_first='log',
         else:
             result = result.subs(DE.backsubs)
             if isinstance(i, Integral):
-                i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)
+                if DE.transcendental:
+                    i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)
+                else:
+                    i = Integral(i.function.subs(DE.backsubs), *i.limits)
             if not separate_integral:
                 result += i
                 return result
             else:
-
-                if isinstance(i, NonElementaryIntegral):
-                    return (result, i)
-                else:
-                    return (result, 0)
+                return (result, i)

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -458,7 +458,8 @@ class DifferentialExtension:
             if new != old:
                 self.backsubs.append((new, old))
             self.newf = self.newf.xreplace({old: newterm})
-            exps.append(newterm)
+            if isinstance(newterm, exp):
+                exps.append(newterm)
 
         return exps, pows, numpows, sympows, log_new_extension
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -169,8 +169,9 @@ class DifferentialExtension:
     # only create one DifferentialExtension per integration).  Also, it's nice
     # to have a safeguard when debugging.
     __slots__ = ('f', 'origf', 'x', 'T', 'D', 'fa', 'fd', 'Tfuncs',
-        'backsubs', 'exts', 'extargs', 'cases', 'case', 'transcendental',
-        't', 'd', 'newf', 'level', 'ts', 'dummy', 'algebraic')
+            'backsubs', 'exts', 'extargs', 'cases', 'case', 'transcendental',
+            't', 'd', 'newf', 'level', 'ts', 'dummy', 'algebraic',
+            'sign_consts')
 
     def __init__(self, f=None, x=None, handle_first='log',
             dummy=False, extension=None, rewrite_complex=None,
@@ -373,19 +374,35 @@ class DifferentialExtension:
         if self.algebraic:
             # Factor radicands and distribute the fractional power over
             # the factors, so that content like a perfect square does
-            # not become a spurious tower generator.  This chooses
-            # principal branches, like the exp-log representation of
-            # the radicals themselves.
+            # not become a spurious tower generator.  Distributing a
+            # fractional power is not branch-faithful (sqrt(u*v) ==
+            # sqrt(u)*sqrt(v) fails when u and v are both negative), so
+            # unless every factor is provably nonnegative the split is
+            # multiplied by a fresh constant s standing for the exact
+            # branch ratio original/split.  The ratio is locally
+            # constant away from branch points (its logarithmic
+            # derivative vanishes identically) and satisfies s**q == 1,
+            # so s really is a constant of the extension; substituting
+            # it back after integration restores the principal branch
+            # everywhere.
             reps = {}
             for i in self.newf.atoms(Pow):
                 if (i.exp.is_Rational and not i.exp.is_Integer and
                         not i.base.is_Symbol and not isinstance(i.base, exp)):
                     bf = factor(i.base)
                     if bf != i.base and isinstance(bf, (Mul, Pow)):
-                        reps[i] = Mul(*[Pow(b, e*i.exp) for b, e in
-                                        bf.as_powers_dict().items()])
+                        split = Mul(*[Pow(b, e*i.exp) for b, e in
+                                      bf.as_powers_dict().items()])
+                        if all(b.is_nonnegative for b in
+                               bf.as_powers_dict()):
+                            self.backsubs.append((split, i))
+                            reps[i] = split
+                        else:
+                            s = Dummy('s%d' % len(self.sign_consts))
+                            self.sign_consts.append((s, i/split, i.exp.q))
+                            self.backsubs.append((s, i/split))
+                            reps[i] = s*split
             if reps:
-                self.backsubs += [(v, k) for k, v in reps.items()]
                 self.newf = self.newf.xreplace(reps)
 
         # To make the process deterministic, the args are sorted
@@ -783,6 +800,7 @@ class DifferentialExtension:
             # For various things that we change to make things work that we need to
             # change back when we are done.
         self.backsubs = []
+        self.sign_consts = []
         self.Tfuncs = []
         self.newf = self.f
 
@@ -1590,8 +1608,13 @@ def _nontrans_power_relations(DE):
     choices like t1*t2 == 1 for t1 == exp(t0/2), t2 == exp(-t0/2), or
     radicals with dependent arguments.  The kernel test below is then
     incomplete (it can miss actual zeros), though still sound.
+
+    The branch-ratio constants introduced by the radicand splitting are
+    included through their root-of-unity relations s**q == 1 (so that a
+    denominator containing a factor of s**q - 1, formally nonzero but
+    actually zero, is caught).
     """
-    rels = []
+    rels = [(s, s**q - 1) for s, _, q in DE.sign_consts or []]
     for i, ext in enumerate(DE.exts, 1):
         if ext != 'exp':
             continue

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -148,6 +148,7 @@ class DifferentialExtension:
     - d: The top level extension derivation, as defined by the current
       derivation (see level below).
     - case: The string representation of the case of self.d.
+    - transcendental: Whether all the extensions in the tower are transcendental
     (Note that self.T and self.D will always contain the complete extension,
     regardless of the level.  Therefore, you should ALWAYS use DE.t and DE.d
     instead of DE.T[-1] and DE.D[-1].  If you want to have a list of the
@@ -168,8 +169,8 @@ class DifferentialExtension:
     # only create one DifferentialExtension per integration).  Also, it's nice
     # to have a safeguard when debugging.
     __slots__ = ('f', 'origf', 'x', 'T', 'D', 'fa', 'fd', 'Tfuncs',
-        'backsubs', 'exts', 'extargs', 'cases', 'case', 't', 'd', 'newf',
-        'level', 'ts', 'dummy')
+        'backsubs', 'exts', 'extargs', 'cases', 'case', 'transcendental',
+        't', 'd', 'newf', 'level', 'ts', 'dummy')
 
     def __init__(self, f=None, x=None, handle_first='log', dummy=False, extension=None, rewrite_complex=None):
         """
@@ -208,7 +209,7 @@ class DifferentialExtension:
         if extension:
             if 'D' not in extension:
                 raise ValueError("At least the key D must be included with "
-                    "the extension flag to DifferentialExtension.")
+                                 "the extension flag to DifferentialExtension.")
             for attr in extension:
                 setattr(self, attr, extension[attr])
 
@@ -217,11 +218,11 @@ class DifferentialExtension:
             return
         elif f is None or x is None:
             raise ValueError("Either both f and x or a manual extension must "
-            "be given.")
+                             "be given.")
 
         if handle_first not in ('log', 'exp'):
             raise ValueError("handle_first must be 'log' or 'exp', not %s." %
-                str(handle_first))
+                             str(handle_first))
 
         # f will be the original function, self.f might change if we reset
         # (e.g., we pull out a constant from an exponential); origf always
@@ -246,7 +247,7 @@ class DifferentialExtension:
             # rewrite the trigonometric components
             for candidates, rule in rewritables.items():
                 self.newf = self.newf.rewrite(candidates, rule)
-            self.newf = cancel(self.newf)
+                self.newf = cancel(self.newf)
         else:
             if any(i.has(x) for i in self.f.atoms(sin, cos, cot, tan, sinh,
                     cosh, coth, tanh, asin, acos, acot, atan)):
@@ -269,11 +270,11 @@ class DifferentialExtension:
                 # We couldn't find a new extension on the last pass, so I guess
                 # we can't do it.
                 raise NotImplementedError("Couldn't find an elementary "
-                    "transcendental extension for %s.  Try using a " % str(f) +
-                    "manual extension with the extension flag.")
+                                          "transcendental extension for %s.  Try using a " % str(f) +
+                                          "manual extension with the extension flag.")
 
             exps, pows, numpows, sympows, log_new_extension = \
-                    self._rewrite_exps_pows(exps, pows, numpows, sympows, log_new_extension)
+                self._rewrite_exps_pows(exps, pows, numpows, sympows, log_new_extension)
 
             logs, symlogs = self._rewrite_logs(logs, symlogs)
 
@@ -308,7 +309,7 @@ class DifferentialExtension:
         return None
 
     def _rewrite_exps_pows(self, exps, pows, numpows,
-            sympows, log_new_extension):
+                           sympows, log_new_extension):
         """
         Rewrite exps/pows for better processing.
         """
@@ -373,16 +374,16 @@ class DifferentialExtension:
         # TODO: This probably doesn't need to be completely recomputed at
         # each pass.
         exps = update_sets(exps, self.newf.atoms(exp),
-            lambda i: i.exp.is_rational_function(*self.T) and
-            i.exp.has(*self.T))
+                           lambda i: i.exp.is_rational_function(*self.T) and
+                           i.exp.has(*self.T))
         pows = update_sets(pows, self.newf.atoms(Pow),
-            lambda i: i.exp.is_rational_function(*self.T) and
-            i.exp.has(*self.T))
+                           lambda i: i.exp.is_rational_function(*self.T) and
+                           i.exp.has(*self.T))
         numpows = update_sets(numpows, set(pows),
-            lambda i: not i.base.has(*self.T))
+                              lambda i: not i.base.has(*self.T))
         sympows = update_sets(sympows, set(pows) - set(numpows),
-            lambda i: i.base.is_rational_function(*self.T) and
-            not i.exp.is_Integer)
+                              lambda i: i.base.is_rational_function(*self.T) and
+                              not i.exp.is_Integer)
 
         # The easiest way to deal with non-base E powers is to convert them
         # into base E, integrate, and then convert back.
@@ -394,8 +395,9 @@ class DifferentialExtension:
             # exp to do that :)
             if i in sympows:
                 if i.exp.is_Rational:
-                    raise NotImplementedError("Algebraic extensions are "
-                        "not supported (%s)." % str(i))
+                    self.transcendental = False
+                    # raise NotImplementedError("Algebraic extensions are "
+                    #                           "not supported (%s)." % str(i))
                 # We can add a**b only if log(a) in the extension, because
                 # a**b == exp(b*log(a)).
                 basea, based = frac_in(i.base, self.t)
@@ -412,7 +414,7 @@ class DifferentialExtension:
                     self.backsubs += [(new, old)]
                     log_new_extension = self._log_part([log(i.base)])
                     exps = update_sets(exps, self.newf.atoms(exp), lambda i:
-                        i.exp.is_rational_function(*self.T) and i.exp.has(*self.T))
+                                       i.exp.is_rational_function(*self.T) and i.exp.has(*self.T))
                     continue
                 ans, u, const = A
                 newterm = exp(i.exp*(log(const) + u))
@@ -432,7 +434,7 @@ class DifferentialExtension:
             else:
                 # i in numpows
                 newterm = new
-            # TODO: Just put it in self.Tfuncs
+                # TODO: Just put it in self.Tfuncs
             self.backsubs.append((new, old))
             self.newf = self.newf.xreplace({old: newterm})
             exps.append(newterm)
@@ -445,12 +447,12 @@ class DifferentialExtension:
         """
         atoms = self.newf.atoms(log)
         logs = update_sets(logs, atoms,
-            lambda i: i.args[0].is_rational_function(*self.T) and
-            i.args[0].has(*self.T))
+                           lambda i: i.args[0].is_rational_function(*self.T) and
+                           i.args[0].has(*self.T))
         symlogs = update_sets(symlogs, atoms,
-            lambda i: i.has(*self.T) and i.args[0].is_Pow and
-            i.args[0].base.is_rational_function(*self.T) and
-            not i.args[0].exp.is_Integer)
+                              lambda i: i.has(*self.T) and i.args[0].is_Pow and
+                              i.args[0].base.is_rational_function(*self.T) and
+                              not i.args[0].exp.is_Integer)
 
         # We can handle things like log(x**y) by converting it to y*log(x)
         # This will fix not only symbolic exponents of the argument, but any
@@ -482,11 +484,12 @@ class DifferentialExtension:
             self.T = [i.gen for i in self.D]
         if not self.x:
             self.x = self.T[0]
-        self.cases = [get_case(d, t) for d, t in zip(self.D, self.T)]
-        self.level = -1
-        self.t = self.T[self.level]
-        self.d = self.D[self.level]
-        self.case = self.cases[self.level]
+            self.cases = [get_case(d, t) for d, t in zip(self.D, self.T)]
+            self.level = -1
+            self.t = self.T[self.level]
+            self.d = self.D[self.level]
+            self.case = self.cases[self.level]
+            self.transcendental = False
 
     def _exp_part(self, exps):
         """
@@ -532,7 +535,7 @@ class DifferentialExtension:
                     self.newf = self.newf.xreplace({exp(arg): exp(const)*Mul(*[
                         u**power for u, power in ans])})
                     self.newf = self.newf.xreplace({exp(p*exparg):
-                        exp(const*p) * Mul(*[u**power for u, power in ans])
+                                                    exp(const*p) * Mul(*[u**power for u, power in ans])
                         for exparg, p in others})
                     # TODO: Add something to backsubs to put exp(const*p)
                     # back together.
@@ -561,36 +564,36 @@ class DifferentialExtension:
                     if const or len(ans) > 1:
                         rad = Mul(*[term**(power/n) for term, power in ans])
                         self.newf = self.newf.xreplace({exp(p*exparg):
-                            exp(const*p)*rad for exparg, p in others})
+                                                        exp(const*p)*rad for exparg, p in others})
                         self.newf = self.newf.xreplace(dict(list(zip(reversed(self.T),
-                            reversed([f(self.x) for f in self.Tfuncs])))))
+                                                                     reversed([f(self.x) for f in self.Tfuncs])))))
                         restart = True
                         break
                     else:
                         # TODO: give algebraic dependence in error string
-                        raise NotImplementedError("Cannot integrate over "
-                            "algebraic extensions.")
+                        # raise NotImplementedError("Cannot integrate over "
+                        #     "algebraic extensions.")
+                        self.algebraic = False
 
+            arga, argd = frac_in(arg, self.t)
+            darga = (argd*derivation(Poly(arga, self.t), self) -
+                     arga*derivation(Poly(argd, self.t), self))
+            dargd = argd**2
+            darga, dargd = darga.cancel(dargd, include=True)
+            darg = darga.as_expr()/dargd.as_expr()
+            self.t = next(self.ts)
+            self.T.append(self.t)
+            self.extargs.append(arg)
+            self.exts.append('exp')
+            self.D.append(darg.as_poly(self.t, expand=False)*Poly(self.t,
+                                                                  self.t, expand=False))
+            if self.dummy:
+                i = Dummy("i")
             else:
-                arga, argd = frac_in(arg, self.t)
-                darga = (argd*derivation(Poly(arga, self.t), self) -
-                    arga*derivation(Poly(argd, self.t), self))
-                dargd = argd**2
-                darga, dargd = darga.cancel(dargd, include=True)
-                darg = darga.as_expr()/dargd.as_expr()
-                self.t = next(self.ts)
-                self.T.append(self.t)
-                self.extargs.append(arg)
-                self.exts.append('exp')
-                self.D.append(darg.as_poly(self.t, expand=False)*Poly(self.t,
-                    self.t, expand=False))
-                if self.dummy:
-                    i = Dummy("i")
-                else:
-                    i = Symbol('i')
+                i = Symbol('i')
                 self.Tfuncs += [Lambda(i, exp(arg.subs(self.x, i)))]
                 self.newf = self.newf.xreplace(
-                        {exp(exparg): self.t**p for exparg, p in others})
+                    {exp(exparg): self.t**p for exparg, p in others})
                 new_extension = True
 
         if restart:
@@ -658,7 +661,7 @@ class DifferentialExtension:
             else:
                 arga, argd = frac_in(arg, self.t)
                 darga = (argd*derivation(Poly(arga, self.t), self) -
-                    arga*derivation(Poly(argd, self.t), self))
+                         arga*derivation(Poly(argd, self.t), self))
                 dargd = argd**2
                 darg = darga.as_expr()/dargd.as_expr()
                 self.t = next(self.ts)
@@ -666,14 +669,14 @@ class DifferentialExtension:
                 self.extargs.append(arg)
                 self.exts.append('log')
                 self.D.append(cancel(darg.as_expr()/arg).as_poly(self.t,
-                    expand=False))
+                                                                 expand=False))
                 if self.dummy:
                     i = Dummy("i")
                 else:
                     i = Symbol('i')
-                self.Tfuncs += [Lambda(i, log(arg.subs(self.x, i)))]
-                self.newf = self.newf.xreplace({log(arg): self.t})
-                new_extension = True
+                    self.Tfuncs += [Lambda(i, log(arg.subs(self.x, i)))]
+                    self.newf = self.newf.xreplace({log(arg): self.t})
+                    new_extension = True
 
         return new_extension
 
@@ -691,7 +694,7 @@ class DifferentialExtension:
         exts, extargs).
         """
         return (self.fa, self.fd, self.D, self.T, self.Tfuncs,
-            self.backsubs, self.exts, self.extargs)
+                self.backsubs, self.exts, self.extargs)
 
     # NOTE: this printing doesn't follow the Python's standard
     # eval(repr(DE)) == DE, where DE is the DifferentialExtension object,
@@ -726,6 +729,7 @@ class DifferentialExtension:
         self.t = self.x
         self.T = [self.x]
         self.D = [Poly(1, self.x)]
+        self.transcendental = True
         self.level = -1
         self.exts = []
         self.extargs = []
@@ -734,8 +738,8 @@ class DifferentialExtension:
         else:
             # For testing
             self.ts = numbered_symbols('t')
-        # For various things that we change to make things work that we need to
-        # change back when we are done.
+            # For various things that we change to make things work that we need to
+            # change back when we are done.
         self.backsubs = []
         self.Tfuncs = []
         self.newf = self.f
@@ -783,7 +787,7 @@ class DifferentialExtension:
         """
         if self.level >= -1:
             raise ValueError("The level of the differential extension cannot "
-                "be incremented any further.")
+                             "be incremented any further.")
 
         self.level += 1
         self.t = self.T[self.level]
@@ -804,7 +808,7 @@ class DifferentialExtension:
         """
         if self.level <= -len(self.T):
             raise ValueError("The level of the differential extension cannot "
-                "be decremented any further.")
+                             "be decremented any further.")
 
         self.level -= 1
         self.t = self.T[self.level]

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -31,7 +31,7 @@ from sympy.core.add import Add
 from sympy.core.function import Function, Lambda
 from sympy.core.mul import Mul
 from sympy.core.intfunc import ilcm
-from sympy.core.numbers import I, Rational, oo, zoo
+from sympy.core.numbers import Float, I, Rational, oo, zoo
 from sympy.core.power import Pow
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
@@ -47,7 +47,7 @@ from .integrals import integrate, Integral
 from .heurisch import _symbols
 from .rationaltools import log_to_real
 from sympy.polys.rationaltools import together
-from sympy.polys.polyerrors import PolynomialError
+from sympy.polys.polyerrors import NotInvertible, PolynomialError
 from sympy.polys.polytools import (real_roots, cancel, Poly, gcd, rem, factor,
     reduced)
 from sympy.polys.rootoftools import RootSum
@@ -1599,7 +1599,19 @@ def residue_reduce(a, d, DE, z=None, invert=True):
 
             if invert:
                 h_lc = Poly(Poly(h, DE.t).LC(), DE.t, field=True, expand=False)
-                inv = Poly(h_lc, z, field=True).invert(s)
+                try:
+                    inv = Poly(h_lc, z, field=True).invert(s)
+                except NotInvertible:
+                    if DE.transcendental:
+                        raise
+                    # The leading coefficient shares a factor with this
+                    # resultant factor, so this residue term cannot be
+                    # normalized.  Give the residues up: the uncaptured
+                    # mass stays in the remainder f - Dg, and b == False
+                    # sends the level down the give-up path, whose
+                    # nonelementary conclusion is degraded to an honest
+                    # unevaluated Integral for non-transcendental towers.
+                    return (H, False)
                 coeffs = [S.One]
 
                 for coeff in h.coeffs()[1:]:
@@ -2539,6 +2551,16 @@ def risch_integrate(f, x, extension=None, handle_first='log',
     function).
     """
     f = S(f)
+
+    if algebraic and f.has(Float):
+        # The algebraic towers do exact arithmetic: a Float coefficient
+        # becomes a rational with an astronomical denominator
+        # (0.333333333333333 == 333333333333333/10**15) and the
+        # structure-theorem constant systems grind on it, while nothing
+        # exact can be concluded from inexact input anyway.  Leave
+        # radical integrands with Floats to the numeric-friendly
+        # fallbacks in integrate().
+        algebraic = False
 
     DE = extension or DifferentialExtension(f, x, handle_first=handle_first,
             dummy=True, rewrite_complex=rewrite_complex, algebraic=algebraic)

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -137,8 +137,10 @@ class DifferentialExtension:
       For back-substitution after integration.
     - backsubs: A (possibly empty) list of further substitutions to be made on
       the final integral to make it look more like the integrand.
-    - exts:
-    - extargs:
+    - exts: The type ('exp' or 'log') of each extension; exts[i]
+      describes T[i + 1] (T[0] == x is not an extension).
+    - extargs: The argument of the exp or log of each extension, indexed
+      like exts.
     - cases: List of string representations of the cases of T.
     - t: The top level extension variable, as defined by the current level
       (see level below).
@@ -663,8 +665,8 @@ class DifferentialExtension:
         self.T = [self.x]
         self.D = [Poly(1, self.x)]
         self.level = -1
-        self.exts = [None]
-        self.extargs = [None]
+        self.exts = []
+        self.extargs = []
         if self.dummy:
             self.ts = numbered_symbols('t', cls=Dummy)
         else:
@@ -687,8 +689,9 @@ class DifferentialExtension:
         Returns
         =======
 
-        list: A list of indices of 'exts' where extension of
-            type 'extension' is present.
+        list: A list of indices into T (and D) of the extensions of
+            type 'extension'.  Note that self.exts[i] describes the
+            extension T[i + 1], since T[0] == x is not an extension.
 
         Examples
         ========
@@ -703,7 +706,7 @@ class DifferentialExtension:
         [1]
 
         """
-        return [i for i, ext in enumerate(self.exts) if ext == extension]
+        return [i for i, ext in enumerate(self.exts, 1) if ext == extension]
 
     def increment_level(self):
         """

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1819,6 +1819,61 @@ def _nontrans_sign_assignments(DE, exprs):
             for combo in product(*values)]
 
 
+def _nontrans_vet(result, DE):
+    """
+    Final check of a sign-carrying result before the ratio constants
+    are substituted back, returning False if the result must be
+    rejected.
+
+    The acceptance filter runs per tower level, but the base case
+    (everything collapsed to a rational function of x and the ratio
+    constants) never reaches it, and ratint() over QQ(s) can divide by
+    s-polynomials that vanish at attained values.  So the total result
+    is vetted under every possible assignment of the ratio constants:
+    the denominator must stay out of the relation kernel, the leading
+    coefficients of RootSum defining polynomials must not vanish
+    (specialization would silently change the root set, which no
+    value check can see), and the assigned result must not evaluate
+    to nan or an infinity.
+
+    Only constants in positions that can turn singular need
+    assigning: denominators at any depth (the top-level one, and
+    those inside function arguments and fractional-power bases, which
+    as_numer_denom() does not see into), arguments of non-entire
+    functions (log(0) is zoo, but no finite exp() argument is
+    singular), exponents, and RootSum defining polynomials.  A
+    constant occurring purely as a numerator polynomial factor cannot
+    produce a singularity.  Nested structures are covered by the
+    atoms() walks being recursive.
+    """
+    den = cancel(result).as_numer_denom()[1]
+    risky = [den]
+    for fn in result.atoms(Function):
+        if isinstance(fn, exp):
+            risky.extend(cancel(arg).as_numer_denom()[1]
+                         for arg in fn.args)
+        else:
+            risky.extend(fn.args)
+    for p in result.atoms(Pow):
+        risky.append(p.exp)
+        if not p.exp.is_Integer:
+            risky.append(cancel(p.base).as_numer_denom()[1])
+    rootsums = list(result.atoms(RootSum))
+    risky.extend(rs.poly.as_expr() for rs in rootsums)
+    assignments = _nontrans_sign_assignments(DE, risky)
+    if assignments is None:
+        return False
+    for sig in assignments:
+        if _nontrans_is_kernel(den.subs(sig), DE):
+            return False
+        if any(_nontrans_is_kernel(rs.poly.LC().subs(sig), DE)
+               for rs in rootsums):
+            return False
+        if result.subs(sig).has(S.NaN, oo, zoo):
+            return False
+    return True
+
+
 def _nontrans_accept(elem, g2, i, a, d, DE, z):
     """
     Acceptance filter for a candidate result of integrate_primitive()
@@ -2426,27 +2481,7 @@ def risch_integrate(f, x, extension=None, handle_first='log',
             result = result.subs([(o, n) for o, n in DE.backsubs
                                   if o not in sign_symbols])
             if sign_symbols:
-                # The acceptance filter runs per level, but the base
-                # case (everything collapsed to a rational function of
-                # x and the ratio constants) never reaches it, and
-                # ratint() over QQ(s) can divide by s-polynomials that
-                # vanish at attained values.  So vet the total result
-                # under every possible assignment of the ratio
-                # constants before substituting them.  Only constants
-                # in positions that can turn singular need assigning:
-                # the denominator, function arguments (log(0) is zoo),
-                # and exponents -- a constant occurring purely as a
-                # numerator polynomial factor cannot produce one.
-                den = cancel(result).as_numer_denom()[1]
-                risky = [den]
-                risky.extend(arg for fn in result.atoms(Function)
-                             for arg in fn.args)
-                risky.extend(p.exp for p in result.atoms(Pow))
-                assignments = _nontrans_sign_assignments(DE, risky)
-                if assignments is None or any(
-                        _nontrans_is_kernel(den.subs(sig), DE) or
-                        result.subs(sig).has(S.NaN, oo, zoo)
-                        for sig in assignments):
+                if not _nontrans_vet(result, DE):
                     if not separate_integral:
                         return Integral(f, x)
                     return (S.Zero, Integral(f, x))

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -170,9 +170,11 @@ class DifferentialExtension:
     # to have a safeguard when debugging.
     __slots__ = ('f', 'origf', 'x', 'T', 'D', 'fa', 'fd', 'Tfuncs',
         'backsubs', 'exts', 'extargs', 'cases', 'case', 'transcendental',
-        't', 'd', 'newf', 'level', 'ts', 'dummy')
+        't', 'd', 'newf', 'level', 'ts', 'dummy', 'algebraic')
 
-    def __init__(self, f=None, x=None, handle_first='log', dummy=False, extension=None, rewrite_complex=None):
+    def __init__(self, f=None, x=None, handle_first='log',
+            dummy=False, extension=None, rewrite_complex=None,
+            algebraic=False):
         """
         Tries to build a transcendental extension tower from ``f`` with respect to ``x``.
 
@@ -205,6 +207,8 @@ class DifferentialExtension:
         testing/debugging purposes.
         """
         # XXX: If you need to debug this function, set the break point here
+
+        self.algebraic = algebraic
 
         if extension:
             if 'D' not in extension:
@@ -384,7 +388,8 @@ class DifferentialExtension:
                            i.exp.has(*self.T))
         pows = update_sets(pows, self.newf.atoms(Pow),
                            lambda i: i.exp.is_rational_function(*self.T) and
-                           (i.exp.has(*self.T) or (i.exp.is_Rational and not i.exp.is_Integer)))
+                           (i.exp.has(*self.T) or (self.algebraic and
+                            i.exp.is_Rational and not i.exp.is_Integer)))
         numpows = update_sets(numpows, set(pows),
                               lambda i: not i.base.has(*self.T))
         sympows = update_sets(sympows, set(pows) - set(numpows),
@@ -401,9 +406,12 @@ class DifferentialExtension:
             # exp to do that :)
             if i in sympows:
                 if i.exp.is_Rational:
+                    if not self.algebraic:
+                        raise NotImplementedError("Algebraic extensions are "
+                            "not supported (%s).  Rerun with algebraic=True "
+                            "to represent it as an exp-log tower "
+                            "(experimental)." % str(i))
                     self.transcendental = False
-                    # raise NotImplementedError("Algebraic extensions are "
-                    #                           "not supported (%s)." % str(i))
                 # We can add a**b only if log(a) in the extension, because
                 # a**b == exp(b*log(a)).
                 basea, based = frac_in(i.base, self.t)
@@ -585,11 +593,10 @@ class DifferentialExtension:
                             restart = True
                             break
                         # else: fall through to add extension normally
-                    else:
+                    elif not self.algebraic:
                         # TODO: give algebraic dependence in error string
-                        # raise NotImplementedError("Cannot integrate over "
-                        #     "algebraic extensions.")
-                        pass
+                        raise NotImplementedError("Cannot integrate over "
+                            "algebraic extensions.")
 
             arga, argd = frac_in(arg, self.t)
             darga = (argd*derivation(Poly(arga, self.t), self) -
@@ -2043,7 +2050,7 @@ class NonElementaryIntegral(Integral):
 
 def risch_integrate(f, x, extension=None, handle_first='log',
                     separate_integral=False, rewrite_complex=None,
-                    conds='piecewise'):
+                    conds='piecewise', algebraic=False):
     r"""
     The Risch Integration Algorithm.
 
@@ -2155,7 +2162,7 @@ def risch_integrate(f, x, extension=None, handle_first='log',
     f = S(f)
 
     DE = extension or DifferentialExtension(f, x, handle_first=handle_first,
-            dummy=True, rewrite_complex=rewrite_complex)
+            dummy=True, rewrite_complex=rewrite_complex, algebraic=algebraic)
     fa, fd = DE.fa, DE.fd
 
     result = S.Zero

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -2256,11 +2256,19 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
             # sqrt(u) does not become 1 when a parameter vanishes).  Nor
             # can the degenerate branch replace only the qas/qds piece:
             # the generic decomposition itself divides by qds, so every
-            # piece of it may be invalid there.  Since the caller still
-            # adds ret and keeps integrating the residual, the branch
-            # is the unevaluated rest of this level minus ret, so that
-            # the assembled degenerate value is exactly
-            # Integral(a/d - resid) + (the residual's integral).
+            # piece of it may be invalid there.
+            if not b:
+                # with a residual returned separately, no branch value
+                # can survive the degenerate substitution (both the
+                # rest of the level and the residual keep the vanishing
+                # denominator); give the level up so the caller retries
+                # the original integrand whole
+                return (S.Zero, Integral(cancel(
+                    (a.as_expr()/d.as_expr()).subs(s)), DE.x), False)
+            # everything else this level produced is inside ret, so the
+            # branch is the unevaluated rest of the level minus ret,
+            # and the assembled degenerate value is exactly
+            # Integral(a/d - i) plus the continuing constant's integral
             fallback = Integral(cancel((a.as_expr()/d.as_expr()
                 - resid).subs(s)), DE.x) - ret
         ret += Piecewise(

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -28,7 +28,7 @@ from types import GeneratorType
 from functools import reduce
 
 from sympy.core.add import Add
-from sympy.core.function import Lambda
+from sympy.core.function import Function, Lambda
 from sympy.core.mul import Mul
 from sympy.core.intfunc import ilcm
 from sympy.core.numbers import I, Rational, oo, zoo
@@ -1677,7 +1677,6 @@ def _nontrans_branch_corrections(result, DE):
     region.
     """
     from sympy.core.numbers import pi
-    from sympy.polys.polyroots import roots
 
     x = DE.x
     sign_subs = {s: R for s, R, _ in DE.sign_consts}
@@ -1687,20 +1686,25 @@ def _nontrans_branch_corrections(result, DE):
 
     # Breakpoints: real roots of every factor under a ratio (numerator
     # and denominator -- the ratios jump only where some factor crosses
-    # zero or infinity).  Only exactly-representable, provably-real
-    # roots are usable; others just leave their jump uncorrected.
+    # zero or infinity).  The set must be *complete*: a missing root
+    # would let a side sample cross an unrecognized breakpoint and
+    # certify a nonlocal ratio value, so real_roots() (exact isolation)
+    # is used and every factor must yield its full real-root set or no
+    # correction is attempted at all.
+    from sympy.polys.polyerrors import CoercionFailed, DomainError
     pts = set()
     for _, R, _ in DE.sign_consts:
         for p in R.atoms(Pow):
             for b in p.base.as_numer_denom():
                 if not b.has(x):
                     continue
+                if b.free_symbols != {x}:
+                    return subbed
                 try:
-                    rs = roots(Poly(b, x))
-                except PolynomialError:
-                    continue
-                pts.update(r for r in rs
-                           if r.is_real is True and r.is_comparable)
+                    pts.update(Poly(b, x).real_roots())
+                except (PolynomialError, DomainError, CoercionFailed,
+                        NotImplementedError):
+                    return subbed
     if not pts:
         return subbed
     pts = sorted(pts, key=lambda r: r.evalf(30))
@@ -1778,21 +1782,25 @@ def _nontrans_is_kernel(e, DE):
     return cancel(e) == 0
 
 
-def _nontrans_sign_assignments(DE):
+def _nontrans_sign_assignments(DE, exprs):
     """
-    Every assignment of the branch-ratio constants to their possible
-    root-of-unity values, as a list of substitution dicts ([{}] when
-    there are none), or None if the assignments cannot be enumerated
-    in exact radical-free-of-transcendentals form (a root of unity of
-    high order whose cos/sin do not evaluate, or too many
-    combinations) -- the caller must then reject the candidate, since
-    the per-branch denominator check cannot be run.
+    Every assignment of the branch-ratio constants occurring in
+    ``exprs`` to their possible root-of-unity values, as a list of
+    substitution dicts ([{}] when none occur), or None if the
+    assignments cannot be enumerated in exact
+    radical-free-of-transcendentals form (a root of unity of high
+    order whose cos/sin do not evaluate, or too many combinations) --
+    the caller must then reject the candidate, since the per-branch
+    check cannot be run.  Constants absent from ``exprs`` need no
+    assignment: substituting them cannot change the checked
+    expressions.
     """
     from itertools import product
 
     from sympy.core.numbers import pi
 
-    consts = DE.sign_consts or []
+    consts = [sc for sc in DE.sign_consts or []
+              if any(e.has(sc[0]) for e in exprs)]
     values = []
     for _, _, q in consts:
         vals = []
@@ -1865,14 +1873,14 @@ def _nontrans_accept(elem, g2, i, a, d, DE, z):
         residue_reduce_derivation(g2, DE, z) - i)
     if total != 0:
         return False
-    assignments = _nontrans_sign_assignments(DE)
-    if assignments is None:
-        return False
     checked = [elem, i]
     for qz, sz in g2:
         checked.extend([qz.as_expr(), sz.as_expr()])
-    for e in checked:
-        den = cancel(e).as_numer_denom()[1]
+    dens = [cancel(e).as_numer_denom()[1] for e in checked]
+    assignments = _nontrans_sign_assignments(DE, dens)
+    if assignments is None:
+        return False
+    for den in dens:
         for sig in assignments:
             if _nontrans_is_kernel(den.subs(sig), DE):
                 return False
@@ -2424,12 +2432,19 @@ def risch_integrate(f, x, extension=None, handle_first='log',
                 # ratint() over QQ(s) can divide by s-polynomials that
                 # vanish at attained values.  So vet the total result
                 # under every possible assignment of the ratio
-                # constants before substituting them.
-                assignments = _nontrans_sign_assignments(DE)
+                # constants before substituting them.  Only constants
+                # in positions that can turn singular need assigning:
+                # the denominator, function arguments (log(0) is zoo),
+                # and exponents -- a constant occurring purely as a
+                # numerator polynomial factor cannot produce one.
+                den = cancel(result).as_numer_denom()[1]
+                risky = [den]
+                risky.extend(arg for fn in result.atoms(Function)
+                             for arg in fn.args)
+                risky.extend(p.exp for p in result.atoms(Pow))
+                assignments = _nontrans_sign_assignments(DE, risky)
                 if assignments is None or any(
-                        _nontrans_is_kernel(
-                            cancel(result).as_numer_denom()[1].subs(sig),
-                            DE) or
+                        _nontrans_is_kernel(den.subs(sig), DE) or
                         result.subs(sig).has(S.NaN, oo, zoo)
                         for sig in assignments):
                     if not separate_integral:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -44,6 +44,7 @@ from sympy.functions.elementary.trigonometric import (atan, sin, cos,
     tan, acot, cot, asin, acos)
 from .integrals import integrate, Integral
 from .heurisch import _symbols
+from .rationaltools import log_to_atan, _roots_real_complex
 from sympy.polys.polyerrors import PolynomialError
 from sympy.polys.polytools import (real_roots, cancel, Poly, gcd,
     reduced)
@@ -1363,11 +1364,6 @@ def residue_reduce(a, d, DE, z=None, invert=True):
     This is ``ResidueReduce`` (the Lazard-Rioboo-Trager version) from
     Section 5.6 of Bronstein's book.
     """
-    # TODO: Use log_to_atan() from rationaltools.py
-    # If r = residue_reduce(...), then the logarithmic part is given by:
-    # sum([RootSum(a[0].as_poly(z), lambda i: i*log(a[1].as_expr()).subs(z,
-    # i)).subs(t, log(x)) for a in r[0]])
-
     z = z or Dummy('z')
     a, d = a.cancel(d, include=True)
     a, d = a.to_field().mul_ground(1/d.LC()), d.to_field().mul_ground(1/d.LC())
@@ -1430,16 +1426,82 @@ def residue_reduce(a, d, DE, z=None, invert=True):
     return (H, b)
 
 
+def residue_reduce_log_to_real(s, h, DE, z):
+    """
+    Try to express a term returned by residue_reduce() using real functions.
+
+    Explanation
+    ===========
+
+    Given a pair ``(s, h)`` from the tuple returned by residue_reduce(),
+    return a sum of real logarithms and arc-tangents of polynomials in
+    ``DE.t`` whose derivative equals that of RootSum(s, Lambda(z,
+    z*log(h))), or None if s has no complex roots or if its roots cannot
+    all be computed explicitly.  The rewriting is only valid when the
+    generators of the differential extension represent real functions.
+
+    This is Rioboo's ``LogToReal`` from Section 2.8 of Bronstein's book,
+    applied to the output of ``ResidueReduce``: the roots of s are the
+    residues, playing the part of the roots of the Rothstein-Trager
+    resultant in Chapter 2, and h plays the part of the resultant's
+    remainder.
+    """
+    from sympy.simplify.radsimp import collect
+
+    if s.as_expr().has(I) or h.as_expr().has(I) or any(
+            f(DE.x).has(I) for f in DE.Tfuncs):
+        return None
+
+    rs = _roots_real_complex(s)
+    if rs is None:
+        return None
+    reals, complexes = rs
+    if not complexes:
+        return None
+
+    u, v = Dummy('u'), Dummy('v')
+    H = h.as_expr().xreplace({z: u + I*v}).expand()
+    H_map = collect(H, I, evaluate=False)
+    a, b = H_map.get(S.One, S.Zero), H_map.get(I, S.Zero)
+
+    result = S.Zero
+    for r_u, r_v in complexes:
+        A = Poly(a.xreplace({u: r_u, v: r_v}), DE.t)
+        B = Poly(b.xreplace({u: r_u, v: r_v}), DE.t)
+
+        result += r_u*log((A**2 + B**2).as_expr())
+        if not (A.is_zero or B.is_zero):
+            # If A or B is zero, this term is a constant.
+            result += r_v*log_to_atan(A, B)
+
+    for r in reals:
+        result += r*log(h.as_expr().xreplace({z: r}))
+
+    return result
+
+
 def residue_reduce_to_basic(H, DE, z):
     """
     Converts the tuple returned by residue_reduce() into a Basic expression.
+
+    Terms whose residues come in complex-conjugate pairs are rewritten as
+    real logarithms and arc-tangents using residue_reduce_log_to_real();
+    the remaining terms are returned as RootSums.
     """
     # TODO: check what Lambda does with RootOf
     i = Dummy('i')
     s = list(zip(reversed(DE.T), reversed([f(DE.x) for f in DE.Tfuncs])))
 
-    return sum(RootSum(a[0].as_poly(z), Lambda(i, i*log(a[1].as_expr()).subs(
-        {z: i}).subs(s))) for a in H)
+    result = S.Zero
+    for a in H:
+        real = residue_reduce_log_to_real(a[0].as_poly(z), a[1], DE, z)
+        if real is not None:
+            result += real.subs(s)
+        else:
+            result += RootSum(a[0].as_poly(z), Lambda(i, i*log(
+                a[1].as_expr()).subs({z: i}).subs(s)))
+
+    return result
 
 
 def residue_reduce_derivation(H, DE, z):

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -44,7 +44,7 @@ from sympy.functions.elementary.trigonometric import (atan, sin, cos,
     tan, acot, cot, asin, acos)
 from .integrals import integrate, Integral
 from .heurisch import _symbols
-from .rationaltools import log_to_atan, _roots_real_complex
+from .rationaltools import log_to_real
 from sympy.polys.polyerrors import PolynomialError
 from sympy.polys.polytools import (real_roots, cancel, Poly, gcd,
     reduced)
@@ -1426,75 +1426,28 @@ def residue_reduce(a, d, DE, z=None, invert=True):
     return (H, b)
 
 
-def residue_reduce_log_to_real(s, h, DE, z):
-    """
-    Try to express a term returned by residue_reduce() using real functions.
-
-    Explanation
-    ===========
-
-    Given a pair ``(s, h)`` from the tuple returned by residue_reduce(),
-    return a sum of real logarithms and arc-tangents of polynomials in
-    ``DE.t`` whose derivative equals that of RootSum(s, Lambda(z,
-    z*log(h))), or None if s has no complex roots or if its roots cannot
-    all be computed explicitly.  The rewriting is only valid when the
-    generators of the differential extension represent real functions.
-
-    This is Rioboo's ``LogToReal`` from Section 2.8 of Bronstein's book,
-    applied to the output of ``ResidueReduce``: the roots of s are the
-    residues, playing the part of the roots of the Rothstein-Trager
-    resultant in Chapter 2, and h plays the part of the resultant's
-    remainder.
-    """
-    from sympy.simplify.radsimp import collect
-
-    if s.as_expr().has(I) or h.as_expr().has(I) or any(
-            f(DE.x).has(I) for f in DE.Tfuncs):
-        return None
-
-    rs = _roots_real_complex(s)
-    if rs is None:
-        return None
-    reals, complexes = rs
-    if not complexes:
-        return None
-
-    u, v = Dummy('u'), Dummy('v')
-    H = h.as_expr().xreplace({z: u + I*v}).expand()
-    H_map = collect(H, I, evaluate=False)
-    a, b = H_map.get(S.One, S.Zero), H_map.get(I, S.Zero)
-
-    result = S.Zero
-    for r_u, r_v in complexes:
-        A = Poly(a.xreplace({u: r_u, v: r_v}), DE.t)
-        B = Poly(b.xreplace({u: r_u, v: r_v}), DE.t)
-
-        result += r_u*log((A**2 + B**2).as_expr())
-        if not (A.is_zero or B.is_zero):
-            # If A or B is zero, this term is a constant.
-            result += r_v*log_to_atan(A, B)
-
-    for r in reals:
-        result += r*log(h.as_expr().xreplace({z: r}))
-
-    return result
-
-
 def residue_reduce_to_basic(H, DE, z):
     """
     Converts the tuple returned by residue_reduce() into a Basic expression.
 
-    Terms whose residues come in complex-conjugate pairs are rewritten as
-    real logarithms and arc-tangents using residue_reduce_log_to_real();
-    the remaining terms are returned as RootSums.
+    Terms whose residues can all be computed explicitly are rewritten as
+    real logarithms and arc-tangents using log_to_real() (Rioboo's
+    algorithm from Section 2.8 of Bronstein's book, with the roots of
+    each s_i as the residues and S_i in place of the Rothstein-Trager
+    resultant's remainder); the remaining terms are returned as RootSums.
+    log_to_real() is only valid over a real field, so it is not used when
+    I appears in a term or in the extension tower.
     """
     # TODO: check what Lambda does with RootOf
     i = Dummy('i')
     s = list(zip(reversed(DE.T), reversed([f(DE.x) for f in DE.Tfuncs])))
+    real_tower = not any(f(DE.x).has(I) for f in DE.Tfuncs)
 
     result = S.Zero
     for a in H:
-        real = residue_reduce_log_to_real(a[0].as_poly(z), a[1], DE, z)
+        real = None
+        if real_tower and not (a[0].as_expr().has(I) or a[1].as_expr().has(I)):
+            real = log_to_real(a[1], a[0].as_poly(z), DE.t, z)
         if real is not None:
             result += real.subs(s)
         else:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -46,7 +46,7 @@ from .integrals import integrate, Integral
 from .heurisch import _symbols
 from .rationaltools import log_to_real
 from sympy.polys.polyerrors import PolynomialError
-from sympy.polys.polytools import (real_roots, cancel, Poly, gcd,
+from sympy.polys.polytools import (real_roots, cancel, Poly, gcd, rem,
     reduced)
 from sympy.polys.rootoftools import RootSum
 from sympy.utilities.iterables import numbered_symbols
@@ -1549,6 +1549,107 @@ def residue_reduce_derivation(H, DE, z):
         DE).as_expr().subs(z, i)/a[1].as_expr().subs(z, i))) for a in H))
 
 
+def _nontrans_power_relations(DE):
+    """
+    The known algebraic relations of a non-transcendental tower.
+
+    Returns (t, rel) pairs, ordered by tower level, where rel == 0 in
+    the actual (evaluated) tower and rel is polynomial in t with its
+    leading coefficient free of t and of every higher generator.  Only
+    generators of the form t == exp(c*tj) with c == p/q a non-integer
+    Rational and tj == log(u) are recognized; such a t represents
+    u**(p/q) and satisfies t**q == u**p.
+
+    TODO: relations among *several* radicals are not captured -- branch
+    choices like t1*t2 == 1 for t1 == exp(t0/2), t2 == exp(-t0/2), or
+    radicals with dependent arguments.  The kernel test below is then
+    incomplete (it can miss actual zeros), though still sound.
+    """
+    rels = []
+    for i, ext in enumerate(DE.exts, 1):
+        if ext != 'exp':
+            continue
+        coeff, rest = DE.extargs[i - 1].as_coeff_Mul()
+        if (coeff.is_Rational and not coeff.is_Integer and rest in DE.T[1:]
+                and DE.exts[DE.T.index(rest) - 1] == 'log'):
+            u = DE.extargs[DE.T.index(rest) - 1]
+            p, q = coeff.p, coeff.q
+            if p >= 0:
+                rel = DE.T[i]**q - u**p
+            else:
+                rel = DE.T[i]**q*u**-p - 1
+            rels.append((DE.T[i], rel))
+    return rels
+
+
+def _nontrans_is_kernel(e, DE):
+    """
+    Decide whether e, polynomial in the tower generators, evaluates to
+    zero in a non-transcendental tower (i.e. lies in the kernel of the
+    evaluation map), by reducing modulo the recognized power relations,
+    highest generator first.  The relations are triangular (each
+    involves only its own and lower generators), so this terminates,
+    and e evaluates to zero iff the reduced form is zero -- exactly, if
+    the quotient by the recognized relations is an integral domain
+    (always true for a single radical), and soundly-but-incompletely
+    otherwise (see _nontrans_power_relations()).
+    """
+    e = cancel(e)
+    for t, r in reversed(_nontrans_power_relations(DE)):
+        if e.has(t):
+            e = rem(e, r, t)
+    return cancel(e) == 0
+
+
+def _nontrans_accept(elem, g2, i, a, d, DE, z):
+    """
+    Acceptance filter for a candidate result of integrate_primitive()
+    or integrate_hyperexponential() over a non-transcendental tower:
+
+    1. a/d == D(elem) + D(residue part) + i must hold as a formal
+       rational-function identity in the tower generators, decided by
+       cancel() -- pure rational arithmetic, no algebraic
+       simplification.
+    2. The denominators of elem and i must not evaluate to zero under
+       the tower's algebraic relations (_nontrans_is_kernel()).
+
+    Why this suffices: the machinery computes in the formal field
+    Q(x, t0, ..., tn), where the generators really are transcendental,
+    and the actual functions are the image of an evaluation map that is
+    defined only on elements whose denominators avoid the kernel of the
+    tower's relations (t**2 - x for t representing sqrt(x)).  A formal
+    identity between elements on which the evaluation is defined pushes
+    forward to an identity of functions, since the evaluation commutes
+    with the derivation by construction.  So a candidate passing both
+    checks is a genuine antiderivative relation, no matter what invalid
+    transcendence assumptions were used to find it.  The checks cannot
+    vouch for *negative* conclusions (nonelementary proofs), which is
+    why those are separately degraded to unevaluated Integrals.
+
+    Check 1 catches machinery bugs surfacing under the broken
+    hypotheses; check 2 catches the subtler failure mode: the formal
+    field has genuinely new constants (D(t**2/x) == 0 for t
+    representing sqrt(x)), so internal divisions by formally-nonzero
+    constants can smuggle kernel factors (t**2/x - 1, which evaluates
+    to zero) into denominators while keeping the formal identity
+    intact.
+
+    TODO: the arguments of the residue-part logarithms are divisors of
+    d for the log terms produced by residue_reduce(), hence kernel-free
+    whenever d is, but the z-dependent coefficients inside RootSum
+    terms are not checked here.
+    """
+    lhs = cancel(a.as_expr()/d.as_expr())
+    total = cancel(lhs - derivation(elem, DE, basic=True) -
+        residue_reduce_derivation(g2, DE, z) - i)
+    if total != 0:
+        return False
+    for e in (elem, i):
+        if _nontrans_is_kernel(cancel(e).as_numer_denom()[1], DE):
+            return False
+    return True
+
+
 def integrate_primitive_polynomial(p, DE):
     """
     Integration of primitive polynomials.
@@ -1627,6 +1728,10 @@ def integrate_primitive(a, d, DE, z=None):
         i = cancel(a.as_expr()/d.as_expr() - (g1[1]*derivation(g1[0], DE) -
             g1[0]*derivation(g1[1], DE)).as_expr()/(g1[1]**2).as_expr() -
             residue_reduce_derivation(g2, DE, z))
+        if not DE.transcendental and not _nontrans_accept(
+                g1[0].as_expr()/g1[1].as_expr(), g2, i, a, d, DE, z):
+            return (S.Zero, Integral(cancel(
+                (a.as_expr()/d.as_expr()).subs(s)), DE.x), False)
         if DE.transcendental:
             i = NonElementaryIntegral(cancel(i).subs(s), DE.x)
         else:
@@ -1640,6 +1745,11 @@ def integrate_primitive(a, d, DE, z=None):
     p = p.as_poly(DE.t)
 
     q, i, b = integrate_primitive_polynomial(p, DE)
+    if not DE.transcendental and not _nontrans_accept(
+            g1[0].as_expr()/g1[1].as_expr() + q.as_expr(), g2, i.as_expr(),
+            a, d, DE, z):
+        return (S.Zero, Integral(cancel(
+            (a.as_expr()/d.as_expr()).subs(s)), DE.x), False)
 
     ret = ((g1[0].as_expr()/g1[1].as_expr() + q.as_expr()).subs(s) +
         residue_reduce_to_basic(g2, DE, z))
@@ -1749,6 +1859,10 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
         i = cancel(a.as_expr()/d.as_expr() - (g1[1]*derivation(g1[0], DE) -
             g1[0]*derivation(g1[1], DE)).as_expr()/(g1[1]**2).as_expr() -
             residue_reduce_derivation(g2, DE, z))
+        if not DE.transcendental and not _nontrans_accept(
+                g1[0].as_expr()/g1[1].as_expr(), g2, i, a, d, DE, z):
+            return (S.Zero, Integral(cancel(
+                (a.as_expr()/d.as_expr()).subs(s)), DE.x), False)
         if DE.transcendental:
             i = NonElementaryIntegral(cancel(i.subs(s)), DE.x)
         else:
@@ -1763,6 +1877,18 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
     pp = as_poly_1t(p, DE.t, z)
 
     qa, qd, b = integrate_hyperexponential_polynomial(pp, DE, z)
+
+    if not DE.transcendental:
+        if b:
+            it = pp.nth(0, 0)
+        else:
+            # Same residual as in the not-b branch below.
+            it = p - (qd*derivation(qa, DE) - qa*derivation(qd, DE)
+                ).as_expr()/(qd**2).as_expr()
+        if not _nontrans_accept(g1[0].as_expr()/g1[1].as_expr() +
+                qa.as_expr()/qd.as_expr(), g2, it, a, d, DE, z):
+            return (S.Zero, Integral(cancel(
+                (a.as_expr()/d.as_expr()).subs(s)), DE.x), False)
 
     i = pp.nth(0, 0)
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -2248,8 +2248,14 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
 
         # XXX: Does qd = 0 always necessarily correspond to the exponential
         # equaling 1?
+        cond = Ne(qds, 0)
         if DE.transcendental:
             fallback = integrate((p - i).subs(DE.t, 1).subs(s), DE.x)
+        elif cond is S.true:
+            # the denominator provably cannot vanish; there is no
+            # degenerate branch
+            ret += qas/qds
+            cond = None
         else:
             # t == 1 encodes "the exponential degenerates to 1", which
             # has no meaning for an algebraic generator (t representing
@@ -2271,10 +2277,11 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
             # Integral(a/d - i) plus the continuing constant's integral
             fallback = Integral(cancel((a.as_expr()/d.as_expr()
                 - resid).subs(s)), DE.x) - ret
-        ret += Piecewise(
-                (qas/qds, Ne(qds, 0)),
-                (fallback, True)
-            )
+        if cond is not None:
+            ret += Piecewise(
+                    (qas/qds, cond),
+                    (fallback, True)
+                )
     else:
         ret += qas/qds
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -150,7 +150,13 @@ class DifferentialExtension:
     - d: The top level extension derivation, as defined by the current
       derivation (see level below).
     - case: The string representation of the case of self.d.
-    - transcendental: Whether all the extensions in the tower are transcendental
+    - transcendental: Whether the tower is proven purely transcendental:
+      every extension is transcendental and every structure-theorem
+      question asked about the tower was decided.  When False -- because
+      an extension is algebraic, or because an undecided question was
+      answered "no" without proof -- nonexistence answers cannot be
+      trusted, so nonelementary conclusions are degraded to unevaluated
+      Integrals and solved results are independently vetted.
     (Note that self.T and self.D will always contain the complete extension,
     regardless of the level.  Therefore, you should ALWAYS use DE.t and DE.d
     instead of DE.T[-1] and DE.D[-1].  If you want to have a list of the

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -2221,19 +2221,22 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
 
     qa, qd, b = integrate_hyperexponential_polynomial(pp, DE, z)
 
+    i = pp.nth(0, 0)
+    if b:
+        resid = i
+    else:
+        # the residual that the not-b branch below will return.  The
+        # arithmetic is done on expressions: as Polys, qa and qd can
+        # disagree about whether the residue dummy z belongs to the
+        # ground domain, which fails to unify.
+        resid = p - (qd.as_expr()*derivation(qa, DE).as_expr() -
+            qa.as_expr()*derivation(qd, DE).as_expr())/qd.as_expr()**2
+
     if not DE.transcendental:
-        if b:
-            it = pp.nth(0, 0)
-        else:
-            # Same residual as in the not-b branch below.
-            it = p - (qd*derivation(qa, DE) - qa*derivation(qd, DE)
-                ).as_expr()/(qd**2).as_expr()
         if not _nontrans_accept(g1[0].as_expr()/g1[1].as_expr() +
-                qa.as_expr()/qd.as_expr(), g2, it, a, d, DE, z):
+                qa.as_expr()/qd.as_expr(), g2, resid, a, d, DE, z):
             return (S.Zero, Integral(cancel(
                 (a.as_expr()/d.as_expr()).subs(s)), DE.x), False)
-
-    i = pp.nth(0, 0)
 
     ret = ((g1[0].as_expr()/g1[1].as_expr()).subs(s) \
         + residue_reduce_to_basic(g2, DE, z))
@@ -2250,12 +2253,16 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
         else:
             # t == 1 encodes "the exponential degenerates to 1", which
             # has no meaning for an algebraic generator (t representing
-            # sqrt(u) does not become 1 when a parameter vanishes);
-            # leave the degenerate branch unevaluated.  Only the piece
-            # whose generic antiderivative is qas/qds goes in -- the
-            # other components of the answer and the residual are
-            # accounted for by the caller
-            fallback = Integral(cancel((p - i).subs(s)), DE.x)
+            # sqrt(u) does not become 1 when a parameter vanishes).  Nor
+            # can the degenerate branch replace only the qas/qds piece:
+            # the generic decomposition itself divides by qds, so every
+            # piece of it may be invalid there.  Since the caller still
+            # adds ret and keeps integrating the residual, the branch
+            # is the unevaluated rest of this level minus ret, so that
+            # the assembled degenerate value is exactly
+            # Integral(a/d - resid) + (the residual's integral).
+            fallback = Integral(cancel((a.as_expr()/d.as_expr()
+                - resid).subs(s)), DE.x) - ret
         ret += Piecewise(
                 (qas/qds, Ne(qds, 0)),
                 (fallback, True)
@@ -2264,12 +2271,10 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
         ret += qas/qds
 
     if not b:
-        i = p - (qd*derivation(qa, DE) - qa*derivation(qd, DE)).as_expr()/\
-            (qd**2).as_expr()
         if DE.transcendental:
-            i = NonElementaryIntegral(cancel(i).subs(s), DE.x)
+            i = NonElementaryIntegral(cancel(resid).subs(s), DE.x)
         else:
-            i = Integral(cancel(i).subs(s), DE.x)
+            i = Integral(cancel(resid).subs(s), DE.x)
     return (ret, i, b)
 
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -212,6 +212,12 @@ class DifferentialExtension:
                                  "the extension flag to DifferentialExtension.")
             for attr in extension:
                 setattr(self, attr, extension[attr])
+            if 'transcendental' not in extension:
+                # A manual extension may declare transcendental=False to
+                # mark an algebraic tower (e.g. t representing x**(S(1)/2)
+                # as exp(log(x)/2)); nonelementary conclusions are then
+                # invalid and are degraded to unevaluated Integrals.
+                self.transcendental = True
 
             self._auto_attrs()
 
@@ -411,7 +417,13 @@ class DifferentialExtension:
                     # rather prove that it has no elementary integral)
                     # without first manually rewriting it as exp(x*log(x))
                     self.newf = self.newf.xreplace({old: new})
-                    self.backsubs += [(new, old)]
+                    if new != old:
+                        # new == old happens when exp auto-simplifies the
+                        # rewritten form straight back (e.g.
+                        # exp(log(x)/2) -> sqrt(x) on the first pass,
+                        # before log(x) is a tower symbol); an identity
+                        # pair would just pollute backsubs.
+                        self.backsubs += [(new, old)]
                     log_new_extension = self._log_part([log(i.base)])
                     exps = update_sets(exps, self.newf.atoms(exp), lambda i:
                                        i.exp.is_rational_function(*self.T) and i.exp.has(*self.T))
@@ -435,7 +447,8 @@ class DifferentialExtension:
                 # i in numpows
                 newterm = new
                 # TODO: Just put it in self.Tfuncs
-            self.backsubs.append((new, old))
+            if new != old:
+                self.backsubs.append((new, old))
             self.newf = self.newf.xreplace({old: newterm})
             exps.append(newterm)
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -167,9 +167,9 @@ class DifferentialExtension:
     # of the class easily (the memory use doesn't matter too much, since we
     # only create one DifferentialExtension per integration).  Also, it's nice
     # to have a safeguard when debugging.
-    __slots__ = ('f', 'x', 'T', 'D', 'fa', 'fd', 'Tfuncs', 'backsubs',
-        'exts', 'extargs', 'cases', 'case', 't', 'd', 'newf', 'level',
-        'ts', 'dummy')
+    __slots__ = ('f', 'origf', 'x', 'T', 'D', 'fa', 'fd', 'Tfuncs',
+        'backsubs', 'exts', 'extargs', 'cases', 'case', 't', 'd', 'newf',
+        'level', 'ts', 'dummy')
 
     def __init__(self, f=None, x=None, handle_first='log', dummy=False, extension=None, rewrite_complex=None):
         """
@@ -224,8 +224,10 @@ class DifferentialExtension:
                 str(handle_first))
 
         # f will be the original function, self.f might change if we reset
-        # (e.g., we pull out a constant from an exponential)
+        # (e.g., we pull out a constant from an exponential); origf always
+        # stays the expression the user handed in
         self.f = f
+        self.origf = f
         self.x = x
         # setting the default value 'dummy'
         self.dummy = dummy
@@ -322,7 +324,19 @@ class DifferentialExtension:
 
         ratpows_repl = [
             (i, i.base.base**(i.exp*i.base.exp)) for i in ratpows]
-        self.backsubs += [(j, i) for i, j in ratpows_repl]
+        # exp(u)**q == exp(q*u) is exact for integer q, but for
+        # fractional q the left side is a principal root that differs
+        # from exp(q*u) by a locally constant root of unity off the real
+        # line.  Radicals of exponentials also arise internally (the
+        # radical case of _exp_part substitutes t**(p/n) and restarts),
+        # and rewriting those into the answer turned correctly
+        # integrated results into non-antiderivatives at complex points.
+        # So the notation is only restored where it is the user's own:
+        # a fractional power is put back only if it appears in the
+        # original integrand.
+        self.backsubs += [(j, i) for i, j in ratpows_repl
+                          if i.exp.is_Integer or
+                          (self.origf is not None and self.origf.has(i))]
         self.newf = self.newf.xreplace(dict(ratpows_repl))
 
         # To make the process deterministic, the args are sorted

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -46,7 +46,7 @@ from .integrals import integrate, Integral
 from .heurisch import _symbols
 from .rationaltools import log_to_real
 from sympy.polys.polyerrors import PolynomialError
-from sympy.polys.polytools import (real_roots, cancel, Poly, gcd, rem,
+from sympy.polys.polytools import (real_roots, cancel, Poly, gcd, rem, factor,
     reduced)
 from sympy.polys.rootoftools import RootSum
 from sympy.utilities.iterables import numbered_symbols
@@ -369,6 +369,24 @@ class DifferentialExtension:
             else:
                 subs_map[i] = j
         self.newf = self.newf.xreplace(subs_map)
+
+        if self.algebraic:
+            # Factor radicands and distribute the fractional power over
+            # the factors, so that content like a perfect square does
+            # not become a spurious tower generator.  This chooses
+            # principal branches, like the exp-log representation of
+            # the radicals themselves.
+            reps = {}
+            for i in self.newf.atoms(Pow):
+                if (i.exp.is_Rational and not i.exp.is_Integer and
+                        not i.base.is_Symbol and not isinstance(i.base, exp)):
+                    bf = factor(i.base)
+                    if bf != i.base and isinstance(bf, (Mul, Pow)):
+                        reps[i] = Mul(*[Pow(b, e*i.exp) for b, e in
+                                        bf.as_powers_dict().items()])
+            if reps:
+                self.backsubs += [(v, k) for k, v in reps.items()]
+                self.newf = self.newf.xreplace(reps)
 
         # To make the process deterministic, the args are sorted
         # so that functions with smaller op-counts are processed first.

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1848,8 +1848,11 @@ def _nontrans_vet(result, DE):
     """
     den = cancel(result).as_numer_denom()[1]
     risky = [den]
+    # entire functions: no finite argument is singular (tan, cot,
+    # coth have poles and atan is singular at +-I, so they stay risky)
+    entire = (exp, sin, cos, sinh, cosh)
     for fn in result.atoms(Function):
-        if isinstance(fn, exp):
+        if isinstance(fn, entire):
             risky.extend(cancel(arg).as_numer_denom()[1]
                          for arg in fn.args)
         else:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -493,6 +493,22 @@ class DifferentialExtension:
                     continue
                 ans, u, const = A
                 newterm = exp(i.exp*(log(const) + u))
+                if i.exp.is_Rational and not i.exp.is_Integer:
+                    # log(base) can differ from log(const) + u by
+                    # 2*pi*I times an integer winding (log(-1) above is
+                    # the principal choice), so this rewrite needs the
+                    # same branch-ratio correction as the radicand
+                    # split: e.g. it maps sqrt(-w) to I*sqrt(w), which
+                    # has the wrong sign where w < 0
+                    images = dict(zip(reversed(self.T),
+                        reversed([f(self.x) for f in self.Tfuncs])))
+                    ratio = i/newterm.xreplace(images)
+                    if ratio != 1:
+                        s = Dummy('s%d' % len(self.sign_consts))
+                        self.sign_consts.append((s, ratio, i.exp.q))
+                        self.backsubs.append((s, ratio))
+                        self.transcendental = False
+                        newterm = s*newterm
                 # Under the current implementation, exp kills terms
                 # only if they are of the form a*log(x), where a is a
                 # Number.  This case should have already been killed by the
@@ -515,6 +531,10 @@ class DifferentialExtension:
             self.newf = self.newf.xreplace({old: newterm})
             if isinstance(newterm, exp):
                 exps.append(newterm)
+            elif isinstance(newterm, Mul):
+                # a branch-ratio constant may ride along; only the exp
+                # factor belongs in the worklist
+                exps.extend(a for a in newterm.args if isinstance(a, exp))
 
         return exps, pows, numpows, sympows, log_new_extension
 
@@ -1694,8 +1714,10 @@ def _nontrans_branch_corrections(result, DE):
     from sympy.polys.polyerrors import CoercionFailed, DomainError
     pts = set()
     for _, R, _ in DE.sign_consts:
-        for p in R.atoms(Pow):
-            for b in p.base.as_numer_denom():
+        pieces = [p.base for p in R.atoms(Pow)]
+        pieces.extend(lg.args[0] for lg in R.atoms(log))
+        for piece in pieces:
+            for b in piece.as_numer_denom():
                 if not b.has(x):
                     continue
                 if b.free_symbols != {x}:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -31,7 +31,7 @@ from sympy.core.add import Add
 from sympy.core.function import Lambda
 from sympy.core.mul import Mul
 from sympy.core.intfunc import ilcm
-from sympy.core.numbers import I, Rational
+from sympy.core.numbers import I, Rational, oo, zoo
 from sympy.core.power import Pow
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
@@ -313,6 +313,8 @@ class DifferentialExtension:
                     self.reset()
                     self.sign_consts = sign_consts
                     self.backsubs += [(s, R) for s, R, _ in sign_consts]
+                    if sign_consts:
+                        self.transcendental = False
                     exp_new_extension = True
                     continue
 
@@ -2416,6 +2418,23 @@ def risch_integrate(f, x, extension=None, handle_first='log',
             result = result.subs([(o, n) for o, n in DE.backsubs
                                   if o not in sign_symbols])
             if sign_symbols:
+                # The acceptance filter runs per level, but the base
+                # case (everything collapsed to a rational function of
+                # x and the ratio constants) never reaches it, and
+                # ratint() over QQ(s) can divide by s-polynomials that
+                # vanish at attained values.  So vet the total result
+                # under every possible assignment of the ratio
+                # constants before substituting them.
+                assignments = _nontrans_sign_assignments(DE)
+                if assignments is None or any(
+                        _nontrans_is_kernel(
+                            cancel(result).as_numer_denom()[1].subs(sig),
+                            DE) or
+                        result.subs(sig).has(S.NaN, oo, zoo)
+                        for sig in assignments):
+                    if not separate_integral:
+                        return Integral(f, x)
+                    return (S.Zero, Integral(f, x))
                 if i == 0:
                     result = _nontrans_branch_corrections(result, DE)
                 else:

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -2525,10 +2525,14 @@ def risch_integrate(f, x, extension=None, handle_first='log',
                     i = NonElementaryIntegral(i.function.subs(DE.backsubs), i.limits)
                 else:
                     i = Integral(i.function.subs(DE.backsubs), *i.limits)
+            leaked = result.free_symbols
+            if isinstance(i, Integral):
+                leaked = leaked | i.function.free_symbols
             if not DE.transcendental and \
-                    result.free_symbols - f.free_symbols - {x}:
+                    leaked - f.free_symbols - {x}:
                 # an internal symbol survived the back-substitutions (a
-                # tower Dummy leaked into a residue term, say); the
+                # tower Dummy leaked into a residue term, say), in the
+                # elementary part or in the residual integrand; the
                 # result is unusable and must not be returned
                 if not separate_integral:
                     return Integral(f, x)

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -31,7 +31,7 @@ from sympy.core.add import Add
 from sympy.core.function import Lambda
 from sympy.core.mul import Mul
 from sympy.core.intfunc import ilcm
-from sympy.core.numbers import Float, I, Rational
+from sympy.core.numbers import I, Rational
 from sympy.core.power import Pow
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
@@ -300,10 +300,19 @@ class DifferentialExtension:
                     # first be folded back into newf, or the Dummy leaks
                     # into the final result as a free symbol and the
                     # original notation is never re-encountered by the
-                    # rebuild.
-                    self.newf = self.newf.subs(self.backsubs)
+                    # rebuild.  The branch-ratio constants are the
+                    # exception: their Dummys stay in newf as opaque
+                    # constants, so their mapping must instead survive
+                    # the reset and be re-recorded.
+                    sign_consts = self.sign_consts
+                    ratio_dummies = {s for s, _, _ in sign_consts}
+                    self.newf = self.newf.subs(
+                        [(a, b) for a, b in self.backsubs
+                         if a not in ratio_dummies])
                     self.f = self.newf
                     self.reset()
+                    self.sign_consts = sign_consts
+                    self.backsubs += [(s, R) for s, R, _ in sign_consts]
                     exp_new_extension = True
                     continue
 
@@ -404,6 +413,13 @@ class DifferentialExtension:
                             self.sign_consts.append((s, i/split, i.exp.q))
                             self.backsubs.append((s, i/split))
                             reps[i] = s*split
+                            # results are only generic in s (it is not a
+                            # transcendental constant but a root of
+                            # unity), so even if every radical collapses
+                            # to integer powers the candidates need the
+                            # acceptance filter and nonelementary
+                            # conclusions are invalid
+                            self.transcendental = False
             if reps:
                 self.newf = self.newf.xreplace(reps)
 
@@ -1644,16 +1660,21 @@ def _nontrans_branch_corrections(result, DE):
     jump by a constant where the ratio changes value (the real roots
     and poles of the radicand factors).  Following Jeffrey, Labahn,
     von Mohrenschildt & Rich (Theorem 5), subtracting
-    J*sign(x - r) with J == (G(r+) - G(r-))/2 at each such breakpoint
-    r restores continuity, extending the answer to Jeffrey's domain of
-    maximum extent.  The corrections are locally constant, so they
-    never affect the derivative; every step here is therefore free to
-    give up (unlocatable breakpoints, an unrecognizable ratio value, a
-    singular or infinite jump), leaving the plain substitution, which
-    is already correct on each region.
+    J*(x - r)/sqrt((x - r)**2) with J == (G(r+) - G(r-))/2 at each
+    such breakpoint r restores continuity on the real line, extending
+    the answer to Jeffrey's domain of maximum extent.  The correction
+    factor equals sign(x - r) for real x but, unlike sign, is locally
+    constant on the complex plane away from the vertical line
+    Re(x) == r, so the answer stays an antiderivative at complex
+    points too (off that line -- the same status as any branch cut).
+    The corrections are locally constant, so they never affect the
+    derivative; every step here is therefore free to give up
+    (unlocatable breakpoints, an unrecognizable ratio value, a
+    singular or infinite jump, an uncertifiable sampling offset),
+    leaving the plain substitution, which is already correct on each
+    region.
     """
     from sympy.core.numbers import pi
-    from sympy.functions.elementary.complexes import sign
     from sympy.polys.polyroots import roots
 
     x = DE.x
@@ -1680,13 +1701,13 @@ def _nontrans_branch_corrections(result, DE):
                            if r.is_real is True and r.is_comparable)
     if not pts:
         return subbed
-    pts = sorted(pts, key=lambda r: float(r))
+    pts = sorted(pts, key=lambda r: r.evalf(30))
 
     def ratio_at(R, q, pt):
-        # the ratio's value just left/right of a breakpoint, snapped to
+        # the ratio's value at an exact off-breakpoint point, snapped to
         # an exact q-th root of unity (None if it isn't recognizably one)
         try:
-            v = complex(R.subs(x, Float(pt)).evalf(30))
+            v = complex(R.subs(x, pt).evalf(30))
         except (TypeError, ValueError):
             return None
         best = None
@@ -1698,15 +1719,22 @@ def _nontrans_branch_corrections(result, DE):
         return best[0] if best else None
 
     corrections = []
-    for r in pts:
-        gap = min([1.0] + [abs(float(r) - float(s2))
-                           for s2 in pts if s2 != r])
-        d = Rational(int(gap/4 * 2**20) or 1, 2**20)
+    for idx, r in enumerate(pts):
+        # an exactly-certified sampling offset: r -+ d must not cross
+        # the neighboring breakpoints, or the side values are nonlocal
+        prev_ = pts[idx - 1] if idx else None
+        next_ = pts[idx + 1] if idx + 1 < len(pts) else None
+        for d in (Rational(1, 2)**k for k in range(2, 64)):
+            if ((prev_ is None or (r - d - prev_).is_positive) and
+                    (next_ is None or (next_ - r - d).is_positive)):
+                break
+        else:
+            continue
         left, right = {}, {}
         ok = True
         for s, R, q in DE.sign_consts:
-            vl = ratio_at(R, q, float(r) - d)
-            vr_ = ratio_at(R, q, float(r) + d)
+            vl = ratio_at(R, q, r - d)
+            vr_ = ratio_at(R, q, r + d)
             if vl is None or vr_ is None:
                 ok = False
                 break
@@ -1725,7 +1753,7 @@ def _nontrans_branch_corrections(result, DE):
             # one cannot be corrected by a constant.  Leave the jump:
             # the result is still an antiderivative on each region.
             continue
-        corrections.append(J*sign(x - r))
+        corrections.append(J*(x - r)*Pow((x - r)**2, Rational(-1, 2)))
     return subbed - Add(*corrections)
 
 
@@ -1746,6 +1774,39 @@ def _nontrans_is_kernel(e, DE):
         if e.has(t):
             e = rem(e, r, t)
     return cancel(e) == 0
+
+
+def _nontrans_sign_assignments(DE):
+    """
+    Every assignment of the branch-ratio constants to their possible
+    root-of-unity values, as a list of substitution dicts ([{}] when
+    there are none), or None if the assignments cannot be enumerated
+    in exact radical-free-of-transcendentals form (a root of unity of
+    high order whose cos/sin do not evaluate, or too many
+    combinations) -- the caller must then reject the candidate, since
+    the per-branch denominator check cannot be run.
+    """
+    from itertools import product
+
+    from sympy.core.numbers import pi
+
+    consts = DE.sign_consts or []
+    values = []
+    for _, _, q in consts:
+        vals = []
+        for j in range(q):
+            v = (cos(2*pi*Rational(j, q)) + I*sin(2*pi*Rational(j, q)))
+            if v.has(sin, cos, exp):
+                return None
+            vals.append(v)
+        values.append(vals)
+    n = 1
+    for vals in values:
+        n *= len(vals)
+        if n > 64:
+            return None
+    return [dict(zip([s for s, _, _ in consts], combo))
+            for combo in product(*values)]
 
 
 def _nontrans_accept(elem, g2, i, a, d, DE, z):
@@ -1787,18 +1848,32 @@ def _nontrans_accept(elem, g2, i, a, d, DE, z):
     alone cannot show it, since the kernel factors cancel against the
     argument's derivative).  TODO: a logarithm argument that itself
     evaluates to zero is not detected here.
+
+    The branch-ratio constants need more than the generic kernel test:
+    s**q - 1 is reducible, so its quotient has zero divisors, and a
+    denominator like s - 1 is formally nonzero yet the actual ratio
+    equals 1 on whole regions.  So every denominator is additionally
+    checked under every assignment of the ratio constants to their
+    possible root-of-unity values (conservative: assignments the
+    ratios never attain are not excluded, so this can over-reject,
+    never under-reject).
     """
     lhs = cancel(a.as_expr()/d.as_expr())
     total = cancel(lhs - derivation(elem, DE, basic=True) -
         residue_reduce_derivation(g2, DE, z) - i)
     if total != 0:
         return False
+    assignments = _nontrans_sign_assignments(DE)
+    if assignments is None:
+        return False
     checked = [elem, i]
     for qz, sz in g2:
         checked.extend([qz.as_expr(), sz.as_expr()])
     for e in checked:
-        if _nontrans_is_kernel(cancel(e).as_numer_denom()[1], DE):
-            return False
+        den = cancel(e).as_numer_denom()[1]
+        for sig in assignments:
+            if _nontrans_is_kernel(den.subs(sig), DE):
+                return False
     return True
 
 

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -2251,9 +2251,11 @@ def integrate_hyperexponential(a, d, DE, z=None, conds='piecewise'):
             # t == 1 encodes "the exponential degenerates to 1", which
             # has no meaning for an algebraic generator (t representing
             # sqrt(u) does not become 1 when a parameter vanishes);
-            # leave the degenerate branch unevaluated
-            fallback = Integral(cancel(
-                (a.as_expr()/d.as_expr()).subs(s)), DE.x)
+            # leave the degenerate branch unevaluated.  Only the piece
+            # whose generic antiderivative is qas/qds goes in -- the
+            # other components of the answer and the residual are
+            # accounted for by the caller
+            fallback = Integral(cancel((p - i).subs(s)), DE.x)
         ret += Piecewise(
                 (qas/qds, Ne(qds, 0)),
                 (fallback, True)
@@ -2425,7 +2427,7 @@ def risch_integrate(f, x, extension=None, handle_first='log',
     If ``separate_integral`` is ``True``, the result is returned as a tuple (ans, i),
     where the integral is ans + i, ans is elementary, and i is either 0, a
     NonElementaryIntegral, or a plain unevaluated Integral (for radical
-    integrands, where nonelementaryness is not proven).  This is useful if
+    integrands, where nonelementarity is not proven).  This is useful if
     you want to try further integrating the leftover part using other
     algorithms to possibly get a solution in terms of special functions.  It
     is False by default.
@@ -2433,7 +2435,7 @@ def risch_integrate(f, x, extension=None, handle_first='log',
     If ``algebraic`` is ``True`` (the default), the transcendental machinery
     is used to solve integrals involving radicals (internally, by representing
     `x**(1/n)` as ``exp(log(x)/n)``). In this case, an unevaluated
-    ``Integral`` result is not a proof of nonelementaryness. It only means the
+    ``Integral`` result is not a proof of nonelementarity. It only means the
     transcendental algorithms aren't able to handle the radical integrand, and
     the full algebraic Risch algorithm may be required.  With
     ``algebraic=False``, radical integrands raise ``NotImplementedError``.

--- a/sympy/integrals/risch.py
+++ b/sympy/integrals/risch.py
@@ -1642,17 +1642,22 @@ def _nontrans_accept(elem, g2, i, a, d, DE, z):
     to zero) into denominators while keeping the formal identity
     intact.
 
-    TODO: the arguments of the residue-part logarithms are divisors of
-    d for the log terms produced by residue_reduce(), hence kernel-free
-    whenever d is, but the z-dependent coefficients inside RootSum
-    terms are not checked here.
+    The residue terms are checked through the coefficient denominators
+    of their root polynomials and logarithm arguments (a kernel there
+    means an infinite residue or an undefined argument; the derivative
+    alone cannot show it, since the kernel factors cancel against the
+    argument's derivative).  TODO: a logarithm argument that itself
+    evaluates to zero is not detected here.
     """
     lhs = cancel(a.as_expr()/d.as_expr())
     total = cancel(lhs - derivation(elem, DE, basic=True) -
         residue_reduce_derivation(g2, DE, z) - i)
     if total != 0:
         return False
-    for e in (elem, i):
+    checked = [elem, i]
+    for qz, sz in g2:
+        checked.extend([qz.as_expr(), sz.as_expr()])
+    for e in checked:
         if _nontrans_is_kernel(cancel(e).as_numer_denom()[1], DE):
             return False
     return True

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -205,7 +205,6 @@ def test_issue_11845b():
     assert not integrate(exp(-y - x**3), (x, 0, 1)).has(Integral)
 
 
-@XFAIL
 def test_issue_11813():
     assert not integrate((a - x)**Rational(-1, 2)*x, (x, 0, a)).has(Integral)
 

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -206,7 +206,7 @@ def test_issue_11845b():
 
 
 def test_issue_11813():
-    assert not integrate((a - x)**Rational(-1, 2)*x, (x, 0, a)).has(Integral)
+    assert integrate((a - x)**Rational(-1, 2)*x, (x, 0, a)) == 4*a**Rational(3, 2)/3
 
 
 @XFAIL

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -397,7 +397,9 @@ def test_heurisch_issue_26930():
     integrand = x**Rational(4, 3)*log(x)
     anti = 3*x**(S(7)/3)*log(x)/7 - 9*x**(S(7)/3)/49
     assert heurisch(integrand, x) == anti
-    assert integrate(integrand, x) == anti
+    # integrate() reaches this through risch, which returns the same
+    # antiderivative with the radical left outside the Add
+    assert integrate(integrand, x) == x**Rational(4, 3)*(21*x*log(x) - 9*x)/49
     assert integrate(integrand, (x, 0, 1)) == -S(9)/49
 
 

--- a/sympy/integrals/tests/test_heurisch.py
+++ b/sympy/integrals/tests/test_heurisch.py
@@ -397,8 +397,6 @@ def test_heurisch_issue_26930():
     integrand = x**Rational(4, 3)*log(x)
     anti = 3*x**(S(7)/3)*log(x)/7 - 9*x**(S(7)/3)/49
     assert heurisch(integrand, x) == anti
-    # integrate() reaches this through risch, which returns the same
-    # antiderivative with the radical left outside the Add
     assert integrate(integrand, x) == x**Rational(4, 3)*(21*x*log(x) - 9*x)/49
     assert integrate(integrand, (x, 0, 1)) == -S(9)/49
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -929,12 +929,7 @@ def test_doit_integrals():
 
 
 def test_issue_4884():
-    assert integrate(sqrt(x)*(1 + x)) == \
-        Piecewise(
-            (2*sqrt(x)*(x + 1)**2/5 - 2*sqrt(x)*(x + 1)/15 - 4*sqrt(x)/15,
-            Abs(x + 1) > 1),
-            (2*I*sqrt(-x)*(x + 1)**2/5 - 2*I*sqrt(-x)*(x + 1)/15 -
-            4*I*sqrt(-x)/15, True))
+    assert integrate(sqrt(x)*(1 + x)) == sqrt(x)*(6*x**2 + 10*x)/15
     assert integrate(x**x*(1 + log(x))) == x**x
 
 def test_issue_18153():
@@ -1052,9 +1047,7 @@ def test_issue_4403():
     x = Symbol('x', real=True)
     y = Symbol('y', positive=True)
     assert integrate(1/(x**2 + y**2)**S('3/2'), x) == \
-        x/(y**2*sqrt(x**2 + y**2))
-    # If y is real and nonzero, we get x*Abs(y)/(y**3*sqrt(x**2 + y**2)),
-    # which results from sqrt(1 + x**2/y**2) = sqrt(x**2 + y**2)/|y|.
+        (x**3 + x*y**2)/(y**2*(x**2 + y**2)**S('3/2'))
 
 
 def test_issue_4403_2():
@@ -1739,7 +1732,10 @@ def test_issue_2975():
     w = Symbol('w')
     C = Symbol('C')
     y = Symbol('y')
-    assert integrate(1/(y**2+C)**(S(3)/2), (y, -w/2, w/2)) == w/(C**(S(3)/2)*sqrt(1 + w**2/(4*C)))
+    F = (C*w/2 + w**3/8)/(C*(C + w**2/4)**(S(3)/2))
+    assert integrate(1/(y**2+C)**(S(3)/2), (y, -w/2, w/2)) == \
+        Piecewise((F - F.subs(w, -w), (C > -oo) & (C < oo) & Ne(C, 0)),
+                  (w, True))
 
 
 def test_issue_7827():
@@ -2032,7 +2028,8 @@ def test_sqrt_quadratic():
     assert integrate(1/sqrt(3*x**2+4*x+5)) == sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/3
     assert integrate(1/sqrt(-3*x**2+4*x+5)) == sqrt(3)*asin(3*sqrt(19)*(x - S(2)/3)/19)/3
     assert integrate(1/sqrt(3*x**2+4*x-5)) == sqrt(3)*log(6*x + 2*sqrt(3)*sqrt(3*x**2 + 4*x - 5) + 4)/3
-    assert integrate(1/sqrt(4*x**2-4*x+1)) == (x - S.Half)*log(x - S.Half)/(2*sqrt((x - S.Half)**2))
+    assert integrate(1/sqrt(4*x**2-4*x+1)) == \
+        (2*x - 1)*log(2*x - 1)/(2*sqrt(4*x**2 - 4*x + 1))
     assert integrate(1/sqrt(a+b*x+c*x**2), x) == \
         Piecewise((log(b + 2*sqrt(c)*sqrt(a + b*x + c*x**2) + 2*c*x)/sqrt(c), Ne(c, 0) & Ne(a - b**2/(4*c), 0)),
                   ((b/(2*c) + x)*log(b/(2*c) + x)/sqrt(c*(b/(2*c) + x)**2), Ne(c, 0)),
@@ -2150,8 +2147,11 @@ def test_old_issues():
     I1 = integrate(cos(log(x**2))/x)
     assert I1 == sin(log(x**2))/2
     # https://github.com/sympy/sympy/issues/5462
+    # (the historical expectation x/(y**3*sqrt(x**2/y**2 + 1)) has the
+    # wrong sign for y < 0)
     I2 = integrate(1/(x**2+y**2)**(Rational(3,2)),x)
-    assert I2 == x/(y**3*sqrt(x**2/y**2 + 1))
+    assert I2 == Piecewise(((x**3 + x*y**2)/(y**2*(x**2 + y**2)**Rational(3,2)),
+        Ne(y**2, 0)), (x, True))
     # https://github.com/sympy/sympy/issues/6278
     I3 = integrate(1/(cos(x)+2),(x,0,2*pi))
     assert I3 == 2*sqrt(3)*pi/3

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2155,6 +2155,9 @@ def test_old_issues():
         Ne(y**2, 0)),
         (Integral(1/(x**2*sqrt(x**2 + y**2) + y**2*sqrt(x**2 + y**2)), x),
         True))
+    # a base-field part must not be double-counted in the degenerate
+    # branch's unevaluated Integral
+    assert integrate(1 + 1/(x**2+y**2)**(Rational(3,2)), x) == x + I2
     # https://github.com/sympy/sympy/issues/6278
     I3 = integrate(1/(cos(x)+2),(x,0,2*pi))
     assert I3 == 2*sqrt(3)*pi/3

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1735,7 +1735,8 @@ def test_issue_2975():
     F = (C*w/2 + w**3/8)/(C*(C + w**2/4)**(S(3)/2))
     assert integrate(1/(y**2+C)**(S(3)/2), (y, -w/2, w/2)) == \
         Piecewise((F - F.subs(w, -w), (C > -oo) & (C < oo) & Ne(C, 0)),
-                  (w, True))
+                  (Integral(1/(C*sqrt(C + y**2) + y**2*sqrt(C + y**2)),
+                            (y, -w/2, w/2)), True))
 
 
 def test_issue_7827():
@@ -2151,7 +2152,9 @@ def test_old_issues():
     # wrong sign for y < 0)
     I2 = integrate(1/(x**2+y**2)**(Rational(3,2)),x)
     assert I2 == Piecewise(((x**3 + x*y**2)/(y**2*(x**2 + y**2)**Rational(3,2)),
-        Ne(y**2, 0)), (x, True))
+        Ne(y**2, 0)),
+        (Integral(1/(x**2*sqrt(x**2 + y**2) + y**2*sqrt(x**2 + y**2)), x),
+        True))
     # https://github.com/sympy/sympy/issues/6278
     I3 = integrate(1/(cos(x)+2),(x,0,2*pi))
     assert I3 == 2*sqrt(3)*pi/3

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -678,9 +678,14 @@ def test_integrate_returns_piecewise():
     assert integrate(exp(x*y), (x, 0, z)) == Piecewise(
         (exp(y*z)/y - 1/y, (y > -oo) & (y < oo) & Ne(y, 0)), (z, True))
     # https://github.com/sympy/sympy/issues/23707
+    # The degenerate slot (x == y + 1, where the integrand is 1 and the
+    # integral is t) is an honest unevaluated Integral: the generic
+    # methods answer wrongly at exactly the parameter values that select
+    # that slot, and validating a candidate on the degenerate variety is
+    # the deferred special-values problem.
     assert integrate(exp(t)*exp(-t*sqrt(x - y)), t) == Piecewise(
-        (-exp(t)/(sqrt(x - y)*exp(t*sqrt(x - y)) - exp(t*sqrt(x - y))),
-        Ne(x, y + 1)), (t, True))
+        (-exp(t)*exp(-t*sqrt(x - y))/(sqrt(x - y) - 1), Ne(sqrt(x - y), 1)),
+        (Integral(exp(t)*exp(-t*sqrt(x - y)), t), True))
 
 
 def test_integrate_max_min():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -39,7 +39,8 @@ from sympy.functions.elementary.integers import floor
 from sympy.integrals.integrals import Integral
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.physics import units
-from sympy.testing.pytest import raises, slow, warns_deprecated_sympy, warns
+from sympy.testing.pytest import (XFAIL, raises, slow, warns_deprecated_sympy,
+    warns)
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.random import verify_numerically
 
@@ -2148,8 +2149,6 @@ def test_old_issues():
     I1 = integrate(cos(log(x**2))/x)
     assert I1 == sin(log(x**2))/2
     # https://github.com/sympy/sympy/issues/5462
-    # (the historical expectation x/(y**3*sqrt(x**2/y**2 + 1)) has the
-    # wrong sign for y < 0)
     I2 = integrate(1/(x**2+y**2)**(Rational(3,2)),x)
     assert I2 == Piecewise(((x**3 + x*y**2)/(y**2*(x**2 + y**2)**Rational(3,2)),
         Ne(y**2, 0)),
@@ -2161,6 +2160,15 @@ def test_old_issues():
     # https://github.com/sympy/sympy/issues/6278
     I3 = integrate(1/(cos(x)+2),(x,0,2*pi))
     assert I3 == 2*sqrt(3)*pi/3
+
+
+@XFAIL
+def test_meijerg_issue_5462_sign():
+    # meijerg returns x/(y**3*sqrt(x**2/y**2 + 1)), which differentiates
+    # back to the integrand only for y > 0
+    f = 1/(x**2 + y**2)**Rational(3, 2)
+    F = integrate(f, x, meijerg=True)
+    assert (F.diff(x) - f).subs({y: -2, x: 1}).equals(0)
 
 
 def test_integral_issue_26566():

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from sympy.core.function import expand_func
 from sympy.core.numbers import (I, Rational, oo, pi)
+from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
 from sympy.functions.elementary.complexes import Abs, arg, re, unpolarify
@@ -720,15 +721,21 @@ def test_issue_8368():
 
 def test_issue_10211():
     from sympy.abc import h, w
+    # (the historical expectation 2*sqrt(1 + w**2/h**2)/h - 2/h has the
+    # wrong sign for h < 0: the integrand is even in h)
+    G = (h**4 + 2*h**2*w**2 + w**4)/(h**2*(h**2 + w**2)**Rational(3, 2))
+    N = (-h**4 - 2*h**2*w**2 - w**4)/(h**2*(h**2 + w**2)**Rational(3, 2))
     assert integrate((1/sqrt((y-x)**2 + h**2)**3), (x,0,w), (y,0,w)) == \
-        2*sqrt(1 + w**2/h**2)/h - 2/h
+        Piecewise((-2*h**2/(h**2)**Rational(3, 2) + G - N,
+                   (h > -oo) & (h < oo) & Ne(h, 0)), (w**2, True))
 
 
 def test_issue_11806():
     from sympy.core.symbol import symbols
     y, L = symbols('y L', positive=True)
+    F = (L**3 + L*y**2)/(y**2*(L**2 + y**2)**Rational(3, 2))
     assert integrate(1/sqrt(x**2 + y**2)**3, (x, -L, L)) == \
-        2*L/(y**2*sqrt(L**2 + y**2))
+        F - F.subs(L, -L)
 
 def test_issue_10681():
     from sympy.polys.domains.realfield import RR

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -725,9 +725,12 @@ def test_issue_10211():
     # wrong sign for h < 0: the integrand is even in h)
     G = (h**4 + 2*h**2*w**2 + w**4)/(h**2*(h**2 + w**2)**Rational(3, 2))
     N = (-h**4 - 2*h**2*w**2 - w**4)/(h**2*(h**2 + w**2)**Rational(3, 2))
+    r = sqrt(h**2 + x**2 - 2*x*y + y**2)
     assert integrate((1/sqrt((y-x)**2 + h**2)**3), (x,0,w), (y,0,w)) == \
         Piecewise((-2*h**2/(h**2)**Rational(3, 2) + G - N,
-                   (h > -oo) & (h < oo) & Ne(h, 0)), (w**2, True))
+                   (h > -oo) & (h < oo) & Ne(h, 0)),
+                  (Integral(1/(h**2*r + x**2*r - 2*x*y*r + y**2*r),
+                            (x, 0, w), (y, 0, w)), True))
 
 
 def test_issue_11806():

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -19,7 +19,7 @@ from sympy.simplify.simplify import simplify
 from sympy.integrals.meijerint import (_rewrite_single, _rewrite1,
     meijerint_indefinite, _inflate_g, _create_lookup_table,
     meijerint_definite, meijerint_inversion)
-from sympy.testing.pytest import slow
+from sympy.testing.pytest import XFAIL, slow
 from sympy.core.random import (verify_numerically,
         random_complex_number as randcplx)
 from sympy.abc import x, y, a, b, c, d, s, t, z
@@ -721,8 +721,6 @@ def test_issue_8368():
 
 def test_issue_10211():
     from sympy.abc import h, w
-    # (the historical expectation 2*sqrt(1 + w**2/h**2)/h - 2/h has the
-    # wrong sign for h < 0: the integrand is even in h)
     G = (h**4 + 2*h**2*w**2 + w**4)/(h**2*(h**2 + w**2)**Rational(3, 2))
     N = (-h**4 - 2*h**2*w**2 - w**4)/(h**2*(h**2 + w**2)**Rational(3, 2))
     r = sqrt(h**2 + x**2 - 2*x*y + y**2)
@@ -731,6 +729,16 @@ def test_issue_10211():
                    (h > -oo) & (h < oo) & Ne(h, 0)),
                   (Integral(1/(h**2*r + x**2*r - 2*x*y*r + y**2*r),
                             (x, 0, w), (y, 0, w)), True))
+
+
+@XFAIL
+def test_meijerg_issue_10211_sign():
+    from sympy.abc import h, w
+    # the integrand is even in h, but meijerg returns
+    # 2*sqrt(1 + w**2/h**2)/h - 2/h, which is odd
+    F = integrate(1/sqrt((y - x)**2 + h**2)**3, (x, 0, w), (y, 0, w),
+                  meijerg=True)
+    assert F.subs({h: 1, w: 1}) == F.subs({h: -1, w: 1})
 
 
 def test_issue_11806():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -15,14 +15,15 @@ from sympy.polys.polymatrix import PolyMatrix as Matrix
 
 from sympy.testing.pytest import raises
 
-from sympy.core import Add
+from sympy.core import Add, Dummy
+from sympy.matrices import MutableDenseMatrix
 from sympy.core.numbers import Rational
 from sympy.functions.elementary.exponential import exp
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.polys.domains.rationalfield import QQ
 from sympy.polys.polytools import Poly, cancel
-from sympy.abc import x, t, n
+from sympy.abc import x, t, n, y
 
 t0, t1, t2, t3, k = symbols('t:4 k')
 
@@ -113,6 +114,29 @@ def test_constant_system():
                  [0, 1, 0],
                  [0, 0, 0],
                  [0, 0, 1]], ring=R), Matrix([0, 1, 0, 0], ring=R))
+
+    # Multiple rows with symbolic constants: pivoting on y is sound, since
+    # y is a nonzero element of the constant field QQ(y)
+    dum = Dummy()
+    A = Matrix([[y, 1, x], [0, y, 1 + x]], dum)
+    u = Matrix([[x + y], [x + 2]], dum)
+    B, v = constant_system(A, u, DE)
+    assert (B.to_Matrix(), v.to_Matrix()) == \
+        (MutableDenseMatrix([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+         MutableDenseMatrix([[(y**2 - 1)/y**2], [1/y], [1]]))
+
+    # An entry whose derivation-quotient rows still contain tower
+    # variables, requiring more than one pass of the elimination loop
+    # ("while A is not constant" in the book's ConstantSystem); the
+    # output must be fully constant
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t0, t0),
+        Poly((t0 + x*t0)*t1, t1)], 'exts': ['exp', 'exp'],
+        'extargs': [x, x*t0]})
+    A = Matrix([[t1, t0]], dum)
+    u = Matrix([[0]], dum)
+    B, v = constant_system(A, u, DE)
+    assert not any(B.to_Matrix()[i, j].has(t0, t1)
+        for i in range(B.rows) for j in range(B.cols))
 
 
 def test_prde_spde():
@@ -333,6 +357,9 @@ def test_limited_integrate():
     # An empty list of special elements (the is_deriv_in_field() case)
     assert limited_integrate(Poly(2*x, x), Poly(1, x), [], DE) == \
         ((Poly(x**2, x), Poly(1, x, domain='QQ')), [])
+    # ... and with a symbolic constant coefficient
+    assert limited_integrate(Poly(2*y*x, x), Poly(1, x), [], DE) == \
+        ((Poly(y*x**2, x), Poly(1, x, domain='QQ')), [])
 
 
 def test_is_log_deriv_k_t_radical():
@@ -350,6 +377,15 @@ def test_is_log_deriv_k_t_radical():
         'exts': ['exp', 'log'], 'extargs': [x, x]})
     assert is_log_deriv_k_t_radical(Poly(x + t/2 + 3, t), Poly(1, t), DE) == \
         ([(t0, 2), (x, 1)], x*t0**2, 2, 3)
+
+
+    # A tower with a symbolic constant parameter: t0 == exp(y*x).
+    # exp(2*y*x) == t0**2 is a K-radical; the structure coefficients are
+    # rational even though the constant field is QQ(y)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(y*t0, t0)],
+        'exts': ['exp'], 'extargs': [y*x]})
+    assert is_log_deriv_k_t_radical(Poly(2*y*x, t0), Poly(1, t0), DE) == \
+        ([(t0, 2)], t0**2, 1, 0)
 
 
 def test_structure_theorem_guards():
@@ -408,6 +444,21 @@ def test_is_deriv_k():
         'exts': ['log'], 'extargs': [1/x]})
     assert is_deriv_k(Poly(1, t), Poly(x, t), DE) == ([(t, 1)], t, 1)
 
+
+    # Linearly dependent tower generators (log(x) and log(x**2)) make the
+    # structure system underdetermined; the solution must still be a
+    # correct full-length coefficient vector (the reduced system used to
+    # be misread as a solution vector and silently zip-truncated)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t0),
+        Poly(2/x, t1)], 'exts': ['log', 'log'],
+        'extargs': [x, x**2]})
+    assert is_deriv_k(Poly(x, t0), Poly(1, t0), DE) == \
+        ([(t0, 1), (t1, 0)], t0, 1)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(2/x, t0),
+        Poly(1/x, t1)], 'exts': ['log', 'log'],
+        'extargs': [x**2, x]})
+    assert is_deriv_k(Poly(x, t0), Poly(1, t0), DE) == \
+        ([(t0, S.Half), (t1, 0)], t0/2, 1)
 
 def test_is_log_deriv_k_t_radical_in_field():
     # NOTE: any potential constant factor in the second element of the result

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -478,6 +478,18 @@ def test_is_log_deriv_k_t_radical_in_field():
     assert is_log_deriv_k_t_radical_in_field(Poly(1, t), Poly(2*x**2, t), DE) == \
         (2, 1/t)
 
+    # exp case: u must come back as an Expr, never as a malformed Poly
+    # with the tower generator inside the coefficient domain (this used
+    # to return Poly(t, x, domain='ZZ[t]')-shaped results, and issued
+    # the deprecated Poly/Expr mixing warning when residue terms were
+    # present)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    assert is_log_deriv_k_t_radical_in_field(Poly(1, t), Poly(1, t), DE) == \
+        (1, t)
+    # f == Dt/t + Dt/(t + 1): the log-derivative of t*(t + 1)
+    assert is_log_deriv_k_t_radical_in_field(Poly(2*t + 1, t),
+        Poly(t + 1, t), DE) == (1, t**2 + t)
+
 
 def test_parametric_log_deriv_structure():
     # The heuristic fails on all of these (z in k at a primitive level);

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from sympy.integrals.risch import DifferentialExtension, derivation
 from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
     prde_linear_constraints, constant_system, prde_spde, prde_no_cancel_b_large,
-    prde_no_cancel_b_small, limited_integrate_reduce, limited_integrate,
+    prde_no_cancel_b_small, prde_no_cancel_b_equal, limited_integrate_reduce,
+    limited_integrate,
     is_deriv_k, is_log_deriv_k_t_radical, parametric_log_deriv_heu,
     is_log_deriv_k_t_radical_in_field, param_poly_rischDE, param_rischDE,
     is_deriv_in_field,
@@ -168,6 +169,36 @@ def test_prde_no_cancel():
     assert V[0] == Matrix([Rational(-1, 2), 0, 0, 1, 0, 0]*3, ring=R)
     assert (Matrix([h])*V[0][6:, :])[0] == Poly(x**2/2, t, domain='QQ(x)')
     assert (Matrix([q])*V[0][:6, :])[0] == Poly(x - S.Half, t, domain='QQ(x)')
+
+
+def test_prde_no_cancel_b_equal():
+    # deg(b) == delta(t) - 1, with t == tan-like (Dt == t**2 + 1)
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
+    # -lc(b)/lc(Dt) == -1 is not a positive integer, so the loop runs to
+    # N == 0: Dq + t*q == 2*t**2 + 1 has the solution q == t
+    assert prde_no_cancel_b_equal(Poly(t, t), [Poly(2*t**2 + 1, t)], 1, DE) == \
+        ([Poly(t, t)], Matrix([[1, -1]], DE.t))
+    # A solution with a nonconstant coefficient and two right hand sides:
+    # q == t**2 solves Dq + t*q == c1 for c == D(t**2) + t*t**2
+    b = Poly(t, t)
+    q = Poly(t**2, t)
+    c = derivation(q, DE) + b*q
+    h, A = prde_no_cancel_b_equal(b, [c, Poly(0, t)], 2, DE)
+    V = A.nullspace()
+    sols = 0
+    for v in V:
+        if v[0] != 0:
+            y = Add(*[(v[2 + j]*h[j]).as_expr() for j in range(len(h))])
+            yp = Poly(y/v[0].as_expr(), t, field=True)
+            if cancel(derivation(yp, DE).as_expr() + (b*yp).as_expr()
+                    - c.as_expr()) == 0:
+                sols += 1
+    assert sols >= 1
+    # When the possible-cancellation degree -lc(b)/lc(Dt) is reached, the
+    # rest is delegated to the cancellation algorithms, which are not yet
+    # implemented for delta(t) >= 2
+    raises(NotImplementedError, lambda: prde_no_cancel_b_equal(
+        Poly(-2*t, t), [Poly(t**4 + 3*t**2, t)], 3, DE))
 
 
 def test_prde_cancel_liouvillian():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -6,6 +6,7 @@ from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
     prde_no_cancel_b_small, prde_no_cancel_b_equal, limited_integrate_reduce,
     limited_integrate,
     is_deriv_k, is_log_deriv_k_t_radical, parametric_log_deriv_heu,
+    parametric_log_deriv, parametric_log_deriv_structure,
     is_log_deriv_k_t_radical_in_field, param_poly_rischDE, param_rischDE,
     is_deriv_in_field,
     prde_cancel_liouvillian)
@@ -405,6 +406,27 @@ def test_is_log_deriv_k_t_radical_in_field():
         (1, t)
     assert is_log_deriv_k_t_radical_in_field(Poly(1, t), Poly(2*x**2, t), DE) == \
         (2, 1/t)
+
+
+def test_parametric_log_deriv_structure():
+    # The heuristic fails on all of these (z in k at a primitive level);
+    # the structure-theorem method (equation (7.44)) decides them.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)],
+        'exts': ['log'], 'extargs': [x]})
+    # f == 1/x == Dx/x, w == 1: 1*f == Dx/x + 0*w
+    assert parametric_log_deriv_structure(Poly(1, t), Poly(x, t),
+        Poly(1, t), Poly(1, t), DE) == (1, 0, x)
+    # f == 1 + 1/(2*x), w == 1: 2*f == Dx/x + 2*w  (through the wrapper,
+    # exercising the heuristic -> structure fallback)
+    assert parametric_log_deriv(Poly(2*x + 1, t), Poly(2*x, t),
+        Poly(1, t), Poly(1, t), DE) == (2, 2, x)
+    # f == 1/(x + 1), w == 1 has the solution (1, 0, x + 1), but x + 1 is
+    # not in the tower, so the structure method is inconclusive (None) and
+    # the wrapper must raise rather than claim no solution exists.
+    assert parametric_log_deriv_structure(Poly(1, t), Poly(x + 1, t),
+        Poly(1, t), Poly(1, t), DE) is None
+    raises(NotImplementedError, lambda: parametric_log_deriv(
+        Poly(1, t), Poly(x + 1, t), Poly(1, t), Poly(1, t), DE))
 
 
 def test_is_deriv_in_field():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -330,6 +330,9 @@ def test_limited_integrate():
     G = [(Poly(1, x), Poly(x, x))]
     assert limited_integrate(Poly(5*x**2, x), Poly(3, x), G, DE) == \
         ((Poly(5*x**3/9, x), Poly(1, x, domain='QQ')), [0])
+    # An empty list of special elements (the is_deriv_in_field() case)
+    assert limited_integrate(Poly(2*x, x), Poly(1, x), [], DE) == \
+        ((Poly(x**2, x), Poly(1, x, domain='QQ')), [])
 
 
 def test_is_log_deriv_k_t_radical():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -12,11 +12,12 @@ from sympy.polys.polymatrix import PolyMatrix as Matrix
 
 from sympy.testing.pytest import raises
 
+from sympy.core import Add
 from sympy.core.numbers import Rational
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.polys.domains.rationalfield import QQ
-from sympy.polys.polytools import Poly
+from sympy.polys.polytools import Poly, cancel
 from sympy.abc import x, t, n
 
 t0, t1, t2, t3, k = symbols('t:4 k')
@@ -189,6 +190,26 @@ def test_prde_cancel_liouvillian():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-t, t)]})
     assert prde_cancel_liouvillian(Poly(0, t, domain='QQ[x]'), [Poly(1, t, domain='QQ(x)')], 0, DE) == \
             ([Poly(1, t, domain='QQ'), Poly(x, t, domain='ZZ(x)')], Matrix([[-1, 0, 1]], DE.t))
+
+    ### 3. case == 'exp' with b != 0 and n > 0.  This exercises the level at
+    ### which eta == Dt/t is computed and the sign of the residual update
+    ### Fi == -(D(h) + b*h), both of which used to be wrong.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    b = Poly(1/x, t, field=True)
+    Q = [Poly((x + 1)*t/x, t, field=True)]
+    h, A = prde_cancel_liouvillian(b, Q, 1, DE)
+    V = A.nullspace()
+    # Dy + y/x == c1*(x + 1)*t/x must have the solution y == t (c1 == 1)
+    found = False
+    for v in V:
+        if v[0] == 0:
+            continue
+        y = Add(*[(v[1 + j]*h[j]).as_expr() for j in range(len(h))])/v[0].as_expr()
+        yp = Poly(y, t, field=True)
+        if cancel(derivation(yp, DE).as_expr() + b.as_expr()*y
+                - Q[0].as_expr()) == 0:
+            found = True
+    assert found
 
 
 def test_param_poly_rischDE():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -18,7 +18,8 @@ from sympy.testing.pytest import raises
 from sympy.core import Add, Dummy
 from sympy.matrices import MutableDenseMatrix
 from sympy.core.numbers import Rational
-from sympy.functions.elementary.exponential import exp
+from sympy.core.numbers import pi
+from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
@@ -417,33 +418,39 @@ def test_structure_theorem_guards():
             raise AssertionError("NotImplementedError was not raised")
 
 
-def test_structure_theorem_nontranscendental_guards():
-    # A structure-system solution with non-rational constants is
-    # undecidable rationality: over a transcendental tower a None
-    # return would be a proof of nonexistence, so these raise; over a
-    # non-transcendental tower every nonelementary conclusion is
-    # degraded to an unevaluated Integral and solved results are vetted
-    # independently, so the undecided question is answered "no
-    # relation" instead of aborting the integration.  Here
-    # t1 == log(x**sqrt(2)), and matching a logarithmic derivative
-    # against Dt1 == sqrt(2)/x needs the constant 1/sqrt(2).
-    for transcendental in (True, False):
+def test_structure_theorem_nonrational_coefficients():
+    # Here t1 == log(x**sqrt(2)), and matching a logarithmic derivative
+    # against Dt1 == sqrt(2)/x needs the constant 1/sqrt(2).  The
+    # structure system's solution is unique and provably irrational, so
+    # "no relation" is a proven answer and the tower stays proven
+    # transcendental.
+    DE = DifferentialExtension(extension={
+        'D': [Poly(1, x), Poly(sqrt(2)/x, t1)],
+        'exts': ['log'], 'extargs': [x**sqrt(2)]})
+    assert is_deriv_k(Poly(x, t1), Poly(1, t1), DE) is None
+    assert is_log_deriv_k_t_radical(Poly(1, t1), Poly(x, t1), DE,
+        Df=False) is None
+    # parametric_log_deriv_structure's None is inconclusive by contract
+    # (the wrapper decides what to do with it), so it never raises on
+    # non-rational constants either
+    assert parametric_log_deriv_structure(Poly(sqrt(2), t1),
+        Poly(x, t1), Poly(1, t1), Poly(x, t1), DE) is None
+    assert DE.transcendental is True
+
+    # With t1 == log(x**log(pi)) the needed constant is 1/log(pi), whose
+    # rationality is undecided (log(pi).is_rational is None), so the
+    # question is answered "no relation" without proof and the tower is
+    # degraded: nonelementary conclusions become unevaluated Integrals
+    # and solved results are vetted.
+    for call in (lambda DE: is_deriv_k(Poly(x, t1), Poly(1, t1), DE),
+            lambda DE: is_log_deriv_k_t_radical(Poly(1, t1), Poly(x, t1),
+                DE, Df=False)):
         DE = DifferentialExtension(extension={
-            'D': [Poly(1, x), Poly(sqrt(2)/x, t1)],
-            'exts': ['log'], 'extargs': [x**sqrt(2)],
-            'transcendental': transcendental})
-        calls = [
-            lambda: is_deriv_k(Poly(x, t1), Poly(1, t1), DE),
-            lambda: is_log_deriv_k_t_radical(Poly(1, t1), Poly(x, t1), DE,
-                Df=False),
-            lambda: parametric_log_deriv_structure(Poly(sqrt(2), t1),
-                Poly(x, t1), Poly(1, t1), Poly(x, t1), DE),
-        ]
-        for call in calls:
-            if transcendental:
-                raises(NotImplementedError, call)
-            else:
-                assert call() is None
+            'D': [Poly(1, x), Poly(log(pi)/x, t1)],
+            'exts': ['log'], 'extargs': [x**log(pi)]})
+        assert DE.transcendental is True
+        assert call(DE) is None
+        assert DE.transcendental is False
 
 
 def test_is_deriv_k():
@@ -535,11 +542,17 @@ def test_parametric_log_deriv_structure():
         Poly(1, t), Poly(1, t), DE) == (2, 2, x)
     # f == 1/(x + 1), w == 1 has the solution (1, 0, x + 1), but x + 1 is
     # not in the tower, so the structure method is inconclusive (None) and
-    # the wrapper must raise rather than claim no solution exists.
+    # the wrapper's "no solution" answer is not a proof: it must degrade
+    # the tower rather than let that answer feed a nonelementary
+    # conclusion.
     assert parametric_log_deriv_structure(Poly(1, t), Poly(x + 1, t),
         Poly(1, t), Poly(1, t), DE) is None
-    raises(NotImplementedError, lambda: parametric_log_deriv(
-        Poly(1, t), Poly(x + 1, t), Poly(1, t), Poly(1, t), DE))
+    assert DE.transcendental is True
+    assert parametric_log_deriv(
+        Poly(1, t), Poly(x + 1, t), Poly(1, t), Poly(1, t), DE) is None
+    assert DE.transcendental is False
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)],
+        'exts': ['log'], 'extargs': [x]})
 
     # Nontrivial n and m: f == 1/(2*x) + 3, w == 2:
     # 2*f == Dx/x + 3*w

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -1,6 +1,6 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from __future__ import annotations
-from sympy.integrals.risch import DifferentialExtension, derivation
+from sympy.integrals.risch import DifferentialExtension, derivation, frac_in
 from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
     prde_linear_constraints, constant_system, prde_spde, prde_no_cancel_b_large,
     prde_no_cancel_b_small, prde_no_cancel_b_equal, limited_integrate_reduce,
@@ -17,6 +17,7 @@ from sympy.testing.pytest import raises
 
 from sympy.core import Add
 from sympy.core.numbers import Rational
+from sympy.functions.elementary.exponential import exp
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.polys.domains.rationalfield import QQ
@@ -427,6 +428,27 @@ def test_parametric_log_deriv_structure():
         Poly(1, t), Poly(1, t), DE) is None
     raises(NotImplementedError, lambda: parametric_log_deriv(
         Poly(1, t), Poly(x + 1, t), Poly(1, t), Poly(1, t), DE))
+
+    # Nontrivial n and m: f == 1/(2*x) + 3, w == 2:
+    # 2*f == Dx/x + 3*w
+    assert parametric_log_deriv_structure(Poly(6*x + 1, t), Poly(2*x, t),
+        Poly(2, t), Poly(1, t), DE) == (2, 3, x)
+
+    # Underdetermined system (w lies in the span of the generators) and a
+    # w == 0 query.  Which solution is returned depends on the free
+    # parameter choice, so check the defining equation n*f == Dv/v + m*w
+    # instead of an exact tuple.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t),
+        Poly(t1, t1)], 'exts': ['log', 'exp'], 'extargs': [x, x]})
+    for f, w in [(1/x + 2, S(3)), (1/x + 5, S.Zero)]:
+        fa, fd = frac_in(f, t1)
+        wa, wd = frac_in(w, t1)
+        A = parametric_log_deriv_structure(fa, fd, wa, wd, DE)
+        assert A is not None
+        n, m, v = A
+        assert n > 0 and n.is_Integer and m.is_Integer
+        vv = v.subs(t1, exp(x))  # t1 == exp(x) in this extension
+        assert cancel(n*f - m*w - vv.diff(x)/vv) == 0
 
 
 def test_is_deriv_in_field():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -19,6 +19,7 @@ from sympy.core import Add, Dummy
 from sympy.matrices import MutableDenseMatrix
 from sympy.core.numbers import Rational
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.polys.domains.rationalfield import QQ
@@ -414,6 +415,35 @@ def test_structure_theorem_guards():
             assert "hypertangent" in str(e)
         else:
             raise AssertionError("NotImplementedError was not raised")
+
+
+def test_structure_theorem_nontranscendental_guards():
+    # A structure-system solution with non-rational constants is
+    # undecidable rationality: over a transcendental tower a None
+    # return would be a proof of nonexistence, so these raise; over a
+    # non-transcendental tower every nonelementary conclusion is
+    # degraded to an unevaluated Integral and solved results are vetted
+    # independently, so the undecided question is answered "no
+    # relation" instead of aborting the integration.  Here
+    # t1 == log(x**sqrt(2)), and matching a logarithmic derivative
+    # against Dt1 == sqrt(2)/x needs the constant 1/sqrt(2).
+    for transcendental in (True, False):
+        DE = DifferentialExtension(extension={
+            'D': [Poly(1, x), Poly(sqrt(2)/x, t1)],
+            'exts': ['log'], 'extargs': [x**sqrt(2)],
+            'transcendental': transcendental})
+        calls = [
+            lambda: is_deriv_k(Poly(x, t1), Poly(1, t1), DE),
+            lambda: is_log_deriv_k_t_radical(Poly(1, t1), Poly(x, t1), DE,
+                Df=False),
+            lambda: parametric_log_deriv_structure(Poly(sqrt(2), t1),
+                Poly(x, t1), Poly(1, t1), Poly(x, t1), DE),
+        ]
+        for call in calls:
+            if transcendental:
+                raises(NotImplementedError, call)
+            else:
+                assert call() is None
 
 
 def test_is_deriv_k():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -262,18 +262,18 @@ def test_limited_integrate():
 
 
 def test_is_log_deriv_k_t_radical():
-    DE = DifferentialExtension(extension={'D': [Poly(1, x)], 'exts': [None],
-        'extargs': [None]})
+    DE = DifferentialExtension(extension={'D': [Poly(1, x)], 'exts': [],
+        'extargs': []})
     assert is_log_deriv_k_t_radical(Poly(2*x, x), Poly(1, x), DE) is None
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(2*t1, t1), Poly(1/x, t2)],
-        'exts': [None, 'exp', 'log'], 'extargs': [None, 2*x, x]})
+        'exts': ['exp', 'log'], 'extargs': [2*x, x]})
     assert is_log_deriv_k_t_radical(Poly(x + t2/2, t2), Poly(1, t2), DE) == \
         ([(t1, 1), (x, 1)], t1*x, 2, 0)
     # TODO: Add more tests
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t0, t0), Poly(1/x, t)],
-        'exts': [None, 'exp', 'log'], 'extargs': [None, x, x]})
+        'exts': ['exp', 'log'], 'extargs': [x, x]})
     assert is_log_deriv_k_t_radical(Poly(x + t/2 + 3, t), Poly(1, t), DE) == \
         ([(t0, 2), (x, 1)], x*t0**2, 2, 3)
 
@@ -283,7 +283,7 @@ def test_structure_theorem_guards():
     # supported by the structure theorems.  When every primitive monomial
     # in it is a logarithm, it is reported as a nonelementary tower.
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t1),
-        Poly(t2, t2)], 'exts': [None, 'log'], 'extargs': [None, x]})
+        Poly(t2, t2)], 'exts': ['log'], 'extargs': [x]})
     for func in (is_deriv_k, is_log_deriv_k_t_radical):
         try:
             func(Poly(t2, t2), Poly(1, t2), DE)
@@ -296,7 +296,7 @@ def test_structure_theorem_guards():
     # arctangent-like monomial) needs the real version of the structure
     # theorems instead.
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t1),
-        Poly(1/(x**2 + 1), t2)], 'exts': [None, 'log'], 'extargs': [None, x]})
+        Poly(1/(x**2 + 1), t2)], 'exts': ['log'], 'extargs': [x]})
     for func in (is_deriv_k, is_log_deriv_k_t_radical):
         try:
             func(Poly(t2, t2), Poly(1, t2), DE)
@@ -308,30 +308,30 @@ def test_structure_theorem_guards():
 
 def test_is_deriv_k():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t1), Poly(1/(x + 1), t2)],
-        'exts': [None, 'log', 'log'], 'extargs': [None, x, x + 1]})
+        'exts': ['log', 'log'], 'extargs': [x, x + 1]})
     assert is_deriv_k(Poly(2*x**2 + 2*x, t2), Poly(1, t2), DE) == \
         ([(t1, 1), (t2, 1)], t1 + t2, 2)
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t1), Poly(t2, t2)],
-        'exts': [None, 'log', 'exp'], 'extargs': [None, x, x]})
+        'exts': ['log', 'exp'], 'extargs': [x, x]})
     assert is_deriv_k(Poly(x**2*t2**3, t2), Poly(1, t2), DE) == \
         ([(x, 3), (t1, 2)], 2*t1 + 3*x, 1)
     # TODO: Add more tests, including ones with exponentials
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(2/x, t1)],
-        'exts': [None, 'log'], 'extargs': [None, x**2]})
+        'exts': ['log'], 'extargs': [x**2]})
     assert is_deriv_k(Poly(x, t1), Poly(1, t1), DE) == \
         ([(t1, S.Half)], t1/2, 1)
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(2/(1 + x), t0)],
-        'exts': [None, 'log'], 'extargs': [None, x**2 + 2*x + 1]})
+        'exts': ['log'], 'extargs': [x**2 + 2*x + 1]})
     assert is_deriv_k(Poly(1 + x, t0), Poly(1, t0), DE) == \
         ([(t0, S.Half)], t0/2, 1)
 
     # Issue 10798
     # DE = DifferentialExtension(log(1/x), x)
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(-1/x, t)],
-        'exts': [None, 'log'], 'extargs': [None, 1/x]})
+        'exts': ['log'], 'extargs': [1/x]})
     assert is_deriv_k(Poly(1, t), Poly(x, t), DE) == ([(t, 1)], t, 1)
 
 

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -6,6 +6,7 @@ from sympy.integrals.prde import (prde_normal_denom, prde_special_denom,
     prde_no_cancel_b_small, limited_integrate_reduce, limited_integrate,
     is_deriv_k, is_log_deriv_k_t_radical, parametric_log_deriv_heu,
     is_log_deriv_k_t_radical_in_field, param_poly_rischDE, param_rischDE,
+    is_deriv_in_field,
     prde_cancel_liouvillian)
 
 from sympy.polys.polymatrix import PolyMatrix as Matrix
@@ -373,6 +374,28 @@ def test_is_log_deriv_k_t_radical_in_field():
         (1, t)
     assert is_log_deriv_k_t_radical_in_field(Poly(1, t), Poly(2*x**2, t), DE) == \
         (2, 1/t)
+
+
+def test_is_deriv_in_field():
+    DE = DifferentialExtension(extension={'D': [Poly(1, x)]})
+    assert is_deriv_in_field(Poly(2*x, x), Poly(1, x), DE) == \
+        (Poly(x**2, x), Poly(1, x, domain='QQ'))
+    assert is_deriv_in_field(Poly(1, x), Poly(x, x), DE) is None
+    # t == log(x): D(x*t) == t + 1; 1/(x*t) == D(log(log(x))) is not in the field
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
+    A = is_deriv_in_field(Poly(t + 1, t), Poly(1, t), DE)
+    assert A is not None
+    va, vd = A
+    vp = Poly(cancel(va.as_expr()/vd.as_expr()), t, field=True)
+    assert cancel(derivation(vp, DE).as_expr() - (t + 1)) == 0
+    assert is_deriv_in_field(Poly(1, t), Poly(x*t, t), DE) is None
+    # t == exp(x): D(x*t**2) == (2*x + 1)*t**2; t is not a derivative
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    A = is_deriv_in_field(Poly((2*x + 1)*t**2, t), Poly(1, t), DE)
+    assert A is not None
+    va, vd = A
+    vp = Poly(cancel(va.as_expr()/vd.as_expr()), t, field=True)
+    assert cancel(derivation(vp, DE).as_expr() - (2*x + 1)*t**2) == 0
 
 
 def test_parametric_log_deriv():

--- a/sympy/integrals/tests/test_prde.py
+++ b/sympy/integrals/tests/test_prde.py
@@ -304,6 +304,22 @@ def test_limited_integrate_reduce():
         (Poly(t, t), Poly(-1/x, t), Poly(t, t), 1, (Poly(x, t), Poly(1, t, domain='ZZ[x]')),
         [(Poly(-x*t, t), Poly(1, t, domain='ZZ[x]'))])
 
+    # An exp case with a nontrivial special part (hs != 1).  This
+    # distinguishes the first return component, which must be hn rather
+    # than a == hn*hs (the book returns a, which does not satisfy the
+    # stated contract): check the contract directly for the known
+    # solution v == 1/(t*x), c1 == 3 of f == Dv + c1*w1.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    fa, fd = frac_in((3*x**2*t - x - 1)/(x**2*t), t)
+    G = [(Poly(1, t), Poly(1, t))]
+    A, b, h, N, g, V = limited_integrate_reduce(fa, fd, G, DE)
+    p = Poly(cancel(h.as_expr()/(t*x)), t, field=True)  # p == v*h
+    assert p.degree(t) <= N
+    lhs = (A*derivation(p, DE) + b*p).as_expr()
+    rhs = cancel(g[0].as_expr()/g[1].as_expr() +
+        3*V[0][0].as_expr()/V[0][1].as_expr())
+    assert cancel(lhs - rhs) == 0
+
 
 def test_limited_integrate():
     DE = DifferentialExtension(extension={'D': [Poly(1, x)]})

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -9,9 +9,10 @@ from sympy.integrals.integrals import integrate
 from sympy.polys.polytools import Poly, cancel
 from sympy.simplify.simplify import simplify
 
-from sympy.integrals.rationaltools import ratint, ratint_logpart, log_to_atan
+from sympy.integrals.rationaltools import (ratint, ratint_logpart,
+    log_to_atan, log_to_real)
 
-from sympy.abc import a, b, x, t
+from sympy.abc import a, b, x, t, y
 
 half = S.Half
 
@@ -180,6 +181,19 @@ def test_log_to_atan():
     fg_ans = 2*atan(2*sqrt(3)*x/3 + sqrt(3)/3)
     assert log_to_atan(f, g) == fg_ans
     assert log_to_atan(g, f) == -fg_ans
+
+
+def test_log_to_real_complex_only():
+    h = Poly(x + 3*y/2 + S.Half, x, domain='QQ[y]')
+    q = Poly(3*y**2 + 1, y, domain='ZZ')
+    ans = 2*sqrt(3)*atan(2*sqrt(3)*x/3 + sqrt(3)/3)/3
+    assert log_to_real(h, q, x, y) == ans
+    assert log_to_real(h, q, x, y, complex_only=True) == ans
+    # With complex_only=True, a q with only real roots is not converted
+    h = Poly(x**2 - 1, x, domain='ZZ')
+    q = Poly(-2*y + 1, y, domain='ZZ')
+    assert log_to_real(h, q, x, y) == log(x**2 - 1)/2
+    assert log_to_real(h, q, x, y, complex_only=True) is None
 
 
 def test_issue_25896():

--- a/sympy/integrals/tests/test_rationaltools.py
+++ b/sympy/integrals/tests/test_rationaltools.py
@@ -6,7 +6,7 @@ from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import atan
 from sympy.integrals.integrals import integrate
-from sympy.polys.polytools import Poly
+from sympy.polys.polytools import Poly, cancel
 from sympy.simplify.simplify import simplify
 
 from sympy.integrals.rationaltools import ratint, ratint_logpart, log_to_atan
@@ -136,6 +136,15 @@ def test_issue_5817():
     assert simplify(ratint(a/(b*c*x**2 + a**2 + b*a), x)) == \
         sqrt(a)*atan(sqrt(
             b)*sqrt(c)*x/(sqrt(a)*sqrt(a + b)))/(sqrt(b)*sqrt(c)*sqrt(a + b))
+
+
+def test_ratint_radical_coefficients():
+    # issue 26502
+    a = symbols('a', positive=True)
+    f = (-x**2 + sqrt(2))/(x**4 - sqrt(2)*x**2 + 1)
+    assert cancel((ratint(f, x).diff(x) - f).together()) == 0
+    g = (2*sqrt(a) - x**2)/(-sqrt(a)*x**2 + a + x**4)
+    assert cancel((ratint(g, x).diff(x) - g).together()) == 0
 
 
 def test_issue_5981():

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -166,6 +166,25 @@ def test_bound_degree():
     assert bound_degree(Poly(t, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), DE) == 0
 
 
+def test_bound_degree_rational_z():
+    # Primitive case with deg(a) == deg(b) and alpha == 1/(x*(x + 1)) ==
+    # Dz/z for z == x/(x + 1) -- a proper ratio in k*, so derivation(z, DE)
+    # inside bound_degree() needs basic=True (z is not polynomial in the
+    # tower generators; this used to crash with SympifyError).
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)],
+        'exts': ['log'], 'extargs': [x]})
+    assert bound_degree(Poly(t, t, field=True),
+        Poly(-t/(x*(x + 1)), t, field=True), Poly(1, t, field=True), DE) == 0
+    # The same alpha end-to-end: Dy - y/(x*(x + 1)) == (x + 1 - t)/(x*(x + 1))
+    # has the solution y == t (plus c*x/(x + 1) for any constant c, so check
+    # the defining equation rather than the exact result).
+    ya, yd = rischDE(Poly(-1, t, field=True), Poly(x*(x + 1), t, field=True),
+        Poly(x + 1 - t, t, field=True), Poly(x*(x + 1), t, field=True), DE)
+    y = ya.as_expr()/yd.as_expr()
+    assert cancel(derivation(Poly(y, t, field=True), DE).as_expr() -
+        y/(x*(x + 1)) - (x + 1 - t)/(x*(x + 1))) == 0
+
+
 def test_bound_degree_undecidable():
     # Exp case with deg(a) == deg(b) and alpha == -lc(b)/lc(a) == 1/(x + 1):
     # deciding whether alpha == m*Dt/t + Dz/z requires log(x + 1), which is

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -189,17 +189,22 @@ def test_bound_degree_rational_z():
 def test_bound_degree_undecidable():
     # Exp case with deg(a) == deg(b) and alpha == -lc(b)/lc(a) == 1/(x + 1):
     # deciding whether alpha == m*Dt/t + Dz/z requires log(x + 1), which is
-    # not in the tower, so parametric_log_deriv() cannot decide and
-    # bound_degree() must raise rather than return an unsound bound.
-    # param_rischDE() propagates this (it used to guess n = 5 instead,
-    # which could truncate the parametric solution basis and turn into a
-    # false proof of nonelementarity downstream in is_deriv_in_field()).
+    # not in the tower, so parametric_log_deriv() cannot decide.  The
+    # returned bound skips the undecided m-correction and so is not a
+    # proof (it could truncate the solution basis); to keep that sound,
+    # the tower's transcendence is downgraded to unproven, which vets
+    # solved results and degrades nonelementary conclusions downstream.
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t0),
         Poly(t1, t1)], 'exts': ['log', 'exp'], 'extargs': [x, x]})
-    raises(NotImplementedError, lambda: bound_degree(Poly(t1, t1),
-        Poly(-t1/(x + 1), t1, field=True), Poly(1, t1), DE))
-    raises(NotImplementedError, lambda: bound_degree(Poly(t1, t1),
-        Poly(-t1/(x + 1), t1, field=True), [Poly(1, t1)], DE, parametric=True))
+    assert DE.transcendental is True
+    assert bound_degree(Poly(t1, t1), Poly(-t1/(x + 1), t1, field=True),
+        Poly(1, t1), DE) == 0
+    assert DE.transcendental is False
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t0),
+        Poly(t1, t1)], 'exts': ['log', 'exp'], 'extargs': [x, x]})
+    assert bound_degree(Poly(t1, t1), Poly(-t1/(x + 1), t1, field=True),
+        [Poly(1, t1)], DE, parametric=True) == 0
+    assert DE.transcendental is False
 
 
 def test_spde():

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -208,6 +208,17 @@ def test_spde():
         (Poly(0, x, domain='ZZ'), Poly(0, x), 0, Poly(0, x), Poly(3*x**3 - 2*x**2, x, domain='QQ'))
     assert spde(Poly(x**2 - x, x), Poly(x**2 - 5*x + 3, x), Poly(x**7 - x**6 - 2*x**4 + 3*x**3 - x**2, x), 5, DE) == \
         (Poly(1, x, domain='QQ'), Poly(x + 1, x, domain='QQ'), 1, Poly(x**4 - x**3, x), Poly(x**3 - x**2, x, domain='QQ'))
+    # n == oo (from rischDE() when bound_degree() cannot decide) must not
+    # loop forever when deg(a) > 0: a == t, b == 1, c == x has no
+    # solution and gcd(a, b) == 1 stays trivial, so no other exit is
+    # ever taken.  This used to spin indefinitely.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    raises(NotImplementedError, lambda: spde(Poly(t, t), Poly(1, t),
+        Poly(x, t, domain='ZZ[x]'), oo, DE))
+    # ...but with deg(a) == 0 it returns immediately, so n == oo is fine.
+    assert spde(Poly(2, t), Poly(t, t), Poly(t, t), oo, DE) == \
+        (Poly(t/2, t, domain='QQ'), Poly(t/2, t, domain='QQ'), oo,
+         Poly(1, t, domain='ZZ'), Poly(0, t, domain='ZZ'))
 
 def test_solve_poly_rde_no_cancel():
     # deg(b) large

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -234,7 +234,11 @@ def test_spde():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
     raises(NotImplementedError, lambda: spde(Poly(t, t), Poly(1, t),
         Poly(x, t, domain='ZZ[x]'), oo, DE))
-    # ...but with deg(a) == 0 it returns immediately, so n == oo is fine.
+    # ...while a solvable positive-degree case with n == oo still reduces
+    # and returns (q == 1 here; c becomes zero after one pass)...
+    assert spde(Poly(t, t), Poly(1, t), Poly(1, t), oo, DE) == \
+        (Poly(0, t), Poly(0, t), 0, Poly(0, t), Poly(1, t, domain='QQ'))
+    # ...and with deg(a) == 0 it returns immediately, so n == oo is fine.
     assert spde(Poly(2, t), Poly(t, t), Poly(t, t), oo, DE) == \
         (Poly(t/2, t, domain='QQ'), Poly(t/2, t, domain='QQ'), oo,
          Poly(1, t, domain='ZZ'), Poly(0, t, domain='ZZ'))

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -166,6 +166,22 @@ def test_bound_degree():
     assert bound_degree(Poly(t, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), DE) == 0
 
 
+def test_bound_degree_undecidable():
+    # Exp case with deg(a) == deg(b) and alpha == -lc(b)/lc(a) == 1/(x + 1):
+    # deciding whether alpha == m*Dt/t + Dz/z requires log(x + 1), which is
+    # not in the tower, so parametric_log_deriv() cannot decide and
+    # bound_degree() must raise rather than return an unsound bound.
+    # param_rischDE() propagates this (it used to guess n = 5 instead,
+    # which could truncate the parametric solution basis and turn into a
+    # false proof of nonelementarity downstream in is_deriv_in_field()).
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t0),
+        Poly(t1, t1)], 'exts': ['log', 'exp'], 'extargs': [x, x]})
+    raises(NotImplementedError, lambda: bound_degree(Poly(t1, t1),
+        Poly(-t1/(x + 1), t1, field=True), Poly(1, t1), DE))
+    raises(NotImplementedError, lambda: bound_degree(Poly(t1, t1),
+        Poly(-t1/(x + 1), t1, field=True), [Poly(1, t1)], DE, parametric=True))
+
+
 def test_spde():
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t**2 + 1, t)]})
     raises(NonElementaryIntegralException, lambda: spde(Poly(t, t), Poly((t - 1)*(t**2 + 1), t), Poly(1, t), 0, DE))

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -213,6 +213,10 @@ def test_solve_poly_rde_no_cancel():
     # The m == 0 branch: Dq + t*q == t has the solution q == 1 (this used
     # to return an Expr instead of a Poly)
     assert no_cancel_equal(Poly(t, t), Poly(t, t), 5, DE) == Poly(1, t)
+    # Immediate u == 0 return: -lc(b)/lc(Dt) == 3 is hit on the first
+    # iteration, reducing to a smaller problem of degree at most 3
+    assert no_cancel_equal(Poly(-3*t, t), Poly(t**2 + 1, t), oo, DE) == \
+        (Poly(0, t), 3, Poly(t**2 + 1, t))
 
 
 def test_solve_poly_rde_cancel():

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -240,7 +240,6 @@ def test_spde():
     assert spde(Poly(t, t), Poly(1, t), Poly(1, t), oo, DE) == \
         (Poly(0, t), Poly(0, t), 0, Poly(0, t), Poly(1, t, domain='QQ'))
     # A SymPy Integer bound must behave like the equal plain int
-    # (this used to loop forever: (S(-1) < 0) is not the True singleton)
     raises(NonElementaryIntegralException, lambda: spde(Poly(t, t),
         Poly(1, t), Poly(x, t, domain='ZZ[x]'), S(1), DE))
     # ...and with deg(a) == 0 it returns immediately, so n == oo is fine.
@@ -300,8 +299,7 @@ def test_solve_poly_rde_cancel():
     # D(x)/x - 2*Dt/t (z == x, m == -2), and the candidate q == 1 + t**2
     # has t**2-coefficient 1, with z*1 == x nonconstant, so no choice of
     # the integration constant removes the term: there is no solution
-    # with n == 0.  (Unconditional stripping used to return q == 1, which
-    # does not solve the equation.)
+    # with n == 0.
     raises(NonElementaryIntegralException, lambda: cancel_exp(
         Poly(1/x - 2, t, field=True),
         Poly(1/x - 2 + t**2/x, t, field=True), 0, DE))

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -1,6 +1,7 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from __future__ import annotations
 from sympy.core.numbers import (I, Rational, oo)
+from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.polys.polytools import Poly, cancel
 from sympy.integrals.risch import (DifferentialExtension, derivation,
@@ -238,6 +239,10 @@ def test_spde():
     # and returns (q == 1 here; c becomes zero after one pass)...
     assert spde(Poly(t, t), Poly(1, t), Poly(1, t), oo, DE) == \
         (Poly(0, t), Poly(0, t), 0, Poly(0, t), Poly(1, t, domain='QQ'))
+    # A SymPy Integer bound must behave like the equal plain int
+    # (this used to loop forever: (S(-1) < 0) is not the True singleton)
+    raises(NonElementaryIntegralException, lambda: spde(Poly(t, t),
+        Poly(1, t), Poly(x, t, domain='ZZ[x]'), S(1), DE))
     # ...and with deg(a) == 0 it returns immediately, so n == oo is fine.
     assert spde(Poly(2, t), Poly(t, t), Poly(t, t), oo, DE) == \
         (Poly(t/2, t, domain='QQ'), Poly(t/2, t, domain='QQ'), oo,

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -286,6 +286,20 @@ def test_solve_poly_rde_cancel():
     raises(NonElementaryIntegralException, lambda: cancel_exp(
         Poly((2*x + 1)/x, t), Poly(1/x**2, t), 0, DE))
 
+    # The t**(-m) stripping in the m < 0 branch is only valid when the
+    # stripped coefficient is C/z for a constant C.  Here b == 1/x - 2 ==
+    # D(x)/x - 2*Dt/t (z == x, m == -2), and the candidate q == 1 + t**2
+    # has t**2-coefficient 1, with z*1 == x nonconstant, so no choice of
+    # the integration constant removes the term: there is no solution
+    # with n == 0.  (Unconditional stripping used to return q == 1, which
+    # does not solve the equation.)
+    raises(NonElementaryIntegralException, lambda: cancel_exp(
+        Poly(1/x - 2, t, field=True),
+        Poly(1/x - 2 + t**2/x, t, field=True), 0, DE))
+    # ...while the same b with c == b has the genuine solution q == 1.
+    assert cancel_exp(Poly(1/x - 2, t, field=True),
+        Poly(1/x - 2, t, field=True), 0, DE) == Poly(1, t)
+
     # primitive
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
 

--- a/sympy/integrals/tests/test_rde.py
+++ b/sympy/integrals/tests/test_rde.py
@@ -222,7 +222,19 @@ def test_solve_poly_rde_cancel():
         Poly(1, t)
     assert cancel_exp(Poly(2*x, t), Poly((1 + 2*x)*t, t), 1, DE) == \
         Poly(t, t)
-    # TODO: Add more exp tests, including tests that require is_deriv_in_field()
+    # The is_deriv_in_field() branch: b == (2*x + 1)/x == D(x)/x + 2*Dt/t
+    # (parametric_log_deriv() gives (1, 2, x)), and Dq + b*q == c has the
+    # solution q == 1 for c == (2*x + 1)/x.
+    assert cancel_exp(Poly((2*x + 1)/x, t), Poly((2*x + 1)/x, t), 0, DE) == \
+        Poly(1, t)
+    # ... but 1/(2*x) also works for c == 1/x (the code finds solutions
+    # with denominators via p/(z*t**m)):
+    assert cancel_exp(Poly((2*x + 1)/x, t), Poly(1/x, t), 0, DE) == \
+        Poly(1/(2*x), t)
+    # c == 1/x**2 requires a' + 2*a == 1/x over QQ(x), which has no
+    # rational solution (pole order mismatch at 0), so no solution exists
+    raises(NonElementaryIntegralException, lambda: cancel_exp(
+        Poly((2*x + 1)/x, t), Poly(1/x**2, t), 0, DE))
 
     # primitive
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
@@ -246,6 +258,16 @@ def test_solve_poly_rde_cancel():
     assert cancel_primitive(Poly(4*x, t), Poly(4*x*t**2 + 2*t/x, t), 3, DE) == \
         Poly(t**2, t)
 
+    # The is_deriv_in_field() branch: b == 1/x == D(x)/x
+    # (is_log_deriv_k_t_radical_in_field() gives (1, x)), and
+    # Dq + b*q == c has the solution q == t for c == (t + 1)/x.
+    assert cancel_primitive(Poly(1/x, t), Poly((t + 1)/x, t), 1, DE) == \
+        Poly(t, t)
+    # z*c == t/(x + 1) has antiderivative t*log(x + 1) - log(x + 1) + x,
+    # which is not in QQ(x, log(x)), so no solution exists
+    raises(NonElementaryIntegralException, lambda: cancel_primitive(
+        Poly(1/x, t), Poly(t/(x*(x + 1)), t), 1, DE))
+
     # The degree bound n must not be clobbered by the index returned from
     # is_log_deriv_k_t_radical_in_field(): b == 1/(2*x) has index 2
     # (2*b == D(x)/x), which used to replace n == 3 and wrongly reject
@@ -255,7 +277,20 @@ def test_solve_poly_rde_cancel():
     c = derivation(q, DE) + b*q
     assert cancel_primitive(b, c, 3, DE) == q
 
-    # TODO: Add more primitive tests, including tests that require is_deriv_in_field()
+    # The b == 0 cancellation case (Dq == c by in-field integration):
+    # primitive (t == log(x)): D(t**2) == 2*t/x
+    assert solve_poly_rde(Poly(0, t), Poly(2*t/x, t), 2, DE) == Poly(t**2, t)
+    # (note Dq == 1/x has the in-field solution q == t == log(x); use an
+    # integrand whose antiderivative needs log(x + 1), which is not in
+    # the field)
+    raises(NonElementaryIntegralException, lambda: solve_poly_rde(
+        Poly(0, t), Poly(t/(x + 1), t), 2, DE))
+    # exp (t == exp(x)): D(x*t) == (x + 1)*t
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)]})
+    assert solve_poly_rde(Poly(0, t), Poly((x + 1)*t, t), 1, DE) == \
+        Poly(x*t, t)
+    raises(NonElementaryIntegralException, lambda: solve_poly_rde(
+        Poly(0, t), Poly(t/x, t), 1, DE))
 
 
 def test_rischDE():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -968,7 +968,7 @@ def test_DifferentialExtension_printing():
         "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]), ('fa', Poly(t1 + t0**2, t1, domain='ZZ[t0]')), "
         "('fd', Poly(1, t1, domain='ZZ')), ('Tfuncs', [Lambda(i, exp(i**2)), Lambda(i, log(t0 + 1))]), "
         "('backsubs', []), ('exts', ['exp', 'log']), ('extargs', [x**2, t0 + 1]), "
-        "('cases', ['base', 'exp', 'primitive']), ('case', 'primitive'), ('t', t1), "
+        "('cases', ['base', 'exp', 'primitive']), ('case', 'primitive'), ('transcendental', True), ('t', t1), "
         "('d', Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')), ('newf', t0**2 + t1), ('level', -1), "
         "('dummy', False)]))")
 

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -793,6 +793,22 @@ def test_risch_integrate():
     assert risch_integrate(log(x**y), x) == x*log(x**y) - x*y
     assert risch_integrate(log(sqrt(x)), x) == x*log(sqrt(x)) - x/2
 
+    # A restart (from the exponential radical path) clears backsubs, so
+    # the branch-constant Dummy recorded by _log_part() must be folded
+    # back into newf first, or it leaks into the result as a free symbol.
+    ans = risch_integrate(log(x) + log(x**2) + exp(x) + exp(x/2 + 1), x)
+    assert ans.free_symbols == {x}
+    assert cancel(diff(ans, x) - (log(x) + log(x**2) + exp(x) +
+        exp(x/2 + 1))) == 0
+
+    # Mixed notation: when the integrand contains both sqrt(exp(x)) and
+    # its folded form exp(x/2), restoring the radical globally would
+    # also rewrite the genuine exp(x/2), so the answer stays in the
+    # exact exponential form.
+    assert risch_integrate(sqrt(exp(x)) + exp(x/2), x) == 4*exp(x/2)
+    # A pure user radical keeps its notation.
+    assert risch_integrate(sqrt(exp(x)), x) == 2*sqrt(exp(x))
+
     # Example 6.2.1
     expr = (exp(x) - x**2 + 2*x)/((exp(x) + x)**2*x**2)*exp((x**2 - 1)/x + 1/(exp(x) + x))
     assert risch_integrate(expr, x) == exp(-x)*exp(1/(x + exp(x)) + (x**2 - 1)/x)

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -530,11 +530,18 @@ def test_DifferentialExtension_exp():
 
 
 def test_DifferentialExtension_log():
-    assert DifferentialExtension(log(x)*log(x + 1)*log(2*x**2 + 2*x), x)._important_attrs == \
-        (Poly(t0*t1**2 + (t0*log(2) + t0**2)*t1, t1), Poly(1, t1),
+    # log(2*x**2 + 2*x) is rewritten in terms of the other two logarithms
+    # plus an opaque locally-constant branch term (restored by backsubs),
+    # not the principal-branch constant log(2), which is only valid where
+    # the arguments are all positive.
+    DE = DifferentialExtension(log(x)*log(x + 1)*log(2*x**2 + 2*x), x)
+    c = DE.backsubs[-1][0]
+    assert DE._important_attrs == \
+        (Poly(t0*t1**2 + (c*t0 + t0**2)*t1, t1), Poly(1, t1),
         [Poly(1, x), Poly(1/x, t0),
         Poly(1/(x + 1), t1, expand=False)], [x, t0, t1],
-        [Lambda(i, log(i)), Lambda(i, log(i + 1))], [], ['log', 'log'],
+        [Lambda(i, log(i)), Lambda(i, log(i + 1))],
+        [(c, log(2*x**2 + 2*x) - log(x) - log(x + 1))], ['log', 'log'],
         [x, x + 1])
     assert DifferentialExtension(x**x*log(x), x)._important_attrs == \
         (Poly(t0*t1, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0),
@@ -545,10 +552,13 @@ def test_DifferentialExtension_log():
 
 def test_DifferentialExtension_symlog():
     # See comment on test_risch_integrate below
-    assert DifferentialExtension(log(x**x), x)._important_attrs == \
-        (Poly(t0*x, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0), Poly((t0 +
+    DE = DifferentialExtension(log(x**x), x)
+    c = DE.backsubs[-1][0]
+    assert DE._important_attrs == \
+        (Poly(t0*x + c, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0), Poly((t0 +
             1)*t1, t1)], [x, t0, t1], [Lambda(i, log(i)), Lambda(i, exp(i*t0))],
-            [(exp(x*log(x)), x**x)], ['log', 'exp'], [x, t0*x])
+            [(exp(x*log(x)), x**x), (c, log(x**x) - x*log(x))],
+            ['log', 'exp'], [x, t0*x])
     assert DifferentialExtension(log(x**y), x)._important_attrs == \
         (Poly(y*t0, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
         [Lambda(i, log(i))], [(y*log(x), log(x**y))], ['log'],
@@ -658,9 +668,11 @@ def test_DifferentialExtension_misc():
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(log(10)*t0, t0)], [x, t0],
         [Lambda(i, exp(i*log(10)))], [(exp(x*log(10)), 10**x)], ['exp'],
         [x*log(10)])
-    assert DifferentialExtension(log(x) + log(x**2), x)._important_attrs == \
-        (Poly(3*t0, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
-        [Lambda(i, log(i))], [], ['log'], [x])
+    DE = DifferentialExtension(log(x) + log(x**2), x)
+    c = DE.backsubs[-1][0]
+    assert DE._important_attrs == \
+        (Poly(3*t0 + c, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
+        [Lambda(i, log(i))], [(c, log(x**2) - 2*log(x))], ['log'], [x])
     assert DifferentialExtension(S.Zero, x)._important_attrs == \
         (Poly(0, x), Poly(1, x), [Poly(1, x)], [x], [], [], [], [])
     assert DifferentialExtension(tan(atan(x).rewrite(log)), x)._important_attrs == \
@@ -751,19 +763,20 @@ def test_risch_integrate():
     e2 = (log(-1/y)/2 - log(1/y)/2)/y - (log(1 - 1/y)/2 - log(1 + 1/y)/2)/y
     ans2 = risch_integrate(e2, y)
     assert ans2 == log(1/y)*log(1 - 1/y)/2 - log(1/y)*log(1 + 1/y)/2 + \
-            NonElementaryIntegral((I*pi*y**2 - 2*y*log(1/y) - I*pi)/(2*y**3 - 2*y), y)
+            NonElementaryIntegral((y**2*(log(-1/y) - log(1/y)) - 2*y*log(1/y)
+                - log(-1/y) + log(1/y))/(2*y**3 - 2*y), y)
     assert expand_log(cancel(diff(ans2, y) - e2), force=True) == 0
 
     # These are tested here in addition to in test_DifferentialExtension above
     # (symlogs) to test that backsubs works correctly.  The integrals should be
     # written in terms of the original logarithms in the integrands.
 
-    # XXX: Unfortunately, making backsubs work on this one is a little
-    # trickier, because x**x is converted to exp(x*log(x)), and so log(x**x)
-    # is converted to x*log(x). (x**2*log(x)).subs(x*log(x), log(x**x)) is
-    # smart enough, the issue is that these splits happen at different places
-    # in the algorithm.  Maybe a heuristic is in order
-    assert risch_integrate(log(x**x), x) == x**2*log(x)/2 - x**2/4
+    # The answer carries the locally-constant difference
+    # log(x**x) - x*log(x) explicitly (it vanishes on the domain where
+    # x**x is real, but not identically), so the original log(x**x)
+    # notation reappears through it.
+    assert risch_integrate(log(x**x), x) == \
+        x**2*log(x)/2 - x**2/4 + x*(log(x**x) - x*log(x))
 
     assert risch_integrate(log(x**y), x) == x*log(x**y) - x*y
     assert risch_integrate(log(sqrt(x)), x) == x*log(sqrt(x)) - x/2

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -532,9 +532,13 @@ def test_DifferentialExtension_exp():
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i/2)),
         Lambda(i, exp(i**2))], [], ['exp', 'exp'],
         [x/2, x**2])
-    assert DifferentialExtension(sqrt(exp(x)), x)._important_attrs == \
-        (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
-        [Lambda(i, exp(i/2))], [(exp(x/2), sqrt(exp(x)))], ['exp'], [x/2])
+    # A user-written radical of an exponential folds to an opaque
+    # locally constant ratio times exp(x/2); backsubs restores it exactly.
+    DE = DifferentialExtension(sqrt(exp(x)), x)
+    c = DE.backsubs[-1][0]
+    assert DE._important_attrs == \
+        (Poly(c*t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
+        [Lambda(i, exp(i/2))], [(c, exp(-x/2)*sqrt(exp(x)))], ['exp'], [x/2])
 
     assert DifferentialExtension(exp(x/2), x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
@@ -801,11 +805,13 @@ def test_risch_integrate():
     assert cancel(diff(ans, x) - (log(x) + log(x**2) + exp(x) +
         exp(x/2 + 1))) == 0
 
-    # Mixed notation: when the integrand contains both sqrt(exp(x)) and
-    # its folded form exp(x/2), restoring the radical globally would
-    # also rewrite the genuine exp(x/2), so the answer stays in the
-    # exact exponential form.
-    assert risch_integrate(sqrt(exp(x)) + exp(x/2), x) == 4*exp(x/2)
+    # Mixed notation: sqrt(exp(x)) and exp(x/2) are different functions
+    # off the real line (a locally constant sign apart), and both keep
+    # their identity: the radical is folded with an opaque ratio that is
+    # restored exactly, so the answer differentiates back to the mixed
+    # integrand on every component.
+    ans = risch_integrate(sqrt(exp(x)) + exp(x/2), x)
+    assert cancel((ans - 2*sqrt(exp(x)) - 2*exp(x/2)).expand()) == 0
     # A pure user radical keeps its notation.
     assert risch_integrate(sqrt(exp(x)), x) == 2*sqrt(exp(x))
 

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -510,15 +510,20 @@ def test_DifferentialExtension_exp():
         (Poly((1 + S.Exp1*t0)*t1 + t0, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i)),
         Lambda(i, exp(i**2))], [], ['exp', 'exp'], [x, x**2])
+    # exp(x/2 + x**2) makes the tower use exp(x/2) internally; the answer
+    # must stay in that exact form, not be rewritten into the principal
+    # root sqrt(exp(x)) the user never wrote (which differs from exp(x/2)
+    # by a locally constant sign off the real line), so no backsubs pair
+    # is recorded.
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x/2 + x**2), x)._important_attrs == \
         (Poly((t0 + 1)*t1 + t0**2, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1],
         [Lambda(i, exp(i/2)), Lambda(i, exp(i**2))],
-        [(exp(x/2), sqrt(exp(x)))], ['exp', 'exp'], [x/2, x**2])
+        [], ['exp', 'exp'], [x/2, x**2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x/2 + x**2 + 3), x)._important_attrs == \
         (Poly((t0*exp(3) + 1)*t1 + t0**2, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i/2)),
-        Lambda(i, exp(i**2))], [(exp(x/2), sqrt(exp(x)))], ['exp', 'exp'],
+        Lambda(i, exp(i**2))], [], ['exp', 'exp'],
         [x/2, x**2])
     assert DifferentialExtension(sqrt(exp(x)), x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
@@ -923,6 +928,7 @@ def test_DifferentialExtension_equality():
 def test_DifferentialExtension_printing():
     DE = DifferentialExtension(exp(2*x**2) + log(exp(x**2) + 1), x)
     assert repr(DE) == ("DifferentialExtension(dict([('f', exp(2*x**2) + log(exp(x**2) + 1)), "
+        "('origf', exp(2*x**2) + log(exp(x**2) + 1)), "
         "('x', x), ('T', [x, t0, t1]), ('D', [Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
         "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]), ('fa', Poly(t1 + t0**2, t1, domain='ZZ[t0]')), "
         "('fd', Poly(1, t1, domain='ZZ')), ('Tfuncs', [Lambda(i, exp(i**2)), Lambda(i, log(t0 + 1))]), "

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -13,6 +13,7 @@ from sympy.functions.elementary.trigonometric import (atan, cot, sin, tan)
 from sympy.polys.polytools import (Poly, cancel, factor)
 from sympy.polys.rationaltools import together
 from sympy.polys.rootoftools import RootSum
+from sympy.integrals.integrals import Integral
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     derivation, splitfactor, splitfactor_sqf, canonical_representation,
     hermite_reduce, polynomial_reduce, residue_reduce, residue_reduce_to_basic,
@@ -20,7 +21,8 @@ from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     integrate_hyperexponential, integrate_hypertangent_polynomial,
     integrate_nonlinear_no_specials, integer_powers, DifferentialExtension,
     risch_integrate, DecrementLevel, NonElementaryIntegral, recognize_log_derivative,
-    recognize_derivative, laurent_series)
+    recognize_derivative, laurent_series, _nontrans_is_kernel,
+    _nontrans_accept)
 from sympy.testing.pytest import raises
 
 from sympy.abc import x, t, nu, z, a, y
@@ -755,6 +757,50 @@ def test_DecrementLevel():
     assert DE.t == t1
     assert DE.d == Poly(t0/(t0 + 1), t1)
     assert DE.case == 'primitive'
+
+
+def test_nontranscendental_tower():
+    # The tower [x, t0 == log(x), t1 == exp(t0/2)], with t1 representing
+    # sqrt(x): a non-transcendental tower, declared as such.
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t0),
+        Poly(t1/(2*x), t1)], 'exts': ['log', 'exp'],
+        'extargs': [x, t0/2], 'transcendental': False})
+    # The formal field has genuinely new constants...
+    assert derivation(t1**2/x, DE, basic=True) == 0
+    # ...whose kernel counterparts (elements evaluating to zero) are
+    # recognized from the power relation t1**2 == x:
+    assert _nontrans_is_kernel(t1**2 - x, DE)
+    assert _nontrans_is_kernel(x*(t1**2/x - 1), DE)
+    assert not _nontrans_is_kernel(t1**2 + x, DE)
+    assert not _nontrans_is_kernel(t1 - x, DE)
+
+    # Acceptance filter for f == t1 (i.e. sqrt(x)):
+    fa, fd = Poly(t1, t1), Poly(1, t1)
+    # the genuine antiderivative 2/3*x*t1 passes...
+    assert _nontrans_accept(Rational(2, 3)*x*t1, [], S.Zero, fa, fd, DE, None)
+    # ...a wrong candidate fails the formal-identity check...
+    assert not _nontrans_accept(x*t1, [], S.Zero, fa, fd, DE, None)
+    # ...and a kernel denominator fails the evaluation check even though
+    # the formal identity holds (x/(t1**2 - x) is a formal constant, so
+    # adding it does not disturb the derivative)
+    assert not _nontrans_accept(Rational(2, 3)*x*t1 + x/(t1**2 - x), [],
+        S.Zero, fa, fd, DE, None)
+
+
+def test_risch_integrate_algebraic():
+    # Proof-of-concept algebraic integration via exp-log towers:
+    # sqrt(y) == exp(log(y)/2).  Solved cases are verified by
+    # _nontrans_accept(), and negative conclusions are degraded to
+    # plain Integrals (nonelementary proofs assume transcendence).
+    y = Symbol('y', positive=True)
+    assert risch_integrate(sqrt(y), y) == 2*y**Rational(3, 2)/3
+    assert risch_integrate(1/sqrt(y), y) == 2*sqrt(y)
+    assert risch_integrate(y*sqrt(y), y) == 2*y**Rational(5, 2)/5
+    # unsolved algebraic integrals must come back as plain Integrals,
+    # never as NonElementaryIntegral
+    r = risch_integrate(exp(sqrt(y)), y)
+    assert r == Integral(exp(sqrt(y)), y)
+    assert not r.has(NonElementaryIntegral)
 
 
 def test_risch_integrate():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -801,6 +801,16 @@ def test_integrate_primitive_nonelementary_residual():
         assert cancel(together(diff(g, x) + i.function - f)) == 0
 
 
+def test_risch_integrate_cancellation():
+    # Requires the parametric Liouvillian cancellation case at the
+    # exponential level (prde_cancel_liouvillian() via limited_integrate());
+    # this used to hang because the coefficient shift i*Dt/t was computed
+    # at the wrong level.
+    e = exp(x)*log(exp(x) + 1)
+    assert risch_integrate(e, x) == \
+        exp(x)*log(exp(x) + 1) - exp(x) + log(exp(x) + 1)
+
+
 def test_bound_degree_limited_integrate():
     # bound_degree() used to raise "TypeError: '>' not supported between
     # instances of 'Poly' and 'int'" on these when the sharp primitive-case

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -491,38 +491,38 @@ def test_DifferentialExtension_exp():
     assert DifferentialExtension(exp(x) + exp(x**2), x)._important_attrs == \
         (Poly(t1 + t0, t1), Poly(1, t1), [Poly(1, x,), Poly(t0, t0),
         Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i)),
-        Lambda(i, exp(i**2))], [], [None, 'exp', 'exp'], [None, x, x**2])
+        Lambda(i, exp(i**2))], [], ['exp', 'exp'], [x, x**2])
     assert DifferentialExtension(exp(x) + exp(2*x), x)._important_attrs == \
         (Poly(t0**2 + t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0, t0)], [x, t0],
-        [Lambda(i, exp(i))], [], [None, 'exp'], [None, x])
+        [Lambda(i, exp(i))], [], ['exp'], [x])
     assert DifferentialExtension(exp(x) + exp(x/2), x)._important_attrs == \
         (Poly(t0**2 + t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)],
-        [x, t0], [Lambda(i, exp(i/2))], [], [None, 'exp'], [None, x/2])
+        [x, t0], [Lambda(i, exp(i/2))], [], ['exp'], [x/2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x + x**2), x)._important_attrs == \
         (Poly((1 + t0)*t1 + t0, t1), Poly(1, t1), [Poly(1, x), Poly(t0, t0),
         Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i)),
-        Lambda(i, exp(i**2))], [], [None, 'exp', 'exp'], [None, x, x**2])
+        Lambda(i, exp(i**2))], [], ['exp', 'exp'], [x, x**2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x + x**2 + 1), x)._important_attrs == \
         (Poly((1 + S.Exp1*t0)*t1 + t0, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i)),
-        Lambda(i, exp(i**2))], [], [None, 'exp', 'exp'], [None, x, x**2])
+        Lambda(i, exp(i**2))], [], ['exp', 'exp'], [x, x**2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x/2 + x**2), x)._important_attrs == \
         (Poly((t0 + 1)*t1 + t0**2, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1],
         [Lambda(i, exp(i/2)), Lambda(i, exp(i**2))],
-        [(exp(x/2), sqrt(exp(x)))], [None, 'exp', 'exp'], [None, x/2, x**2])
+        [(exp(x/2), sqrt(exp(x)))], ['exp', 'exp'], [x/2, x**2])
     assert DifferentialExtension(exp(x) + exp(x**2) + exp(x/2 + x**2 + 3), x)._important_attrs == \
         (Poly((t0*exp(3) + 1)*t1 + t0**2, t1), Poly(1, t1), [Poly(1, x),
         Poly(t0/2, t0), Poly(2*x*t1, t1)], [x, t0, t1], [Lambda(i, exp(i/2)),
-        Lambda(i, exp(i**2))], [(exp(x/2), sqrt(exp(x)))], [None, 'exp', 'exp'],
-        [None, x/2, x**2])
+        Lambda(i, exp(i**2))], [(exp(x/2), sqrt(exp(x)))], ['exp', 'exp'],
+        [x/2, x**2])
     assert DifferentialExtension(sqrt(exp(x)), x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
-        [Lambda(i, exp(i/2))], [(exp(x/2), sqrt(exp(x)))], [None, 'exp'], [None, x/2])
+        [Lambda(i, exp(i/2))], [(exp(x/2), sqrt(exp(x)))], ['exp'], [x/2])
 
     assert DifferentialExtension(exp(x/2), x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(t0/2, t0)], [x, t0],
-        [Lambda(i, exp(i/2))], [], [None, 'exp'], [None, x/2])
+        [Lambda(i, exp(i/2))], [], ['exp'], [x/2])
 
 
 def test_DifferentialExtension_log():
@@ -530,13 +530,13 @@ def test_DifferentialExtension_log():
         (Poly(t0*t1**2 + (t0*log(2) + t0**2)*t1, t1), Poly(1, t1),
         [Poly(1, x), Poly(1/x, t0),
         Poly(1/(x + 1), t1, expand=False)], [x, t0, t1],
-        [Lambda(i, log(i)), Lambda(i, log(i + 1))], [], [None, 'log', 'log'],
-        [None, x, x + 1])
+        [Lambda(i, log(i)), Lambda(i, log(i + 1))], [], ['log', 'log'],
+        [x, x + 1])
     assert DifferentialExtension(x**x*log(x), x)._important_attrs == \
         (Poly(t0*t1, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0),
         Poly((1 + t0)*t1, t1)], [x, t0, t1], [Lambda(i, log(i)),
-        Lambda(i, exp(t0*i))], [(exp(x*log(x)), x**x)], [None, 'log', 'exp'],
-        [None, x, t0*x])
+        Lambda(i, exp(t0*i))], [(exp(x*log(x)), x**x)], ['log', 'exp'],
+        [x, t0*x])
 
 
 def test_DifferentialExtension_symlog():
@@ -544,26 +544,26 @@ def test_DifferentialExtension_symlog():
     assert DifferentialExtension(log(x**x), x)._important_attrs == \
         (Poly(t0*x, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0), Poly((t0 +
             1)*t1, t1)], [x, t0, t1], [Lambda(i, log(i)), Lambda(i, exp(i*t0))],
-            [(exp(x*log(x)), x**x)], [None, 'log', 'exp'], [None, x, t0*x])
+            [(exp(x*log(x)), x**x)], ['log', 'exp'], [x, t0*x])
     assert DifferentialExtension(log(x**y), x)._important_attrs == \
         (Poly(y*t0, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
-        [Lambda(i, log(i))], [(y*log(x), log(x**y))], [None, 'log'],
-        [None, x])
+        [Lambda(i, log(i))], [(y*log(x), log(x**y))], ['log'],
+        [x])
     assert DifferentialExtension(log(sqrt(x)), x)._important_attrs == \
         (Poly(t0, t0), Poly(2, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
-        [Lambda(i, log(i))], [(log(x)/2, log(sqrt(x)))], [None, 'log'],
-        [None, x])
+        [Lambda(i, log(i))], [(log(x)/2, log(sqrt(x)))], ['log'],
+        [x])
 
 
 def test_DifferentialExtension_handle_first():
     assert DifferentialExtension(exp(x)*log(x), x, handle_first='log')._important_attrs == \
         (Poly(t0*t1, t1), Poly(1, t1), [Poly(1, x), Poly(1/x, t0),
         Poly(t1, t1)], [x, t0, t1], [Lambda(i, log(i)), Lambda(i, exp(i))],
-        [], [None, 'log', 'exp'], [None, x, x])
+        [], ['log', 'exp'], [x, x])
     assert DifferentialExtension(exp(x)*log(x), x, handle_first='exp')._important_attrs == \
         (Poly(t0*t1, t1), Poly(1, t1), [Poly(1, x), Poly(t0, t0),
         Poly(1/x, t1)], [x, t0, t1], [Lambda(i, exp(i)), Lambda(i, log(i))],
-        [], [None, 'exp', 'log'], [None, x, x])
+        [], ['exp', 'log'], [x, x])
 
     # This one must have the log first, regardless of what we set it to
     # (because the log is inside of the exponential: x**x == exp(x*log(x)))
@@ -574,7 +574,7 @@ def test_DifferentialExtension_handle_first():
         (Poly((-1 + x - x*t0**2)*t1, t1), Poly(x, t1),
             [Poly(1, x), Poly(1/x, t0), Poly((1 + t0)*t1, t1)], [x, t0, t1],
             [Lambda(i, log(i)), Lambda(i, exp(t0*i))], [(exp(x*log(x)), x**x)],
-            [None, 'log', 'exp'], [None, x, t0*x])
+            ['log', 'exp'], [x, t0*x])
 
 
 def test_DifferentialExtension_all_attrs():
@@ -626,9 +626,9 @@ def test_DifferentialExtension_extension_flag():
     assert DE.case == 'exp'
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(t, t)],
-        'exts': [None, 'exp'], 'extargs': [None, x]})
+        'exts': ['exp'], 'extargs': [x]})
     assert DE._important_attrs == (None, None, [Poly(1, x), Poly(t, t)], [x, t],
-        None, None, [None, 'exp'], [None, x])
+        None, None, ['exp'], [x])
     raises(ValueError, lambda: DifferentialExtension())
 
 
@@ -637,7 +637,7 @@ def test_DifferentialExtension_misc():
     assert DifferentialExtension(sin(y)*exp(x), x)._important_attrs == \
         (Poly(sin(y)*t0, t0, domain='ZZ[sin(y)]'), Poly(1, t0, domain='ZZ'),
         [Poly(1, x, domain='ZZ'), Poly(t0, t0, domain='ZZ')], [x, t0],
-        [Lambda(i, exp(i))], [], [None, 'exp'], [None, x])
+        [Lambda(i, exp(i))], [], ['exp'], [x])
     raises(NotImplementedError, lambda: DifferentialExtension(sin(x), x))
     # cot, acot, and the hyperbolic functions used to fall through to the
     # generic "Couldn't find an elementary transcendental extension" error
@@ -652,15 +652,15 @@ def test_DifferentialExtension_misc():
         assert "Trigonometric and hyperbolic" in str(e)
     assert DifferentialExtension(10**x, x)._important_attrs == \
         (Poly(t0, t0), Poly(1, t0), [Poly(1, x), Poly(log(10)*t0, t0)], [x, t0],
-        [Lambda(i, exp(i*log(10)))], [(exp(x*log(10)), 10**x)], [None, 'exp'],
-        [None, x*log(10)])
+        [Lambda(i, exp(i*log(10)))], [(exp(x*log(10)), 10**x)], ['exp'],
+        [x*log(10)])
     assert DifferentialExtension(log(x) + log(x**2), x)._important_attrs == \
         (Poly(3*t0, t0), Poly(1, t0), [Poly(1, x), Poly(1/x, t0)], [x, t0],
-        [Lambda(i, log(i))], [], [None, 'log'], [None, x])
+        [Lambda(i, log(i))], [], ['log'], [x])
     assert DifferentialExtension(S.Zero, x)._important_attrs == \
-        (Poly(0, x), Poly(1, x), [Poly(1, x)], [x], [], [], [None], [None])
+        (Poly(0, x), Poly(1, x), [Poly(1, x)], [x], [], [], [], [])
     assert DifferentialExtension(tan(atan(x).rewrite(log)), x)._important_attrs == \
-        (Poly(x, x), Poly(1, x), [Poly(1, x)], [x], [], [], [None], [None])
+        (Poly(x, x), Poly(1, x), [Poly(1, x)], [x], [], [], [], [])
 
 
 def test_DifferentialExtension_Rothstein():
@@ -673,7 +673,7 @@ def test_DifferentialExtension_Rothstein():
         [Poly(1, x), Poly(t0, t0), Poly(-(10 + 21*t0 + 10*t0**2)/(1 + 2*t0 +
         t0**2)*t1, t1, domain='ZZ(t0)')], [x, t0, t1],
         [Lambda(i, exp(i)), Lambda(i, exp(1/(t0 + 1) - 10*i))], [],
-        [None, 'exp', 'exp'], [None, x, 1/(t0 + 1) - 10*x])
+        ['exp', 'exp'], [x, 1/(t0 + 1) - 10*x])
 
 
 class _TestingException(Exception):
@@ -838,7 +838,7 @@ def test_DifferentialExtension_printing():
         "('x', x), ('T', [x, t0, t1]), ('D', [Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
         "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]), ('fa', Poly(t1 + t0**2, t1, domain='ZZ[t0]')), "
         "('fd', Poly(1, t1, domain='ZZ')), ('Tfuncs', [Lambda(i, exp(i**2)), Lambda(i, log(t0 + 1))]), "
-        "('backsubs', []), ('exts', [None, 'exp', 'log']), ('extargs', [None, x**2, t0 + 1]), "
+        "('backsubs', []), ('exts', ['exp', 'log']), ('extargs', [x**2, t0 + 1]), "
         "('cases', ['base', 'exp', 'primitive']), ('case', 'primitive'), ('t', t1), "
         "('d', Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')), ('newf', t0**2 + t1), ('level', -1), "
         "('dummy', False)]))")

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -301,6 +301,13 @@ def test_residue_reduce():
     assert residue_reduce(Poly(t, t), Poly(t + sqrt(2), t), DE, z) == \
         ([(Poly(z - 1, z, domain='QQ'), Poly(t + sqrt(2), t))], True)
 
+    # issue 26502: the leading coefficient of the subresultant remainder has
+    # a non-monomial denominator in x
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)], 'Tfuncs': [log]})
+    assert residue_reduce(Poly(-2*x*t - 2*x - 2, t),
+        Poly((x**3 + 2*x**2 + x)*t**2 - x, t), DE, z) == \
+        ([(Poly(z**2 - 1, z, domain='QQ'), Poly(t + z/(x + 1), t, domain='ZZ(x,z)'))], True)
+
 
 def test_integrate_hyperexponential():
     # TODO: Add tests for integrate_hyperexponential() from the book
@@ -806,6 +813,12 @@ def test_risch_integrate():
     # sin(x).rewrite(exp)
     expr = -I*(exp(I*x) - exp(-I*x))/2
     assert risch_integrate(expr, x) == -exp(I*x)/2 - exp(-I*x)/2
+
+    # issue 26502
+    expr = (-2*x*log(x) - 2*x - 2)/(x**3*log(x)**2 + 2*x**2*log(x)**2 +
+        x*log(x)**2 - x)
+    assert risch_integrate(expr, x) == \
+        log(log(x) + 1/(x + 1)) - log(log(x) - 1/(x + 1))
 
 def test_risch_integrate_symbolic_constant():
     # A symbolic constant in the exponential argument; the generic answer

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -896,7 +896,9 @@ def test_risch_integrate_algebraic_branches():
     # non-kernel is not enough for denominators: s - 1 is formally
     # nonzero (a zero divisor mod s**2 - 1) but the ratio equals 1 on
     # whole regions, so acceptance must check every attainable value
-    assert _nontrans_sign_assignments(DE) == [{s: 1}, {s: -1}]
+    assert _nontrans_sign_assignments(DE, [s - 1]) == [{s: 1}, {s: -1}]
+    # constants absent from the checked expressions need no assignment
+    assert _nontrans_sign_assignments(DE, [x + 1]) == [{}]
     z = Dummy('z')
     assert not _nontrans_accept(1/(s - 1), [], S.Zero,
         Poly(0, DE.t), Poly(1, DE.t), DE, z)
@@ -950,6 +952,19 @@ def test_risch_integrate_algebraic_branches():
     f = 1/(x**2 - x**2*sqrt(x**2 + 2*x + 1)/(x + 1) + 1)
     r = risch_integrate(f, x, algebraic=True)
     assert r == Integral(f, x)
+    # a seventh-root ratio has no exact algebraic roots of unity, but
+    # a constant occurring only as a numerator polynomial factor needs
+    # no assignment, so this must not be over-rejected
+    f = (x**2 + 2*x + 1)**Rational(1, 7)
+    r = risch_integrate(f, x, algebraic=True)
+    assert not r.has(Integral)
+    assert deriv_ok(f, r, [-3, 1])
+    # breakpoint sets must be complete: real_roots() isolates the real
+    # root of the quintic exactly (roots() cannot express it)
+    f = sqrt((x**5 - x - 1)**2)
+    r = risch_integrate(f, x, algebraic=True)
+    assert not r.has(Integral)
+    assert deriv_ok(f, r, [0, 2])
 
 
 def test_risch_integrate():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1001,6 +1001,13 @@ def test_risch_integrate_algebraic_branches():
     f = 1/(sqrt(-3*x - 2)*sqrt(3*x + 2))
     r = risch_integrate(f, x, algebraic=True)
     assert deriv_ok(f, r, [-2, 1])
+    # nested proportional radicands: the ratio is built from tower
+    # symbols whose images reference lower generators, so the
+    # back-substitution must be sequential or a Dummy leaks
+    f = sqrt(log(x))/sqrt(-log(x))
+    r = risch_integrate(f, x, algebraic=True)
+    assert r.free_symbols == {x}
+    assert deriv_ok(f, r, [Rational(1, 2), 2])
 
 
 def test_risch_integrate():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -825,9 +825,18 @@ def test_risch_integrate_log_to_atan():
     assert ans == log(exp(2*x) + 2*exp(x) + 2)/2 + 3*atan(exp(x) + 1)
     assert cancel(diff(ans, x) - e) == 0
 
-    # Residues that are real but irrational are still returned as a RootSum
+    # Real irrational residues also give explicit logarithms when the
+    # roots can be computed
     assert risch_integrate(exp(x)/(exp(2*x) - 2), x) == \
-        RootSum(Poly(8*z**2 - 1, z), Lambda(z, z*log(-4*z + exp(x))))
+        sqrt(2)*log(exp(x) - sqrt(2))/4 - sqrt(2)*log(exp(x) + sqrt(2))/4
+
+    # Terms whose residues cannot all be computed explicitly fall back
+    # to a RootSum
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)],
+        'Tfuncs': [log]})
+    H = [(Poly(z**5 - z - 1, z), Poly(t + z, t))]
+    assert residue_reduce_to_basic(H, DE, z) == \
+        RootSum(Poly(z**5 - z - 1, z), Lambda(z, z*log(z + log(x))))
 
 
 def test_integrate_primitive_nonelementary_residual():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -9,7 +9,8 @@ from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.hyperbolic import tanh
-from sympy.functions.elementary.trigonometric import (atan, cot, sin, tan)
+from sympy.functions.elementary.trigonometric import (atan, cos, cot, sin,
+    tan)
 from sympy.polys.polytools import (Poly, cancel, factor)
 from sympy.polys.rationaltools import together
 from sympy.polys.rootoftools import RootSum
@@ -969,9 +970,12 @@ def test_risch_integrate_algebraic_branches():
     DE7 = DifferentialExtension(f, x, algebraic=True)
     [(s7, _, _)] = DE7.sign_consts
     assert _nontrans_vet(s7*x + exp(s7*x), DE7)
+    assert _nontrans_vet(sin(s7*x) + cos(s7*x) + tanh(x)*s7, DE7)
     assert not _nontrans_vet(log(s7*x), DE7)
+    assert not _nontrans_vet(tan(s7*x), DE7)
     assert not _nontrans_vet(1/(x + s7), DE7)
     assert not _nontrans_vet(exp(x/(x + s7)), DE7)
+    assert not _nontrans_vet(sin(x/(x + s7)), DE7)
     t_ = Symbol('t')
     bad = RootSum(Poly((s - 1)*t_**5 + t_ + 1, t_),
                   Lambda(t_, t_*log(x + t_)))

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -818,6 +818,13 @@ def test_risch_integrate_log_to_atan():
     assert ans == log(exp(x) + 3)/2 + atan(exp(x))
     assert cancel(diff(ans, x) - e) == 0
 
+    # Complex residues with a nonzero real part give both a log and an
+    # atan term
+    e = (exp(x) + 4)*exp(x)/((exp(x) + 1)**2 + 1)
+    ans = risch_integrate(e, x)
+    assert ans == log(exp(2*x) + 2*exp(x) + 2)/2 + 3*atan(exp(x) + 1)
+    assert cancel(diff(ans, x) - e) == 0
+
     # Residues that are real but irrational are still returned as a RootSum
     assert risch_integrate(exp(x)/(exp(2*x) - 2), x) == \
         RootSum(Poly(8*z**2 - 1, z), Lambda(z, z*log(-4*z + exp(x))))

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -955,6 +955,21 @@ def test_risch_integrate_algebraic_branches():
     f = 1/(x**2 - x**2*sqrt(x**2 + 2*x + 1)/(x + 1) + 1)
     r = risch_integrate(f, x, algebraic=True)
     assert r == Integral(f, x)
+    # a partially integrated level (unsolved nonconstant part) with a
+    # parameter-dependent denominator: the residual stays outside for
+    # the caller to keep integrating, and the degenerate branch is the
+    # unevaluated rest of the level, so the assembled degenerate value
+    # is Integral(f - resid) + Integral(resid) with nothing counted
+    # twice
+    f = 1/(x**2 + a**2)**Rational(3, 2) + sqrt(x**2 + a**2)
+    r = risch_integrate(f, x)
+    assert r == Piecewise(
+        ((a**2*x + x**3)/(a**2*(a**2 + x**2)**Rational(3, 2)),
+         Ne(a**2, 0)),
+        (Integral((a**2 + 3*x**2)/(a**4*sqrt(a**2 + x**2)
+                  + a**2*x**2*sqrt(a**2 + x**2)), x), True)) + \
+        Integral((a**2*(a**2 + x**2)**2 - 3*x**2)
+                 / (a**2*(a**2 + x**2)**Rational(3, 2)), x)
     # a seventh-root ratio has no exact algebraic roots of unity, but
     # a constant occurring only as a numerator polynomial factor needs
     # no assignment, so this must not be over-rejected

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -810,6 +810,13 @@ def test_risch_integrate_cancellation():
     assert risch_integrate(e, x) == \
         exp(x)*log(exp(x) + 1) - exp(x) + log(exp(x) + 1)
 
+    # Requires the structure-theorem fallback of parametric_log_deriv()
+    # (the heuristic alone raises NotImplementedError on this one)
+    e = log(exp(x) + log(x))
+    g, i = risch_integrate(e, x, separate_integral=True)
+    assert isinstance(i, NonElementaryIntegral)
+    assert cancel(together(diff(g, x) + i.function - e)) == 0
+
 
 def test_bound_degree_limited_integrate():
     # bound_degree() used to raise "TypeError: '>' not supported between

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -943,6 +943,13 @@ def test_risch_integrate_algebraic_branches():
     f = (sqrt(x**2 + 2*x + 1) + x + 1)*exp(x**2)
     r = risch_integrate(f, x, algebraic=True)
     assert not r.has(NonElementaryIntegral)
+    # the base case never reaches the acceptance filter, and ratint()
+    # over QQ(s) can divide by s-polynomials that vanish at attained
+    # values: this candidate is nan on all of x > -1 (where the
+    # integrand is just 1) and must be rejected, not returned
+    f = 1/(x**2 - x**2*sqrt(x**2 + 2*x + 1)/(x + 1) + 1)
+    r = risch_integrate(f, x, algebraic=True)
+    assert r == Integral(f, x)
 
 
 def test_risch_integrate():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -845,6 +845,53 @@ def test_risch_integrate_algebraic():
         algebraic=True) is not None
 
 
+def test_risch_integrate_algebraic_branches():
+    # Distributing a fractional power over the factors of the radicand
+    # is not branch-faithful (sqrt(u*v) != sqrt(u)*sqrt(v) when u and v
+    # are both negative), so the split rides with a branch-ratio
+    # constant that is substituted back after integration.  Each of
+    # these used to come back with a derivative that was wrong on part
+    # of the real line; check the derivative numerically at points in
+    # every affected region (symbolic zero-testing of radical
+    # identities is not reliable enough to use here).
+    def deriv_ok(f, r, pts):
+        err = r.diff(x) - f
+        return all(abs(complex(err.subs(x, p).evalf(30))) < 1e-25
+                   for p in pts)
+
+    # square content: wrong for x < -1 before
+    f = sqrt(x**2 + 2*x + 1)/x
+    r = risch_integrate(f, x, algebraic=True)
+    assert r.free_symbols == {x}
+    assert deriv_ok(f, r, [-3, Rational(-1, 2), 2, 1 + I])
+    # distinct factors both negative: wrong for x < -1 before
+    f = x/sqrt(x**2 - 1)
+    r = risch_integrate(f, x, algebraic=True)
+    assert deriv_ok(f, r, [-2, Rational(1, 2), 2, 1 + I])
+    # odd-order radical with square content (Timofeev ch. 0): wrong for
+    # x < 3 before, returning complex values where the integrand is real
+    f = (x**3 - 5*x**2 + 3*x + 9)**Rational(-2, 3)
+    r = risch_integrate(f, x, algebraic=True)
+    assert deriv_ok(f, r, [-2, Rational(1, 2), 4])
+    # a symbolic constant factor extracted from the radicand: wrong
+    # where c and a + b*x are both negative before
+    a, b, c = symbols('a b c')
+    f = 1/sqrt(c*(a + b*x))
+    r = risch_integrate(f, x, algebraic=True)
+    sub = {a: -2, b: 3, c: Rational(-1, 2)}
+    assert deriv_ok(f.subs(sub), r.subs(sub), [-1, Rational(1, 2), 2])
+
+    # the branch-ratio constants satisfy s**q == 1, and the kernel test
+    # must know it: a denominator containing s**q - 1 is actually zero
+    from sympy.integrals.risch import _nontrans_is_kernel
+    DE = DifferentialExtension(x/sqrt(x**2 - 1), x, algebraic=True)
+    [(s, _, q)] = DE.sign_consts
+    assert q == 2
+    assert _nontrans_is_kernel(s**2 - 1, DE)
+    assert not _nontrans_is_kernel(s - 1, DE)
+    assert not _nontrans_is_kernel(s, DE)
+
+
 def test_risch_integrate():
     assert risch_integrate(t0*exp(x), x) == t0*exp(x)
     assert risch_integrate(sin(x), x, rewrite_complex=True) == -exp(I*x)/2 - exp(-I*x)/2
@@ -1058,7 +1105,7 @@ def test_DifferentialExtension_printing():
         "('backsubs', []), ('exts', ['exp', 'log']), ('extargs', [x**2, t0 + 1]), "
         "('cases', ['base', 'exp', 'primitive']), ('case', 'primitive'), ('transcendental', True), ('t', t1), "
         "('d', Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')), ('newf', t0**2 + t1), ('level', -1), "
-        "('dummy', False), ('algebraic', False)]))")
+        "('dummy', False), ('algebraic', False), ('sign_consts', [])]))")
 
     assert str(DE) == ("DifferentialExtension({fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), "
         "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -828,11 +828,13 @@ def test_risch_integrate_algebraic():
     r = risch_integrate(exp(sqrt(y)), y, algebraic=True)
     assert r == Integral(exp(sqrt(y)), y)
     assert not r.has(NonElementaryIntegral)
-    # nested rational powers: the rewritten exponential collapses to a
-    # Mul, which must not end up in the exps worklist
+    # nested rational powers collapse under the radicand split (the
+    # branch ratio absorbs the fractional-exponent bookkeeping), where
+    # this once raised NotImplementedError from the exps worklist
     a, b, c = symbols('a b c')
-    raises(NotImplementedError, lambda: risch_integrate(
-        (c*(a + b*x)**Rational(3, 2))**Rational(2, 3), x, algebraic=True))
+    r = risch_integrate(
+        (c*(a + b*x)**Rational(3, 2))**Rational(2, 3), x, algebraic=True)
+    assert not r.has(Integral)
     # nested symbolic radicals build towers with EX coefficient matrices
     d = symbols('d')
     raises(NotImplementedError, lambda: risch_integrate(
@@ -855,7 +857,13 @@ def test_risch_integrate_algebraic_branches():
     # every affected region (symbolic zero-testing of radical
     # identities is not reliable enough to use here).
     def deriv_ok(f, r, pts):
+        from sympy import Derivative, sign
         err = r.diff(x) - f
+        # sign() is locally constant and the points avoid its
+        # breakpoints, so its (unevaluatable) derivative is zero there
+        err = err.replace(
+            lambda e: isinstance(e, Derivative) and e.has(sign),
+            lambda e: S.Zero)
         return all(abs(complex(err.subs(x, p).evalf(30))) < 1e-25
                    for p in pts)
 
@@ -890,6 +898,24 @@ def test_risch_integrate_algebraic_branches():
     assert _nontrans_is_kernel(s**2 - 1, DE)
     assert not _nontrans_is_kernel(s - 1, DE)
     assert not _nontrans_is_kernel(s, DE)
+
+    # jump corrections (Jeffrey, Labahn, von Mohrenschildt & Rich):
+    # substituting the ratios back leaves constant jumps at the real
+    # roots and poles of the split factors; a -J*sign(x - r) term
+    # restores continuity there when J is finite and real
+    from sympy import sign
+    r = risch_integrate(3*x**2*sqrt(1 + 1/x**2), x, algebraic=True)
+    assert r.coeff(sign(x)) == -1  # Jeffrey's Example 1, J == 1
+    f = sqrt(x**3 + 4*x**2 + 5*x + 2)  # (x + 1)**2*(x + 2)
+    r = risch_integrate(f, x, algebraic=True)
+    assert r.coeff(sign(x + 1)) == Rational(4, 15)
+    assert deriv_ok(f, r, [Rational(-19, 10), Rational(-3, 2),
+                           Rational(-1, 2), 3])
+    # a complex jump (breakpoint at a singularity of the integrand)
+    # must not be "corrected": that would make the answer complex on
+    # regions where it is real
+    r = risch_integrate(sqrt(x**2 + 2*x + 1)/x, x, algebraic=True)
+    assert not r.has(sign)
 
 
 def test_risch_integrate():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -817,6 +817,14 @@ def test_risch_integrate_cancellation():
     assert isinstance(i, NonElementaryIntegral)
     assert cancel(together(diff(g, x) + i.function - e)) == 0
 
+    # Purely elementary results through the same fallback (these raised
+    # NotImplementedError before)
+    for F in [(x - 1)*log(exp(x) + log(x)), exp(x)*log(exp(x) + log(x))]:
+        e = cancel(diff(F, x))
+        ans = risch_integrate(e, x)
+        assert not ans.has(NonElementaryIntegral)
+        assert cancel(together(diff(ans, x) - e)) == 0
+
 
 def test_bound_degree_limited_integrate():
     # bound_degree() used to raise "TypeError: '>' not supported between

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -965,6 +965,12 @@ def test_risch_integrate_algebraic_branches():
     assert r == Integral(
         (a**4 + 2*a**2*x**2 + x**4 + 1)
         / (a**2*sqrt(a**2 + x**2) + x**2*sqrt(a**2 + x**2)), x)
+    # but with a denominator that provably cannot vanish, a partially
+    # integrated level keeps its elementary part
+    f = x*sqrt(x**2 + 1) + 1/sqrt(x**2 + 1)
+    r = risch_integrate(f, x)
+    assert r == (x**2 + 1)**Rational(3, 2)/3 + \
+        Integral(1/sqrt(x**2 + 1), x)
     # a seventh-root ratio has no exact algebraic roots of unity, but
     # a constant occurring only as a numerator polynomial factor needs
     # no assignment, so this must not be over-rejected

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -956,20 +956,15 @@ def test_risch_integrate_algebraic_branches():
     r = risch_integrate(f, x, algebraic=True)
     assert r == Integral(f, x)
     # a partially integrated level (unsolved nonconstant part) with a
-    # parameter-dependent denominator: the residual stays outside for
-    # the caller to keep integrating, and the degenerate branch is the
-    # unevaluated rest of the level, so the assembled degenerate value
-    # is Integral(f - resid) + Integral(resid) with nothing counted
-    # twice
+    # parameter-dependent denominator: no per-piece degenerate branch
+    # is possible (every piece of the generic decomposition divides by
+    # that denominator, and so does the residual), so the whole level
+    # comes back unevaluated for the caller to retry
     f = 1/(x**2 + a**2)**Rational(3, 2) + sqrt(x**2 + a**2)
     r = risch_integrate(f, x)
-    assert r == Piecewise(
-        ((a**2*x + x**3)/(a**2*(a**2 + x**2)**Rational(3, 2)),
-         Ne(a**2, 0)),
-        (Integral((a**2 + 3*x**2)/(a**4*sqrt(a**2 + x**2)
-                  + a**2*x**2*sqrt(a**2 + x**2)), x), True)) + \
-        Integral((a**2*(a**2 + x**2)**2 - 3*x**2)
-                 / (a**2*(a**2 + x**2)**Rational(3, 2)), x)
+    assert r == Integral(
+        (a**4 + 2*a**2*x**2 + x**4 + 1)
+        / (a**2*sqrt(a**2 + x**2) + x**2*sqrt(a**2 + x**2)), x)
     # a seventh-root ratio has no exact algebraic roots of unity, but
     # a constant occurring only as a numerator polynomial factor needs
     # no assignment, so this must not be over-rejected

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1,7 +1,7 @@
 """Most of these tests come from the examples in Bronstein's book."""
 from __future__ import annotations
 from sympy.core.function import (Function, Lambda, diff, expand_log)
-from sympy.core.numbers import (I, Rational, pi)
+from sympy.core.numbers import (I, Rational, pi, zoo)
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
@@ -785,6 +785,28 @@ def test_nontranscendental_tower():
     # adding it does not disturb the derivative)
     assert not _nontrans_accept(Rational(2, 3)*x*t1 + x/(t1**2 - x), [],
         S.Zero, fa, fd, DE, None)
+
+
+def test_nontranscendental_kernel_reject():
+    # Over [x, t0 == log(x), t1 == exp(t0/2), t2 == exp(x)], the element
+    # t1**2/x - 1 is a formal constant that evaluates to zero, so
+    # f == t2/(1 + (t1**2/x - 1)*t2) is exp(x) as a function while the
+    # formal machinery sees a pole with residue -x/(x - t1**2) -- a
+    # kernel denominator that survives the formal-identity check (it
+    # cancels against the argument's derivative) and must be caught by
+    # the residue-coefficient kernel check in _nontrans_accept().
+    DE = DifferentialExtension(extension={
+        'D': [Poly(1, x), Poly(1/x, t0), Poly(t1/(2*x), t1), Poly(t2, t2)],
+        'exts': ['log', 'exp', 'exp'],
+        'extargs': [x, t0/2, x],
+        'Tfuncs': [log, Lambda(i, sqrt(i)), exp],
+        'transcendental': False})
+    fa, fd = frac_in(cancel(t2/(1 + (t1**2/x - 1)*t2)), t2)
+    ans, it, b = integrate_hyperexponential(fa, fd, DE)
+    assert (ans, b) == (0, False)
+    assert it == Integral(exp(x), x)
+    assert not isinstance(it, NonElementaryIntegral)
+    assert not it.has(zoo)
 
 
 def test_risch_integrate_algebraic():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -833,6 +833,12 @@ def test_risch_integrate_algebraic():
     a, b, c = symbols('a b c')
     raises(NotImplementedError, lambda: risch_integrate(
         (c*(a + b*x)**Rational(3, 2))**Rational(2, 3), x, algebraic=True))
+    # radicands are factored before generators are erected, so content
+    # like a perfect square does not become a spurious radical
+    assert risch_integrate(sqrt(y**2 + 2*y + 1)/y, y, algebraic=True) == \
+        sqrt(y**2 + 2*y + 1) + log(y) - 1
+    assert risch_integrate(sqrt((y + 1)**2*(y + 2))*(y + 2), y,
+        algebraic=True) is not None
 
 
 def test_risch_integrate():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -959,6 +959,27 @@ def test_risch_integrate_algebraic_branches():
     r = risch_integrate(f, x, algebraic=True)
     assert not r.has(Integral)
     assert deriv_ok(f, r, [-3, 1])
+    # the final vetting classifies positions, not mere occurrence: an
+    # unenumerable constant inside an entire function's argument or as
+    # a numerator factor is safe; inside log or a denominator it is
+    # not, and a RootSum leading coefficient that can vanish under an
+    # assignment silently changes the root set and must be rejected
+    from sympy.integrals.risch import _nontrans_vet
+    from sympy.polys.rootoftools import RootSum
+    DE7 = DifferentialExtension(f, x, algebraic=True)
+    [(s7, _, _)] = DE7.sign_consts
+    assert _nontrans_vet(s7*x + exp(s7*x), DE7)
+    assert not _nontrans_vet(log(s7*x), DE7)
+    assert not _nontrans_vet(1/(x + s7), DE7)
+    assert not _nontrans_vet(exp(x/(x + s7)), DE7)
+    t_ = Symbol('t')
+    bad = RootSum(Poly((s - 1)*t_**5 + t_ + 1, t_),
+                  Lambda(t_, t_*log(x + t_)))
+    good = RootSum(Poly((s + 3)*t_**5 + t_ + 1, t_),
+                   Lambda(t_, t_*log(x + t_)))
+    assert bad.has(RootSum) and good.has(RootSum)
+    assert not _nontrans_vet(bad, DE)
+    assert _nontrans_vet(good, DE)
     # breakpoint sets must be complete: real_roots() isolates the real
     # root of the quintic exactly (roots() cannot express it)
     f = sqrt((x**5 - x - 1)**2)

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -12,6 +12,7 @@ from sympy.functions.elementary.hyperbolic import tanh
 from sympy.functions.elementary.trigonometric import (atan, cot, sin, tan)
 from sympy.polys.polytools import (Poly, cancel, factor)
 from sympy.polys.rationaltools import together
+from sympy.polys.rootoftools import RootSum
 from sympy.integrals.risch import (gcdex_diophantine, frac_in, as_poly_1t,
     derivation, splitfactor, splitfactor_sqf, canonical_representation,
     hermite_reduce, polynomial_reduce, residue_reduce, residue_reduce_to_basic,
@@ -797,6 +798,29 @@ def test_risch_integrate_symbolic_constant():
 
 def test_risch_integrate_float():
     assert risch_integrate((-60*exp(x) - 19.2*exp(4*x))*exp(4*x), x) == -2.4*exp(8*x) - 12.0*exp(5*x)
+
+
+def test_risch_integrate_log_to_atan():
+    # Residues that come in complex-conjugate pairs give real arc-tangents
+    # instead of complex logarithms (Bronstein, Section 2.8).
+    e = exp(x)/((exp(x) + 1)**2 + 1)
+    ans = risch_integrate(e, x)
+    assert ans == atan(exp(x) + 1)
+    assert cancel(diff(ans, x) - e) == 0
+
+    assert risch_integrate(exp(x)/(exp(2*x) + 1), x) == atan(exp(x))
+    assert risch_integrate(1/(x*(log(x)**2 + 1)), x) == atan(log(x))
+    assert risch_integrate(1/(x**2 + 1), x) == atan(x)
+
+    # Real and complex residues in a single term
+    e = (exp(2*x) + 2*exp(x) + 7)*exp(x)/(2*(exp(x) + 3)*(exp(2*x) + 1))
+    ans = risch_integrate(e, x)
+    assert ans == log(exp(x) + 3)/2 + atan(exp(x))
+    assert cancel(diff(ans, x) - e) == 0
+
+    # Residues that are real but irrational are still returned as a RootSum
+    assert risch_integrate(exp(x)/(exp(2*x) - 2), x) == \
+        RootSum(Poly(8*z**2 - 1, z), Lambda(z, z*log(-4*z + exp(x))))
 
 
 def test_integrate_primitive_nonelementary_residual():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -816,9 +816,11 @@ def test_risch_integrate_algebraic():
     # _nontrans_accept(), and negative conclusions are degraded to
     # plain Integrals (nonelementary proofs assume transcendence).
     y = Symbol('y', positive=True)
-    # off by default: plain integrate()'s automatic risch attempt must
-    # not start building algebraic towers
-    raises(NotImplementedError, lambda: risch_integrate(sqrt(y), y))
+    # on by default; algebraic=False keeps the purely transcendental
+    # behavior of raising on radicals
+    raises(NotImplementedError, lambda: risch_integrate(sqrt(y), y,
+        algebraic=False))
+    assert risch_integrate(sqrt(y), y) == 2*y**Rational(3, 2)/3
     assert risch_integrate(sqrt(y), y, algebraic=True) == \
         2*y**Rational(3, 2)/3
     assert risch_integrate(1/sqrt(y), y, algebraic=True) == 2*sqrt(y)

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -793,12 +793,17 @@ def test_risch_integrate_algebraic():
     # _nontrans_accept(), and negative conclusions are degraded to
     # plain Integrals (nonelementary proofs assume transcendence).
     y = Symbol('y', positive=True)
-    assert risch_integrate(sqrt(y), y) == 2*y**Rational(3, 2)/3
-    assert risch_integrate(1/sqrt(y), y) == 2*sqrt(y)
-    assert risch_integrate(y*sqrt(y), y) == 2*y**Rational(5, 2)/5
+    # off by default: plain integrate()'s automatic risch attempt must
+    # not start building algebraic towers
+    raises(NotImplementedError, lambda: risch_integrate(sqrt(y), y))
+    assert risch_integrate(sqrt(y), y, algebraic=True) == \
+        2*y**Rational(3, 2)/3
+    assert risch_integrate(1/sqrt(y), y, algebraic=True) == 2*sqrt(y)
+    assert risch_integrate(y*sqrt(y), y, algebraic=True) == \
+        2*y**Rational(5, 2)/5
     # unsolved algebraic integrals must come back as plain Integrals,
     # never as NonElementaryIntegral
-    r = risch_integrate(exp(sqrt(y)), y)
+    r = risch_integrate(exp(sqrt(y)), y, algebraic=True)
     assert r == Integral(exp(sqrt(y)), y)
     assert not r.has(NonElementaryIntegral)
 
@@ -1016,7 +1021,7 @@ def test_DifferentialExtension_printing():
         "('backsubs', []), ('exts', ['exp', 'log']), ('extargs', [x**2, t0 + 1]), "
         "('cases', ['base', 'exp', 'primitive']), ('case', 'primitive'), ('transcendental', True), ('t', t1), "
         "('d', Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')), ('newf', t0**2 + t1), ('level', -1), "
-        "('dummy', False)]))")
+        "('dummy', False), ('algebraic', False)]))")
 
     assert str(DE) == ("DifferentialExtension({fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), "
         "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1268,6 +1268,47 @@ def test_risch_integrate_algebraic_undecidable_structure():
                for p in [-3, Rational(-1, 2), Rational(1, 2), 2, 2 + I])
 
 
+def test_risch_integrate_nonrational_structure_constants():
+    # 2**log(x) == x**log(2) builds the tower exp(log(2)*log(x)) over
+    # QQ(x, log(x)).  The structure system's unique solution log(2) is
+    # provably irrational, so the new exponential is proven not to be a
+    # radical of the tower: the tower stays proven transcendental and
+    # keeps its nonelementary proofs.
+    for f in [2**log(x)/x**2, 2**log(x), 2**log(x)*log(x)]:
+        r = risch_integrate(f, x)
+        assert not r.has(Integral)
+        err = r.diff(x) - f
+        assert all(abs(complex(err.subs(x, p).evalf(30))) < 1e-25
+                   for p in [Rational(1, 3), 2, 5])
+    assert DifferentialExtension(2**log(x)/x**2, x).transcendental is True
+
+    # For 2**x + 3**x the relation between exp(x*log(2)) and
+    # exp(x*log(3)) hinges on the rationality of log(3)/log(2), which
+    # sympy cannot decide, so the tower is built assuming no relation
+    # and its transcendence is downgraded to unproven: solved results
+    # are vetted and nonelementary conclusions become unevaluated
+    # Integrals.
+    f = 2**x + 3**x
+    assert risch_integrate(f, x) == 2**x/log(2) + 3**x/log(3)
+    assert DifferentialExtension(f, x).transcendental is False
+
+    # For 2**x*3**(x**2) the structure system for the second exponential
+    # has no constant solution at all (the argument ratio is not
+    # constant), which is a sound "no relation": the tower stays proven
+    # transcendental and the nonelementary proof stands.
+    r = risch_integrate(2**x*3**(x**2), x)
+    assert isinstance(r, NonElementaryIntegral)
+    assert DifferentialExtension(2**x*3**(x**2), x).transcendental is True
+
+    # pi**log(x)/x needs the rationality of log(pi), which is undecided
+    # (is_rational is None), so this exercises the degraded path end to
+    # end with a solved, vetted result.
+    f = pi**log(x)/x
+    r = risch_integrate(f, x)
+    assert r == exp(log(pi)*log(x))/log(pi)
+    assert DifferentialExtension(f, x).transcendental is False
+
+
 def test_issue_23948():
     f = (
         ( (-2*x**5 + 28*x**4 - 144*x**3 + 324*x**2 - 270*x)*log(x)**2

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -990,6 +990,17 @@ def test_risch_integrate_algebraic_branches():
     r = risch_integrate(f, x, algebraic=True)
     assert not r.has(Integral)
     assert deriv_ok(f, r, [0, 2])
+    # proportional radicands route through the is_deriv_k rewrite,
+    # whose principal log(const) (log(-1) == I*pi) needs the same
+    # branch-ratio correction: sqrt(-w) == I*sqrt(w) has the wrong
+    # sign where w < 0
+    f = sqrt(a + b*x)/sqrt(-a - b*x)
+    r = risch_integrate(f, x, algebraic=True)
+    sub = {a: 2, b: 3}
+    assert deriv_ok(f.subs(sub), r.subs(sub), [-2, 1])
+    f = 1/(sqrt(-3*x - 2)*sqrt(3*x + 2))
+    r = risch_integrate(f, x, algebraic=True)
+    assert deriv_ok(f, r, [-2, 1])
 
 
 def test_risch_integrate():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -1246,7 +1246,8 @@ def test_DifferentialExtension_printing():
         "('backsubs', []), ('exts', ['exp', 'log']), ('extargs', [x**2, t0 + 1]), "
         "('cases', ['base', 'exp', 'primitive']), ('case', 'primitive'), ('transcendental', True), ('t', t1), "
         "('d', Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')), ('newf', t0**2 + t1), ('level', -1), "
-        "('dummy', False), ('algebraic', False), ('sign_consts', [])]))")
+        "('dummy', False), ('algebraic', False), ('sign_consts', []), "
+        "('algebraic_gens', False)]))")
 
     assert str(DE) == ("DifferentialExtension({fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), "
         "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
@@ -1307,6 +1308,38 @@ def test_risch_integrate_nonrational_structure_constants():
     r = risch_integrate(f, x)
     assert r == exp(log(pi)*log(x))/log(pi)
     assert DifferentialExtension(f, x).transcendental is False
+
+    # A proven radical relation (exp(x*log(2)/2 + 1)**2 == E**2*2**x)
+    # discovered after the tower's transcendence was already downgraded
+    # (by the undecided 2**x-vs-3**x relation) must still trigger the
+    # restart-and-regroup rewrite -- restarting is gated on the tower
+    # actually containing algebraic generators, not on unproven
+    # transcendence -- so the relation ends up explicit in the
+    # regrouped generators (2**x == t**2 over t == exp(x*log(2)/2))
+    # instead of an adjoined generator with a relation invisible to
+    # the kernel checks.
+    f = 2**x + 3**x + exp(x*log(2)/2 + 1)
+    DE = DifferentialExtension(f, x)
+    assert DE.extargs == [x*log(2)/2, x*log(3)]
+    assert DE.transcendental is False and DE.algebraic_gens is False
+    r = risch_integrate(f, x)
+    assert not r.has(Integral)
+    err = r.diff(x) - f
+    assert all(abs(complex(err.subs(x, p).evalf(30))) < 1e-25
+               for p in [Rational(1, 3), 2, 5])
+
+    # The same restart in a fully proven tower: the exponential factors
+    # of the radical are folded to exp((p/n)*arg) directly, so the
+    # backsubs fold (exp(x*log(2)) -> 2**x) cannot strand the radical
+    # as sqrt(2**x), which the rebuild would not recognize.
+    f = 2**x + exp(x*log(2)/2 + 1)
+    DE = DifferentialExtension(f, x)
+    assert DE.extargs == [x*log(2)/2]
+    assert DE.transcendental is True
+    r = risch_integrate(f, x)
+    err = r.diff(x) - f
+    assert all(abs(complex(err.subs(x, p).evalf(30))) < 1e-25
+               for p in [Rational(1, 3), 2, 5])
 
 
 def test_issue_23948():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -221,6 +221,9 @@ def test_recognize_derivative():
     assert recognize_derivative(Poly(x, x), Poly((x**2 + 1)**2, x), DE) == True
     assert recognize_derivative(Poly(1, x), Poly((x**2 + 1)**2, x), DE) == False
     assert recognize_derivative(Poly(-2*x, x), Poly((x**2 - 1)**2, x), DE) == True
+    # Multiplicity 3: D(1/(x**2 + 1)**2) == -4*x/(x**2 + 1)**3
+    assert recognize_derivative(Poly(-4*x, x), Poly((x**2 + 1)**3, x), DE) == True
+    assert recognize_derivative(Poly(1, x), Poly((x**2 + 1)**3, x), DE) == False
     # Poles at nonconstant normal primes used to be ignored entirely,
     # giving false positives.  A simple such pole always has a nonzero
     # residue: 1/(t + x) with t = log(x) is not a derivative.
@@ -784,6 +787,13 @@ def test_risch_integrate():
     # sin(x).rewrite(exp)
     expr = -I*(exp(I*x) - exp(-I*x))/2
     assert risch_integrate(expr, x) == -exp(I*x)/2 - exp(-I*x)/2
+
+def test_risch_integrate_symbolic_constant():
+    # A symbolic constant in the exponential argument; the generic answer
+    # holds for y != 0 and the degenerate case is handled by conds
+    assert risch_integrate(exp(x*y), x) == \
+        Piecewise((exp(x*y)/y, Ne(y, 0)), (x, True))
+
 
 def test_risch_integrate_float():
     assert risch_integrate((-60*exp(x) - 19.2*exp(4*x))*exp(4*x), x) == -2.4*exp(8*x) - 12.0*exp(5*x)

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -842,6 +842,11 @@ def test_risch_integrate_algebraic():
     d = symbols('d')
     raises(NotImplementedError, lambda: risch_integrate(
         sqrt(a + b*sqrt(d/x) + c/x), x, algebraic=True))
+    # inexact input skips the algebraic path entirely: the towers do
+    # exact arithmetic, where a Float coefficient becomes a rational
+    # with an astronomical denominator that the structure-theorem
+    # constant systems grind on
+    raises(NotImplementedError, lambda: risch_integrate(1.5*sqrt(y), y))
     # radicands are factored before generators are erected, so content
     # like a perfect square does not become a spurious radical
     assert risch_integrate(sqrt(y**2 + 2*y + 1)/y, y, algebraic=True) == \
@@ -1246,6 +1251,21 @@ def test_DifferentialExtension_printing():
     assert str(DE) == ("DifferentialExtension({fa=Poly(t1 + t0**2, t1, domain='ZZ[t0]'), "
         "fd=Poly(1, t1, domain='ZZ'), D=[Poly(1, x, domain='ZZ'), Poly(2*x*t0, t0, domain='ZZ[x]'), "
         "Poly(2*t0*x/(t0 + 1), t1, domain='ZZ(x,t0)')]})")
+
+
+def test_risch_integrate_algebraic_undecidable_structure():
+    # An undecidable structure question over an algebraic tower (here
+    # parametric_log_deriv()'s heuristic and structure method are both
+    # inconclusive) is answered "no relation" instead of aborting the
+    # integration: nonelementary conclusions are degraded to
+    # unevaluated Integrals and solved results are vetted
+    # independently, so the answer stays sound.  From the Blake corpus.
+    f = 1/(x**2*(x**4 - 1)**Rational(3, 4))
+    r = risch_integrate(f, x)
+    assert not r.has(Integral)
+    err = r.diff(x) - f
+    assert all(abs(complex(err.subs(x, p).evalf(30))) < 1e-25
+               for p in [-3, Rational(-1, 2), Rational(1, 2), 2, 2 + I])
 
 
 def test_issue_23948():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -833,6 +833,10 @@ def test_risch_integrate_algebraic():
     a, b, c = symbols('a b c')
     raises(NotImplementedError, lambda: risch_integrate(
         (c*(a + b*x)**Rational(3, 2))**Rational(2, 3), x, algebraic=True))
+    # nested symbolic radicals build towers with EX coefficient matrices
+    d = symbols('d')
+    raises(NotImplementedError, lambda: risch_integrate(
+        sqrt(a + b*sqrt(d/x) + c/x), x, algebraic=True))
     # radicands are factored before generators are erected, so content
     # like a perfect square does not become a spurious radical
     assert risch_integrate(sqrt(y**2 + 2*y + 1)/y, y, algebraic=True) == \

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -4,7 +4,7 @@ from sympy.core.function import (Function, Lambda, diff, expand_log)
 from sympy.core.numbers import (I, Rational, pi, zoo)
 from sympy.core.relational import Ne
 from sympy.core.singleton import S
-from sympy.core.symbol import (Symbol, symbols)
+from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.functions.elementary.exponential import (exp, log)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
@@ -857,13 +857,7 @@ def test_risch_integrate_algebraic_branches():
     # every affected region (symbolic zero-testing of radical
     # identities is not reliable enough to use here).
     def deriv_ok(f, r, pts):
-        from sympy import Derivative, sign
         err = r.diff(x) - f
-        # sign() is locally constant and the points avoid its
-        # breakpoints, so its (unevaluatable) derivative is zero there
-        err = err.replace(
-            lambda e: isinstance(e, Derivative) and e.has(sign),
-            lambda e: S.Zero)
         return all(abs(complex(err.subs(x, p).evalf(30))) < 1e-25
                    for p in pts)
 
@@ -891,31 +885,64 @@ def test_risch_integrate_algebraic_branches():
 
     # the branch-ratio constants satisfy s**q == 1, and the kernel test
     # must know it: a denominator containing s**q - 1 is actually zero
-    from sympy.integrals.risch import _nontrans_is_kernel
+    from sympy.integrals.risch import (_nontrans_accept,
+        _nontrans_is_kernel, _nontrans_sign_assignments)
     DE = DifferentialExtension(x/sqrt(x**2 - 1), x, algebraic=True)
     [(s, _, q)] = DE.sign_consts
     assert q == 2
     assert _nontrans_is_kernel(s**2 - 1, DE)
     assert not _nontrans_is_kernel(s - 1, DE)
     assert not _nontrans_is_kernel(s, DE)
+    # non-kernel is not enough for denominators: s - 1 is formally
+    # nonzero (a zero divisor mod s**2 - 1) but the ratio equals 1 on
+    # whole regions, so acceptance must check every attainable value
+    assert _nontrans_sign_assignments(DE) == [{s: 1}, {s: -1}]
+    z = Dummy('z')
+    assert not _nontrans_accept(1/(s - 1), [], S.Zero,
+        Poly(0, DE.t), Poly(1, DE.t), DE, z)
+    assert _nontrans_accept(1/(s + 3), [], S.Zero,
+        Poly(0, DE.t), Poly(1, DE.t), DE, z)
 
-    # jump corrections (Jeffrey, Labahn, von Mohrenschildt & Rich):
-    # substituting the ratios back leaves constant jumps at the real
-    # roots and poles of the split factors; a -J*sign(x - r) term
-    # restores continuity there when J is finite and real
-    from sympy import sign
-    r = risch_integrate(3*x**2*sqrt(1 + 1/x**2), x, algebraic=True)
-    assert r.coeff(sign(x)) == -1  # Jeffrey's Example 1, J == 1
+    # jump corrections (Jeffrey, Labahn, von Mohrenschildt & Rich): the
+    # ratio substitution leaves constant jumps at the real roots and
+    # poles of the split factors; a -J*(x - r)/sqrt((x - r)**2) term
+    # (sign(x - r) on the real line, but locally constant on the
+    # complex plane off Re(x) == r) restores continuity there when J
+    # is finite and real
+    def jump(r, bp):
+        eps = Rational(1, 1000)
+        return abs(complex(r.subs(x, bp + eps).evalf(40)) -
+                   complex(r.subs(x, bp - eps).evalf(40)))
+
+    f = 3*x**2*sqrt(1 + 1/x**2)
+    r = risch_integrate(f, x, algebraic=True)
+    assert r.coeff(x*(x**2)**Rational(-1, 2)) == -1  # Example 1, J == 1
+    assert deriv_ok(f, r, [-2, Rational(1, 2), 1 + I])
+    assert jump(r, 0) < 1e-4
     f = sqrt(x**3 + 4*x**2 + 5*x + 2)  # (x + 1)**2*(x + 2)
     r = risch_integrate(f, x, algebraic=True)
-    assert r.coeff(sign(x + 1)) == Rational(4, 15)
     assert deriv_ok(f, r, [Rational(-19, 10), Rational(-3, 2),
-                           Rational(-1, 2), 3])
+                           Rational(-1, 2), 3, 1 + I])
+    assert jump(r, -1) < 1e-4
     # a complex jump (breakpoint at a singularity of the integrand)
     # must not be "corrected": that would make the answer complex on
-    # regions where it is real
+    # regions where it is real -- the discontinuity stays
     r = risch_integrate(sqrt(x**2 + 2*x + 1)/x, x, algebraic=True)
-    assert not r.has(sign)
+    assert jump(r, -1) > 1
+
+    # the _exp_part restart must not lose the branch-ratio state (its
+    # Dummy constants used to leak into the result unsubstituted)
+    f = sqrt(x**2 + 2*x + 1)*(exp(x) + exp(x/2 + 1))
+    r = risch_integrate(f, x, algebraic=True)
+    assert not r.atoms(Dummy)
+    assert deriv_ok(f, r, [-3, 1])
+    # results are only generic in the ratio constants, so collapsed
+    # radicals must not yield nonelementary claims: this integrand is
+    # proportional to s + 1 and vanishes identically where the ratio
+    # is -1, however nonelementary it is elsewhere
+    f = (sqrt(x**2 + 2*x + 1) + x + 1)*exp(x**2)
+    r = risch_integrate(f, x, algebraic=True)
+    assert not r.has(NonElementaryIntegral)
 
 
 def test_risch_integrate():

--- a/sympy/integrals/tests/test_risch.py
+++ b/sympy/integrals/tests/test_risch.py
@@ -806,6 +806,11 @@ def test_risch_integrate_algebraic():
     r = risch_integrate(exp(sqrt(y)), y, algebraic=True)
     assert r == Integral(exp(sqrt(y)), y)
     assert not r.has(NonElementaryIntegral)
+    # nested rational powers: the rewritten exponential collapses to a
+    # Mul, which must not end up in the exps worklist
+    a, b, c = symbols('a b c')
+    raises(NotImplementedError, lambda: risch_integrate(
+        (c*(a + b*x)**Rational(3, 2))**Rational(2, 3), x, algebraic=True))
 
 
 def test_risch_integrate():

--- a/sympy/polys/polymatrix.py
+++ b/sympy/polys/polymatrix.py
@@ -214,7 +214,13 @@ class MutablePolyDenseMatrix:
                 other_ds = DomainScalar(Kx.from_sympy(other), Kx)
             except (CoercionFailed, ValueError):
                 other_ds = DomainScalar.from_sympy(other)
-            return self.from_dm(self._dm * other_ds)
+            dm = self._dm * other_ds
+            if not dm.domain.is_PolynomialRing:
+                # a fallback scalar over a ground domain (e.g. EX) can
+                # drag the product's domain below a polynomial ring,
+                # which from_dm cannot represent
+                dm = dm.convert_to(dm.domain[self.gens])
+            return self.from_dm(dm)
         return NotImplemented
 
     def __rmul__(self, other):
@@ -222,7 +228,10 @@ class MutablePolyDenseMatrix:
             other = _sympify(other)
         if isinstance(other, Expr):
             other_ds = DomainScalar.from_sympy(other)
-            return self.from_dm(other_ds * self._dm)
+            dm = other_ds * self._dm
+            if not dm.domain.is_PolynomialRing:
+                dm = dm.convert_to(dm.domain[self.gens])
+            return self.from_dm(dm)
         return NotImplemented
 
     def __truediv__(self, other):

--- a/sympy/polys/tests/test_polymatrix.py
+++ b/sympy/polys/tests/test_polymatrix.py
@@ -5,11 +5,12 @@ from sympy.polys.polymatrix import PolyMatrix
 from sympy.polys import Poly
 
 from sympy.core.singleton import S
+from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.matrices.dense import Matrix
 from sympy.polys.domains.integerring import ZZ
 from sympy.polys.domains.rationalfield import QQ
 
-from sympy.abc import x, y
+from sympy.abc import t, x, y
 
 
 def _test_polymatrix():
@@ -184,3 +185,10 @@ def test_polymatrix_nullspace():
     raises(ValueError, lambda: PolyMatrix([1, 2], ring=ZZ[x]).nullspace())
     raises(ValueError, lambda: PolyMatrix([1, x], ring=QQ[x]).nullspace())
     assert M.rank() == 1
+
+
+def test_polymatrix_scalar_mul_ground_fallback():
+    M = PolyMatrix([[Poly(x*t, t)]], t)
+    expected = PolyMatrix([[Poly(x*(y + sqrt(y))*t, t, domain='EX')]], t)
+    assert M*(y + sqrt(y)) == expected
+    assert (y + sqrt(y))*M == expected

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -2909,10 +2909,6 @@ def _get_examples_ode_sol_1st_homogeneous_coeff_best():
 
     '1st_homogeneous_coeff_best_04': {
         'eq': (x + sqrt(f(x)**2 - x*f(x)))*f(x).diff(x) - f(x),
-        # equal to C1 - 2*sqrt(-x/f(x) + 1), which is what the inner
-        # integral gave before risch handled it.  The factors are
-        # ordered so that the 2 is not distributed over the difference,
-        # which is how dsolve builds it.
         'sol': [Eq(log(f(x)), C1 + 2/sqrt(-x/f(x) + 1)*(x/f(x) - 1))],
         'slow': True,
     },

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -2909,7 +2909,11 @@ def _get_examples_ode_sol_1st_homogeneous_coeff_best():
 
     '1st_homogeneous_coeff_best_04': {
         'eq': (x + sqrt(f(x)**2 - x*f(x)))*f(x).diff(x) - f(x),
-        'sol': [Eq(log(f(x)), C1 - 2*sqrt(-x/f(x) + 1))],
+        # equal to C1 - 2*sqrt(-x/f(x) + 1), which is what the inner
+        # integral gave before risch handled it.  The factors are
+        # ordered so that the 2 is not distributed over the difference,
+        # which is how dsolve builds it.
+        'sol': [Eq(log(f(x)), C1 + 2/sqrt(-x/f(x) + 1)*(x/f(x) - 1))],
         'slow': True,
     },
 


### PR DESCRIPTION
This is a for now experimental branch testing using the existing transcendental Risch algorithm to compute integrals involving radicals. 

The idea is that since the Risch algorithm handles functions involve `exp` and `log`, to rewrite terms like $\sqrt{x}$ to $e^{\frac{\log(x)}{2}}$. This would normally be rejected by the Risch algorithm because the exponential is not transcendental over $\mathbb{Q}(x, \log(x))$ (since it equals $\sqrt{x}$, an algebraic function). 

However, for the most part, the functions in the transcendental Risch algorithm are still correct for an extension like this, excepting that any "proof" of nonelementaryness is in general invalid. 

This is still experimental because there is a lot of care that needs to be done to ensure this is correct, and also that it's actually usable. If it works. 

This PR builds on top of https://github.com/sympy/sympy/pull/30221. 

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

All code here was written by Fable unless otherwise noted. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- integrals
  - Add support for computing some algebraic integrals using the Risch algorithm. 
<!-- END RELEASE NOTES -->
