### PR TITLE
assumptions: implement early return in `satask`

### DIFF
--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -10,7 +10,7 @@ from sympy.assumptions.ask_generated import get_all_known_matrix_facts, get_all_
 from sympy.assumptions.assume import AppliedPredicate
 from sympy.assumptions.sathandlers import class_fact_registry
 from sympy.core import oo
-from sympy.logic.algorithms.dpll2 import SATSolver
+from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.matrices.kind import MatrixKind
 
@@ -75,7 +75,7 @@ def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
 def check_satisfiability(prop, _prop, factbase):
     # Run `propogate()` on the assumptions
     solver = SATSolver(factbase.data, factbase.variables, set(), factbase.symbols)
-    if solver.propagate() == 20:
+    if solver.propagate() == IpasirStatus.UNSATISFIABLE:
         raise ValueError("Inconsistent Assumptions")
 
     # Check whether proposition is entailed by any of the assigned literals.
@@ -114,7 +114,7 @@ def check_satisfiability(prop, _prop, factbase):
             return answer
 
     # Continue on the propogated solver, just call solve() on it.
-    if solver.solve() == 20:
+    if solver.solve() == IpasirStatus.UNSATISFIABLE:
         raise ValueError("Inconsistent assumptions")
 
     # This model satisfies the factbase, so it witness one of the two
@@ -147,11 +147,11 @@ def check_satisfiability(prop, _prop, factbase):
 
     if not can_be_true and {0} not in sat_true.data:
         true_solver = SATSolver(sat_true.data, sat_true.variables, set(), sat_true.symbols)
-        can_be_true = true_solver.solve() == 10
+        can_be_true = true_solver.solve() == IpasirStatus.SATISFIABLE
 
     if not can_be_false and {0} not in sat_false.data:
         false_solver = SATSolver(sat_false.data, sat_false.variables, set(), sat_false.symbols)
-        can_be_false = false_solver.solve() == 10
+        can_be_false = false_solver.solve() == IpasirStatus.SATISFIABLE
 
     if can_be_true and can_be_false:
         return None

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -10,7 +10,7 @@ from sympy.assumptions.ask_generated import get_all_known_matrix_facts, get_all_
 from sympy.assumptions.assume import AppliedPredicate
 from sympy.assumptions.sathandlers import class_fact_registry
 from sympy.core import oo
-from sympy.logic.inference import satisfiable
+from sympy.logic.algorithms.dpll2 import SATSolver
 from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.matrices.kind import MatrixKind
 
@@ -73,12 +73,85 @@ def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
 
 
 def check_satisfiability(prop, _prop, factbase):
+    # Run `propogate()` on the assumptions
+    solver = SATSolver(factbase.data, factbase.variables, set(), factbase.symbols)
+    if solver.propagate() == 20:
+        raise ValueError("Inconsistent Assumptions")
+
+    # Check whether proposition is entailed by any of the assigned literals.
+    for clauses, answer in ((prop.clauses, True), (_prop.clauses, False)):
+        all_satisfied = True # Flag to check if all clauses are satisfied
+        for clause in clauses:
+            satisfied = False # Flag to check if the clause can be satisfied
+            all_lits_false = True # Flag to track if all literals in a clause are false
+            for lit in clause:
+                # fixed() takes an int in this factbase's numbering, not a
+                # Literal. Predicates it never encoded cannot have been fixed.
+                # For example `Q.gt` and other relational predicate.
+                var = factbase.encoding.get(lit.lit)
+                if var is None:
+                    lit_is_implied = 0
+                else:
+                    lit_is_implied = solver.fixed(-var if lit.is_Not else var)
+                if lit_is_implied == 1:
+                    satisfied = True
+                    all_lits_false = False
+                    break
+                if lit_is_implied == 0:
+                    all_lits_false = False
+            if satisfied:
+                continue
+            if all_lits_false:
+                # If the current clause is false then the CNF in scan
+                # is false, by false meaning the opposite of the `answer`
+                return not answer
+            # Undecided. This CNF cannot be entailed any more, but keep
+            # scanning, since a later clause may still turn out to be false.
+            all_satisfied = False
+
+        if all_satisfied:
+            # If everything works out, just return answer
+            return answer
+
+    # Continue on the propogated solver, just call solve() on it.
+    if solver.solve() == 20:
+        raise ValueError("Inconsistent assumptions")
+
+    # This model satisfies the factbase, so it witness one of the two
+    # searches below: whichever of prop and _prop it satisfies.
+    # Whichever it satisfies, we just need to build a solver for the other side.
+    prop_in_model = True
+    for clause in prop.clauses:
+        unknown_lit = False
+        for lit in clause:
+            var = factbase.encoding.get(lit.lit)
+            if var is None:
+                unknown_lit = True
+                continue
+            value = -var if lit.is_Not else var
+            if solver.val(value) == value:
+                break
+        else:
+            prop_in_model = None if unknown_lit else False
+            break
+
     sat_true = factbase.copy()
     sat_false = factbase.copy()
     sat_true.add_from_cnf(prop)
     sat_false.add_from_cnf(_prop)
