### PR TITLE
Enhance refine_Pow to handle S.Exp1 while preserving refine_exp

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1811,6 +1811,7 @@ amsuhane <ayushsuhane99@iitkgp.ac.in> amsuhane <“ayushsuhane99@iitkgp.ac.in”
 anca-mc <anca-mc@users.noreply.github.com>
 andreo <andrey.torba@gmail.com>
 arooshiverma <av22@iitbbs.ac.in>
+aryawadhwa <aryawadhwa2@gmail.com>
 asthapaikacse <paikaasthaatwork@gmail.com>
 atharvParlikar <atharvparlikar@gmail.com>
 bharatAmeria <21001019007@jcboseust.ac.in> bharatAmeria <147488804+bharatAmeria@users.noreply.github.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -161,6 +161,24 @@ def refine_Pow(expr, assumptions):
             if isinstance(expr.base, Pow):
                 return abs(expr.base.base) ** (expr.base.exp * expr.exp)
 
+        if expr.base is S.Exp1:
+            coeff = expr.exp.as_coefficient(S.Pi * S.ImaginaryUnit)
+            if coeff is not None:
+                integer_terms = []
+                remaining_terms = []
+                terms = coeff.args if coeff.is_Add else (coeff,)
+                for term in terms:
+                    if ask(Q.integer(term), assumptions):
+                        integer_terms.append(term)
+                    else:
+                        remaining_terms.append(term)
+
+                if integer_terms:
+                    integer_part = Add(*integer_terms)
+                    remaining_part = Add(*remaining_terms)
+                    phase = expr.base**(S.Pi * S.ImaginaryUnit * remaining_part)
+                    return (-1)**integer_part * phase
+
         if expr.base is S.NegativeOne:
             if expr.exp.is_Add:
 

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -4,6 +4,7 @@ from sympy.assumptions.refine import refine, refine_sin_cos
 from sympy.calculus.accumulationbounds import AccumBounds
 from sympy.core.expr import Expr
 from sympy.core.numbers import (I, Rational, nan, pi)
+from sympy.core.power import Pow
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.complexes import (Abs, arg, im, re, sign)
@@ -94,6 +95,12 @@ def test_exp():
     assert refine(exp(2*pi*I*(x + y + Rational(1, 4))),
         Q.integer(x) & Q.integer(y)) == I
     assert refine(exp(pi*I*x), Q.integer(x)) == (-1)**x
+
+    # Ensure Pow(E, ...) simplifies identically
+    assert refine(Pow(S.Exp1, pi*I*2*x, evaluate=False), Q.integer(x)) == 1
+    assert refine(Pow(S.Exp1, pi*I*2*(x + S.Half), evaluate=False), Q.integer(x)) == -1
+    assert refine(Pow(S.Exp1, pi*I*x, evaluate=False), Q.odd(x)) == -1
+    assert refine(Pow(S.Exp1, pi*I*x, evaluate=False), Q.integer(x)) == (-1)**x
 
 def test_Piecewise():
     assert refine(Piecewise((1, x < 0), (3, True)), (x < 0)) == 1


### PR DESCRIPTION
<!-- Please carefully follow the SymPy contributing guidelines: https://docs.sympy.org/dev/contributing/index.html -->

### Description

This PR improves `refine` to properly simplify expressions involving `Pow(S.Exp1, ...)`, handling them identically to the `exp` function.

Previously, `refine(Pow(S.Exp1, pi*I*2*x), Q.integer(x))` did not evaluate, while `refine(exp(2*pi*I*x), Q.integer(x))` did, even though they represent the same mathematical entity in SymPy.

**Changes Made:**
* Updated `refine_Pow` in `sympy/assumptions/refine.py` to extract integer and remaining parts of the exponent when the base is `S.Exp1`, mimicking the logic of `refine_exp`.
* Added tests in `test_refine.py` to ensure `Pow(S.Exp1, ...)` evaluates correctly under `Q.integer` and `Q.odd` assumptions.
* Explicitly preserved the `refine_exp` function for downstream backward compatibility.

### Breaking Changes
None.

### Tests
- [x] Added tests for `Pow(S.Exp1, ...)` in `sympy/assumptions/tests/test_refine.py`.
- [x] Ran `./bin/test` and ensured all tests passed.

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Handled `E**x` identically to `exp(x)` in `refine`.
<!-- END RELEASE NOTES -->
