### PR TITLE
combinatorics: fix coset_rank for trivial permutation groups

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1545,6 +1545,8 @@ Shravas K Rao <shravas@gmail.com>
 Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
 Shruti Mangipudi <shruti2395@gmail.com>
 Shuai Zhou <shuaivzhou@berkeley.edu>
+Shubh Gupta <guptashubh926@gmail.com> <142342135+titanShubh@users.noreply.github.com>
+Shubh Gupta <guptashubh926@gmail.com> titanShubh <guptashubh926@gmail.com>
 Shubham Abhang <shubhamabhang77@gmail.com>
 Shubham Agrawal <shubham.ag6845@gmail.com>
 Shubham Kumar Jha <skjha832@gmail.com> ShubhamKJha <skjha832@gmail.com>

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1188,11 +1188,11 @@ class PermutationGroup(Basic):
         >>> f[0] == tr[0][f1[0]]
         True
 
-        If g is not an element of G then [] is returned:
+        If g is not an element of G then None is returned:
 
         >>> c = Permutation(5, 6, 7)
-        >>> G.coset_factor(c)
-        []
+        >>> G.coset_factor(c) is None
+        True
 
         See Also
         ========
@@ -1200,7 +1200,9 @@ class PermutationGroup(Basic):
         sympy.combinatorics.util._strip
 
         """
-        if isinstance(g, (Cycle, Permutation)):
+        if isinstance(g, Cycle):
+            g = g.list(self._degree)
+        elif isinstance(g, Permutation):
             g = g.list()
         if len(g) != self._degree:
             # this could either adjust the size or return [] immediately
@@ -1219,12 +1221,12 @@ class PermutationGroup(Basic):
                 factors.append(beta)
                 continue
             if beta not in basic_orbits[i]:
-                return []
+                return None
             u = transversals[i][beta]._array_form
             h = _af_rmul(_af_invert(u), h)
             factors.append(beta)
         if h != I:
-            return []
+            return None
         if factor_index:
             return factors
         tr = self.basic_transversals
@@ -1262,6 +1264,8 @@ class PermutationGroup(Basic):
                 return product
 
         f = self.coset_factor(g, True)
+        if f is None:
+            return []
         for i, j in enumerate(f):
             slp = self._transversal_slp[i][j]
             for s in slp:
@@ -1304,18 +1308,8 @@ class PermutationGroup(Basic):
         coset_factor
 
         """
-        if not self.base:
-            if isinstance(g, Cycle):
-                g = g.list(self._degree)
-            elif isinstance(g, Permutation):
-                g = g.list()
-            if len(g) != self._degree:
-                raise ValueError('g should be the same size as permutations of G')
-            if g == list(range(self._degree)):
-                return 0
-            return None
         factors = self.coset_factor(g, True)
-        if not factors:
+        if factors is None:
             return None
         rank = 0
         b = 1
@@ -1772,7 +1766,7 @@ class PermutationGroup(Basic):
             g = Permutation(g, size=self.degree)
         if g in self.generators:
             return True
-        return bool(self.coset_factor(g.array_form, True))
+        return self.coset_factor(g.array_form, True) is not None
 
     @property
     def is_perfect(self):
@@ -2135,7 +2129,7 @@ class PermutationGroup(Basic):
         for g1 in gens1:
             for g2 in gens2:
                 p = _af_rmuln(g1, g2, _af_invert(g1))
-                if not new_self.coset_factor(p, True):
+                if new_self.coset_factor(p, True) is None:
                     return False
         return True
 

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1304,6 +1304,10 @@ class PermutationGroup(Basic):
         coset_factor
 
         """
+        if not self.base:
+            if self.contains(g):
+                return 0
+            return None
         factors = self.coset_factor(g, True)
         if not factors:
             return None

--- a/sympy/combinatorics/perm_groups.py
+++ b/sympy/combinatorics/perm_groups.py
@@ -1305,7 +1305,13 @@ class PermutationGroup(Basic):
 
         """
         if not self.base:
-            if self.contains(g):
+            if isinstance(g, Cycle):
+                g = g.list(self._degree)
+            elif isinstance(g, Permutation):
+                g = g.list()
+            if len(g) != self._degree:
+                raise ValueError('g should be the same size as permutations of G')
+            if g == list(range(self._degree)):
                 return 0
             return None
         factors = self.coset_factor(g, True)

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -255,6 +255,22 @@ def test_coset_rank():
     assert G.coset_unrank(48) is None
     assert G.coset_unrank(G.coset_rank(gens[0])) == gens[0]
 