-    can_be_true = satisfiable(sat_true)
-    can_be_false = satisfiable(sat_false)
+
+    # Search only for the side the witness which is remaining
+    # Build the solver for that side
+    can_be_true = prop_in_model == True
+    can_be_false = prop_in_model == False
+
+    if not can_be_true and {0} not in sat_true.data:
+        true_solver = SATSolver(sat_true.data, sat_true.variables, set(), sat_true.symbols)
+        can_be_true = true_solver.solve() == 10
+
+    if not can_be_false and {0} not in sat_false.data:
+        false_solver = SATSolver(sat_false.data, sat_false.variables, set(), sat_false.symbols)
+        can_be_false = false_solver.solve() == 10
 
     if can_be_true and can_be_false:
         return None

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -73,10 +73,26 @@ def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
 
 
 def check_satisfiability(prop, _prop, factbase):
-    # Run `propogate()` on the assumptions
-    solver = SATSolver(factbase.data, factbase.variables, set(), factbase.symbols)
+    sat_true = factbase.copy()
+    sat_true.data = []
+    sat_true.add_from_cnf(prop)
+
+    sat_false = sat_true.copy()
+    sat_false.data = []
+    sat_false.add_from_cnf(_prop)
+
+    # The propositions only go in once the facts have had their say, so a
+    # question the facts alone settle never pays for them.
+    selector = len(sat_false.encoding) + 1
+    solver = SATSolver(factbase.data, range(1, selector + 1), set(), sat_false.symbols + [selector])
+
+    # EncodedCNF encodes False as the literal 0, which the solver cannot see
+    # as false.
+    if {0} in factbase.data:
+        raise ValueError("Inconsistent assumptions")
+
     if solver.propagate() == IpasirStatus.UNSATISFIABLE:
-        raise ValueError("Inconsistent Assumptions")
+        raise ValueError("Inconsistent assumptions")
 
     # Check whether proposition is entailed by any of the assigned literals.
     for clauses, answer in ((prop.clauses, True), (_prop.clauses, False)):
@@ -85,10 +101,9 @@ def check_satisfiability(prop, _prop, factbase):
             satisfied = False # Flag to check if the clause can be satisfied
             all_lits_false = True # Flag to track if all literals in a clause are false
             for lit in clause:
-                # fixed() takes an int in this factbase's numbering, not a
-                # Literal. Predicates it never encoded cannot have been fixed.
-                # For example `Q.gt` and other relational predicate.
-                var = factbase.encoding.get(lit.lit)
+                # fixed() takes an int in this solver's numbering, not a
+                # Literal, and the False literal has no variable of its own.
+                var = sat_false.encoding.get(lit.lit)
                 if var is None:
                     lit_is_implied = 0
                 else:
@@ -113,45 +128,22 @@ def check_satisfiability(prop, _prop, factbase):
             # If everything works out, just return answer
             return answer
 
+    # Dropping the 0 leaves a side nothing can satisfy as the unit {guard}.
+    for side, guard in ((sat_true, -selector), (sat_false, selector)):
+        for clause in side.data:
+            solver.clause((clause - {0}) | {guard})
+
     # Continue on the propogated solver, just call solve() on it.
     if solver.solve() == IpasirStatus.UNSATISFIABLE:
         raise ValueError("Inconsistent assumptions")
 
-    # This model satisfies the factbase, so it witness one of the two
-    # searches below: whichever of prop and _prop it satisfies.
-    # Whichever it satisfies, we just need to build a solver for the other side.
-    prop_in_model = True
-    for clause in prop.clauses:
-        unknown_lit = False
-        for lit in clause:
-            var = factbase.encoding.get(lit.lit)
-            if var is None:
-                unknown_lit = True
-                continue
-            value = -var if lit.is_Not else var
-            if solver.val(value) == value:
-                break
-        else:
-            prop_in_model = None if unknown_lit else False
-            break
+    # The model settles the side it activated, so ask about the other one.
+    witnessed = solver.val(selector)
+    solver.assume(-witnessed)
+    other = solver.solve() == IpasirStatus.SATISFIABLE
 
