### PR TITLE
Remove is_eq/is_ge dependency from equality.py

### DIFF
--- a/sympy/assumptions/relation/equality.py
+++ b/sympy/assumptions/relation/equality.py
@@ -15,12 +15,112 @@ References
 """
 from __future__ import annotations
 from sympy.assumptions import Q
-from sympy.core.relational import is_eq, is_neq, is_gt, is_ge, is_lt, is_le
 
 from .binrel import BinaryRelation
 
 __all__ = ['EqualityPredicate', 'UnequalityPredicate', 'StrictGreaterThanPredicate',
     'GreaterThanPredicate', 'StrictLessThanPredicate', 'LessThanPredicate']
+
+
+def _query(predicate_ctor, expr, assumptions):
+    """Resolve a *unary* predicate (Q.zero, Q.infinite, Q.extended_real, ...)
+    on `expr`.
+
+    First tries the cheap, already-known fuzzy property on the expression
+    itself (e.g. `expr.is_zero`) - this alone answers the large majority of
+    cases (structural facts, and facts implied by assumptions declared on the
+    symbols that make up `expr`, e.g. `symbols('m', integer=True)`).
+
+    If that's inconclusive, falls back to ``_ask_recursive`` - the fast
+    fact/dispatch-only lookup introduced by GH-28129/#29921 - to also take
+    local *assumptions* (the second argument to ask()) into account. Unlike
+    ask(), ``_ask_recursive`` never invokes the expensive satask solver, so
+    this cannot trigger another costly top-level ask() cycle - which is the
+    exact complaint in GH-29863 (citing GH-28129) about calling is_eq/is_ge
+    from here.
+    """
+    prop = getattr(expr, 'is_' + predicate_ctor.name, None)
+    if prop is not None:
+        return prop
+    from sympy.assumptions.ask import _ask_recursive
+    return _ask_recursive(predicate_ctor(expr), assumptions)
+
+
+def _fuzzy_eq(lhs, rhs, assumptions=True):
+    """Fuzzy equality check that avoids calling is_eq(), and therefore avoids
+    the ask() <-> is_eq() mutual recursion described in GH-29863 (is_eq routes
+    through AssumptionsWrapper straight back into ask(Q.eq(...))).
+    """
+    from sympy.core.numbers import NaN
+    from sympy.core.logic import fuzzy_xor
+    from sympy.logic.boolalg import BooleanAtom, Boolean
+
+    # NaN is never equal to anything, not even itself - must be checked
+    # before the structural `lhs == rhs` shortcut below, since sympy defines
+    # NaN == NaN as structurally True.
+    if isinstance(lhs, NaN) or isinstance(rhs, NaN):
+        return False
+
+    if lhs == rhs:
+        return True
+
+    if all(isinstance(i, BooleanAtom) for i in (lhs, rhs)):
+        return False  # True != False (and they weren't equal above)
+
+    if not (lhs.is_Symbol or rhs.is_Symbol) and (
+            isinstance(lhs, Boolean) != isinstance(rhs, Boolean)):
+        return False  # only Booleans can equal Booleans; avoids lhs - rhs below
+
+    lhs_inf = _query(Q.infinite, lhs, assumptions)
+    rhs_inf = _query(Q.infinite, rhs, assumptions)
+    if lhs_inf or rhs_inf:
+        if fuzzy_xor([lhs_inf, rhs_inf]):
+            return False
+        lhs_real = _query(Q.extended_real, lhs, assumptions)
+        rhs_real = _query(Q.extended_real, rhs, assumptions)
+        if fuzzy_xor([lhs_real, rhs_real]):
+            return False
+        # both infinite & both real (or both known non-real): fall through
+        # to the diff-based check below, which handles +-oo vs +-oo.
+
+    diff = lhs - rhs
+    if isinstance(diff, NaN):
+        # e.g. zoo - zoo, or an indeterminate difference between two
+        # complex infinities that aren't structurally identical
+        return None
+
+    return _query(Q.zero, diff, assumptions)
+
+
+def _fuzzy_ge(lhs, rhs, assumptions=True):
+    """Fuzzy >= check that avoids calling is_ge(), and therefore avoids the
+    ask() <-> is_ge() mutual recursion described in GH-29863.
+    """
+    from sympy.core.numbers import NaN
+
+    if isinstance(lhs, NaN) or isinstance(rhs, NaN):
+        return None
+
+    if lhs == rhs:
+        return True
+
+    lhs_real = _query(Q.extended_real, lhs, assumptions)
+    rhs_real = _query(Q.extended_real, rhs, assumptions)
+    if not (lhs_real and rhs_real):
+        # is_ge also bails out unless both sides are confirmed extended real
+        return None
+
+    if (_query(Q.infinite, lhs, assumptions) and
+            _query(Q.extended_positive, lhs, assumptions)) or \
+       (_query(Q.infinite, rhs, assumptions) and
+            _query(Q.extended_negative, rhs, assumptions)):
+        return True
+
+    diff = lhs - rhs
+    if isinstance(diff, NaN):
+        return None
+
+    return _query(Q.extended_nonnegative, diff, assumptions)
 
 
 class EqualityPredicate(BinaryRelation):
@@ -61,10 +161,8 @@ class EqualityPredicate(BinaryRelation):
         return Q.ne
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
-            # default assumptions for is_eq is None
-            assumptions = None
-        return is_eq(*args, assumptions)
+        # Use non-recursive helper; avoids ask()<->is_eq() cycle (GH-29863)
+        return _fuzzy_eq(*args, assumptions)
 
 
 class UnequalityPredicate(BinaryRelation):
@@ -105,10 +203,9 @@ class UnequalityPredicate(BinaryRelation):
         return Q.eq
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
-            # default assumptions for is_neq is None
-            assumptions = None
-        return is_neq(*args, assumptions)
+        # Use non-recursive helper; avoids ask()<->is_neq() cycle (GH-29863)
+        res = _fuzzy_eq(*args, assumptions)
+        return None if res is None else not res
 
 
 class StrictGreaterThanPredicate(BinaryRelation):
@@ -153,10 +250,10 @@ class StrictGreaterThanPredicate(BinaryRelation):
         return Q.le
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
-            # default assumptions for is_gt is None
-            assumptions = None
-        return is_gt(*args, assumptions)
+        # Use non-recursive helper; avoids ask()<->is_gt() cycle (GH-29863)
+        # gt(a,b) := not ge(b,a)
+        res = _fuzzy_ge(args[1], args[0], assumptions)
+        return None if res is None else not res
 
 
 class GreaterThanPredicate(BinaryRelation):
@@ -201,10 +298,8 @@ class GreaterThanPredicate(BinaryRelation):
         return Q.lt
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
-            # default assumptions for is_ge is None
-            assumptions = None
-        return is_ge(*args, assumptions)
+        # Use non-recursive helper; avoids ask()<->is_ge() cycle (GH-29863)
+        return _fuzzy_ge(*args, assumptions)
 
 
 class StrictLessThanPredicate(BinaryRelation):
@@ -249,10 +344,10 @@ class StrictLessThanPredicate(BinaryRelation):
         return Q.ge
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
-            # default assumptions for is_lt is None
-            assumptions = None
-        return is_lt(*args, assumptions)
+        # Use non-recursive helper; avoids ask()<->is_lt() cycle (GH-29863)
+        # lt(a,b) := not ge(a,b)
+        res = _fuzzy_ge(*args, assumptions)
+        return None if res is None else not res
 
 
 class LessThanPredicate(BinaryRelation):
@@ -297,7 +392,6 @@ class LessThanPredicate(BinaryRelation):
         return Q.gt
 
     def eval(self, args, assumptions=True):
-        if assumptions == True:
-            # default assumptions for is_le is None
-            assumptions = None
-        return is_le(*args, assumptions)
+        # Use non-recursive helper; avoids ask()<->is_le() cycle (GH-29863)
+        # le(a,b) := ge(b,a)
+        return _fuzzy_ge(args[1], args[0], assumptions)

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -159,6 +159,44 @@ def test_equality():
     # test transitivity
     assert ask(Q.eq(x,z), Q.eq(x,y) & Q.eq(y,z)) is True
 
+    # Regression tests for GH-29863: EqualityPredicate/GreaterThanPredicate
+    # (and friends) used to call is_eq/is_ge from sympy.core.relational,
+    # which routes through AssumptionsWrapper straight back into ask() for
+    # sub-predicates like Q.zero - a recursive pattern related to GH-28129.
+    # These cases exercise the paths that a naive non-recursive
+    # reimplementation is most likely to get wrong.
+    from sympy.core.numbers import nan, oo, zoo, I
+    from sympy.core.singleton import S
+
+    # NaN is never equal to anything, not even itself, even though it is
+    # structurally equal to itself (S.NaN == S.NaN is True in Python).
+    assert ask(Q.eq(nan, nan)) is False
+    assert ask(Q.ne(nan, nan)) is True
+    assert ask(Q.eq(nan, 0)) is False
+
+    # infinities: same-signed/complex infinities compare unequal to
+    # differently-typed infinities
+    assert ask(Q.eq(oo, oo)) is True
+    assert ask(Q.eq(-oo, oo)) is False
+    assert ask(Q.eq(zoo, oo)) is False
+    assert ask(Q.eq(zoo, zoo)) is True
+
+    # Booleans only equal Booleans; a bare Symbol must not be treated as a
+    # Boolean here even though Symbol is technically a Boolean subclass
+    assert ask(Q.eq(S.true, S.true)) is True
+    assert ask(Q.eq(S.true, S.false)) is False
+    assert ask(Q.eq(S.true, 1)) is False
+    assert ask(Q.eq(x, 0), Q.zero(x)) is True
+
+    # complex vs real
+    assert ask(Q.eq(I, 1)) is False
+
+    # a symbol's own declared assumptions must resolve fuzzy facts about
+    # compound expressions without needing local assumptions passed to ask()
+    m = symbols('m', integer=True)
+    assert ask(Q.ge(m**2, 0)) is True
+    assert ask(Q.gt(m**2, -1)) is True
+
 
 @XFAIL
 def test_equality_failing():

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -161,7 +161,7 @@ def test_equality():
     assert ask(Q.eq(x,z), Q.eq(x,y) & Q.eq(y,z)) is True
 
     # Regression tests for GH-29863: EqualityPredicate/GreaterThanPredicate
-    # (and friends) used to call is_eq/is_ge from sympy.core.relational,
+    # (and friends) used to call is_eq/is_ge from sympy.core.relational ,
     # which routes through AssumptionsWrapper straight back into ask() for
     # sub-predicates like Q.zero - a recursive pattern related to GH-28129.
     # These cases exercise the paths that a naive non-recursive

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -5,7 +5,8 @@ from sympy.assumptions.ask import Q, ask
 
 from sympy.core import symbols, Symbol
 from sympy.matrices.expressions.matexpr import MatrixSymbol
-from sympy.core.numbers import I
+from sympy.core.numbers import nan, oo, zoo, I
+from sympy.core.singleton import S
 
 from sympy.testing.pytest import raises, XFAIL
 x, y, z = symbols("x y z", real=True)
@@ -165,8 +166,6 @@ def test_equality():
     # sub-predicates like Q.zero - a recursive pattern related to GH-28129.
     # These cases exercise the paths that a naive non-recursive
     # reimplementation is most likely to get wrong.
-    from sympy.core.numbers import nan, oo, zoo, I
-    from sympy.core.singleton import S
 
     # NaN is never equal to anything, not even itself, even though it is
     # structurally equal to itself (S.NaN == S.NaN is True in Python).


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->
 Remove is_eq/is_ge dependency from equality.py
#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #29863 

#### Brief description of what is fixed or changed
'equality.py' previously used 'is_eq'/'is_ge' and related helpers from
'sympy.core.relational'. These can re-enter the assumptions system through
'AssumptionsWrapper', causing recursive and unnecessary 'ask()'/'satask()'
calls.

This change removes those dependencies and uses '_fuzzy_eq' and
'_fuzzy_ge' with '_ask_recursive'. The helpers first check existing fuzzy
properties and only use the fact/dispatch-only recursive lookup when local
assumptions are needed.

Regression tests were added for NaN, infinities, Boolean-vs-number
equality, and local-assumption cases.

The assumptions test suite passes with the same results as before:
154 passed, 11 xfailed on master and fix-ask-relational-recursion branch.

#### Other comments
Benchmark: 'sympy/assumptions/tests/', 10 runs on each branch.

All testing and benchmarking were performed locally on Ubuntu 24.04.4 LTS


'master':
run  1: 17.342s
run  2: 18.065s
run  3: 18.737s
run  4: 18.400s
run  5: 17.392s
run  6: 19.257s
run  7: 19.873s
run  8: 19.529s
run  9: 17.591s
run 10: 17.045s

min = 17.045s
max = 19.873s
avg = 18.323s

'fix-ask-relational-recursion':
run  1: 10.545s
run  2: 10.405s
run  3: 10.289s
run  4: 10.419s
run  5: 10.310s
run  6: 10.345s
run  7: 10.291s
run  8: 10.349s
run  9: 10.555s
run 10: 10.578s

min = 10.289s
max = 10.578s
avg = 10.408s


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

This PR was developed with assistance from Claude . Claude was 
used to assist with the `_query`, `_fuzzy_eq`, and `_fuzzy_ge` implementation
and differential testing. All testing and benchmarking were performed
locally. I reviewed the implementation, tests, and benchmark results before
submitting.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * Avoid recursive `ask()`/`satask()` calls from relational predicates by
    removing their dependency on `is_eq`/`is_ge` and related helpers.

<!-- END RELEASE NOTES -->