+    # Trivial groups (order 1, base is [])
+    G_triv = PermutationGroup(Permutation([0, 1, 2]))
+    assert G_triv.order() == 1
+    assert G_triv.base == []
+    assert G_triv.coset_rank(G_triv.identity) == 0
+    assert G_triv.coset_unrank(0) == G_triv.identity
+    assert G_triv.coset_unrank(1) is None
+    assert G_triv.coset_rank(Permutation([1, 0, 2])) is None
+
+    G_triv1 = PermutationGroup(Permutation(0))
+    assert G_triv1.order() == 1
+    assert G_triv1.base == []
+    assert G_triv1.coset_rank(G_triv1.identity) == 0
+    assert G_triv1.coset_unrank(0) == G_triv1.identity
+    assert G_triv1.coset_unrank(1) is None
+
 
 def test_coset_factor():
     a = Permutation([0, 2, 1])

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -6,11 +6,11 @@ from sympy.combinatorics.named_groups import SymmetricGroup, CyclicGroup,\
     DihedralGroup, AlternatingGroup, AbelianGroup, RubikGroup
 from sympy.combinatorics.perm_groups import (PermutationGroup,
     _orbit_transversal, Coset, SymmetricPermutationGroup)
-from sympy.combinatorics.permutations import Permutation
+from sympy.combinatorics.permutations import Permutation, Cycle
 from sympy.combinatorics.polyhedron import tetrahedron as Tetra, cube
 from sympy.combinatorics.testutil import _verify_bsgs, _verify_centralizer,\
     _verify_normal_closure
-from sympy.testing.pytest import skip, XFAIL, slow
+from sympy.testing.pytest import skip, XFAIL, slow, raises
 
 rmul = Permutation.rmul
 
@@ -259,15 +259,27 @@ def test_coset_rank():
     G_triv = PermutationGroup(Permutation([0, 1, 2]))
     assert G_triv.order() == 1
     assert G_triv.base == []
+    # Permutation input
     assert G_triv.coset_rank(G_triv.identity) == 0
+    assert G_triv.coset_rank(Permutation([0, 1, 2])) == 0
+    assert G_triv.coset_rank(Permutation([1, 0, 2])) is None
+    # Cycle input
+    assert G_triv.coset_rank(Cycle()) == 0
+    assert G_triv.coset_rank(Cycle(0, 1)) is None
+    # Array form list input
+    assert G_triv.coset_rank([0, 1, 2]) == 0
+    assert G_triv.coset_rank([1, 0, 2]) is None
+    # Size mismatch raises ValueError matching coset_factor
+    raises(ValueError, lambda: G_triv.coset_rank([0, 1]))
+    # Unrank
     assert G_triv.coset_unrank(0) == G_triv.identity
     assert G_triv.coset_unrank(1) is None
-    assert G_triv.coset_rank(Permutation([1, 0, 2])) is None
 
     G_triv1 = PermutationGroup(Permutation(0))
     assert G_triv1.order() == 1
     assert G_triv1.base == []
     assert G_triv1.coset_rank(G_triv1.identity) == 0
+    assert G_triv1.coset_rank([0]) == 0
     assert G_triv1.coset_unrank(0) == G_triv1.identity
     assert G_triv1.coset_unrank(1) is None
 

--- a/sympy/combinatorics/tests/test_perm_groups.py
+++ b/sympy/combinatorics/tests/test_perm_groups.py
@@ -288,7 +288,7 @@ def test_coset_factor():
     a = Permutation([0, 2, 1])
     G = PermutationGroup([a])
     c = Permutation([2, 1, 0])
-    assert not G.coset_factor(c)
+    assert G.coset_factor(c) is None
     assert G.coset_rank(c) is None
 
     a = Permutation([2, 0, 1, 3, 4, 5])
@@ -296,7 +296,7 @@ def test_coset_factor():
     g = PermutationGroup([a, b])
     assert g.order() == 360
     d = Permutation([1, 0, 2, 3, 4, 5])
-    assert not g.coset_factor(d.array_form)
+    assert g.coset_factor(d.array_form) is None
     assert not g.contains(d)
     assert Permutation(2) in G
     c = Permutation([1, 0, 2, 3, 5, 4])
@@ -310,7 +310,7 @@ def test_coset_factor():
     assert g.contains(c)
     G = PermutationGroup([Permutation([2, 1, 0])])
     p = Permutation([1, 0, 2])
-    assert G.coset_factor(p) == []
+    assert G.coset_factor(p) is None
 
 
 def test_orbits():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #28677

#### Brief description of what is fixed or changed

Fix `coset_factor` to return `None` when `g` is not a member of `G` (instead of `[]`).
This allows distinguishing non-members (`None`) from successful factorizations of trivial groups with an empty base (`[]`).

Consequently:
1. `PermutationGroup.coset_rank` checks for `factors is None`.
2. `PermutationGroup.contains` checks `self.coset_factor(...) is not None`.
3. Trivial groups of order 1 correctly return `coset_rank(g) == 0` for identity and `None` for non-members.

#### Other comments

All tests in `test_perm_groups.py` pass.

#### AI Generation Disclosure

As a new contributor learning the codebase, I was assisted by an AI coding assistant in drafting the code and test cases. All changes have been tested locally.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* combinatorics
  * `coset_factor` now returns `None` for non-members.
  * Fixed `coset_rank` on trivial permutation groups.
<!-- END RELEASE NOTES -->