-    sat_true = factbase.copy()
-    sat_false = factbase.copy()
-    sat_true.add_from_cnf(prop)
-    sat_false.add_from_cnf(_prop)
-
-    # Search only for the side the witness which is remaining
-    # Build the solver for that side
-    can_be_true = prop_in_model == True
-    can_be_false = prop_in_model == False
-
-    if not can_be_true and {0} not in sat_true.data:
-        true_solver = SATSolver(sat_true.data, sat_true.variables, set(), sat_true.symbols)
-        can_be_true = true_solver.solve() == IpasirStatus.SATISFIABLE
-
-    if not can_be_false and {0} not in sat_false.data:
-        false_solver = SATSolver(sat_false.data, sat_false.variables, set(), sat_false.symbols)
-        can_be_false = false_solver.solve() == IpasirStatus.SATISFIABLE
+    can_be_true = witnessed > 0 or other
+    can_be_false = witnessed < 0 or other
 
     if can_be_true and can_be_false:
         return None

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -15,7 +15,8 @@ from sympy.assumptions.cnf import CNF, EncodedCNF
 from sympy.matrices.kind import MatrixKind
 
 
-def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
+def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo,
+           early_return=False):
     """
     Function to evaluate the proposition with assumptions using SAT algorithm.
 
@@ -45,6 +46,10 @@ def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
         Number of times that relevant facts are recursively extracted.
         Default is infinite times until no new fact is found.
 
+    early_return : bool, optional.
+        If ``True``, answer from the propagated facts alone, trusting
+        *assumptions* to be consistent. Default is ``False``.
+
     Returns
     =======
 
@@ -69,10 +74,10 @@ def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
         use_known_facts=use_known_facts, iterations=iterations)
     sat.add_from_cnf(assumptions)
 
-    return check_satisfiability(props, _props, sat)
+    return check_satisfiability(props, _props, sat, early_return)
 
 
-def check_satisfiability(prop, _prop, factbase):
+def check_satisfiability(prop, _prop, factbase, early_return=False):
     if {0} in factbase.data:
         raise ValueError("Inconsistent assumptions")
 
@@ -85,10 +90,11 @@ def check_satisfiability(prop, _prop, factbase):
         raise ValueError("Inconsistent assumptions")
 
     # Check whether proposition is entailed by any of the assigned literals.
-    for clauses, answer in ((prop.clauses, True), (_prop.clauses, False)):
-        entailed = solver._is_entailed(clauses, true_false_guarded.encoding)
-        if entailed is not None:
-            return answer if entailed else not answer
+    if early_return:
+        for clauses, answer in ((prop.clauses, True), (_prop.clauses, False)):
+            entailed = solver._is_entailed(clauses, true_false_guarded.encoding)
+            if entailed is not None:
+                return answer if entailed else not answer
 
     # Continue on the propogated solver, just call solve() on it.
     if solver.solve() == IpasirStatus.UNSATISFIABLE:

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -91,10 +91,13 @@ def check_satisfiability(prop, _prop, factbase, early_return=False):
 
     # Check whether proposition is entailed by any of the assigned literals.
     if early_return:
-        for clauses, answer in ((prop.clauses, True), (_prop.clauses, False)):
-            entailed = solver._is_entailed(clauses, true_false_guarded.encoding)
-            if entailed is not None:
-                return answer if entailed else not answer
+        entailed = solver._is_entailed(prop.clauses, true_false_guarded.encoding)
+        if entailed is not None:
+            return entailed
+
+        entailed = solver._is_entailed(_prop.clauses, true_false_guarded.encoding)
+        if entailed is not None:
+            return not entailed
 
     # Continue on the propogated solver, just call solve() on it.
     if solver.solve() == IpasirStatus.UNSATISFIABLE:

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -73,37 +73,22 @@ def satask(proposition, assumptions=True, use_known_facts=True, iterations=oo):
 
 
 def check_satisfiability(prop, _prop, factbase):
-    sat_true = factbase.copy()
-    sat_true.data = []
-    sat_true.add_from_cnf(prop)
-
-    sat_false = sat_true.copy()
-    sat_false.data = []
-    sat_false.add_from_cnf(_prop)
-
-    # The propositions only go in once the facts have had their say, so a
-    # question the facts alone settle never pays for them.
-    selector = len(sat_false.encoding) + 1
-    solver = SATSolver(factbase.data, range(1, selector + 1), set(), sat_false.symbols + [selector])
-
-    # EncodedCNF encodes False as the literal 0, which the solver cannot see
-    # as false.
     if {0} in factbase.data:
         raise ValueError("Inconsistent assumptions")
 
+    true_false_guarded, selector = _encode_with_selector(prop, _prop, factbase)
+
+    # Run `propogate()` on the assumptions
+    solver = SATSolver(true_false_guarded.data, range(1, selector + 1), set(),
+                       true_false_guarded.symbols + [selector])
     if solver.propagate() == IpasirStatus.UNSATISFIABLE:
         raise ValueError("Inconsistent assumptions")
 
     # Check whether proposition is entailed by any of the assigned literals.
     for clauses, answer in ((prop.clauses, True), (_prop.clauses, False)):
-        entailed = _is_entailed(clauses, solver, sat_false.encoding)
+        entailed = solver._is_entailed(clauses, true_false_guarded.encoding)
         if entailed is not None:
             return answer if entailed else not answer
-
-    # Dropping the 0 leaves a side nothing can satisfy as the unit {guard}.
-    for side, guard in ((sat_true, -selector), (sat_false, selector)):
-        for clause in side.data:
-            solver.clause((clause - {0}) | {guard})
 
     # Continue on the propogated solver, just call solve() on it.
     if solver.solve() == IpasirStatus.UNSATISFIABLE:
@@ -133,26 +118,24 @@ def check_satisfiability(prop, _prop, factbase):
         raise ValueError("Inconsistent assumptions")
 
 
-def _is_entailed(clauses, solver, encoding):
+def _encode_with_selector(prop, _prop, factbase):
+    """Return *factbase* with the clauses of prop and _prop added to it, and
+    the selector variable that activates prop when true and _prop when false.
     """
-    Return True if the literals *solver* has fixed make the CNF *clauses*
-    true, False if they make it false, and None if they leave it undecided.
-    """
-    entailed = True
-    for clause in clauses:
-        # fixed() takes an int in this solver's numbering, not a Literal,
-        # and a predicate it never encoded cannot have been fixed.
-        values = [solver.fixed(-var if lit.is_Not else var)
-                  if (var := encoding.get(lit.lit)) else 0
-                  for lit in clause]
+    true_false_guarded = factbase.copy()
+    sides = [[true_false_guarded.encode(clause) for clause in side.clauses]
+             for side in (prop, _prop)]
 
