### PR TITLE
Print ArrayTensorProduct and ArrayAdd with tensor-product notation

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2107,7 +2107,9 @@ class LatexPrinter(Printer):
             if isinstance(a, (Add, ArrayAdd)):
                 s = r"\left(%s\right)" % s
             elements.append(s)
-        return r' \otimes '.join(elements)
+        # \boxtimes is the notation for the tensor product of arrays used in
+        # the documentation (\otimes is the Kronecker product):
+        return r' \boxtimes '.join(elements)
 
     def _print_ArrayAdd(self, expr):
         return ' + '.join([self._print(a) for a in expr.args])

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -2099,6 +2099,19 @@ class LatexPrinter(Printer):
         elements = [self._print(a) for a in expr.args]
         return r' \wedge '.join(elements)
 
+    def _print_ArrayTensorProduct(self, expr):
+        from sympy.tensor.array.expressions.array_expressions import ArrayAdd
+        elements = []
+        for a in expr.args:
+            s = self._print(a)
+            if isinstance(a, (Add, ArrayAdd)):
+                s = r"\left(%s\right)" % s
+            elements.append(s)
+        return r' \otimes '.join(elements)
+
+    def _print_ArrayAdd(self, expr):
+        return ' + '.join([self._print(a) for a in expr.args])
+
     def _print_Tuple(self, expr):
         return self._print_tuple(expr)
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -798,11 +798,14 @@ class PrettyPrinter(Printer):
     def _print_ArrayTensorProduct(self, expr):
         from sympy.core.add import Add
         from sympy.tensor.array.expressions.array_expressions import ArrayAdd
+        # Squared times (the LaTeX \boxtimes) is the notation for the tensor
+        # product of arrays used in the documentation; the circled times of
+        # TensorProduct denotes the Kronecker product there.
         if self._use_unicode:
-            circled_times = "\u2297"
+            boxed_times = "\u22a0"
         else:
-            circled_times = ".*"
-        return self._print_seq(expr.args, None, None, circled_times,
+            boxed_times = ".*"
+        return self._print_seq(expr.args, None, None, boxed_times,
             parenthesize=lambda x: isinstance(x, (Add, ArrayAdd)) or
                 precedence_traditional(x) <= PRECEDENCE["Mul"])
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -795,6 +795,20 @@ class PrettyPrinter(Printer):
         return self._print_seq(expr.args, None, None, wedge_symbol,
             parenthesize=lambda x: precedence_traditional(x) <= PRECEDENCE["Mul"])
 
+    def _print_ArrayTensorProduct(self, expr):
+        from sympy.core.add import Add
+        from sympy.tensor.array.expressions.array_expressions import ArrayAdd
+        if self._use_unicode:
+            circled_times = "\u2297"
+        else:
+            circled_times = ".*"
+        return self._print_seq(expr.args, None, None, circled_times,
+            parenthesize=lambda x: isinstance(x, (Add, ArrayAdd)) or
+                precedence_traditional(x) <= PRECEDENCE["Mul"])
+
+    def _print_ArrayAdd(self, expr):
+        return self._print_seq(expr.args, None, None, ' + ')
+
     def _print_Trace(self, e):
         D = self._print(e.arg)
         D = prettyForm(*D.parens('(',')'))

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3795,6 +3795,19 @@ def test_tensor_TensorProduct():
     assert upretty(TensorProduct(A, B, A)) == "A\u2297B\u2297A"
 
 
+def test_tensor_ArrayTensorProduct():
+    from sympy.tensor.array.expressions import ArrayAdd, ArrayTensorProduct
+    A = MatrixSymbol("A", 3, 4)
+    B = MatrixSymbol("B", 4, 5)
+    C = MatrixSymbol("C", 3, 4)
+    assert upretty(ArrayTensorProduct(A, B)) == "A\u2297B"
+    assert pretty(ArrayTensorProduct(A, B)) == "A.*B"
+    assert upretty(ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(C, B))) == \
+        "A\u2297B + C\u2297B"
+    assert upretty(ArrayTensorProduct(ArrayAdd(A, C), B)) == "(A + C)\u2297B"
+    assert upretty(ArrayTensorProduct(A + C, B)) == "(A + C)\u2297B"
+
+
 def test_diffgeom_print_WedgeProduct():
     from sympy.diffgeom.rn import R2
     from sympy.diffgeom import WedgeProduct

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -3800,12 +3800,12 @@ def test_tensor_ArrayTensorProduct():
     A = MatrixSymbol("A", 3, 4)
     B = MatrixSymbol("B", 4, 5)
     C = MatrixSymbol("C", 3, 4)
