### PR TITLE
speed up rs_nth_root for n=2 by exploiting that sqrt(p) = p/invsqrt(p)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1172,8 +1172,8 @@ Nabanita Dash <dashnabanita@gmail.com> Naba7 <dashnabanita@gmail.com>
 Nabanita Dash <dashnabanita@gmail.com> Nabanita Dash <31562743+Naba7@users.noreply.github.com>
 Naman Gera <namangera15@gmail.com> Naman Gera <43007653+namannimmo10@users.noreply.github.com>
 Naman Gera <namangera15@gmail.com> Namannimmo <namangera15@gmail.com>
-Natalia Nawara <fankalemura@gmail.com>
 Natalia L. Skirrow <dronebetterdronebetter@gmail.com> DroneBetter <58664547+DroneBetter@users.noreply.github.com>
+Natalia Nawara <fankalemura@gmail.com>
 Nathan Alison <nathan.f.alison@gmail.com> <nathan@ubuntu.(none)>
 Nathan Goldbaum <ngoldbau@illinois.edu>
 Nathan Musoke <nathan.musoke@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1173,6 +1173,7 @@ Nabanita Dash <dashnabanita@gmail.com> Nabanita Dash <31562743+Naba7@users.norep
 Naman Gera <namangera15@gmail.com> Naman Gera <43007653+namannimmo10@users.noreply.github.com>
 Naman Gera <namangera15@gmail.com> Namannimmo <namangera15@gmail.com>
 Natalia Nawara <fankalemura@gmail.com>
+Natalia L. Skirrow <dronebetterdronebetter@gmail.com> DroneBetter <58664547+DroneBetter@users.noreply.github.com>
 Nathan Alison <nathan.f.alison@gmail.com> <nathan@ubuntu.(none)>
 Nathan Goldbaum <ngoldbau@illinois.edu>
 Nathan Musoke <nathan.musoke@gmail.com>

--- a/sympy/polys/ring_series.py
+++ b/sympy/polys/ring_series.py
@@ -916,6 +916,8 @@ def _nth_root1(p, n, x, prec):
         p1 += p1/n - tmp/n
     if sign:
         return p1
+    elif n == 2:
+        return rs_mul(p1, p, x, precx)
     else:
         return _series_inversion1(p1, x, prec)
 


### PR DESCRIPTION
#### References to other Issues or PRs
none applicable

#### Brief description of what is fixed or changed
so you see i was working on an OEIS draft on [A039821](https://oeis.org/draft/A039821), and trying to write a program that lies somewhere satisfying on the Pareto hull of smallness and fastness; at one point i tried translating my friend Peter Luschny's SageMath program, which is based on the exponential generating function
```python
def A039821_list(N):
    R,x = ring('x',QQ)
    coeffs={(0,): QQ.one, (1,): QQ(-2)}
    f=p=1
    for n in range(2,N+1,2): coeffs[(n,)] = bernoulli(n) * (p:=p*8) / (f:=f*(n-1)*n>>1)
    g = R.from_dict(coeffs)

    t=time()
    f = rs_nth_root(g, 2, x, N + 1)
    print(time()-t)

    scale = 1
    return [abs(int(f.get((n,), 0) * (scale:=scale*(4*n-2))))>>1 for n in range(1,N+1)]
```
(although I eventually settled upon one based on the 'ordinary g.f.' as a formal power series but do not worry about that)

while perusing the docs, i perchanced upon the source, and noticed that `_nth_root1(p, n, x, prec)` actually computes `_series_inversion1(_nth_root1(p, -n, x, prec), x, prec)`; when `n = 2`, `rs_mul(_nth_root1(p, -n, x, prec), p, x, precx)` is a little bit faster.

before:
```python
>>> hash(tuple(A039821_list(1<<9)))
9.96287202835083
8387083080995523063
```
after:
```python
>>> hash(tuple(A039821_list(1<<9)))
7.646448135375977
8387083080995523063
```
#### AI Generation Disclosure
no intelligence, artificial or otherwise, has been employed; i typed the two lines in the github website's builtin editor with my humanoid typing appendages

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* polys
  * When `n = 2`, `rs_nth_root` (which usually computes the inverse `n`th root then reciprocates) now multiplies the inverse by the original instead of reciprocating.
<!-- END RELEASE NOTES -->