### PR TITLE
Answer more assumptions queries in the recursive handlers

### DIFF
--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -215,7 +215,9 @@ def _(expr, assumptions):
 
 @SingularPredicate.register(MatrixExpr)
 def _(expr, assumptions):
-    if expr.is_square and _ask_recursive(Q.invertible(expr), assumptions) is False:
+    if expr.is_square is False:
+        return False
+    if _ask_recursive(Q.invertible(expr), assumptions) is False:
         return True
 
 

--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -24,7 +24,7 @@ from ..predicates.matrices import (SquarePredicate, SymmetricPredicate,
     InvertiblePredicate, OrthogonalPredicate, UnitaryPredicate,
     FullRankPredicate, PositiveDefinitePredicate, UpperTriangularPredicate,
     LowerTriangularPredicate, DiagonalPredicate, IntegerElementsPredicate,
-    RealElementsPredicate, ComplexElementsPredicate)
+    RealElementsPredicate, ComplexElementsPredicate, SingularPredicate)
 
 
 def _Factorization(predicate, expr, assumptions):
@@ -139,6 +139,8 @@ def _(expr, assumptions):
         return False
     if Q.invertible(expr) in conjuncts(assumptions):
         return True
+    if _ask_recursive(Q.fullrank(expr), assumptions):
+        return True
 
 @InvertiblePredicate.register_many(Identity, Inverse)
 def _(expr, assumptions):
@@ -207,6 +209,14 @@ def _(expr, assumptions):
     if expr.rowblocksizes != expr.colblocksizes:
         return None
     return fuzzy_and([_ask_recursive(Q.invertible(a), assumptions) for a in expr.diag])
+
+
+# SingularPredicate
+
+@SingularPredicate.register(MatrixExpr)
+def _(expr, assumptions):
+    if expr.is_square and _ask_recursive(Q.invertible(expr), assumptions) is False:
+        return True
 
 
 # OrthogonalPredicate

--- a/sympy/assumptions/handlers/order.py
+++ b/sympy/assumptions/handlers/order.py
@@ -324,11 +324,11 @@ def _(expr, assumptions):
 
     if expr.is_number:
         return _PositivePredicate_number(expr, assumptions)
+    zero_base = _ask_recursive(Q.zero(expr.base), assumptions)
+    if zero_base and _ask_recursive(Q.positive(expr.exp), assumptions):
+        return False
     if _ask_recursive(Q.even(expr.exp), assumptions) and _ask_recursive(Q.real(expr.base), assumptions):
-        zero_base = _ask_recursive(Q.zero(expr.base), assumptions)
-        if zero_base and _ask_recursive(Q.positive(expr.exp), assumptions):
-            return False
-        elif zero_base is False:
+        if zero_base is False:
             return True
     if _ask_recursive(Q.positive(expr.base), assumptions):
         if _ask_recursive(Q.real(expr.exp), assumptions):

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -41,6 +41,7 @@ def test_singular():
     assert ask(Q.singular(X)) is None
     assert ask(Q.singular(X), Q.invertible(X)) is False
     assert ask(Q.singular(X), ~Q.invertible(X)) is True
+    assert ask(Q.singular(Y)) is False
 
 def test_invertible_fullrank():
     assert ask(Q.invertible(X), Q.fullrank(X)) is True

--- a/sympy/assumptions/tests/test_matrices.py
+++ b/sympy/assumptions/tests/test_matrices.py
@@ -42,7 +42,6 @@ def test_singular():
     assert ask(Q.singular(X), Q.invertible(X)) is False
     assert ask(Q.singular(X), ~Q.invertible(X)) is True
 
-@XFAIL
 def test_invertible_fullrank():
     assert ask(Q.invertible(X), Q.fullrank(X)) is True
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Continues and Requires #30175 to be merged
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Changed three handlers, so that queries can be answered by `_ask_recursive` which earlier used to fall through and was answered by `satask`. The handlers have enough information to answer them.

- `Pow Positive Handler`: The zero base test was under a check if the exponent is even or odd, but `0**x` is 0 for any positive `x`, moving it out correctly answers the query `Q.positive(x**y), Q.zero(x) & Q.positive(y)`
- `Matrix Invertible Handler`: It just missed the check for Matrix should be full ranked for being invertible.
- `Matrix Singular Handler`: The predicate did not have any handlers and the only thing answering `Q.singular` was `_ask_single_fact`, which cannot get `True` out of `~Q.invertible(X)`. Added a handler that returns `False` for a
  non-square matrix

#### Other comments
There might be conflicts to resolve after #30175 is merged.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Updated the handlers in `handlers/marices.py` using Claude Code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
