### PR TITLE
Add type annotations to sympy.calculus.finite_diff

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1826,6 +1826,7 @@ der-blaue-elefant <github@kklein.de>
 dimasvq <dimas.vq.2020@bristol.ac.uk>
 dispasha <dispasha@users.noreply.github.com>
 dodo <palumbododo@gmail.com> Dodopalu <87149525+Dodopalu@users.noreply.github.com>
+dongyanghe212 <dongyanghe212@MBA-GJN73QVJGF-2224.local>
 dps7ud <dps7ud@virginia.edu>
 dranknight09 <cbhaavan@gmail.com>
 dustyrockpyle <dustyrockpyle@gmail.com>

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from collections.abc import Sequence  # noqa: TC003
 from typing import TYPE_CHECKING, cast
 
+from sympy.core.expr import Expr
 from sympy.core.function import Derivative
 from sympy.core.singleton import S
 from sympy.core.function import Subs
@@ -31,7 +32,6 @@ from sympy.utilities.iterables import iterable
 
 if TYPE_CHECKING:
     from sympy.core.basic import Basic
-    from sympy.core.expr import Expr
     from sympy.core.symbol import Symbol
 
 

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -18,6 +18,9 @@ for:
 """
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
 from sympy.core.function import Derivative
 from sympy.core.singleton import S
 from sympy.core.function import Subs
@@ -26,8 +29,14 @@ from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable
 
 
+if TYPE_CHECKING:
+    from sympy.core.basic import Basic
+    from sympy.core.expr import Expr
+    from sympy.core.symbol import Symbol
 
-def finite_diff_weights(order, x_list, x0=S.One):
+
+
+def finite_diff_weights(order: int, x_list: Sequence[Expr], x0: Expr = S.One) -> list[list[list[Expr]]]:
     """
     Calculates the finite difference weights for an arbitrarily spaced
     one-dimensional grid (``x_list``) for derivatives at ``x0`` of order
@@ -194,7 +203,7 @@ def finite_diff_weights(order, x_list, x0=S.One):
     return delta
 
 
-def apply_finite_diff(order, x_list, y_list, x0=S.Zero):
+def apply_finite_diff(order: int, x_list: Sequence[Expr], y_list: Sequence[Expr], x0: Expr = S.Zero) -> Expr:
     """
     Calculates the finite difference approximation of
     the derivative of requested order at ``x0`` from points
@@ -281,7 +290,7 @@ def apply_finite_diff(order, x_list, y_list, x0=S.Zero):
     return derivative
 
 
-def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
+def _as_finite_diff(derivative: Derivative | Expr, points: Sequence[Expr] | Expr = 1, x0: Expr | None = None, wrt: Symbol | None = None) -> Basic:
     """
     Returns an approximation of a derivative of a function in
     the form of a finite difference formula. The expression is a
@@ -405,8 +414,8 @@ def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
         x in points], x0)
 
 
-def differentiate_finite(expr, *symbols,
-                         points=1, x0=None, wrt=None, evaluate=False):
+def differentiate_finite(expr: Expr, *symbols: Symbol,
+                         points: Sequence[Expr] | Expr = 1, x0: Expr | None = None, wrt: Symbol | None = None, evaluate: bool = False) -> Expr:
     r""" Differentiate expr and replace Derivatives with finite differences.
 
     Parameters

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -18,7 +18,8 @@ for:
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Sequence  # noqa: TC003
+from typing import TYPE_CHECKING, cast
 
 from sympy.core.function import Derivative
 from sympy.core.singleton import S
@@ -29,7 +30,6 @@ from sympy.utilities.iterables import iterable
 
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
     from sympy.core.basic import Basic
     from sympy.core.expr import Expr
     from sympy.core.symbol import Symbol
@@ -172,16 +172,16 @@ def finite_diff_weights(order: int, x_list: Sequence[Expr], x0: Expr = S.One) ->
 
     """
     # The notation below closely corresponds to the one used in the paper.
-    order = S(order)
-    if not order.is_number:
+    order_ = S(order)
+    if not order_.is_number:
         raise ValueError("Cannot handle symbolic order.")
-    if order < 0:
+    if order_ < 0:
         raise ValueError("Negative derivative order illegal.")
-    if int(order) != order:
+    if int(order_) != order_:
         raise ValueError("Non-integer order illegal")
-    M = order
+    M = int(order_)
     N = len(x_list) - 1
