### PR TITLE
Makes PermutationGroup.order() return python int

### DIFF
--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -126,6 +126,7 @@ class PermutationGroup(Basic):
 
     """
     is_group = True
+    _order: int | None
 
     def __new__(cls, *args, dups=True, **kwargs):
         """The default constructor. Accepts Cycle and Permutation forms.
@@ -3000,7 +3001,7 @@ class PermutationGroup(Basic):
         """
         return _orbits(self._degree, self._generators)
 
-    def order(self):
+    def order(self) -> int:
         """Return the order of the group: the number of permutations that
         can be generated from elements of the group.
 
@@ -3040,11 +3041,11 @@ class PermutationGroup(Basic):
             return self._order
         if self._is_sym:
             n = self._degree
-            self._order = factorial(n)
+            self._order = _factorial(n)
             return self._order
         if self._is_alt:
             n = self._degree
-            self._order = factorial(n)/2
+            self._order = _factorial(n)//2
             return self._order
 
         m = prod([len(x) for x in self.basic_transversals])
@@ -4558,7 +4559,7 @@ class PermutationGroup(Basic):
             m = G.order()
             n = 0
             while m % p == 0:
-                m = m/p
+                m = m // p
                 n += 1
                 if m == 1:
                     return True, n

--- a/sympy/combinatorics/tests/test_character_table.py
+++ b/sympy/combinatorics/tests/test_character_table.py
@@ -154,7 +154,7 @@ def test_generic_character_table(group):
     assert all(r in c for r, c in zip(reps, cc))
 
     tbl = table.as_matrix()
-    order = int(G.order())
+    order = G.order()
     assert tbl.shape[0] == tbl.shape[1] == len(cc)
     assert all(v == 1 for v in tbl[0, :])
     assert tbl[:, 0].dot(tbl[:, 0]) == order

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -965,12 +965,12 @@ def test_sylow_subgroup():
     G = SymmetricGroup(100)
     S = G.sylow_subgroup(3)
     assert G.order() % S.order() == 0
-    assert G.order()/S.order() % 3 > 0
+    assert G.order() // S.order() % 3 > 0
 
     G = AlternatingGroup(100)
     S = G.sylow_subgroup(2)
     assert G.order() % S.order() == 0
-    assert G.order()/S.order() % 2 > 0
+    assert G.order() // S.order() % 2 > 0
 
     G = DihedralGroup(18)
     S = G.sylow_subgroup(p=2)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Previously, `PermutationGroup.order()` returned SymPy integers or Python integers. This PR makes it always return Python integers.

Reproduction code
```python
from sympy.combinatorics import *
G1,G2 = SymmetricGroup(5), PermutationGroup(Permutation([1,2,0]))
type(G1.order()), type(G2.order())
```

Before PR: `(<class 'sympy.core.numbers.Integer'>, <class 'int'>)`

After PR: `(<class 'int'>, <class 'int'>)`

#### Other comments

In SymPy, PermutationGroups are always finite. But some other classes, e.g., FpGroups, might be infinite and the order is infinity. This PR only changes PermutationGroups.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Fixed the order of a PermutationGroup to always return a Python integer instead of a SymPy integer.
<!-- END RELEASE NOTES -->
