### PR TITLE
Fix invalid merging of KroneckerProduct sums in combine_kronecker

### DIFF
--- a/sympy/matrices/expressions/kronecker.py
+++ b/sympy/matrices/expressions/kronecker.py
@@ -1,9 +1,8 @@
 """Implementation of the Kronecker product"""
 from __future__ import annotations
-from functools import reduce
 from math import prod
 
-from sympy.core import Mul, sympify
+from sympy.core import Mul, S, sympify
 from sympy.functions import adjoint
 from sympy.matrices.exceptions import ShapeError
 from sympy.matrices.expressions.matexpr import MatrixExpr
@@ -213,10 +212,23 @@ class KroneckerProduct(MatrixExpr):
         return flatten(canon(typed({KroneckerProduct: distribute(KroneckerProduct, MatAdd)}))(self))
 
     def _kronecker_add(self, other):
+        # The sum of two Kronecker products can be written as a single
+        # Kronecker product only if the arguments coincide in all factors
+        # except at most one: A x B + C x B = (A + C) x B.  Merging more
+        # than one factor at a time is invalid, as the product distributes
+        # over every factor: (A + C) x (B + D) is the sum of FOUR
+        # Kronecker products.
         if self.structurally_equal(other):
-            return self.__class__(*[a + b for (a, b) in zip(self.args, other.args)])
-        else:
-            return self + other
+            diff = [i for i, (a, b) in enumerate(zip(self.args, other.args))
+                    if a != b]
+            if len(diff) == 0:
+                return 2*self
+            if len(diff) == 1:
+                i = diff[0]
+                newargs = list(self.args)
+                newargs[i] = newargs[i] + other.args[i]
+                return self.__class__(*newargs)
+        return self + other
 
     def _kronecker_mul(self, other):
         if self.has_matching_shape(other):
@@ -351,11 +363,46 @@ canonicalize = exhaust(condition(lambda x: isinstance(x, KroneckerProduct),
                                  do_one(*rules)))
 
 
-def _kronecker_dims_key(expr):
+def _coeff_kron(expr):
+    """Split *expr* into a scalar coefficient and a KroneckerProduct, or
+    return None if *expr* is not a scalar multiple of a KroneckerProduct."""
     if isinstance(expr, KroneckerProduct):
-        return tuple(a.shape for a in expr.args)
+        return S.One, expr
+    if isinstance(expr, MatMul):
+        coeff, matrices = expr.as_coeff_matrices()
+        if len(matrices) == 1 and isinstance(matrices[0], KroneckerProduct):
+            return coeff, matrices[0]
+    return None
+
+
+def _kronecker_dims_key(expr):
+    ck = _coeff_kron(expr)
+    if ck is not None:
+        return tuple(a.shape for a in ck[1].args)
     else:
         return (0,)
+
+
+def _kronecker_merge_add(pair1, pair2):
+    """Merge two (coefficient, KroneckerProduct) pairs into a single pair
+    representing their sum, or return None if they cannot be merged.
+
+    The sum of two Kronecker products is itself a Kronecker product only
+    when the factors coincide in all slots except at most one:
+    c1*(A x B) + c2*(C x B) = (c1*A + c2*C) x B.
+    """
+    (c1, k1), (c2, k2) = pair1, pair2
+    if not k1.structurally_equal(k2):
+        return None
+    diff = [i for i, (a, b) in enumerate(zip(k1.args, k2.args)) if a != b]
+    if len(diff) == 0:
+        return (c1 + c2, k1)
+    if len(diff) == 1:
+        i = diff[0]
+        newargs = list(k1.args)
+        newargs[i] = c1*k1.args[i] + c2*k2.args[i]
+        return (S.One, k1.__class__(*newargs))
+    return None
 
 
 def kronecker_mat_add(expr):
@@ -364,8 +411,19 @@ def kronecker_mat_add(expr):
     if not args:
         return expr
 
-    krons = [reduce(lambda x, y: x._kronecker_add(y), group)
-             for group in args.values()]
+    krons = []
+    for group in args.values():
+        # Greedily merge each addend into the first mergeable partner:
+        merged: list[tuple] = []
+        for pair in map(_coeff_kron, group):
+            for i, other in enumerate(merged):
+                combined = _kronecker_merge_add(other, pair)
+                if combined is not None:
+                    merged[i] = combined
+                    break
+            else:
+                merged.append(pair)
+        krons.extend([coeff*kron for coeff, kron in merged])
 
     if not nonkrons:
         return MatAdd(*krons)
@@ -412,8 +470,15 @@ def combine_kronecker(expr):
     >>> B = MatrixSymbol('B', n, m)
     >>> combine_kronecker(KroneckerProduct(A, B)*KroneckerProduct(B, A))
     KroneckerProduct(A*B, B*A)