-    delta = [[[0 for nu in range(N+1)] for n in range(N+1)] for
+    delta: list[list[list[Expr]]] = [[[S.Zero for nu in range(N+1)] for n in range(N+1)] for
              m in range(M+1)]
     delta[0][0][0] = S.One
     c1 = S.One
@@ -191,7 +191,7 @@ def finite_diff_weights(order: int, x_list: Sequence[Expr], x0: Expr = S.One) ->
             c3 = x_list[n] - x_list[nu]
             c2 = c2 * c3
             if n <= M:
-                delta[n][n-1][nu] = 0
+                delta[n][n-1][nu] = S.Zero
             for m in range(min(n, M)+1):
                 delta[m][n][nu] = (x_list[n]-x0)*delta[m][n-1][nu] -\
                     m*delta[m-1][n-1][nu]
@@ -284,13 +284,13 @@ def apply_finite_diff(order: int, x_list: Sequence[Expr], y_list: Sequence[Expr]
 
     delta = finite_diff_weights(order, x_list, x0)
 
-    derivative = 0
+    derivative: Expr = S.Zero
     for nu in range(len(x_list)):
         derivative += delta[order][N][nu]*y_list[nu]
     return derivative
 
 
-def _as_finite_diff(derivative: Derivative | Expr, points: Sequence[Expr] | Expr = 1, x0: Expr | None = None, wrt: Symbol | None = None) -> Basic:
+def _as_finite_diff(derivative: Basic, points: Sequence[Expr] | Expr = S.One, x0: Expr | None = None, wrt: Symbol | None = None) -> Basic:
     """
     Returns an approximation of a derivative of a function in
     the form of a finite difference formula. The expression is a
@@ -375,6 +375,8 @@ def _as_finite_diff(derivative: Derivative | Expr, points: Sequence[Expr] | Expr
             [_as_finite_diff(ar, points, x0, wrt) for ar
              in derivative.args], **derivative.assumptions0)
 
+    assert isinstance(derivative, Derivative)
+
     if wrt is None:
         old = None
         for v in derivative.variables:
@@ -390,32 +392,35 @@ def _as_finite_diff(derivative: Derivative | Expr, points: Sequence[Expr] | Expr
         x0 = wrt
 
     if not iterable(points):
+        points = cast(Expr, points)
         if getattr(points, 'is_Function', False) and wrt in points.args:
             points = points.subs(wrt, x0)
         # points is simply the step-size, let's make it a
         # equidistant sequence centered around x0
         if order % 2 == 0:
             # even order => odd number of points, grid point included
-            points = [x0 + points*i for i
+            points_seq: Sequence[Expr] = [x0 + points*i for i
                       in range(-order//2, order//2 + 1)]
         else:
             # odd order => even number of points, half-way wrt grid point
-            points = [x0 + points*S(i)/2 for i
+            points_seq = [x0 + points*S(i)/2 for i
                       in range(-order, order + 1, 2)]
+    else:
+        points_seq = cast(Sequence[Expr], points)
     others = [wrt, 0]
     for v in set(derivative.variables):
         if v == wrt:
             continue
         others += [v, derivative.variables.count(v)]
-    if len(points) < order+1:
+    if len(points_seq) < order+1:
         raise ValueError("Too few points for order %d" % order)
-    return apply_finite_diff(order, points, [
+    return apply_finite_diff(order, points_seq, [
         Derivative(derivative.expr.subs({wrt: x}), *others) for
-        x in points], x0)
+        x in points_seq], x0)
 
 
 def differentiate_finite(expr: Expr, *symbols: Symbol,
-                         points: Sequence[Expr] | Expr = 1, x0: Expr | None = None, wrt: Symbol | None = None, evaluate: bool = False) -> Expr:
+                         points: Sequence[Expr] | Expr = S.One, x0: Expr | None = None, wrt: Symbol | None = None, evaluate: bool = False) -> Basic:
     r""" Differentiate expr and replace Derivatives with finite differences.
 
     Parameters
@@ -463,7 +468,7 @@ def differentiate_finite(expr: Expr, *symbols: Symbol,
     if any(term.is_Derivative for term in list(preorder_traversal(expr))):
         evaluate = False
 
-    Dexpr = expr.diff(*symbols, evaluate=evaluate)
+    Dexpr: Derivative = cast(Derivative, expr.diff(*symbols, evaluate=evaluate))
     if evaluate:
         sympy_deprecation_warning("""
         The evaluate flag to differentiate_finite() is deprecated.

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -18,7 +18,6 @@ for:
 """
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from sympy.core.function import Derivative
@@ -30,6 +29,7 @@ from sympy.utilities.iterables import iterable
 
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from sympy.core.basic import Basic
     from sympy.core.expr import Expr
     from sympy.core.symbol import Symbol


### PR DESCRIPTION
Adds missing type annotations to improve code quality and enable better IDE support and static type checking.

Annotations added to:
- `finite_diff_weights`: , , 
- `apply_finite_diff`: , , , `x0: Expr`
- `_as_finite_diff`: , , `x0: Expr | None`, `wrt: Symbol | None`
- `differentiate_finite`: , , , `x0: Expr | None`, `wrt: Symbol | None`, `evaluate: bool`

No behavioral changes - typing only. All existing imports preserved and `from __future__ import annotations` was already present.

Issue: https://github.com/sympy/sympy/issues/28806

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->