### PR TITLE
Improve 1unit vector printing

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -674,9 +674,9 @@ Friedrich Hagedorn <friedrich_h@gmx.de>
 Frédéric Chapoton <fchapoton2@gmail.com> fchapoton <fchapoton2@gmail.com>
 G. D. McBain <gdmcbain@protonmail.com>
 Gabriel Bernardino <gabriel.bernardino@upf.edu>
-Gabriele Busiello <69717061+Kr4dh@users.noreply.github.com> Kr4dh <busiellogabriele954@gmail.com>
-Gabriele Busiello <69717061+Kr4dh@users.noreply.github.com> Kr4dh <69717061+Kr4dh@users.noreply.github.com>
 Gabriel Orisaka <orisaka@gmail.com>
+Gabriele Busiello <69717061+Kr4dh@users.noreply.github.com> Kr4dh <69717061+Kr4dh@users.noreply.github.com>
+Gabriele Busiello <69717061+Kr4dh@users.noreply.github.com> Kr4dh <busiellogabriele954@gmail.com>
 Gaetano Guerriero <x.guerriero@tin.it>
 Gagan Mishra <simonsimple305@gmail.com> Gagan Mishra <70949548+GaganMishra305@users.noreply.github.com>
 Gagandeep Singh <Gmadaan450@gmail.com> Gagandeep61 <gmadaan450@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -674,6 +674,8 @@ Friedrich Hagedorn <friedrich_h@gmx.de>
 Frédéric Chapoton <fchapoton2@gmail.com> fchapoton <fchapoton2@gmail.com>
 G. D. McBain <gdmcbain@protonmail.com>
 Gabriel Bernardino <gabriel.bernardino@upf.edu>
+Gabriele Busiello <69717061+Kr4dh@users.noreply.github.com> Kr4dh <busiellogabriele954@gmail.com>
+Gabriele Busiello <69717061+Kr4dh@users.noreply.github.com> Kr4dh <69717061+Kr4dh@users.noreply.github.com>
 Gabriel Orisaka <orisaka@gmail.com>
 Gaetano Guerriero <x.guerriero@tin.it>
 Gagan Mishra <simonsimple305@gmail.com> Gagan Mishra <70949548+GaganMishra305@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1509,3 +1509,4 @@ Benjamin A. Beasley <code@musicinmybrain.net>
 Henry <henrybrewer00@gmail.com>
 Matthew M <mmythen@gmail.com>
 Sreekant Baheti <60787859+Sreekant13@users.noreply.github.com>
+Gabriele Busiello 69717061+Kr4dh@users.noreply.github.com

--- a/AUTHORS
+++ b/AUTHORS
@@ -1509,4 +1509,4 @@ Benjamin A. Beasley <code@musicinmybrain.net>
 Henry <henrybrewer00@gmail.com>
 Matthew M <mmythen@gmail.com>
 Sreekant Baheti <60787859+Sreekant13@users.noreply.github.com>
-Gabriele Busiello 69717061+Kr4dh@users.noreply.github.com
+Gabriele Busiello <69717061+Kr4dh@users.noreply.github.com>

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -46,8 +46,7 @@ def test_latex_printer():
 
 def test_vector_pretty_print():
 
-    # TODO : The unit vectors should print with subscripts but they just
-    # print as `n_x` instead of making `x` a subscript with unicode.
+   
 
     # TODO : The pretty print division does not print correctly here:
     # w = alpha * N.x + sin(omega) * N.y + alpha / beta * N.z
@@ -57,15 +56,15 @@ def test_vector_pretty_print():
 a  n_x + b n_y + c*sin(alpha) n_z\
 """
     uexpected = """\
- 2                           \n\
-a  n_x + b n_y + c⋅sin(α) n_z\
+ 2                          \n\
+a  nₓ + b n_y + c⋅sin(α) n_z\
 """
 
     assert ascii_vpretty(v) == expected
     assert unicode_vpretty(v) == uexpected
 
     expected = 'alpha n_x + sin(omega) n_y + alpha*beta n_z'
-    uexpected = 'α n_x + sin(ω) n_y + α⋅β n_z'
+    uexpected = 'α nₓ + sin(ω) n_y + α⋅β n_z'
 
     assert ascii_vpretty(w) == expected
     assert unicode_vpretty(w) == uexpected
@@ -77,10 +76,10 @@ a       b + c       c     \n\
 b         a         b     \
 """
     uexpected = """\
-                     2    \n\
-a       b + c       c     \n\
-─ n_x + ───── n_y + ── n_z\n\
-b         a         b     \
+                    2    \n\
+a      b + c       c     \n\
+─ nₓ + ───── n_y + ── n_z\n\
+b        a         b     \
 """
 
     assert ascii_vpretty(o) == expected
