### PR TITLE
Add commutativity_simplify() for sums of explicit tensor products

### DIFF
--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -97,7 +97,8 @@ def test_matrix_derivative_non_matrix_result():
     assert A.diff(A) == AdA
     assert A.T.diff(A) == PermuteDims(ArrayTensorProduct(I, I), Permutation(3)(1, 2, 3))
     assert (2*A).diff(A) == PermuteDims(ArrayTensorProduct(2*I, I), Permutation(3)(1, 2))
-    assert MatAdd(A, A).diff(A) == ArrayAdd(AdA, AdA)
+    # The two identical addend derivatives are collected:
+    assert MatAdd(A, A).diff(A) == PermuteDims(ArrayTensorProduct(2*I, I), Permutation(3)(1, 2))
     assert (A + B).diff(A) == AdA
 
 

--- a/sympy/tensor/array/expressions/__init__.py
+++ b/sympy/tensor/array/expressions/__init__.py
@@ -168,11 +168,13 @@ __all__ = [
     "convert_array_to_indexed",
     "convert_indexed_to_array",
     "array_derive",
+    "collect_tensor_products",
 ]
 
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayAdd, PermuteDims, ArrayDiagonal, \
     ArrayContraction, Reshape, ArraySymbol, ArrayElement, ZeroArray, OneArray, ArrayElementwiseApplyFunc
 from sympy.tensor.array.expressions.arrayexpr_derivatives import array_derive
+from sympy.tensor.array.expressions.simplification import collect_tensor_products
 from sympy.tensor.array.expressions.from_array_to_indexed import convert_array_to_indexed
 from sympy.tensor.array.expressions.from_array_to_matrix import convert_array_to_matrix
 from sympy.tensor.array.expressions.from_indexed_to_array import convert_indexed_to_array

--- a/sympy/tensor/array/expressions/__init__.py
+++ b/sympy/tensor/array/expressions/__init__.py
@@ -169,12 +169,13 @@ __all__ = [
     "convert_indexed_to_array",
     "array_derive",
     "collect_tensor_products",
+    "commutativity_simplify",
 ]
 
 from sympy.tensor.array.expressions.array_expressions import ArrayTensorProduct, ArrayAdd, PermuteDims, ArrayDiagonal, \
     ArrayContraction, Reshape, ArraySymbol, ArrayElement, ZeroArray, OneArray, ArrayElementwiseApplyFunc
 from sympy.tensor.array.expressions.arrayexpr_derivatives import array_derive
-from sympy.tensor.array.expressions.simplification import collect_tensor_products
+from sympy.tensor.array.expressions.simplification import collect_tensor_products, commutativity_simplify
 from sympy.tensor.array.expressions.from_array_to_indexed import convert_array_to_indexed
 from sympy.tensor.array.expressions.from_array_to_matrix import convert_array_to_matrix
 from sympy.tensor.array.expressions.from_indexed_to_array import convert_indexed_to_array

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -246,6 +246,10 @@ def _split_scalar_coefficient(arg):
     scalar factors are extracted from ``MatMul`` objects and from ``Mul``
     objects containing a single array-shaped factor.
     """
+    if isinstance(arg, (_ArrayExpr, _CodegenArrayAbstract)):
+        # Array expressions are kept whole, even when they have rank 0
+        # (e.g. a full contraction):
+        return S.One, arg
     if isinstance(arg, MatMul):
         coeff, matrices = arg.as_coeff_matrices()
         if coeff is S.One:
@@ -330,17 +334,32 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
 
         scalars = [arg for arg in args if _is_plain_scalar(arg)]
         if scalars:
-            coeff = Mul.fromiter(scalars)
+            # Structurally noncommutative rank-0 factors (e.g. a rank-0
+            # ArrayElementwiseApplyFunc, possibly inside a Mul) are kept
+            # as separate arguments, so that e.g. the conversion to
+            # matrix expressions can process them individually; only
+            # commutative scalars are merged into the coefficient:
+            comm_scalars = []
+            nc_scalars = []
+            for arg in scalars:
+                if isinstance(arg, Mul):
+                    comm_scalars.extend([f for f in arg.args if f.is_commutative])
+                    nc_scalars.extend([f for f in arg.args if not f.is_commutative])
+                elif arg.is_commutative is False:
+                    nc_scalars.append(arg)
+                else:
+                    comm_scalars.append(arg)
+            coeff = Mul.fromiter(comm_scalars)
             array_args = [arg for arg in args if not _is_plain_scalar(arg)]
             if coeff.is_zero is True:
                 shapes = reduce(operator.add, [get_shape(i) for i in array_args], ())
                 return ZeroArray(*shapes)
-            if not array_args:
+            if not array_args and not nc_scalars:
                 return coeff
             if coeff is S.One:
-                args = array_args
+                args = nc_scalars + array_args
             else:
-                args = [coeff] + array_args
+                args = [coeff] + nc_scalars + array_args
 
         ndim_list = [get_ndim(arg) for arg in args]
 
@@ -424,6 +443,50 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
         return tensorproduct(*[arg.as_explicit() if hasattr(arg, "as_explicit") else arg for arg in self.args])
 
 
+def _array_term_as_coeff_arrays(term):
+    """Decompose *term* into a scalar coefficient and a tuple of
+    coefficient-free array factors.
+
+    An ``ArrayTensorProduct`` is decomposed argument by argument (using
+    ``_split_scalar_coefficient``); any other expression is treated as a
+    single factor.  The result is the pair ``(coefficient, arrays)``, with
+    ``arrays`` an empty tuple if *term* is entirely scalar.
+    """
+    if isinstance(term, ArrayTensorProduct):
+        coeff = S.One
+        arrays = []
+        for arg in term.args:
+            c, array = _split_scalar_coefficient(arg)
+            coeff = coeff * c
+            if array is not None:
+                arrays.append(array)
+        return coeff, tuple(arrays)
+    c, array = _split_scalar_coefficient(term)
+    if array is None:
+        return c, ()
+    return c, (array,)
+
+
+def _array_term_from_coeff_arrays(coeff, arrays):
+    """Rebuild an array expression from the decomposition returned by
+    ``_array_term_as_coeff_arrays``.
+
+    A scalar coefficient multiplying a single ``MatrixExpr`` is absorbed
+    into it (giving a ``MatMul``); otherwise it is kept as a leading
+    rank-0 argument of the tensor product.
+    """
+    if not arrays:
+        return coeff
+    if coeff is S.One:
+        if len(arrays) == 1:
+            return arrays[0]
+        return _array_tensor_product(*arrays)
+    if len(arrays) == 1 and isinstance(arrays[0], MatrixExpr) and \
+            coeff.is_commutative is not False:
+        return coeff*arrays[0]
+    return _array_tensor_product(coeff, *arrays)
+
+
 class ArrayAdd(_CodegenArrayAbstract):
     r"""
     Class for elementwise array additions.
