### PR TITLE
ArrayTensorProduct: normalize scalar factors and fix Mul argument shapes

### DIFF
--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -23,6 +23,7 @@ from sympy.core.symbol import (Dummy, Symbol)
 from sympy.matrices.matrixbase import MatrixBase
 from sympy.matrices.expressions.diagonal import diagonalize_vector
 from sympy.matrices.expressions.matexpr import MatrixExpr
+from sympy.matrices.expressions.matmul import MatMul
 from sympy.matrices.expressions.special import ZeroMatrix
 from sympy.tensor.array.arrayop import (permutedims, tensorcontraction, tensordiagonal, tensorproduct)
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
@@ -237,6 +238,35 @@ class _CodegenArrayAbstract(Expr):
             return self._canonicalize()
 
 
+def _split_scalar_coefficient(arg):
+    """Split *arg* into a scalar coefficient and its array part.
+
+    Return the pair ``(coefficient, array)``, where ``array`` is None if
+    *arg* is entirely scalar.  Only structural splitting is performed:
+    scalar factors are extracted from ``MatMul`` objects and from ``Mul``
+    objects containing a single array-shaped factor.
+    """
+    if isinstance(arg, MatMul):
+        coeff, matrices = arg.as_coeff_matrices()
+        if coeff is S.One:
+            return S.One, arg
+        rest = MatMul(*matrices) if len(matrices) > 1 else matrices[0]
+        return coeff, rest
+    if isinstance(arg, Mul):
+        scalars = [f for f in arg.args if get_shape(f) == ()]
+        arrays = [f for f in arg.args if get_shape(f) != ()]
+        if len(arrays) == 1:
+            return Mul(*scalars), arrays[0]
+        if len(arrays) > 1:
+            # A Mul of multiple array-shaped factors is not a well-defined
+            # array expression; leave it untouched.
+            return S.One, arg
+        return arg, None
+    if get_shape(arg) == ():
+        return arg, None
+    return S.One, arg
+
+
 class ArrayTensorProduct(_CodegenArrayAbstract):
     r"""
     Class to represent the tensor product of array-like objects.
@@ -244,6 +274,22 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
 
     def __new__(cls, *args, **kwargs):
         args = [_sympify(arg) for arg in args]
+
+        # A Mul argument containing an array-shaped factor (e.g.
+        # 2*ArraySymbol("A", (2, 2))) has no shape attribute and would be
+        # wrongly treated as a scalar; split it into its scalar coefficient
+        # and its array part:
+        normalized_args = []
+        for arg in args:
+            if isinstance(arg, Mul) and not isinstance(arg, MatrixExpr):
+                coeff, array = _split_scalar_coefficient(arg)
+                if array is not None:
+                    if coeff is not S.One:
+                        normalized_args.append(coeff)
+                    normalized_args.append(array)
+                    continue
+            normalized_args.append(arg)
+        args = normalized_args
 
         canonicalize = kwargs.pop("canonicalize", False)
 
@@ -264,6 +310,37 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
     def _canonicalize(self):
         args = self.args
         args = self._flatten(args)
+
+        # Merge scalar (rank-0) arguments into a single leading scalar
+        # factor, so that e.g. ArrayTensorProduct(x, A, y, B) becomes
+        # ArrayTensorProduct(x*y, A, B).  The scalar is kept as a rank-0
+        # argument (instead of returning Mul(coefficient, ...)) so that
+        # the result remains a valid array expression with a well-defined
+        # shape.  Scalar coefficients inside MatrixExpr arguments (e.g.
+        # ArrayTensorProduct(2*M, N) with M a MatrixSymbol) are NOT
+        # extracted, as the matrix-recognition machinery in
+        # from_array_to_matrix relies on matrix arguments keeping their
+        # coefficients; use _split_scalar_coefficient to compare
+        # arguments modulo their scalar coefficient.
+        def _is_plain_scalar(arg):
+            # Rank-0 array expressions (e.g. full contractions) are not
+            # merged: the branches below lift them into the expression.
+            return (get_shape(arg) == () and
+                    not isinstance(arg, (_ArrayExpr, _CodegenArrayAbstract)))
+
+        scalars = [arg for arg in args if _is_plain_scalar(arg)]
+        if scalars:
+            coeff = Mul.fromiter(scalars)
+            array_args = [arg for arg in args if not _is_plain_scalar(arg)]
+            if coeff.is_zero is True:
+                shapes = reduce(operator.add, [get_shape(i) for i in array_args], ())
+                return ZeroArray(*shapes)
+            if not array_args:
+                return coeff
+            if coeff is S.One:
+                args = array_args
+            else:
+                args = [coeff] + array_args
 
         ndim_list = [get_ndim(arg) for arg in args]
 

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -13,7 +13,7 @@ from sympy.combinatorics import Permutation
 from sympy.tensor.array.expressions.array_expressions import ZeroArray, OneArray, ArraySymbol, ArrayElement, \
     PermuteDims, ArrayContraction, ArrayTensorProduct, ArrayDiagonal, \
     ArrayAdd, nest_permutation, ArrayElementwiseApplyFunc, _EditArrayContraction, _ArgE, _array_tensor_product, \
-    _array_contraction, _array_diagonal, _array_add, _permute_dims, Reshape, ArraySum
+    _array_contraction, _array_diagonal, _array_add, _permute_dims, Reshape, ArraySum, _split_scalar_coefficient
 from sympy.testing.pytest import raises
 
 i, j, k, l, m, n = symbols("i j k l m n")
@@ -230,6 +230,51 @@ def test_flattening_issue_28823():
 
     expr = ArrayDiagonal(ArrayDiagonal(ArrayDiagonal(A, (0, 1)), (0, 1)), (1, 2))
     assert expr.doit() == ArrayDiagonal(A, (0, 1), (2, 3), (5, 6))
+
+
+def test_arrayexpr_tensor_product_scalar_coefficients():
+    x, y = symbols("x y")
+    Ms = MatrixSymbol("Ms", k, k)
+    Ns = MatrixSymbol("Ns", k, k)
+
+    # Scalar (rank-0) arguments are merged into a single leading scalar
+    # factor during canonicalization:
+    assert ArrayTensorProduct(x, M, y, N).doit() == ArrayTensorProduct(x*y, M, N)
+    assert ArrayTensorProduct(x, M, y, N).doit().shape == (k, k, k, k)
+    assert ArrayTensorProduct(2, M, 3, N).doit() == ArrayTensorProduct(6, M, N)
+
+    # A zero scalar coefficient gives a ZeroArray of the full shape:
+    assert ArrayTensorProduct(0, M, N).doit() == ZeroArray(k, k, k, k)
+    assert ArrayTensorProduct(x, M, 0, N).doit() == ZeroArray(k, k, k, k)
+
+    # A product of scalars only collapses to a plain scalar product:
+    assert ArrayTensorProduct(x, y).doit() == x*y
+
+    # A Mul argument containing an array factor used to be silently
+    # treated as a scalar, computing a wrong shape; it is now split into
+    # its scalar coefficient and its array part on construction:
+    tp = ArrayTensorProduct(2*M, N)
+    assert tp.args == (2, M, N)
+    assert tp.shape == (k, k, k, k)
+    assert tp.doit() == ArrayTensorProduct(2, M, N)
+    assert ArrayTensorProduct(x*y*M, N).doit() == ArrayTensorProduct(x*y, M, N)
+
+    # Scalar coefficients of MatrixExpr arguments are kept in place, as
+    # the matrix-recognition machinery relies on them:
+    assert ArrayTensorProduct(2*Ms, Ns).doit() == ArrayTensorProduct(2*Ms, Ns)
+
+    # Rank-0 array expressions (e.g. full contractions) are not merged
+    # into the scalar coefficient:
+    tr = ArrayContraction(Ms, (0, 1))
+    assert _array_tensor_product(3, tr) == ArrayContraction(ArrayTensorProduct(3, Ms), (0, 1))
+
+    # _split_scalar_coefficient splits arguments modulo their scalar
+    # coefficient:
+    from sympy import S
+    assert _split_scalar_coefficient(2*Ms) == (2, Ms)
+    assert _split_scalar_coefficient(Ms) == (S.One, Ms)
+    assert _split_scalar_coefficient(x*y) == (x*y, None)
+    assert _split_scalar_coefficient(2*M) == (2, M)
 
 
 def test_arrayexpr_array_diagonal():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30268. Prerequisite for the term-collection work proposed in #30269.

#### Brief description of what is fixed or changed

Two changes to how `ArrayTensorProduct` handles scalar coefficients:

1. **Bug fix**: a `Mul` argument containing an array-shaped factor, such as `ArrayTensorProduct(2*ArraySymbol("A", (2, 3)), B)`, used to be silently treated as a scalar (a `Mul` has no `shape` attribute), so the expression reported the wrong shape (`(3, 4)` instead of `(2, 3, 3, 4)`). Such arguments are now split on construction into their scalar coefficient and their array part.

2. **Normalization**: canonicalization (via `doit()`) now merges plain rank-0 arguments into a single leading scalar factor (`ArrayTensorProduct(x, A, y, B)` → `ArrayTensorProduct(x*y, A, B)`); a zero coefficient gives `ZeroArray`, and a product of scalars only collapses to a plain product. Rank-0 *array expressions* (e.g. full contractions) are not merged, as the existing canonicalization branches lift them into the expression.

#### Other comments

One deliberate scope adjustment with respect to the issue: scalar coefficients embedded in `MatrixExpr` arguments (e.g. `ArrayTensorProduct(2*M, N)` with `M` a `MatrixSymbol`) are **not** extracted during canonicalization. I tried that first, and it breaks ~20 tests in `from_array_to_matrix`/matrix derivatives: the matrix-recognition machinery indexes matrix arguments positionally (two axes per argument) and its own `_a2m_tensor_product` convention absorbs scalars into the first matrix factor, so a leading rank-0 coefficient argument is incompatible with it. Instead, the new helper `_split_scalar_coefficient()` provides the "compare modulo scalar coefficient" primitive that #30269 needs, without changing the stored representation of matrix arguments.

#### AI Generation Disclosure

This change was implemented with the assistance of Claude (Anthropic), working under the direction of the author, who reviewed the changes.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Fixed `ArrayTensorProduct` silently computing a wrong shape when an argument was a `Mul` containing an array factor (e.g. `2*ArraySymbol(...)`); such arguments are now split into scalar coefficient and array part.
  * `ArrayTensorProduct.doit()` now merges scalar (rank-0) arguments into a single leading scalar factor, returning `ZeroArray` for a zero coefficient.
<!-- END RELEASE NOTES -->