-        # One false clause makes the whole CNF false. An undecided one only
-        # rules out entailment, so keep looking for a false clause.
-        if all(value == -1 for value in values):
-            return False
-        entailed = entailed and 1 in values
+    # One past the last predicate, so the selector is a variable of its own.
+    selector = len(true_false_guarded.encoding) + 1
 
-    return entailed or None
+    for clauses, guard in zip(sides, (-selector, selector)):
+        # Dropping the 0 that encodes False leaves a side nothing can satisfy
+        # as the unit {guard}.
+        true_false_guarded.data += [(clause - {0}) | {guard}
+                                    for clause in clauses]
+
+    return true_false_guarded, selector
 
 
 def extract_predargs(proposition, assumptions=None):

--- a/sympy/assumptions/satask.py
+++ b/sympy/assumptions/satask.py
@@ -96,37 +96,9 @@ def check_satisfiability(prop, _prop, factbase):
 
     # Check whether proposition is entailed by any of the assigned literals.
     for clauses, answer in ((prop.clauses, True), (_prop.clauses, False)):
-        all_satisfied = True # Flag to check if all clauses are satisfied
-        for clause in clauses:
-            satisfied = False # Flag to check if the clause can be satisfied
-            all_lits_false = True # Flag to track if all literals in a clause are false
-            for lit in clause:
-                # fixed() takes an int in this solver's numbering, not a
-                # Literal, and the False literal has no variable of its own.
-                var = sat_false.encoding.get(lit.lit)
-                if var is None:
-                    lit_is_implied = 0
-                else:
-                    lit_is_implied = solver.fixed(-var if lit.is_Not else var)
-                if lit_is_implied == 1:
-                    satisfied = True
-                    all_lits_false = False
-                    break
-                if lit_is_implied == 0:
-                    all_lits_false = False
-            if satisfied:
-                continue
-            if all_lits_false:
-                # If the current clause is false then the CNF in scan
-                # is false, by false meaning the opposite of the `answer`
-                return not answer
-            # Undecided. This CNF cannot be entailed any more, but keep
-            # scanning, since a later clause may still turn out to be false.
-            all_satisfied = False
-
-        if all_satisfied:
-            # If everything works out, just return answer
-            return answer
+        entailed = _is_entailed(clauses, solver, sat_false.encoding)
+        if entailed is not None:
+            return answer if entailed else not answer
 
     # Dropping the 0 leaves a side nothing can satisfy as the unit {guard}.
     for side, guard in ((sat_true, -selector), (sat_false, selector)):