@@ -431,6 +494,21 @@ class ArrayAdd(_CodegenArrayAbstract):
 
     def __new__(cls, *args, **kwargs):
         args = [_sympify(arg) for arg in args]
+
+        # A Mul argument containing an array-shaped factor (e.g.
+        # 2*ArraySymbol("A", (2, 2))) has no shape attribute and would be
+        # wrongly treated as a scalar; convert it to a tensor product of
+        # its scalar coefficient and its array part:
+        normalized_args = []
+        for arg in args:
+            if isinstance(arg, Mul) and not isinstance(arg, MatrixExpr):
+                coeff, array = _split_scalar_coefficient(arg)
+                if array is not None:
+                    normalized_args.append(ArrayTensorProduct(coeff, array))
+                    continue
+            normalized_args.append(arg)
+        args = normalized_args
+
         ndims = [get_ndim(arg) for arg in args]
         ndims = list(set(ndims))
         if len(ndims) != 1:
@@ -459,6 +537,13 @@ class ArrayAdd(_CodegenArrayAbstract):
 
         shapes = [get_shape(arg) for arg in args]
         args = [arg for arg in args if not isinstance(arg, (ZeroArray, ZeroMatrix))]
+
+        # Collect terms that are equal up to a scalar coefficient by
+        # summing their coefficients, e.g. 2*(A x B) + 3*(A x B) becomes
+        # 5*(A x B):
+        if len(args) > 1:
+            args = self._collect_scalar_coefficients(args)
+
         if len(args) == 0:
             if any(i for i in shapes if i is None):
                 raise NotImplementedError("cannot handle addition of ZeroMatrix/ZeroArray and undefined shape object")
@@ -466,6 +551,41 @@ class ArrayAdd(_CodegenArrayAbstract):
         elif len(args) == 1:
             return args[0]
         return self.func(*args, canonicalize=False)
+
+    @classmethod
+    def _collect_scalar_coefficients(cls, args):
+        """Merge addends that are equal up to a scalar coefficient.
+
+        Each addend is decomposed into a scalar coefficient and a tuple
+        of coefficient-free array factors; addends with the same factor
+        tuple are merged by summing their coefficients.  Addends whose
+        summed coefficient is zero are dropped.
+        """
+        coeff_map: dict[tuple, Expr] = {}
+        scalar_terms = []
+        for arg in args:
+            coeff, arrays = _array_term_as_coeff_arrays(arg)
+            if not arrays:
+                # Rank-0 scalar addends are kept untouched, so that a sum
+                # of scalars remains an ArrayAdd:
+                scalar_terms.append(arg)
+                continue
+            if arrays in coeff_map:
+                coeff_map[arrays] = coeff_map[arrays] + coeff
+            else:
+                coeff_map[arrays] = coeff
+
+        if all(coeff is S.One for coeff in coeff_map.values()) and \
+                len(coeff_map) + len(scalar_terms) == len(args):
+            # Nothing to merge:
+            return args
+
+        new_args = []
+        for arrays, coeff in coeff_map.items():
+            if coeff.is_zero is True:
+                continue
+            new_args.append(_array_term_from_coeff_arrays(coeff, arrays))
+        return new_args + scalar_terms
 
     @classmethod
     def _flatten_args(cls, args):

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -23,6 +23,7 @@ from sympy.core.symbol import (Dummy, Symbol)
 from sympy.matrices.matrixbase import MatrixBase
 from sympy.matrices.expressions.diagonal import diagonalize_vector
 from sympy.matrices.expressions.matexpr import MatrixExpr
+from sympy.matrices.expressions.matmul import MatMul
 from sympy.matrices.expressions.special import ZeroMatrix
 from sympy.tensor.array.arrayop import (permutedims, tensorcontraction, tensordiagonal, tensorproduct)
 from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
@@ -237,6 +238,35 @@ class _CodegenArrayAbstract(Expr):
             return self._canonicalize()
 
 