-    assert upretty(ArrayTensorProduct(A, B)) == "A\u2297B"
+    assert upretty(ArrayTensorProduct(A, B)) == "A\u22a0B"
     assert pretty(ArrayTensorProduct(A, B)) == "A.*B"
     assert upretty(ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(C, B))) == \
-        "A\u2297B + C\u2297B"
-    assert upretty(ArrayTensorProduct(ArrayAdd(A, C), B)) == "(A + C)\u2297B"
-    assert upretty(ArrayTensorProduct(A + C, B)) == "(A + C)\u2297B"
+        "A\u22a0B + C\u22a0B"
+    assert upretty(ArrayTensorProduct(ArrayAdd(A, C), B)) == "(A + C)\u22a0B"
+    assert upretty(ArrayTensorProduct(A + C, B)) == "(A + C)\u22a0B"
 
 
 def test_diffgeom_print_WedgeProduct():

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2868,6 +2868,20 @@ def test_TensorProduct_printing():
     assert latex(TensorProduct(A, B)) == r"A \otimes B"
 
 
+def test_ArrayTensorProduct_printing():
+    from sympy.tensor.array.expressions import ArrayAdd, ArrayTensorProduct
+    A = MatrixSymbol("A", 3, 4)
+    B = MatrixSymbol("B", 4, 5)
+    C = MatrixSymbol("C", 3, 4)
+    assert latex(ArrayTensorProduct(A, B)) == r"A \otimes B"
+    assert latex(ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(C, B))) == \
+        r"A \otimes B + C \otimes B"
+    assert latex(ArrayTensorProduct(ArrayAdd(A, C), B)) == \
+        r"\left(A + C\right) \otimes B"
+    assert latex(ArrayTensorProduct(A + C, B)) == \
+        r"\left(A + C\right) \otimes B"
+
+
 def test_WedgeProduct_printing():
     from sympy.diffgeom.rn import R2
     from sympy.diffgeom import WedgeProduct

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -2873,13 +2873,13 @@ def test_ArrayTensorProduct_printing():
     A = MatrixSymbol("A", 3, 4)
     B = MatrixSymbol("B", 4, 5)
     C = MatrixSymbol("C", 3, 4)
-    assert latex(ArrayTensorProduct(A, B)) == r"A \otimes B"
+    assert latex(ArrayTensorProduct(A, B)) == r"A \boxtimes B"
     assert latex(ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(C, B))) == \
-        r"A \otimes B + C \otimes B"
+        r"A \boxtimes B + C \boxtimes B"
     assert latex(ArrayTensorProduct(ArrayAdd(A, C), B)) == \
-        r"\left(A + C\right) \otimes B"
+        r"\left(A + C\right) \boxtimes B"
     assert latex(ArrayTensorProduct(A + C, B)) == \
-        r"\left(A + C\right) \otimes B"
+        r"\left(A + C\right) \boxtimes B"
 
 
 def test_WedgeProduct_printing():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30271.

#### Brief description of what is fixed or changed

The latex and pretty printers used to print `ArrayTensorProduct` and `ArrayAdd` in raw functional form (`\operatorname{ArrayTensorProduct}\left(A, B\right)`). They now use the tensor-product notation of the [matrix derivatives documentation](https://docs.sympy.org/dev/explanation/modules/matrices/matrixderivatives.html), which writes $A \boxtimes B$ for `ArrayTensorProduct` and reserves $\otimes$ for the Kronecker product:

- LaTeX: `A \boxtimes B`, with `Add`/`ArrayAdd` arguments parenthesized (`\left(A + C\right) \boxtimes B`);
- pretty printer: `A⊠B` in unicode mode, `A.*B` in ASCII mode;
- `ArrayAdd` is printed as an ordinary sum of its terms (`A⊠B + C⊠B`).

The str printer is unchanged, keeping an ASCII re-parseable form.

#### Other comments

Tests added next to the existing `TensorProduct` printing tests in `test_latex.py` and `test_pretty.py`.

#### AI Generation Disclosure

This change was implemented with the assistance of Claude (Anthropic), working under the direction of the author, who reviewed the changes.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * `ArrayTensorProduct` and `ArrayAdd` are now printed with tensor-product notation (`A \boxtimes B` in LaTeX, `A⊠B` in unicode pretty printing) instead of raw functional form.
<!-- END RELEASE NOTES -->

