### PR TITLE
combinatorics: implement dominance order for IntegerPartition

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1545,6 +1545,8 @@ Shravas K Rao <shravas@gmail.com>
 Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
 Shruti Mangipudi <shruti2395@gmail.com>
 Shuai Zhou <shuaivzhou@berkeley.edu>
+Shubh Gupta <guptashubh926@gmail.com> <142342135+titanShubh@users.noreply.github.com>
+Shubh Gupta <guptashubh926@gmail.com> titanShubh <guptashubh926@gmail.com>
 Shubham Abhang <shubhamabhang77@gmail.com>
 Shubham Agrawal <shubham.ag6845@gmail.com>
 Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -574,6 +574,118 @@ class IntegerPartition(Basic):
         """
         return "\n".join([char*i for i in self.partition])
 
+    def dominates(self, other):
+        r"""
+        Return True if self dominates other in the dominance (majorization)
+        partial order on integer partitions.
+
+        Explanation
+        ===========
+
+        For two integer partitions `\lambda = (\lambda_1, \lambda_2, \dots)`
+        and `\mu = (\mu_1, \mu_2, \dots)` of the same integer `n`, `\lambda`
+        dominates `\mu` (written `\lambda \unrhd \mu`) if and only if for all
+        integers `j \ge 1`:
+
+        .. math:: \sum_{i=1}^j \lambda_i \ge \sum_{i=1}^j \mu_i
+
+        where partitions are padded with zeros as necessary.
+
+        If `self` and `other` do not partition the same integer, `False` is
+        returned.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics.partitions import IntegerPartition
+        >>> p1 = IntegerPartition([4, 1, 1])
+        >>> p2 = IntegerPartition([3, 2, 1])
+        >>> p1.dominates(p2)
+        True
+        >>> p2.dominates(p1)
+        False
+
+        Dominance is a partial order, so partitions can be incomparable:
+
+        >>> p3 = IntegerPartition([3, 3])
+        >>> p1.dominates(p3)
+        False
+        >>> p3.dominates(p1)
+        False
+
+        The partition `[n]` dominates every partition of `n`:
+
+        >>> top = IntegerPartition([6])
+        >>> all(top.dominates(IntegerPartition(p)) for p in [[5, 1], [4, 2], [3, 3], [2, 2, 2]])
+        True
+
+        Duality with conjugate partitions: `\lambda \unrhd \mu \iff \mu' \unrhd \lambda'`
+
+        >>> c1 = IntegerPartition(p1.conjugate)
+        >>> c2 = IntegerPartition(p2.conjugate)
+        >>> c2.dominates(c1)
+        True
+
+        Passing a raw list or dictionary is also supported:
+
+        >>> p1.dominates([3, 2, 1])
+        True
+
+        See Also
+        ========
+
+        is_dominated_by, conjugate
+
+        References
+        ==========
+
+        .. [1] https://en.wikipedia.org/wiki/Dominance_order
+        .. [2] Stanley, R. P. Enumerative Combinatorics, Vol. 2.
+
+        """
+        if not isinstance(other, IntegerPartition):
+            other = IntegerPartition(other)
+        if self.integer != other.integer:
+            return False
+        a = self.partition
+        b = other.partition
+        sum_a = 0
+        sum_b = 0
+        len_a = len(a)
+        len_b = len(b)
+        for i in range(max(len_a, len_b)):
+            sum_a += a[i] if i < len_a else 0
+            sum_b += b[i] if i < len_b else 0
+            if sum_a < sum_b:
+                return False
+        return True
+
+    def is_dominated_by(self, other):
+        """
+        Return True if self is dominated by other in the dominance
+        (majorization) partial order.
+
+        Examples
+        ========
+
+        >>> from sympy.combinatorics.partitions import IntegerPartition
+        >>> p1 = IntegerPartition([3, 2, 1])
+        >>> p2 = IntegerPartition([4, 1, 1])
+        >>> p1.is_dominated_by(p2)
+        True
+        >>> p2.is_dominated_by(p1)
+        False
+
+        See Also
+        ========
+
+        dominates
+
+        """
+        if not isinstance(other, IntegerPartition):
+            other = IntegerPartition(other)
+        return other.dominates(self)
+
     def __str__(self):
         return str(list(self.partition))
 

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -130,4 +130,64 @@ def test_rgs():
 def test_ordered_partition_9608():
     a = Partition([1, 2, 3], [4])
     b = Partition([1, 2], [3, 4])
-    assert list(ordered([a,b], Set._infimum_key))
+    assert list(ordered([a, b], Set._infimum_key))
+
+
+def test_integer_partition_dominance():
+    p1 = IntegerPartition([4, 1, 1])
+    p2 = IntegerPartition([3, 2, 1])
+    p3 = IntegerPartition([3, 3])
+    p4 = IntegerPartition([2, 2, 2])
+
+    # Basic dominance relations for n=6
+    assert p1.dominates(p2) is True
+    assert p2.is_dominated_by(p1) is True
+    assert p2.dominates(p1) is False
+    assert p1.is_dominated_by(p2) is False
+
+    assert p3.dominates(p4) is True
+    assert p4.dominates(p3) is False
+
+    # Incomparable partitions for n=6
+    assert p1.dominates(p3) is False
+    assert p3.dominates(p1) is False
+    assert p1.is_dominated_by(p3) is False
+    assert p3.is_dominated_by(p1) is False
+
+    # Top [n] dominates all, bottom [1^n] is dominated by all
+    top = IntegerPartition([6])
+    bottom = IntegerPartition([1, 1, 1, 1, 1, 1])
+    for p in [p1, p2, p3, p4, top, bottom]:
+        assert top.dominates(p) is True
+        assert p.is_dominated_by(top) is True
+        assert p.dominates(bottom) is True
+        assert bottom.is_dominated_by(p) is True
+
+    # Reflexivity
+    assert p1.dominates(p1) is True
+    assert p1.is_dominated_by(p1) is True
+
+    # Coercion with list / tuple / dict
+    assert p1.dominates([3, 2, 1]) is True
+    assert p1.dominates((3, 2, 1)) is True
+    assert p1.dominates({3: 1, 2: 1, 1: 1}) is True
+    assert p2.is_dominated_by([4, 1, 1]) is True
+
+    # Different integer partitions are incomparable
+    p_diff = IntegerPartition([5])
+    assert p1.dominates(p_diff) is False
+    assert p_diff.dominates(p1) is False
+    assert p1.is_dominated_by(p_diff) is False
+
+    # Conjugation Duality Theorem: lambda >= mu <=> mu' >= lambda'
+    for n in range(1, 8):
+        parts = [IntegerPartition(p) for p in partitions(n)]
+        for a in parts:
+            for b in parts:
+                ca = IntegerPartition(a.conjugate)
+                cb = IntegerPartition(b.conjugate)
+                assert a.dominates(b) == cb.dominates(ca)
+                assert a.is_dominated_by(b) == b.dominates(a)
+                # Antisymmetry
+                if a.dominates(b) and b.dominates(a):
+                    assert a.partition == b.partition


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #22599

#### Brief description of what is fixed or changed

This PR implements the dominance (majorization) partial order on integer partitions in `sympy.combinatorics.partitions.IntegerPartition`:

1. **`dominates(self, other)`**:
   - For partitions `\lambda` and `\mu` of the same integer `n`, returns `True` if `\sum_{i=1}^j \lambda_i \ge \sum_{i=1}^j \mu_i` for all `j \ge 1`.
   - Accepts `IntegerPartition` instances, or raw sequences/dictionaries (e.g. `[3, 2, 1]`, `{3: 1, 2: 1, 1: 1}`).
   - Returns `False` for partitions with different sums or incomparable pairs.

2. **`is_dominated_by(self, other)`**:
   - Dual method returning `other.dominates(self)`.

3. **Tests & Doctests**:
   - Added unit tests in `test_partitions.py` testing poset axioms (reflexivity, antisymmetry), incomparable partitions (such as `[3, 3]` vs `[4, 1, 1]`), poset bounds (`[n]` and `[1^n]`), coercion, and conjugation duality (`\lambda \unrhd \mu \iff \mu' \unrhd \lambda'`).
   - Added complete docstring examples with doctest verification.

#### Other comments

All tests in `test_partitions.py` and doctests pass with zero failures.

#### AI Generation Disclosure

As a new contributor learning the codebase, I was assisted by an AI coding assistant in drafting the code and test cases. All changes have been tested locally.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * Added `dominates` and `is_dominated_by` methods to `IntegerPartition` for computing the dominance (majorization) partial order.
<!-- END RELEASE NOTES -->