+def _split_scalar_coefficient(arg):
+    """Split *arg* into a scalar coefficient and its array part.
+
+    Return the pair ``(coefficient, array)``, where ``array`` is None if
+    *arg* is entirely scalar.  Only structural splitting is performed:
+    scalar factors are extracted from ``MatMul`` objects and from ``Mul``
+    objects containing a single array-shaped factor.
+    """
+    if isinstance(arg, MatMul):
+        coeff, matrices = arg.as_coeff_matrices()
+        if coeff is S.One:
+            return S.One, arg
+        rest = MatMul(*matrices) if len(matrices) > 1 else matrices[0]
+        return coeff, rest
+    if isinstance(arg, Mul):
+        scalars = [f for f in arg.args if get_shape(f) == ()]
+        arrays = [f for f in arg.args if get_shape(f) != ()]
+        if len(arrays) == 1:
+            return Mul(*scalars), arrays[0]
+        if len(arrays) > 1:
+            # A Mul of multiple array-shaped factors is not a well-defined
+            # array expression; leave it untouched.
+            return S.One, arg
+        return arg, None
+    if get_shape(arg) == ():
+        return arg, None
+    return S.One, arg
+
+
 class ArrayTensorProduct(_CodegenArrayAbstract):
     r"""
     Class to represent the tensor product of array-like objects.
@@ -244,6 +274,22 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
 
     def __new__(cls, *args, **kwargs):
         args = [_sympify(arg) for arg in args]
+
+        # A Mul argument containing an array-shaped factor (e.g.
+        # 2*ArraySymbol("A", (2, 2))) has no shape attribute and would be
+        # wrongly treated as a scalar; split it into its scalar coefficient
+        # and its array part:
+        normalized_args = []
+        for arg in args:
+            if isinstance(arg, Mul) and not isinstance(arg, MatrixExpr):
+                coeff, array = _split_scalar_coefficient(arg)
+                if array is not None:
+                    if coeff is not S.One:
+                        normalized_args.append(coeff)
+                    normalized_args.append(array)
+                    continue
+            normalized_args.append(arg)
+        args = normalized_args
 
         canonicalize = kwargs.pop("canonicalize", False)
 
@@ -264,6 +310,37 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
     def _canonicalize(self):
         args = self.args
         args = self._flatten(args)
+
+        # Merge scalar (rank-0) arguments into a single leading scalar
+        # factor, so that e.g. ArrayTensorProduct(x, A, y, B) becomes
+        # ArrayTensorProduct(x*y, A, B).  The scalar is kept as a rank-0
+        # argument (instead of returning Mul(coefficient, ...)) so that
+        # the result remains a valid array expression with a well-defined
+        # shape.  Scalar coefficients inside MatrixExpr arguments (e.g.
+        # ArrayTensorProduct(2*M, N) with M a MatrixSymbol) are NOT
+        # extracted, as the matrix-recognition machinery in
+        # from_array_to_matrix relies on matrix arguments keeping their
+        # coefficients; use _split_scalar_coefficient to compare
+        # arguments modulo their scalar coefficient.
+        def _is_plain_scalar(arg):
+            # Rank-0 array expressions (e.g. full contractions) are not
+            # merged: the branches below lift them into the expression.
+            return (get_shape(arg) == () and
+                    not isinstance(arg, (_ArrayExpr, _CodegenArrayAbstract)))
+
+        scalars = [arg for arg in args if _is_plain_scalar(arg)]
+        if scalars:
+            coeff = Mul.fromiter(scalars)
+            array_args = [arg for arg in args if not _is_plain_scalar(arg)]
+            if coeff.is_zero is True:
+                shapes = reduce(operator.add, [get_shape(i) for i in array_args], ())
+                return ZeroArray(*shapes)
+            if not array_args:
+                return coeff
+            if coeff is S.One:
+                args = array_args
+            else:
+                args = [coeff] + array_args
 
         ndim_list = [get_ndim(arg) for arg in args]
 

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -744,7 +744,11 @@ def _a2m_tensor_product(*args):
     if len(arrays) == 0:
         return scalar
     if scalar != 1:
-        if isinstance(arrays[0], _CodegenArrayAbstract):
+        # A structurally noncommutative scalar (e.g. a rank-0
+        # ArrayElementwiseApplyFunc) cannot be absorbed into a MatMul
+        # coefficient; keep it as a rank-0 tensor-product factor:
+        if isinstance(arrays[0], _CodegenArrayAbstract) or \
+                scalar.is_commutative is False:
             arrays = [scalar] + arrays
         else:
             arrays[0] *= scalar

--- a/sympy/tensor/array/expressions/simplification.py
+++ b/sympy/tensor/array/expressions/simplification.py
@@ -22,9 +22,9 @@ intermediate expressions, so they are not applied automatically.
 from __future__ import annotations
 
 import itertools
+from typing import TYPE_CHECKING
 
 from sympy.core.basic import Basic
-from sympy.core.expr import Expr
 from sympy.core.function import expand
 from sympy.core.singleton import S
 from sympy.matrices.matrixbase import MatrixBase
@@ -34,6 +34,9 @@ from sympy.tensor.array.ndim_array import NDimArray
 from sympy.tensor.array.expressions.array_expressions import (
     ArrayAdd, ZeroArray, _array_add, _array_term_as_coeff_arrays,
     _array_term_from_coeff_arrays, get_shape)
+
+if TYPE_CHECKING:
+    from sympy.core.expr import Expr
 
 
 def collect_tensor_products(expr):

--- a/sympy/tensor/array/expressions/simplification.py
+++ b/sympy/tensor/array/expressions/simplification.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import itertools
 
 from sympy.core.basic import Basic
+from sympy.core.expr import Expr
 from sympy.core.function import expand
 from sympy.core.singleton import S
 from sympy.matrices.matrixbase import MatrixBase
@@ -269,11 +270,11 @@ def _commutativity_simplify_add(add: ArrayAdd):
 
     # Decompose every term into elementary-basis components and group the
     # prefactors by (elementary basis, remaining factors):
-    groups: dict[tuple, dict[tuple, Basic]] = {}
+    groups: dict[tuple, dict[tuple, Expr]] = {}
     for coeff, arrays in terms:
-        decomposed = [(coeff, {})]
+        decomposed: list[tuple[Expr, dict[int, tuple]]] = [(coeff, {})]
         for i in comm_slots:
-            new_decomposed = []
+            new_decomposed: list[tuple[Expr, dict[int, tuple]]] = []
             for prefactor, basis_map in decomposed:
                 for index, entry in _iter_nonzero_entries(arrays[i]):
                     new_basis_map = dict(basis_map)

--- a/sympy/tensor/array/expressions/simplification.py
+++ b/sympy/tensor/array/expressions/simplification.py
@@ -214,7 +214,7 @@ def commutativity_simplify(expr):
     The two addends below represent the same tensor, with the scalar
     ``z`` placed in a different factor:
 
-    >>> from sympy import Array, Symbol, symbols
+    >>> from sympy import Array, Symbol
     >>> from sympy.tensor.array.expressions import ArrayAdd, ArrayTensorProduct
     >>> from sympy.tensor.array.expressions import commutativity_simplify
     >>> z = Symbol("z")

--- a/sympy/tensor/array/expressions/simplification.py
+++ b/sympy/tensor/array/expressions/simplification.py
@@ -1,23 +1,37 @@
 """
 Opt-in simplification functions for array expressions.
 
-This module provides :func:`collect_tensor_products`, which collects sums
-of tensor products whose factors coincide in all slots except at most one
-by using the multilinearity of the tensor product:
+This module provides two simplification functions for sums of tensor
+products:
 
-    A x B + A x C  ->  A x (B + C)
+- :func:`collect_tensor_products` collects sums of tensor products whose
+  factors coincide in all slots except at most one by using the
+  multilinearity of the tensor product:
+
+      A x B + A x C  ->  A x (B + C)
+
+- :func:`commutativity_simplify` additionally decomposes explicit
+  commutative factors into the elementary-array basis, so that terms
+  which distribute their scalar entries differently across the factors
+  can be compared, combined and cancelled.
 
 Unlike the automatic collection of proportional terms performed by