@@ -88,7 +87,7 @@ b         a         b     \
 
     # https://github.com/sympy/sympy/issues/26731
     assert ascii_vpretty(-A.x) == '-a_x'
-    assert unicode_vpretty(-A.x) == '-a_x'
+    assert unicode_vpretty(-A.x) == '-aₓ'
 
     # https://github.com/sympy/sympy/issues/26799
     assert ascii_vpretty(0*A.x) == '0'
@@ -194,14 +193,14 @@ a  n_x|n_y + b n_y|n_y + c*sin(alpha) n_z|n_y\
 """
 
     uexpected = """\
- 2                                       \n\
-a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
+ 2                                      \n\
+a  nₓ⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
 """
     assert ascii_vpretty(y) == expected
     assert unicode_vpretty(y) == uexpected
 
     expected = 'alpha n_x|n_x + sin(omega) n_y|n_z + alpha*beta n_z|n_x'
-    uexpected = 'α n_x⊗n_x + sin(ω) n_y⊗n_z + α⋅β n_z⊗n_x'
+    uexpected = 'α nₓ⊗nₓ + sin(ω) n_y⊗n_z + α⋅β n_z⊗nₓ'
     assert ascii_vpretty(x) == expected
     assert unicode_vpretty(x) == uexpected
 
@@ -209,10 +208,10 @@ a  n_x⊗n_y + b n_y⊗n_y + c⋅sin(α) n_z⊗n_y\
     assert unicode_vpretty(Dyadic([])) == '0'
 
     assert ascii_vpretty(xx) == '- n_x|n_y - n_x|n_z'
-    assert unicode_vpretty(xx) == '- n_x⊗n_y - n_x⊗n_z'
+    assert unicode_vpretty(xx) == '- nₓ⊗n_y - nₓ⊗n_z'
 
     assert ascii_vpretty(xx2) == 'n_x|n_y + n_x|n_z'
-    assert unicode_vpretty(xx2) == 'n_x⊗n_y + n_x⊗n_z'
+    assert unicode_vpretty(xx2) == 'nₓ⊗n_y + nₓ⊗n_z'
 
 
 def test_dyadic_latex():
@@ -283,28 +282,28 @@ def test_issue_13354():
 def test_vector_derivative_printing():
     # First order
     v = omega.diff() * N.x
-    assert unicode_vpretty(v) == 'ω̇ n_x'
+    assert unicode_vpretty(v) == 'ω̇ nₓ'
     assert ascii_vpretty(v) == "omega'(t) n_x"
 
     # Second order
     v = omega.diff().diff() * N.x
 
     assert vlatex(v) == r'\ddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == 'ω̈ n_x'
+    assert unicode_vpretty(v) == 'ω̈ nₓ'
     assert ascii_vpretty(v) == "omega''(t) n_x"
 
     # Third order
     v = omega.diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\dddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == 'ω⃛ n_x'
+    assert unicode_vpretty(v) == 'ω⃛ nₓ'
     assert ascii_vpretty(v) == "omega'''(t) n_x"
 
     # Fourth order
     v = omega.diff().diff().diff().diff() * N.x
 
     assert vlatex(v) == r'\ddddot{\omega}\mathbf{\hat{n}_x}'
-    assert unicode_vpretty(v) == 'ω⃜ n_x'
+    assert unicode_vpretty(v) == 'ω⃜ nₓ'
     assert ascii_vpretty(v) == "omega''''(t) n_x"
 
     # Fifth order
@@ -319,11 +318,11 @@ d             \n\
 dt            \
 '''
     uexpected = '''\
- 5        \n\
-d         \n\
-───(ω) n_x\n\
-  5       \n\
-dt        \
+ 5       \n\
+d        \n\
+───(ω) nₓ\n\
+  5      \n\
+dt       \
 '''
     assert unicode_vpretty(v) == uexpected
     assert ascii_vpretty(v) == expected
@@ -367,11 +366,11 @@ a        \n\
 - n_x|n_y\n\
 b        \
 '''
-    uexpected = '''\
-a        \n\
-─ n_x⊗n_y\n\
-b        \
-'''
+    uexpected = """\
+a       \n\
+─ nₓ⊗n_y\n\
+b       \
+"""
 
     assert ascii_vpretty(first_test) == expected
     assert unicode_vpretty(first_test) == uexpected
@@ -384,9 +383,9 @@ a + b        \n\
   c          \
 '''
     uexpected = '''\
-a + b        \n\
-───── n_x⊗n_y\n\
-  c          \
+a + b       \n\
+───── nₓ⊗n_y\n\
+  c         \
 '''
 
     assert ascii_vpretty(second_test) == expected
@@ -401,9 +400,9 @@ a           c        \n\
 b           b        \
 '''
     uexpected ='''\
-a           c        \n\
-─ n_x⊗n_y + ─ n_y⊗n_z\n\
-b           b        \
+a          c        \n\
+─ nₓ⊗n_y + ─ n_y⊗n_z\n\
+b          b        \
 '''
 
     assert ascii_vpretty(third_test) == expected
@@ -420,10 +419,10 @@ d n_x|n_z + -------------------- n_y|n_y\n\
                    b + c                \
 '''
     uexpected = '''\
-             2  2      2                \n\
-            a ⋅c  + a⋅b  + b⋅c⋅d        \n\
-d n_x⊗n_z + ──────────────────── n_y⊗n_y\n\
-                   b + c                \
+            2  2      2                \n\
+           a ⋅c  + a⋅b  + b⋅c⋅d        \n\
+d nₓ⊗n_z + ──────────────────── n_y⊗n_y\n\
+                  b + c                \
 '''
 
     assert ascii_vpretty(fourth_test) == expected

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -424,4 +424,3 @@ d nₓ⊗n_z + ──────────────────── n_y�
 
     assert ascii_vpretty(fourth_test) == expected
     assert unicode_vpretty(fourth_test) == uexpected
-    

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -424,3 +424,4 @@ d nₓ⊗n_z + ──────────────────── n_y�
 
     assert ascii_vpretty(fourth_test) == expected
     assert unicode_vpretty(fourth_test) == uexpected
+    

--- a/sympy/physics/vector/tests/test_printing.py
+++ b/sympy/physics/vector/tests/test_printing.py
@@ -45,9 +45,6 @@ def test_latex_printer():
 
 
 def test_vector_pretty_print():
-
-   
-
     # TODO : The pretty print division does not print correctly here:
     # w = alpha * N.x + sin(omega) * N.y + alpha / beta * N.z
 

--- a/sympy/physics/vector/vector.py
+++ b/sympy/physics/vector/vector.py
@@ -258,6 +258,7 @@ class Vector(Printable, EvalfMixin):
     def _pretty(self, printer):
         """Pretty Printing method. """
         from sympy.printing.pretty.stringpict import prettyForm
+        from sympy.core.symbol import Symbol  # <--- NUOVA IMPORTAZIONE
 
         terms = []
 
@@ -273,11 +274,12 @@ class Vector(Printable, EvalfMixin):
                 if M[i] == 0:
                     continue
                 elif M[i] == 1:
-                    terms.append(prettyForm(N.pretty_vecs[i]))
+                    # Chiediamo al printer di stampare un Simbolo, attivando la magia Unicode!
+                    terms.append(printer._print(Symbol(N.pretty_vecs[i])))
                 elif M[i] == -1:
-                    terms.append(prettyForm("-1") * prettyForm(N.pretty_vecs[i]))
+                    terms.append(prettyForm("-1") * printer._print(Symbol(N.pretty_vecs[i])))
                 else:
-                    terms.append(juxtapose(M[i], N.pretty_vecs[i]))
+                    terms.append(juxtapose(M[i], Symbol(N.pretty_vecs[i])))
 
         if terms:
             pretty_result = prettyForm.__add__(*terms)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
I haven't found a specific PR on Github. I just saw looking at the code that there was a TODO to be done and 
I tried to solve the problem. The TODO was left here: "sympy/physics/vector/tests/test_printing.py"

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

In few words, I saw that in sympy/vector/tests/test_printing.py the function called test_vector_pretty_print() had this TODO: The unit vectors should print with subscripts but they just print as `n_x` instead of making `x` a subscript with unicode.
I fixed it by going to sympy/sympy/vector/vector.py by passing vectors not as simple strings of char but as Symbols.
then in sympy/physics/vector/tests/test_printing.py I changed these 4 functions: test_vector_pretty_print, test_dyadic_pretty_print, test_vector_derivative_printing, test_issue_12157. What I did was just replace in the  uexpected variables in the functions the _x with the ₓ .Then I just realigned the fraction  bars. I of course updated the time derivative format too.



#### Other comments


#### AI Generation Disclosure

Since I'm new to fixing bugs and writing code for a big project i was assisted by Google  Gemini Pro 3.1 extended thinking during all the process. I of course have tested whether every test passed correctly.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* physics.vector
  * Fixed unicode pretty printing for unit vectors.

<!-- END RELEASE NOTES -->