+
+    A sum of Kronecker products can be written as a single Kronecker
+    product only when the factors coincide in all slots except at most
+    one:
+
+    >>> combine_kronecker(KroneckerProduct(A, B)+KroneckerProduct(B.T, B))
+    KroneckerProduct(A + B.T, B)
     >>> combine_kronecker(KroneckerProduct(A, B)+KroneckerProduct(B.T, A.T))
-    KroneckerProduct(A + B.T, B + A.T)
+    KroneckerProduct(A, B) + KroneckerProduct(B.T, A.T)
     >>> C = MatrixSymbol('C', n, n)
     >>> D = MatrixSymbol('D', m, m)
     >>> combine_kronecker(KroneckerProduct(C, D)**m)

--- a/sympy/matrices/expressions/tests/test_kronecker.py
+++ b/sympy/matrices/expressions/tests/test_kronecker.py
@@ -118,9 +118,45 @@ def test_KroneckerProduct_combine_add():
 def test_KroneckerProduct_combine_mul():
     X = MatrixSymbol('X', m, n)
     Y = MatrixSymbol('Y', m, n)
+    # A sum of Kronecker products is a single Kronecker product only when
+    # the factors coincide in all slots except at most one; merging every
+    # slot at once used to produce the wrong result (A + B) x (X + Y):
     kp1 = kronecker_product(A, X)
     kp2 = kronecker_product(B, Y)
-    assert combine_kronecker(kp1+kp2) == kronecker_product(A+B, X+Y)
+    assert combine_kronecker(kp1 + kp2) == kp1 + kp2
+
+    # One differing slot merges by linearity:
+    assert combine_kronecker(kronecker_product(A, X) + kronecker_product(B, X)) == \
+        kronecker_product(A + B, X)
+    assert combine_kronecker(kronecker_product(A, X) + kronecker_product(A, Y)) == \
+        kronecker_product(A, X + Y)
+
+    # Scalar multiples of Kronecker products are merged as well:
+    assert combine_kronecker(2*kronecker_product(A, X) + 3*kronecker_product(B, X)) == \
+        kronecker_product(2*A + 3*B, X)
+    assert combine_kronecker(2*kronecker_product(A, X) + 3*kronecker_product(A, X)) == \
+        5*kronecker_product(A, X)
+
+    # More than two addends:
+    assert combine_kronecker(kronecker_product(A, X) + kronecker_product(B, X)
+                             + kronecker_product(A, Y)) in [
+        kronecker_product(A + B, X) + kronecker_product(A, Y),
+        kronecker_product(A, X + Y) + kronecker_product(B, X)]
+
+
+def test_KroneckerProduct_combine_add_numeric():
+    # Numeric check that combine_kronecker preserves the value of sums:
+    m1 = Matrix([[1, 2], [3, 4]])
+    m2 = Matrix([[0, 1], [1, 0]])
+    m3 = Matrix([[2, 0], [0, 2]])
+    X = MatrixSymbol('X', 2, 2)
+    Y = MatrixSymbol('Y', 2, 2)
+    W2 = MatrixSymbol('W2', 2, 2)
+    expr = KroneckerProduct(X, Y) + KroneckerProduct(W2, Y)
+    combined = combine_kronecker(expr)
+    reps = {X: m1, Y: m2, W2: m3}
+    assert expr.subs(reps).doit().as_explicit() == \
+        combined.subs(reps).doit().as_explicit()
 
 
 def test_KroneckerProduct_combine_pow():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30272. The invalid rewrite was found while reviewing #30131.

#### Brief description of what is fixed or changed

`combine_kronecker` used to rewrite any sum of structurally equal Kronecker products by merging every factor slot at once, e.g. `KroneckerProduct(A, X) + KroneckerProduct(B, Y)` into `KroneckerProduct(A + B, X + Y)`, which is not a valid identity (the Kronecker product distributes over each factor, so the right-hand side expands to four Kronecker products). The bug was asserted by a doctest and by `test_KroneckerProduct_combine_mul`.

The merge is now restricted to the valid case, in which the factors coincide in all slots except at most one: `KP(A, X) + KP(B, X) -> KP(A + B, X)`. In addition, `kronecker_mat_add` now merges scalar multiples of Kronecker products (`2*KP(A, X) + 3*KP(B, X) -> KP(2*A + 3*B, X)`), which were previously ignored, and merges greedily within each same-shape group instead of reducing pairwise (the pairwise reduction would have crashed on groups with unmergeable members, since `MatAdd` has no `_kronecker_add` method).

#### Other comments

The wrong doctest of `combine_kronecker` and the wrong test assertion are updated, and a numeric regression test comparing explicit values before/after `combine_kronecker` is added.

#### AI Generation Disclosure

This fix was implemented with the assistance of Claude (Anthropic), working under the direction of the author, who reviewed the changes. The bug was identified and numerically verified during an assisted review of PR #30131.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* matrices
  * Fixed `combine_kronecker`, which produced mathematically wrong results for sums of Kronecker products by merging every factor at once; sums are now combined only when the factors coincide in all slots except at most one, and scalar multiples of Kronecker products are merged as well.
<!-- END RELEASE NOTES -->
