### PR TITLE
evaluateFalse: parsing of minus sign improved

### DIFF
--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -445,6 +445,7 @@ def test_evaluate_false():
         '2 - 2**2': Add(2, Mul(-1, Pow(2, 2, evaluate=False), evaluate=False), evaluate=False),
         '-(2*3)': Mul(Integer(-1), Mul(Integer(2), Integer(3), evaluate=False), evaluate=False),
         '-(x + 2)': Mul(Integer(-1), Add(Symbol('x'), Integer(2), evaluate=False), evaluate=False),
+        '-(2*3/3)': Mul(Integer(-1), Mul(Integer(2), Integer(3), Pow(Integer(3), Integer(-1), evaluate=False), evaluate=False), evaluate=False)
     }
     for case, result in cases.items():
         assert sympify(case, evaluate=False) == result

--- a/sympy/core/tests/test_sympify.py
+++ b/sympy/core/tests/test_sympify.py
@@ -443,6 +443,8 @@ def test_evaluate_false():
         '2 * 4 * 6 + 8': Add(Mul(2, 4, 6, evaluate=False), 8, evaluate=False),
         '2 - 8 / 4': Add(2, Mul(-1, Mul(8, Pow(4, -1, evaluate=False), evaluate=False), evaluate=False), evaluate=False),
         '2 - 2**2': Add(2, Mul(-1, Pow(2, 2, evaluate=False), evaluate=False), evaluate=False),
+        '-(2*3)': Mul(Integer(-1), Mul(Integer(2), Integer(3), evaluate=False), evaluate=False),
+        '-(x + 2)': Mul(Integer(-1), Add(Symbol('x'), Integer(2), evaluate=False), evaluate=False),
     }
     for case, result in cases.items():
         assert sympify(case, evaluate=False) == result

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1176,6 +1176,20 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
                 result.append(arg)
         return result
 
+    def visit_UnaryOp(self, node):
+        if isinstance(node.op, ast.USub):
+            operand = self.visit(node.operand)
+            if (isinstance(operand, ast.Call)
+                    and isinstance(operand.func, ast.Name)
+                    and operand.func.id in ('Add', 'Mul')):
+                new_node = ast.Call(
+                    func=ast.Name(id='Mul', ctx=ast.Load()),
+                    args=[ast.UnaryOp(op=ast.USub(), operand=ast.Constant(1)), operand],
+                    keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
+                )
+                return new_node
+        return self.generic_visit(node)
+
     def visit_BinOp(self, node):
         if node.op.__class__ in self.operators:
             sympy_class = self.operators[node.op.__class__]

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -1177,17 +1177,16 @@ class EvaluateFalseTransformer(ast.NodeTransformer):
         return result
 
     def visit_UnaryOp(self, node):
-        if isinstance(node.op, ast.USub):
+        if (isinstance(node.op, ast.USub)
+                and isinstance(node.operand, ast.BinOp)
+                and isinstance(node.operand.op, (ast.Add, ast.Mult, ast.Div))):
             operand = self.visit(node.operand)
-            if (isinstance(operand, ast.Call)
-                    and isinstance(operand.func, ast.Name)
-                    and operand.func.id in ('Add', 'Mul')):
-                new_node = ast.Call(
-                    func=ast.Name(id='Mul', ctx=ast.Load()),
-                    args=[ast.UnaryOp(op=ast.USub(), operand=ast.Constant(1)), operand],
-                    keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
-                )
-                return new_node
+            new_node = ast.Call(
+                func=ast.Name(id='Mul', ctx=ast.Load()),
+                args=[ast.UnaryOp(op=ast.USub(), operand=ast.Constant(1)), operand],
+                keywords=[ast.keyword(arg='evaluate', value=ast.Constant(value=False))]
+            )
+            return new_node
         return self.generic_visit(node)
 
     def visit_BinOp(self, node):


### PR DESCRIPTION
When the minus sign is used as a unary operator, the parsing has not the intended behabior when evaluate=False. Indeed, the operand could be partially evaluated: see examples below.

Examples:

In [1]: from sympy import parse_expr

In [2]: parse_expr('-(2*3*4)', evaluate=False)
Out[2]: -6*4

Now the output is -2*3*4.

In [3]: parse_expr('-(x+2*3*4)', evaluate=False)
Out[3]: -x - 24

Now the output is -(x + 2*3*4).

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* parsing
  * Modified EvaluateFalseTransformer to transform the unary minus sign into Mul(-1,..., evaluate=False)
<!-- END RELEASE NOTES -->