@@ -159,6 +131,28 @@ def check_satisfiability(prop, _prop, factbase):
         # assumptions, global_assumptions, and relevant_facts are
         # inconsistent.
         raise ValueError("Inconsistent assumptions")
+
+
+def _is_entailed(clauses, solver, encoding):
+    """
+    Return True if the literals *solver* has fixed make the CNF *clauses*
+    true, False if they make it false, and None if they leave it undecided.
+    """
+    entailed = True
+    for clause in clauses:
+        # fixed() takes an int in this solver's numbering, not a Literal,
+        # and a predicate it never encoded cannot have been fixed.
+        values = [solver.fixed(-var if lit.is_Not else var)
+                  if (var := encoding.get(lit.lit)) else 0
+                  for lit in clause]
+
+        # One false clause makes the whole CNF false. An undecided one only
+        # rules out entailment, so keep looking for a false clause.
+        if all(value == -1 for value in values):
+            return False
+        entailed = entailed and 1 in values
+
+    return entailed or None
 
 
 def extract_predargs(proposition, assumptions=None):

--- a/sympy/assumptions/tests/test_satask.py
+++ b/sympy/assumptions/tests/test_satask.py
@@ -415,3 +415,22 @@ def test_matrix_predicates():
         Q.lower_triangular(X) & Q.upper_triangular(X)) is True
     assert satask(Q.invertible(X), Q.fullrank(X) & Q.square(X)) is True
     assert satask(Q.singular(X), ~Q.invertible(X)) is True
+
+
+def test_satask_early_return():
+    # Propagation alone cannot see that these assumptions contradict, so the
+    # search has to run before an answer can be trusted.
+    ass = (Q.real(x) & (Q.positive(x) | Q.negative(x))
+           & Implies(Q.positive(x), Q.zero(x)) & Implies(Q.negative(x), Q.zero(x)))
+
+    raises(ValueError, lambda: satask(Q.real(x), ass))
+    raises(ValueError, lambda: satask(Q.complex(x), ass))
+    raises(ValueError, lambda: satask(Q.zero(x), ass))
+
+    assert satask(Q.real(x), ass, early_return=True) is True
+    assert satask(Q.zero(x), Q.positive(x), early_return=True) is False
+    assert satask(Q.positive(x), Q.real(x), early_return=True) is None
+    assert satask(Q.real(x) & Q.nonzero(x), Q.positive(x), early_return=True) is True
+    assert satask(Q.positive(x) | Q.negative(x), Q.real(x) & Q.nonzero(x),
+                  early_return=True) is True
+    assert satask(S.false, Q.real(x), early_return=True) is False

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -619,6 +619,27 @@ class SATSolver:
         """
         return self.levels[-1]
 
+    def _is_entailed(self, clauses, encoding):
+        """Return True if the literals fixed so far make the CNF *clauses*
+        true, False if they make it false, and None if they leave it
+        undecided. *encoding* numbers their predicates as this solver does.
+        """
+        entailed = True
+        for clause in clauses:
+            # fixed() takes an int in this solver's numbering, not a Literal,
+            # and a predicate it never encoded cannot have been fixed.
+            values = [self.fixed(-var if lit.is_Not else var)
+                      if (var := encoding.get(lit.lit)) else 0
+                      for lit in clause]
+
+            # One false clause makes the whole CNF false. An undecided one
+            # only rules out entailment, so keep looking for a false clause.
+            if all(value == -1 for value in values):
+                return False
+            entailed = entailed and 1 in values
+
+        return entailed or None
+
     def _clause_sat(self, cls):
         """Check if a clause is satisfied by the current variable setting.
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #30121
Fixes: https://github.com/sympy/sympy/issues/30155
Fixes: https://github.com/sympy/sympy/issues/30206
Fixes: #30314

Requires #30201 and #30326  to be merged 
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Removed `satisfiable` calls in `satask.py` and now satask directly interacts with the `SATSolver`.

Assuming #30201 gets merged, and all the IPASIR functions exist in `SATSolver`, `satask.check_satisfiability` was rewritten to return early on simpler cases, increasing the performance of `satask`.


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Wrote the logic for function `_is_entailed` by hand and then asked Claude to refactor it to make it more simpler and easy to follow.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
