### PR TITLE
refactoring the heugcd algorithm

### DIFF
--- a/sympy/polys/heuristicgcd.py
+++ b/sympy/polys/heuristicgcd.py
@@ -1,11 +1,38 @@
-"""Heuristic polynomial GCD algorithm (HEUGCD). """
+"""Heuristic polynomial GCD algorithm (HEUGCD)."""
+
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from sympy.polys.domains.integerring import ZZ
+from sympy.polys.orderings import MonomialOrder, lex
+from sympy.polys.sparsetools import (
+    _smp_imul_ground,
+    _smp_iprimitive,
+    _smp_iquo_ground,
+    _smp_isub,
+    smp_LC,
+    smp_content,
+    smp_div_list,
+    smp_evaluate,
+    smp_neg,
+    smp_quo_ground,
+    smp_subs_drop,
+    smp_trunc_ground,
+)
 
 from .polyerrors import HeuristicGCDFailed
 
+if TYPE_CHECKING:
+    from sympy.polys.sparsetools import smp
+    from sympy.external.gmpy import MPZ
+    from sympy.polys.rings import PolyElement
+
 HEU_GCD_MAX = 6
 
-def heugcd(f, g):
+
+def heugcd(
+    f: PolyElement[MPZ], g: PolyElement[MPZ]
+) -> tuple[PolyElement[MPZ], PolyElement[MPZ], PolyElement[MPZ]]:
     """
     Heuristic polynomial GCD in ``Z[X]``.
 
@@ -53,98 +80,129 @@ def heugcd(f, g):
     .. [1] [Liao95]_
 
     """
-    assert f.ring == g.ring and f.ring.domain.is_ZZ
-
     ring = f.ring
-    x0 = ring.gens[0]
-    domain = ring.domain
+    assert ring == g.ring and ring.domain.is_ZZ
+    h, cff, cfg = smp_heugcd(f, g, ring.ngens, ring.order)
+    return f.new(h), f.new(cff), f.new(cfg)
 
-    gcd, f, g = f.extract_ground(g)
 
-    f_norm = f.max_norm()
-    g_norm = g.max_norm()
+def smp_heugcd(
+    f: smp[MPZ], g: smp[MPZ], n: int, order: MonomialOrder = lex
+) -> tuple[smp[MPZ], smp[MPZ], smp[MPZ]]:
 
-    B = domain(2*min(f_norm, g_norm) + 29)
+    fc = smp_content(f, n, ZZ)
+    gc = smp_content(g, n, ZZ)
+    gcd = ZZ.gcd(fc, gc)
 