-``ArrayAdd`` canonicalization, this transformation can grow intermediate
-factors, so it is not applied automatically.
+``ArrayAdd`` canonicalization, these transformations can grow
+intermediate expressions, so they are not applied automatically.
 """
 from __future__ import annotations
 
+import itertools
+
 from sympy.core.basic import Basic
+from sympy.core.function import expand
 from sympy.core.singleton import S
+from sympy.matrices.matrixbase import MatrixBase
 from sympy.matrices.expressions.matexpr import MatrixExpr
+from sympy.tensor.array.dense_ndim_array import ImmutableDenseNDimArray
+from sympy.tensor.array.ndim_array import NDimArray
 from sympy.tensor.array.expressions.array_expressions import (
-    ArrayAdd, _array_add, _array_term_as_coeff_arrays,
+    ArrayAdd, ZeroArray, _array_add, _array_term_as_coeff_arrays,
     _array_term_from_coeff_arrays, get_shape)
 
 
@@ -95,11 +109,20 @@ def _merge_single_slot(term1, term2):
         return None
     i = diff[0]
     a, b = arrays1[i], arrays2[i]
-    sa, sb = _scale_slot(c1, a), _scale_slot(c2, b)
-    if isinstance(sa, MatrixExpr) and isinstance(sb, MatrixExpr):
-        slot = sa + sb
+    if isinstance(a, (NDimArray, MatrixBase)) and \
+            isinstance(b, (NDimArray, MatrixBase)) and \
+            c1.is_commutative is not False and \
+            c2.is_commutative is not False:
+        # Two explicit factors: perform the sum explicitly.
+        aa = ImmutableDenseNDimArray(a) if isinstance(a, MatrixBase) else a
+        bb = ImmutableDenseNDimArray(b) if isinstance(b, MatrixBase) else b
+        slot = aa*c1 + bb*c2
     else:
-        slot = _array_add(sa, sb)
+        sa, sb = _scale_slot(c1, a), _scale_slot(c2, b)
+        if isinstance(sa, MatrixExpr) and isinstance(sb, MatrixExpr):
+            slot = sa + sb
+        else:
+            slot = _array_add(sa, sb)
     new_arrays = list(arrays1)
     new_arrays[i] = slot
     return (S.One, tuple(new_arrays))
@@ -128,3 +151,159 @@ def _collect_array_add(add: ArrayAdd):
         return add
     return _array_add(*[_array_term_from_coeff_arrays(c, arrays)
                         for c, arrays in terms])
+
+
+def _is_explicit_commutative(factor):
+    """Return True if *factor* is an explicit array whose entries contain
+    no noncommutative symbols."""
+    if isinstance(factor, (NDimArray, MatrixBase)):
+        return all(getattr(s, "is_commutative", True) is not False
+                   for s in factor.free_symbols)
+    return False
+
+
+def _iter_nonzero_entries(factor):
+    """Iterate over the (index, entry) pairs of the nonzero entries of an
+    explicit array or matrix."""
+    shape = get_shape(factor)
+    for index in itertools.product(*[range(int(d)) for d in shape]):
+        entry = factor[index if len(index) > 1 else index[0]]
+        if entry == S.Zero or getattr(entry, "is_zero", None) is True:
+            continue
+        yield index, entry
+
+
+def _basis_array(shape, index):
+    """Return the elementary array of the given *shape* with a single 1
+    at position *index*."""
+    total = 1
+    for d in shape:
+        total *= int(d)
+    flat_position = 0
+    for d, i in zip(shape, index):
+        flat_position = flat_position*int(d) + i
+    data = [S.Zero]*total
+    data[flat_position] = S.One
+    return ImmutableDenseNDimArray(data).reshape(*[int(d) for d in shape])
+
+
+def commutativity_simplify(expr):
+    """
+    Simplify a sum of tensor products by decomposing explicit commutative
+    factors into the elementary-array basis.
+
+    Each addend of an ``ArrayAdd`` (whose addends must be tensor products
+    with the same number of factors and the same factor shapes) is
+    processed as follows: every factor which is an explicit array with no
+    noncommutative entries is decomposed into elementary arrays, with its
+    entries collected into the scalar prefactor.  Terms with the same
+    elementary basis and the same remaining (noncommutative or symbolic)
+    factors are then combined by summing their prefactors, cancelling
+    terms whose sum of prefactors is zero.  Finally the surviving terms
+    are recombined with :func:`collect_tensor_products`.
+
+    This makes it possible to combine and cancel terms which distribute
+    scalar entries differently across their factors, a situation
+    :func:`collect_tensor_products` alone cannot handle since the factors
+    differ in more than one slot.  The transformation is applied
+    recursively to the whole expression tree.
+
+    Examples
+    ========
+
+    The two addends below represent the same tensor, with the scalar
+    ``z`` placed in a different factor:
+
+    >>> from sympy import Array, Symbol, symbols
+    >>> from sympy.tensor.array.expressions import ArrayAdd, ArrayTensorProduct
+    >>> from sympy.tensor.array.expressions import commutativity_simplify
+    >>> z = Symbol("z")
+    >>> u = Symbol("u", commutative=False)
+    >>> X = Array([[u, 0], [0, u]])
+    >>> E00 = Array([[1, 0], [0, 0]])
+    >>> zE00 = Array([[z, 0], [0, 0]])
+    >>> expr = ArrayAdd(ArrayTensorProduct(zE00, E00, X), ArrayTensorProduct(E00, zE00, X))
+    >>> commutativity_simplify(expr)
+    ArrayTensorProduct(2*z, [[1, 0], [0, 0]], [[1, 0], [0, 0]], [[u, 0], [0, u]])
+
+    Cancelling terms are detected:
+
+    >>> from sympy.tensor.array.expressions import ArrayTensorProduct
+    >>> expr = ArrayAdd(ArrayTensorProduct(zE00, E00, X), ArrayTensorProduct(-1, E00, zE00, X))
+    >>> commutativity_simplify(expr)
+    ZeroArray(2, 2, 2, 2, 2, 2)
+    """
+    if not isinstance(expr, Basic):
+        return expr
+    if expr.args and not isinstance(expr, (NDimArray, MatrixBase)):
+        newargs = [commutativity_simplify(arg) for arg in expr.args]
+        if list(newargs) != list(expr.args):
+            expr = expr.func(*newargs)
+    if isinstance(expr, ArrayAdd):
+        return _commutativity_simplify_add(expr)
+    return expr
+
+
+def _commutativity_simplify_add(add: ArrayAdd):
+    terms = [_array_term_as_coeff_arrays(arg) for arg in add.args]
+
+    # The addends must be tensor products with aligned factor shapes:
+    if any(not arrays for _, arrays in terms):
+        return _collect_array_add(add)
+    n = len(terms[0][1])
+    if any(len(arrays) != n for _, arrays in terms):
+        return _collect_array_add(add)
+    shapes = [get_shape(a) for a in terms[0][1]]
+    if any([get_shape(a) for a in arrays] != shapes for _, arrays in terms):
+        return _collect_array_add(add)
+    if any(None in (s or (None,)) or not all(getattr(d, "is_Integer", isinstance(d, int)) for d in s)
+           for s in shapes):
+        # Symbolic dimensions cannot be decomposed entry by entry:
+        return _collect_array_add(add)
+
+    comm_slots = [i for i in range(n)
+                  if all(_is_explicit_commutative(arrays[i]) for _, arrays in terms)]
+    if not comm_slots:
+        return _collect_array_add(add)
+    nc_slots = [i for i in range(n) if i not in comm_slots]
+
+    # Decompose every term into elementary-basis components and group the
+    # prefactors by (elementary basis, remaining factors):
+    groups: dict[tuple, dict[tuple, Basic]] = {}
+    for coeff, arrays in terms:
+        decomposed = [(coeff, {})]
+        for i in comm_slots:
+            new_decomposed = []
+            for prefactor, basis_map in decomposed:
+                for index, entry in _iter_nonzero_entries(arrays[i]):
+                    new_basis_map = dict(basis_map)
+                    new_basis_map[i] = index
+                    new_decomposed.append((prefactor*entry, new_basis_map))
+            decomposed = new_decomposed
+        nc_tuple = tuple(arrays[i] for i in nc_slots)
+        for prefactor, basis_map in decomposed:
+            key = tuple(basis_map[i] for i in comm_slots)
+            ncmap = groups.setdefault(key, {})
+            ncmap[nc_tuple] = ncmap.get(nc_tuple, S.Zero) + prefactor
+
+    # Rebuild the surviving terms:
+    new_terms = []
+    for key, ncmap in groups.items():
+        basis_arrays = {i: _basis_array(shapes[i], index)
+                        for i, index in zip(comm_slots, key)}
+        for nc_tuple, coeff in ncmap.items():
+            coeff = expand(coeff)
+            if coeff.is_zero is True:
+                continue
+            nc_iter = iter(nc_tuple)
+            arrays = tuple(basis_arrays[i] if i in basis_arrays else next(nc_iter)
+                           for i in range(n))
+            new_terms.append(_array_term_from_coeff_arrays(coeff, arrays))
+
+    if not new_terms:
+        return ZeroArray(*[d for s in shapes for d in s])
+    if len(new_terms) == 1:
+        result = new_terms[0]
+    else:
+        result = _array_add(*new_terms)
+    return collect_tensor_products(result)

--- a/sympy/tensor/array/expressions/simplification.py
+++ b/sympy/tensor/array/expressions/simplification.py
@@ -1,0 +1,130 @@
+"""
+Opt-in simplification functions for array expressions.
+
+This module provides :func:`collect_tensor_products`, which collects sums
+of tensor products whose factors coincide in all slots except at most one
+by using the multilinearity of the tensor product:
+
+    A x B + A x C  ->  A x (B + C)
+
+Unlike the automatic collection of proportional terms performed by
+``ArrayAdd`` canonicalization, this transformation can grow intermediate
+factors, so it is not applied automatically.
+"""
+from __future__ import annotations
+
+from sympy.core.basic import Basic
+from sympy.core.singleton import S
+from sympy.matrices.expressions.matexpr import MatrixExpr
+from sympy.tensor.array.expressions.array_expressions import (
+    ArrayAdd, _array_add, _array_term_as_coeff_arrays,
+    _array_term_from_coeff_arrays, get_shape)
+
+
+def collect_tensor_products(expr):
+    """
+    Collect sums of tensor products differing in at most one factor.
+
+    Addends of an ``ArrayAdd`` whose tensor-product factors coincide in
+    all slots except at most one are merged by linearity in the differing
+    slot: ``A x B + A x C`` becomes ``A x (B + C)``.  Scalar coefficients
+    are absorbed into the differing slot.  The transformation is applied
+    recursively to the whole expression tree.
+
+    Examples
+    ========
+
+    >>> from sympy import MatrixSymbol
+    >>> from sympy.tensor.array.expressions import ArrayAdd, ArrayTensorProduct
+    >>> from sympy.tensor.array.expressions import collect_tensor_products
+    >>> A = MatrixSymbol("A", 2, 2)
+    >>> B = MatrixSymbol("B", 2, 2)
+    >>> C = MatrixSymbol("C", 2, 2)
+
+    >>> collect_tensor_products(ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(A, C)))
+    ArrayTensorProduct(A, B + C)
+
+    Scalar coefficients are absorbed into the merged slot:
+
+    >>> expr = ArrayAdd(ArrayTensorProduct(2, A, B), ArrayTensorProduct(3, C, B))
+    >>> collect_tensor_products(expr)
+    ArrayTensorProduct(2*A + 3*C, B)
+
+    Terms differing in more than one slot are left alone:
+
+    >>> D = MatrixSymbol("D", 2, 2)
+    >>> expr = ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(C, D))
+    >>> collect_tensor_products(expr) == expr
+    True
+    """
+    if not isinstance(expr, Basic):
+        return expr
+    if expr.args:
+        newargs = [collect_tensor_products(arg) for arg in expr.args]
+        if list(newargs) != list(expr.args):
+            expr = expr.func(*newargs)
+    if isinstance(expr, ArrayAdd):
+        return _collect_array_add(expr)
+    return expr
+
+
+def _scale_slot(coeff, arg):
+    """Multiply the array factor *arg* by the scalar *coeff*."""
+    if coeff is S.One:
+        return arg
+    return _array_term_from_coeff_arrays(coeff, (arg,))
+
+
+def _merge_single_slot(term1, term2):
+    """Merge two ``(coefficient, factors)`` pairs into a single pair
+    representing their sum, or return None if they cannot be merged.
+
+    The sum of two tensor products is itself a tensor product only when
+    the factors coincide in all slots except at most one:
+    ``c1*(A x B) + c2*(C x B) = (c1*A + c2*C) x B``.
+    """
+    (c1, arrays1), (c2, arrays2) = term1, term2
+    if len(arrays1) != len(arrays2) or len(arrays1) == 0:
+        return None
+    if any(get_shape(a) != get_shape(b) for a, b in zip(arrays1, arrays2)):
+        return None
+    diff = [i for i, (a, b) in enumerate(zip(arrays1, arrays2)) if a != b]
+    if len(diff) == 0:
+        return (c1 + c2, arrays1)
+    if len(diff) != 1:
+        return None
+    i = diff[0]
+    a, b = arrays1[i], arrays2[i]
+    sa, sb = _scale_slot(c1, a), _scale_slot(c2, b)
+    if isinstance(sa, MatrixExpr) and isinstance(sb, MatrixExpr):
+        slot = sa + sb
+    else:
+        slot = _array_add(sa, sb)
+    new_arrays = list(arrays1)
+    new_arrays[i] = slot
+    return (S.One, tuple(new_arrays))
+
+
+def _collect_array_add(add: ArrayAdd):
+    terms = [_array_term_as_coeff_arrays(arg) for arg in add.args]
+
+    # Merge greedily until no pair of terms can be merged any more (a
+    # merged slot can enable further merges with other terms):
+    while True:
+        merged: list[tuple] = []
+        for term in terms:
+            for i, other in enumerate(merged):
+                combined = _merge_single_slot(other, term)
+                if combined is not None:
+                    merged[i] = combined
+                    break
+            else:
+                merged.append(term)
+        if len(merged) == len(terms):
+            break
+        terms = merged
+
+    if len(terms) == len(add.args):
+        return add
+    return _array_add(*[_array_term_from_coeff_arrays(c, arrays)
+                        for c, arrays in terms])

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -733,7 +733,8 @@ def test_array_expressions_no_canonicalization():
     assert expr.doit() == ArrayAdd(M, N, P)
 
     expr = ArrayAdd(M, ArrayAdd(N, ArrayAdd(P, M)))
-    assert expr.doit() == ArrayAdd(M, N, P, M)
+    # The two occurrences of M are collected on canonicalization:
+    assert expr.doit() == ArrayAdd(ArrayTensorProduct(2, M), N, P)
     assert expr._canonicalize() == ArrayAdd(M, N, ArrayAdd(P, M))
 
     expr = ArrayAdd(M, ZeroArray(k, k), N)

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -13,7 +13,7 @@ from sympy.combinatorics import Permutation
 from sympy.tensor.array.expressions.array_expressions import ZeroArray, OneArray, ArraySymbol, ArrayElement, \
     PermuteDims, ArrayContraction, ArrayTensorProduct, ArrayDiagonal, \
     ArrayAdd, nest_permutation, ArrayElementwiseApplyFunc, _EditArrayContraction, _ArgE, _array_tensor_product, \
-    _array_contraction, _array_diagonal, _array_add, _permute_dims, Reshape, ArraySum
+    _array_contraction, _array_diagonal, _array_add, _permute_dims, Reshape, ArraySum, _split_scalar_coefficient
 from sympy.testing.pytest import raises
 
 i, j, k, l, m, n = symbols("i j k l m n")
@@ -230,6 +230,51 @@ def test_flattening_issue_28823():
 
     expr = ArrayDiagonal(ArrayDiagonal(ArrayDiagonal(A, (0, 1)), (0, 1)), (1, 2))
     assert expr.doit() == ArrayDiagonal(A, (0, 1), (2, 3), (5, 6))
+
+
+def test_arrayexpr_tensor_product_scalar_coefficients():
+    x, y = symbols("x y")
+    Ms = MatrixSymbol("Ms", k, k)
+    Ns = MatrixSymbol("Ns", k, k)
+
+    # Scalar (rank-0) arguments are merged into a single leading scalar
+    # factor during canonicalization:
+    assert ArrayTensorProduct(x, M, y, N).doit() == ArrayTensorProduct(x*y, M, N)
+    assert ArrayTensorProduct(x, M, y, N).doit().shape == (k, k, k, k)
+    assert ArrayTensorProduct(2, M, 3, N).doit() == ArrayTensorProduct(6, M, N)
+
+    # A zero scalar coefficient gives a ZeroArray of the full shape:
+    assert ArrayTensorProduct(0, M, N).doit() == ZeroArray(k, k, k, k)
+    assert ArrayTensorProduct(x, M, 0, N).doit() == ZeroArray(k, k, k, k)
+
+    # A product of scalars only collapses to a plain scalar product:
+    assert ArrayTensorProduct(x, y).doit() == x*y
+
+    # A Mul argument containing an array factor used to be silently
+    # treated as a scalar, computing a wrong shape; it is now split into
+    # its scalar coefficient and its array part on construction:
+    tp = ArrayTensorProduct(2*M, N)
+    assert tp.args == (2, M, N)
+    assert tp.shape == (k, k, k, k)
+    assert tp.doit() == ArrayTensorProduct(2, M, N)
+    assert ArrayTensorProduct(x*y*M, N).doit() == ArrayTensorProduct(x*y, M, N)
+
+    # Scalar coefficients of MatrixExpr arguments are kept in place, as
+    # the matrix-recognition machinery relies on them:
+    assert ArrayTensorProduct(2*Ms, Ns).doit() == ArrayTensorProduct(2*Ms, Ns)
+
+    # Rank-0 array expressions (e.g. full contractions) are not merged
+    # into the scalar coefficient:
+    tr = ArrayContraction(Ms, (0, 1))
+    assert _array_tensor_product(3, tr) == ArrayContraction(ArrayTensorProduct(3, Ms), (0, 1))
+
+    # _split_scalar_coefficient splits arguments modulo their scalar
+    # coefficient:
+    from sympy import S
+    assert _split_scalar_coefficient(2*Ms) == (2, Ms)
+    assert _split_scalar_coefficient(Ms) == (S.One, Ms)
+    assert _split_scalar_coefficient(x*y) == (x*y, None)
+    assert _split_scalar_coefficient(2*M) == (2, M)
 
 
 def test_arrayexpr_array_diagonal():

--- a/sympy/tensor/array/expressions/tests/test_simplification.py
+++ b/sympy/tensor/array/expressions/tests/test_simplification.py
@@ -112,3 +112,103 @@ def test_array_add_collect_derivative_regression():
     I = Identity(k)
     assert MatAdd(Ak, Ak).diff(Ak) == \
         PermuteDims(ArrayTensorProduct(2*I, I), Permutation(3)(1, 2))
+
+
+def test_commutativity_simplify():
+    from sympy import Symbol
+    from sympy.tensor.array.expressions import commutativity_simplify
+
+    z, w = symbols("z w")
+    u = Symbol("u", commutative=False)
+    v = Symbol("v", commutative=False)
+
+    E00 = Array([[1, 0], [0, 0]])
+    E11 = Array([[0, 0], [0, 1]])
+    X = Array([[u, 0], [0, v]])
+    zE00 = Array([[z, 0], [0, 0]])
+
+    # The scalar z can be moved between commutative factors; the two
+    # addends differ in two slots, so collect_tensor_products alone
+    # cannot merge them, but the basis decomposition can:
+    expr = ArrayAdd(ArrayTensorProduct(zE00, E00, X),
+                    ArrayTensorProduct(E00, zE00, X))
+    collected = collect_tensor_products(expr)
+    assert isinstance(collected, ArrayAdd)
+    assert commutativity_simplify(expr) == ArrayTensorProduct(2*z, E00, E00, X)
+
+    # Cancellation of terms with redistributed entries:
+    expr = ArrayAdd(ArrayTensorProduct(zE00, E00, X),
+                    ArrayTensorProduct(-1, E00, zE00, X))
+    assert commutativity_simplify(expr) == ZeroArray(2, 2, 2, 2, 2, 2)
+
+    # Decomposing a full matrix regroups its entries; the result is
+    # value-equivalent to the input:
+    M = Array([[z, w], [w, z]])
+    expr = ArrayAdd(ArrayTensorProduct(M, X), ArrayTensorProduct(zE00, X))
+    simplified = commutativity_simplify(expr)
+    assert simplified.as_explicit() == expr.as_explicit()
+
+    # Non-decomposable sums fall back to plain collection:
+    expr = ArrayAdd(ArrayTensorProduct(Ra, Rb), ArrayTensorProduct(Rc, Rb))
+    assert commutativity_simplify(expr) == ArrayTensorProduct(ArrayAdd(Ra, Rc), Rb)
+
+    # Terms whose noncommutative factors coincide merge even when every
+    # commutative factor differs, when the basis components match:
+    Y = Array([[u, v], [v, u]])
+    expr = ArrayAdd(ArrayTensorProduct(2*E00, Y), ArrayTensorProduct(E00, Y),
+                    ArrayTensorProduct(E11, Y))
+    simplified = commutativity_simplify(expr)
+    assert simplified.as_explicit() == expr.as_explicit()
+
+
+def test_commutativity_simplify_commutator_example():
+    # A miniature version of the Dirac-commutator computation of
+    # PR #30131: expand [D, a] = D.a - a.D as a sum of tensor products
+    # of explicit matrices with noncommutative entries, then verify that
+    # commutativity_simplify preserves the value while reducing the
+    # number of addends:
+    from sympy import Symbol
+    from sympy.tensor.array.expressions import commutativity_simplify
+
+    z, w = symbols("z w")
+    ups = Symbol("Upsilon", commutative=False)
+    upsc = Symbol("Upsilon_c", commutative=False)
+
+    pL = Array([[1, 0], [0, 0]])
+    pR = Array([[0, 0], [0, 1]])
+    m = Array([[0, ups], [upsc, 0]])
+    a1 = Array([[z, 0], [0, w]])
+    a2 = Array([[w, 0], [0, z]])
+    id2 = Array([[1, 0], [0, 1]])
+
+    # Terms of the expanded commutator (schematically).  With this
+    # symmetric choice of algebra elements the commutator vanishes
+    # identically, which the basis decomposition detects:
+    terms = [
+        ArrayTensorProduct(pL, m, a1),
+        ArrayTensorProduct(pR, m, a2),
+        ArrayTensorProduct(-1, a1, m, pL),
+        ArrayTensorProduct(-1, a2, m, pR),
+        ArrayTensorProduct(z, pL, m, id2),
+        ArrayTensorProduct(-z, pL, m, id2),
+    ]
+    expr = ArrayAdd(*terms)
+    assert expr.as_explicit() == ZeroArray(2, 2, 2, 2, 2, 2).as_explicit()
+    assert commutativity_simplify(expr) == ZeroArray(2, 2, 2, 2, 2, 2)
+
+    # An asymmetric variant does not vanish; the six addends collapse to
+    # two basis terms:
+    a1b = Array([[z, 0], [0, 3*w]])
+    terms = [
+        ArrayTensorProduct(pL, m, a1b),
+        ArrayTensorProduct(pR, m, a2),
+        ArrayTensorProduct(-1, a1b, m, pL),
+        ArrayTensorProduct(-1, a2, m, pR),
+        ArrayTensorProduct(z, pL, m, id2),
+        ArrayTensorProduct(-z, pL, m, id2),
+    ]
+    expr = ArrayAdd(*terms)
+    simplified = commutativity_simplify(expr)
+    assert simplified.as_explicit() == expr.as_explicit()
+    assert isinstance(simplified, ArrayAdd)
+    assert len(simplified.args) == 2

--- a/sympy/tensor/array/expressions/tests/test_simplification.py
+++ b/sympy/tensor/array/expressions/tests/test_simplification.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from sympy import Array, MatrixSymbol, symbols
+from sympy.matrices.expressions.special import Identity
+from sympy.tensor.array.expressions import ArrayAdd, ArrayContraction, ArrayTensorProduct, \
+    ArraySymbol, PermuteDims, collect_tensor_products
+from sympy.tensor.array.expressions.array_expressions import ZeroArray
+
+x, y, k = symbols("x y k")
+
+A = MatrixSymbol("A", 2, 2)
+B = MatrixSymbol("B", 2, 2)
+C = MatrixSymbol("C", 2, 2)
+D = MatrixSymbol("D", 2, 2)
+
+Ra = ArraySymbol("Ra", (2, 3))
+Rb = ArraySymbol("Rb", (3, 4))
+Rc = ArraySymbol("Rc", (2, 3))
+
+
+def test_array_add_collect_coefficients():
+    # Automatic collection of proportional terms in ArrayAdd.doit():
+    T = ArrayTensorProduct(Ra, Rb)
+    assert ArrayAdd(T, T).doit() == ArrayTensorProduct(2, Ra, Rb)
+    assert ArrayAdd(ArrayTensorProduct(2, Ra, Rb),
+                    ArrayTensorProduct(3, Ra, Rb)).doit() == ArrayTensorProduct(5, Ra, Rb)
+    assert ArrayAdd(T, ArrayTensorProduct(-1, Ra, Rb)).doit() == ZeroArray(2, 3, 3, 4)
+    assert ArrayAdd(ArrayTensorProduct(x, Ra, Rb),
+                    ArrayTensorProduct(y, Ra, Rb)).doit() == ArrayTensorProduct(x + y, Ra, Rb)
+
+    # Scalar coefficients inside MatrixExpr factors are also recognized:
+    assert ArrayAdd(ArrayTensorProduct(2*A, B),
+                    ArrayTensorProduct(3, A, B)).doit() == ArrayTensorProduct(5, A, B)
+
+    # Single matrix leaves merge to a MatMul:
+    assert ArrayAdd(A, A).doit() == 2*A
+
+    # Terms that are not proportional are not merged:
+    e = ArrayAdd(ArrayTensorProduct(Ra, Rb), ArrayTensorProduct(Rc, Rb))
+    assert e.doit() == e
+
+    # A Mul argument containing an array factor is normalized:
+    assert ArrayAdd(2*Ra, Rc).doit() == ArrayAdd(ArrayTensorProduct(2, Ra), Rc)
+
+    # Sums of scalars remain ArrayAdd objects:
+    M3 = MatrixSymbol("M3", 3, 3)
+    e = ArrayAdd(M3[0, 0], M3[1, 1])
+    assert e.doit() == e
+
+
+def test_collect_tensor_products():
+    # Single differing slot merges by linearity:
+    assert collect_tensor_products(
+        ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(A, C))) == \
+        ArrayTensorProduct(A, B + C)
+    assert collect_tensor_products(
+        ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(C, B))) == \
+        ArrayTensorProduct(A + C, B)
+
+    # Scalar coefficients are absorbed into the merged slot:
+    assert collect_tensor_products(
+        ArrayAdd(ArrayTensorProduct(2, A, B), ArrayTensorProduct(3, C, B))) == \
+        ArrayTensorProduct(2*A + 3*C, B)
+
+    # More than one differing slot: no merge
+    e = ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(C, D))
+    assert collect_tensor_products(e) == e
+
+    # A merge can enable further merges:
+    e = ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(A, C),
+                 ArrayTensorProduct(C, B + C))
+    assert collect_tensor_products(e) == ArrayTensorProduct(A + C, B + C)
+
+    # Three factors, middle slot:
+    e = ArrayAdd(ArrayTensorProduct(A, B, C), ArrayTensorProduct(A, D, C))
+    assert collect_tensor_products(e) == ArrayTensorProduct(A, B + D, C)
+
+    # Applies recursively inside other array operators:
+    e = ArrayContraction(ArrayAdd(ArrayTensorProduct(A, B), ArrayTensorProduct(A, C)), (1, 2))
+    assert collect_tensor_products(e) == ArrayContraction(ArrayTensorProduct(A, B + C), (1, 2))
+
+    # Non-matrix array factors:
+    e = ArrayAdd(ArrayTensorProduct(Ra, Rb), ArrayTensorProduct(Rc, Rb))
+    assert collect_tensor_products(e) == ArrayTensorProduct(ArrayAdd(Ra, Rc), Rb)
+
+    # Non-ArrayAdd expressions pass through unchanged:
+    assert collect_tensor_products(ArrayTensorProduct(A, B)) == ArrayTensorProduct(A, B)
+    assert collect_tensor_products(x + y) == x + y
+
+
+def test_collect_tensor_products_numeric():
+    a = Array([[1, 2], [3, 4]])
+    b = Array([[0, 1], [1, 0]])
+    c = Array([[2, 0], [0, 2]])
+
+    for e in [
+        ArrayAdd(ArrayTensorProduct(a, b), ArrayTensorProduct(a, c)),
+        ArrayAdd(ArrayTensorProduct(2, a, b), ArrayTensorProduct(3, c, b)),
+        ArrayAdd(ArrayTensorProduct(a, b, c), ArrayTensorProduct(a, c, c)),
+    ]:
+        collected = collect_tensor_products(e)
+        assert collected.as_explicit() == e.as_explicit()
+        # something was actually collected:
+        assert not isinstance(collected, ArrayAdd)
+
+
+def test_array_add_collect_derivative_regression():
+    # Collection makes derivatives of sums with repeated addends compact:
+    from sympy.combinatorics import Permutation
+    from sympy.matrices.expressions.matadd import MatAdd
+    Ak = MatrixSymbol("Ak", k, k)
+    I = Identity(k)
+    assert MatAdd(Ak, Ak).diff(Ak) == \
+        PermuteDims(ArrayTensorProduct(2*I, I), Permutation(3)(1, 2))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30270. **Stacked on #30276** (which is stacked on #30275) — merge those first and this diff reduces to one commit. The heuristic is a port to array expressions of the simplification algorithm proposed in PR #30131.

#### Brief description of what is fixed or changed

Adds the opt-in function `commutativity_simplify()` to `sympy.tensor.array.expressions`.

For an `ArrayAdd` whose addends are tensor products with aligned factor shapes, every factor that is an *explicit* array with no noncommutative entries is decomposed into the elementary-array basis, with its entries collected into the scalar prefactor. Terms with the same elementary basis and the same remaining (noncommutative or symbolic) factors are combined by summing prefactors — cancelling terms whose prefactor sum is zero — and the surviving terms are recombined with `collect_tensor_products()` so that they fold back into compact explicit arrays.

This combines and cancels addends that distribute scalar entries differently across their factors (e.g. `(z·E00)⊗E00⊗X + E00⊗(z·E00)⊗X` → `2z·E00⊗E00⊗X`), which single-slot collection (#30276) cannot handle since the factors differ in more than one slot. This is the typical situation in the noncommutative-geometry computations that motivated PR #30131 — commutators of operators represented as sums of tensor products of explicit matrices with noncommutative entries. The test suite includes a miniature version of that PR's Dirac-commutator computation, where the symmetric case is recognized as identically zero and the asymmetric case collapses from six addends to two.

#### Other comments

The transformation is opt-in (not applied by `doit()`), since the basis decomposition can grow intermediate expressions before shrinking them. Sums that cannot be decomposed (symbolic factors everywhere, symbolic dimensions, non-aligned shapes) fall back to plain single-slot collection.

#### AI Generation Disclosure

This change was implemented with the assistance of Claude (Anthropic), working under the direction of the author, who reviewed the changes. The algorithm design is due to the author of PR #30131 (@grdi1), as credited in #30270.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* tensor
  * Added `commutativity_simplify()`, which simplifies sums of tensor products of explicit arrays (possibly with noncommutative entries) by decomposing the commutative factors into the elementary-array basis, combining and cancelling terms, and recombining the result.
<!-- END RELEASE NOTES -->
