### PR TITLE
docs: document rref return value

### DIFF
--- a/sympy/matrices/reductions.py
+++ b/sympy/matrices/reductions.py
@@ -395,6 +395,15 @@ def _rref(
         each pivot is normalized to be `1` before row operations are
         used to zero above and below the pivot.
 
+    Returns
+    =======
+
+    tuple
+        A tuple ``(rref_matrix, pivot_columns)`` where ``rref_matrix`` is
+        the reduced row-echelon form of the matrix and ``pivot_columns``
+        is a tuple of the column indices of the pivot columns.  If
+        ``pivots=False``, only ``rref_matrix`` is returned.
+
     Examples
     ========
 


### PR DESCRIPTION
## What does this PR do?

`Matrix.rref()` docstring lacked a `Returns` section, leaving the return tuple structure `(rref_matrix, pivot_columns)` and the `pivots=False` variant undocumented.

Closes #12006

## Changes

- `sympy/matrices/reductions.py`: add a `Returns` section to `_rref` documenting the returned tuple and the `pivots=False` single-matrix variant.

## Verification

- `python -m py_compile sympy/matrices/reductions.py` passes.
- `Matrix.rref.__doc__` now contains `Returns` and `pivot_columns`; `Matrix([[1,2],[3,4]]).rref()` still returns `(Matrix([[1,0],[0,1]]), (0,1))`.