-    x = max(min(B, 99*domain.sqrt(B)),
-            2*min(f_norm // abs(f.LC),
-                  g_norm // abs(g.LC)) + 4)
+    f = smp_quo_ground(f, gcd, n, ZZ)
+    g = smp_quo_ground(g, gcd, n, ZZ)
 
-    for i in range(0, HEU_GCD_MAX):
-        ff = f.evaluate(x0, x)
-        gg = g.evaluate(x0, x)
+    abs = ZZ.abs
 
-        if ff and gg:
-            if ring.ngens == 1:
-                h, cff, cfg = domain.cofactors(ff, gg)
+    f_norm = max(abs(el) for el in f.values())
+    g_norm = max(abs(el) for el in g.values())
+    B = ZZ(2 * min(f_norm, g_norm) + 29)
+
+    x = max(
+        min(B, 99 * ZZ.sqrt(B)),
+        2
+        * min(
+            f_norm // abs(smp_LC(f, n, ZZ, order)),
+            g_norm // abs(smp_LC(g, n, ZZ, order)),
+        )
+        + 4,
+    )
+
+    h0: MPZ | smp[MPZ]
+    cff0: MPZ | smp[MPZ]
+    cfg0: MPZ | smp[MPZ]
+
+    for _ in range(0, HEU_GCD_MAX):
+        if n == 1:
+            ff = smp_evaluate(f, {0: x}, n, ZZ)
+            gg = smp_evaluate(g, {0: x}, n, ZZ)
+            if ff and gg:
+                h0, cff0, cfg0 = ZZ.cofactors(ff, gg)
             else:
-                h, cff, cfg = heugcd(ff, gg)
+                x = 73794 * x * ZZ.sqrt(ZZ.sqrt(x)) // 27011
+                continue
+        else:
+            ff = smp_subs_drop(f, {0: x}, n, ZZ)
+            gg = smp_subs_drop(g, {0: x}, n, ZZ)
+            if ff and gg:
+                h0, cff0, cfg0 = smp_heugcd(ff, gg, n - 1, order)
+            else:
+                x = 73794 * x * ZZ.sqrt(ZZ.sqrt(x)) // 27011
+                continue
 
-            h = _gcd_interpolate(h, x, ring)
-            h = h.primitive()[1]
+        h = _gcd_interpolate(h0, x, n, order)
+        _smp_iprimitive(h, n, ZZ)
 
-            cff_, r = f.div(h)
+        [cff_], r = smp_div_list(f, [h], n, ZZ, order)
+
+        if not r:
+            [cfg_], r = smp_div_list(g, [h], n, ZZ, order)
+            if not r:
+                _smp_imul_ground(h, gcd, n, ZZ)
+                return h, cff_, cfg_
+
+        cff = _gcd_interpolate(cff0, x, n, order)
+
+        [h], r = smp_div_list(f, [cff], n, ZZ, order)
+
+        if not r:
+            [cfg_], r = smp_div_list(g, [h], n, ZZ, order)
 
             if not r:
-                cfg_, r = g.div(h)
+                _smp_imul_ground(h, gcd, n, ZZ)
+                return h, cff, cfg_
 
-                if not r:
-                    h = h.mul_ground(gcd)
-                    return h, cff_, cfg_
+        cfg = _gcd_interpolate(cfg0, x, n, order)
 
-            cff = _gcd_interpolate(cff, x, ring)
-
-            h, r = f.div(cff)
-
+        [h], r = smp_div_list(g, [cfg], n, ZZ, order)
+        if not r:
+            [cff_], r = smp_div_list(f, [h], n, ZZ, order)
             if not r:
-                cfg_, r = g.div(h)
+                _smp_imul_ground(h, gcd, n, ZZ)
+                return h, cff_, cfg
 
-                if not r:
-                    h = h.mul_ground(gcd)
-                    return h, cff, cfg_
+        x = 73794 * x * ZZ.sqrt(ZZ.sqrt(x)) // 27011
+    raise HeuristicGCDFailed("no luck")
 
-            cfg = _gcd_interpolate(cfg, x, ring)
 
-            h, r = g.div(cfg)
-
-            if not r:
-                cff_, r = f.div(h)
-
-                if not r:
-                    h = h.mul_ground(gcd)
-                    return h, cff_, cfg
-
-        x = 73794*x * domain.sqrt(domain.sqrt(x)) // 27011
-
-    raise HeuristicGCDFailed('no luck')
-
-def _gcd_interpolate(h, x, ring):
-    """Interpolate polynomial GCD from integer GCD. """
-    f, i = ring.zero, 0
+def _gcd_interpolate(
+    h: MPZ | smp[MPZ], x: MPZ, n: int, order: MonomialOrder
+) -> smp[MPZ]:
+    """Interpolate polynomial GCD from integer GCD."""
+    f: smp[MPZ] = {}
+    i = 0
 
     # TODO: don't expose poly repr implementation details
-    if ring.ngens == 1:
+    if isinstance(h, dict):  # h is a polynomial
         while h:
-            g = h % x
-            if g > x // 2: g -= x
-            h = (h - g) // x
+            g = smp_trunc_ground(h, x, n - 1, ZZ)
+            _smp_isub(h, g, n - 1, ZZ)
+            _smp_iquo_ground(h, x, n - 1, ZZ)
 
             # f += X**i*g
             if g:
-                f[(i,)] = g
-            i += 1
-    else:
-        while h:
-            g = h.trunc_ground(x)
-            h = (h - g).quo_ground(x)
-
-            # f += X**i*g
-            if g:
-                for monom, coeff in g.iterterms():
+                for monom, coeff in g.items():
                     f[(i,) + monom] = coeff
             i += 1
 
-    if f.LC < 0:
-        return -f
+    else:  # h is a scalar
+        while h:
+            c = h % x
+            if c > x // 2:
+                c -= x
+            h = (h - c) // x
+
+            # f += X**i*c
+            if c:
+                f[(i,)] = c
+            i += 1
+
+    if smp_LC(f, n, ZZ, order) < 0:
+        return smp_neg(f, n, ZZ)
     else:
-        return  f
+        return f

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -2883,7 +2883,7 @@ class PolyElement(
     def _gcd_ZZ(
         self, other: PolyElement[Er]
     ) -> tuple[PolyElement[Er], PolyElement[Er], PolyElement[Er]]:
-        return heugcd(self, other)
+        return heugcd(self, other) # type: ignore
 
     def _gcd_QQ(
         self, g: PolyElement[Er]

--- a/sympy/polys/sparsetools.py
+++ b/sympy/polys/sparsetools.py
@@ -398,6 +398,11 @@ def smp_sub_ground(d: smp[Er], c: Er, n: int, domain: Domain[Er]) -> smp[Er]:
     return h
 
 
+def smp_neg(f: smp[Er], n: int, domain: Domain[Er]) -> smp[Er]:
+    # Return the opposite of a sparse polynomial.
+    return {mon: -coeff for mon, coeff in f.items() if coeff}
+
+
 def _smp_isub_ground(d: smp[Er], c: Er, n: int, domain: Domain[Er]) -> None:
     # Subtract a ground coefficient from a sparse polynomial in place.
     if not c:


### PR DESCRIPTION


<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Refactoring the heugcd algorithm so that it works on dictionaries rather than on PolyElement objects.

#### Other comments
The idea here is that all the gcd functions should work on the smp data structure, so that the rings.py `.gcd()` method can rely on an API, that will include the dispatching and refactoring, that works on the smp data structure.

I tested this implementation against the old one, and I saw that this one is faster on small polynomials, while on big polynomials  the two versions become more or less equivalent in runtime.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* polys
  * refactor the heuristicgcd algorithm so that it works on the smp data structure, and not on PolyElement objects
<!-- END RELEASE NOTES -->
