### PR TITLE
Improve Expr.is_constant to take care of assumptions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -436,6 +436,7 @@ Benjamin Fishbein <fishbeinb@gmail.com>
 Benjamin Gudehus <hastebrot@gmail.com>
 Benjamin McDonald <mcdonald.ben@gmail.com>
 Benjamin Wolba <mail@benjaminwolba.com>
+Benoît Gschwind <benoit.gschwind@mailbox.org>
 Bernhard R. Link <brlink@debian.org>
 Bharat Raghunathan <bharatraghunthan9767@gmail.com> Bharat123rox <bharatraghunthan9767@gmail.com>
 Bharath M R <catchmrbharath@gmail.com>

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -685,6 +685,8 @@ class Expr(Basic, EvalfMixin):
         True
         """
 
+        from sympy.functions.elementary.complexes import Abs
+
         simplify = flags.get('simplify', True)
 
         if self.is_number:
@@ -716,37 +718,167 @@ class Expr(Basic, EvalfMixin):
 
         # try numerical evaluation to see if we get two different values
         failing_number = None
-        if wrt_number == free:
-            # try 0 (for a) and 1 (for b)
-            try:
-                a = expr.subs(list(zip(free, [0]*len(free))),
-                    simultaneous=True)
-                if a is S.NaN:
-                    # evaluation may succeed when substitution fails
-                    a = expr._random(None, 0, 0, 0, 0)
-            except ZeroDivisionError:
-                a = None
-            if a is not None and a is not S.NaN:
+        if wrt_number == free and all(sym.is_finite is not False for sym in free):
+
+            # TRY FORMAL SUBTITUTION S.Zero, S.One, -S.One
+            # They are tried only if they comply assumptions
+
+            # Try S.Zero
+            a = S.NaN
+            if all(sym.is_zero is not False for sym in free):
                 try:
-                    b = expr.subs(list(zip(free, [1]*len(free))),
-                        simultaneous=True)
-                    if b is S.NaN:
-                        # evaluation may succeed when substitution fails
-                        b = expr._random(None, 1, 0, 1, 0)
+                    subs = dict.fromkeys(free, S.Zero)
+                    a = expr.subs(subs, simultaneous=True)
                 except ZeroDivisionError:
-                    b = None
-                if b is not None and b is not S.NaN and b.equals(a) is False:
-                    return False
-                # try random real
-                b = expr._random(None, -1, 0, 1, 0)
-                if b is not None and b is not S.NaN and b.equals(a) is False:
-                    return False
-                # try random complex
-                b = expr._random()
-                if b is not None and b is not S.NaN:
-                    if b.equals(a) is False:
-                        return False
-                    failing_number = a if a.is_number else b
+                    a = S.NaN
+            if a is None: a = S.NaN
+
+            # Try S.One
+            b = S.NaN
+            if all(sym.is_positive is not False for sym in free):
+                try:
+                    subs = dict.fromkeys(free, S.One)
+                    b = expr.subs(subs, simultaneous=True)
+                except ZeroDivisionError:
+                    b = S.NaN
+                if b is None: b = S.NaN
+                if (b is not S.NaN):
+                    if (a is not S.NaN):
+                        if b.equals(a) is False:
+                            return False
+                        failing_number = b if b.is_number else a
+
+            # Try -S.One
+            c = S.NaN
+            if all(sym.is_negative is not False for sym in free):
+                try:
+                    subs = dict.fromkeys(free, -S.One)
+                    c = expr.subs(subs, simultaneous=True)
+                except ZeroDivisionError:
+                    c = S.NaN
+                if c is None: c = S.NaN
+                if (c is not S.NaN):
+                    if (a is not S.NaN):
+                        if c.equals(a) is False:
+                            return False
+                        failing_number = c if c.is_number else a
+                    if (b is not S.NaN):
+                        if c.equals(b) is False:
+                            return False
+                        failing_number = c if c.is_number else b
+
+
+            # TRY APROXIMATE SUBTITUTION 0.0, 1.0, -1.0, random real,
+            # random complex.
+            # They are tried only if they comply assumptions.
+            # Cauton: Use low precision evaluation, i.e. 12 to avoid false
+            # negative, because the test is conclusive if result is NOT equals.
+
+            # Try 0.0
+            a = S.NaN
+            if all(sym.is_zero is not False for sym in free):
+                try:
+                    subs = dict.fromkeys(free, 0.0)
+                    a = expr.evalf(12, subs=subs)
+                except ZeroDivisionError:
+                    a = S.NaN
+            if a is None: a = S.NaN
+
+            # Try 1.0
+            b = S.NaN
+            if all(sym.is_positive is not False for sym in free):
+                try:
+                    subs = dict.fromkeys(free, 1.0)
+                    b = expr.evalf(12, subs=subs)
+                except ZeroDivisionError:
+                    b = S.NaN
+
+                if b is None: b = S.NaN
+                if (b is not S.NaN):
+                    if (a is not S.NaN):
+                        delta = Abs(b - a)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = b if b.is_number else a
+
+            # Try -1.0
+            c = S.NaN
+            if all(sym.is_negative is not False for sym in free):
+                try:
+                    subs = dict.fromkeys(free, -1.0)
+                    c = expr.evalf(12, subs=subs)
+                except ZeroDivisionError:
+                    c = S.NaN
+
+                if c is None: c = S.NaN
+                if (c is not S.NaN):
+                    if (a is not S.NaN):
+                        delta = Abs(c - a)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = c if c.is_number else a
+                    if (b is not S.NaN):
+                        delta = Abs(c - b)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = c if c.is_number else b
+
+            # Try real
+            d = S.NaN
+            if all(sym.is_real is not False for sym in free):
+                try:
+                    d = expr._random(12, -1.0, 0.0, 1.0, 0.0)
+                except ZeroDivisionError:
+                    d = S.NaN
+
+                if d is None: d = S.NaN
+                if (d is not S.NaN):
+                    if (a is not S.NaN):
+                        delta = Abs(d - a)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = d if d.is_number else a
+                    if (b is not S.NaN):
+                        delta = Abs(d - b)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = d if d.is_number else b
+                    if (c is not S.NaN):
+                        delta = Abs(d - c)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = d if d.is_number else c
+
+            # Try complex
+            e = S.NaN
+            if all(sym.is_complex is not False for sym in free):
+                try:
+                    e = expr._random(12, -1.0, -1.0, 1.0, 1.0)
+                except ZeroDivisionError:
+                    e = S.NaN
+
+                if e is None: e = S.NaN
+                if (e is not S.NaN):
+                    if (a is not S.NaN):
+                        delta = Abs(e - a)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = e if e.is_number else a
+                    if (b is not S.NaN):
+                        delta = Abs(e - b)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = e if e.is_number else b
+                    if (c is not S.NaN):
+                        delta = Abs(e - c)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = e if e.is_number else c
+                    if (d is not S.NaN):
+                        delta = Abs(e - d)
+                        if delta.is_number and delta > 1e-12:
+                            return False
+                        failing_number = e if e.is_number else d
 
         # now we will test each wrt symbol (or all free symbols) to see if the
         # expression depends on them or not using differentiation. This is

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -731,6 +731,8 @@ class Expr(Basic, EvalfMixin):
                     a = expr.subs(subs, simultaneous=True)
                 except ZeroDivisionError:
                     a = S.NaN
+                except ValueError:
+                    a = S.NaN
             if a is None: a = S.NaN
 
             # Try S.One
@@ -741,6 +743,8 @@ class Expr(Basic, EvalfMixin):
                     b = expr.subs(subs, simultaneous=True)
                 except ZeroDivisionError:
                     b = S.NaN
+                except ValueError:
+                    a = S.NaN
                 if b is None: b = S.NaN
                 if (b is not S.NaN):
                     if (a is not S.NaN):
@@ -756,6 +760,8 @@ class Expr(Basic, EvalfMixin):
                     c = expr.subs(subs, simultaneous=True)
                 except ZeroDivisionError:
                     c = S.NaN
+                except ValueError:
+                    a = S.NaN
                 if c is None: c = S.NaN
                 if (c is not S.NaN):
                     if (a is not S.NaN):
@@ -782,6 +788,8 @@ class Expr(Basic, EvalfMixin):
                     a = expr.evalf(12, subs=subs)
                 except ZeroDivisionError:
                     a = S.NaN
+                except ValueError:
+                    a = S.NaN
             if a is None: a = S.NaN
 
             # Try 1.0
@@ -792,6 +800,8 @@ class Expr(Basic, EvalfMixin):
                     b = expr.evalf(12, subs=subs)
                 except ZeroDivisionError:
                     b = S.NaN
+                except ValueError:
+                    a = S.NaN
 
                 if b is None: b = S.NaN
                 if (b is not S.NaN):
@@ -809,6 +819,8 @@ class Expr(Basic, EvalfMixin):
                     c = expr.evalf(12, subs=subs)
                 except ZeroDivisionError:
                     c = S.NaN
+                except ValueError:
+                    a = S.NaN
 
                 if c is None: c = S.NaN
                 if (c is not S.NaN):
@@ -830,6 +842,8 @@ class Expr(Basic, EvalfMixin):
                     d = expr._random(12, -1.0, 0.0, 1.0, 0.0)
                 except ZeroDivisionError:
                     d = S.NaN
+                except ValueError:
+                    a = S.NaN
 
                 if d is None: d = S.NaN
                 if (d is not S.NaN):
@@ -856,6 +870,8 @@ class Expr(Basic, EvalfMixin):
                     e = expr._random(12, -1.0, -1.0, 1.0, 1.0)
                 except ZeroDivisionError:
                     e = S.NaN
+                except ValueError:
+                    a = S.NaN
 
                 if e is None: e = S.NaN
                 if (e is not S.NaN):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -716,19 +716,23 @@ class Expr(Basic, EvalfMixin):
         # Don't attempt substitution or differentiation with non-number symbols
         wrt_number = {sym for sym in wrt if sym.kind is NumberKind}
 
+        # substitute symbols that are known to be zero
+        num_expr = expr.subs({f: S.Zero for f in wrt_number if f.is_zero}, simultaneous=True)
+        num_free = {f for f in wrt_number if f.is_zero is not True}
+
         # try numerical evaluation to see if we get two different values
         failing_number = None
-        if wrt_number == free and all(sym.is_finite is not False for sym in free):
+        if wrt_number == free and (len(num_free) > 0) and all(sym.is_finite is not False for sym in num_free):
 
             # TRY FORMAL SUBTITUTION S.Zero, S.One, -S.One
             # They are tried only if they comply assumptions
 
             # Try S.Zero
             a = S.NaN
-            if all(sym.is_zero is not False for sym in free):
+            if all(sym.is_zero is not False for sym in num_free):
                 try:
-                    subs = dict.fromkeys(free, S.Zero)
-                    a = expr.subs(subs, simultaneous=True)
+                    subs = dict.fromkeys(num_free, S.Zero)
+                    a = num_expr.subs(subs, simultaneous=True)
                 except ZeroDivisionError:
                     a = S.NaN
                 except ValueError:
@@ -737,10 +741,10 @@ class Expr(Basic, EvalfMixin):
 
             # Try S.One
             b = S.NaN
-            if all(sym.is_positive is not False for sym in free):
+            if all(sym.is_positive is not False for sym in num_free):
                 try:
-                    subs = dict.fromkeys(free, S.One)
-                    b = expr.subs(subs, simultaneous=True)
+                    subs = dict.fromkeys(num_free, S.One)
+                    b = num_expr.subs(subs, simultaneous=True)
                 except ZeroDivisionError:
                     b = S.NaN
                 except ValueError:
@@ -754,10 +758,10 @@ class Expr(Basic, EvalfMixin):
 
             # Try -S.One
             c = S.NaN
-            if all(sym.is_negative is not False for sym in free):
+            if all(sym.is_negative is not False for sym in num_free):
                 try:
-                    subs = dict.fromkeys(free, -S.One)
-                    c = expr.subs(subs, simultaneous=True)
+                    subs = dict.fromkeys(num_free, -S.One)
+                    c = num_expr.subs(subs, simultaneous=True)
                 except ZeroDivisionError:
                     c = S.NaN
                 except ValueError:
@@ -782,10 +786,10 @@ class Expr(Basic, EvalfMixin):
 
             # Try 0.0
             a = S.NaN
-            if all(sym.is_zero is not False for sym in free):
+            if all(sym.is_zero is not False for sym in num_free):
                 try:
-                    subs = dict.fromkeys(free, 0.0)
-                    a = expr.evalf(12, subs=subs)
+                    subs = dict.fromkeys(num_free, 0.0)
+                    a = num_expr.evalf(12, subs=subs)
                 except ZeroDivisionError:
                     a = S.NaN
                 except ValueError:
@@ -794,10 +798,10 @@ class Expr(Basic, EvalfMixin):
 
             # Try 1.0
             b = S.NaN
-            if all(sym.is_positive is not False for sym in free):
+            if all(sym.is_positive is not False for sym in num_free):
                 try:
-                    subs = dict.fromkeys(free, 1.0)
-                    b = expr.evalf(12, subs=subs)
+                    subs = dict.fromkeys(num_free, 1.0)
+                    b = num_expr.evalf(12, subs=subs)
                 except ZeroDivisionError:
                     b = S.NaN
                 except ValueError:
@@ -813,10 +817,10 @@ class Expr(Basic, EvalfMixin):
 
             # Try -1.0
             c = S.NaN
-            if all(sym.is_negative is not False for sym in free):
+            if all(sym.is_negative is not False for sym in num_free):
                 try:
-                    subs = dict.fromkeys(free, -1.0)
-                    c = expr.evalf(12, subs=subs)
+                    subs = dict.fromkeys(num_free, -1.0)
+                    c = num_expr.evalf(12, subs=subs)
                 except ZeroDivisionError:
                     c = S.NaN
                 except ValueError:
@@ -837,9 +841,9 @@ class Expr(Basic, EvalfMixin):
 
             # Try real
             d = S.NaN
-            if all(sym.is_real is not False for sym in free):
+            if all(sym.is_real is not False for sym in num_free):
                 try:
-                    d = expr._random(12, -1.0, 0.0, 1.0, 0.0)
+                    d = num_expr._random(12, -1.0, 0.0, 1.0, 0.0)
                 except ZeroDivisionError:
                     d = S.NaN
                 except ValueError:
@@ -865,9 +869,9 @@ class Expr(Basic, EvalfMixin):
 
             # Try complex
             e = S.NaN
-            if all(sym.is_complex is not False for sym in free):
+            if all(sym.is_complex is not False for sym in num_free):
                 try:
-                    e = expr._random(12, -1.0, -1.0, 1.0, 1.0)
+                    e = num_expr._random(12, -1.0, -1.0, 1.0, 1.0)
                 except ZeroDivisionError:
                     e = S.NaN
                 except ValueError:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1948,7 +1948,7 @@ def test_equals():
         2*sqrt(2)*x**(S(3)/2)*(1 + 1/(2*x))**(S(5)/2)/(-6 - 3/x)
     ans = sqrt(2*x + 1)*(6*x**2 + x - 1)/15
     diff = i - ans
-    assert diff.equals(0) is None  # should be False, but previously this was False due to wrong intermediate result
+    assert diff.equals(0) is False
     assert diff.subs(x, Rational(-1, 2)/2) == 7*sqrt(2)/120
     # there are regions for x for which the expression is True, for
     # example, when x < -1/2 or x > 0 the expression is zero

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -2227,7 +2227,7 @@ def test_issue_6325():
 def test_issue_7426():
     f1 = a % c
     f2 = x % z
-    assert f1.equals(f2) is None
+    assert f1.equals(f2) is False
 
 
 def test_issue_11122():

--- a/sympy/geometry/tests/test_point.py
+++ b/sympy/geometry/tests/test_point.py
@@ -10,7 +10,6 @@ from sympy.geometry import Line, Point, Point2D, Point3D, Line3D, Plane
 from sympy.geometry.entity import rotate, scale, translate, GeometryEntity
 from sympy.matrices import Matrix
 from sympy.utilities.iterables import subsets, permutations, cartes
-from sympy.utilities.misc import Undecidable
 from sympy.testing.pytest import raises, warns
 
 
@@ -106,7 +105,7 @@ def test_point():
     assert Point.is_scalar_multiple(Point(1, 1), (-1, -1))
     assert Point.is_scalar_multiple(Point(0, 0), (0, -1))
     # test when is_scalar_multiple can't be determined
-    raises(Undecidable, lambda: Point.is_scalar_multiple(Point(sympify("x1%y1"), sympify("x2%y2")), Point(0, 1)))
+    assert Point.is_scalar_multiple(Point(sympify("x1%y1"), sympify("x2%y2")), Point(0, 1)) is False
 
     assert Point(0, 1).orthogonal_direction == Point(1, 0)
     assert Point(1, 0).orthogonal_direction == Point(0, 1)


### PR DESCRIPTION
#### References to other Issues or PRs

Related to #30048
Partialy fix #19584
Fix #17354

#### Brief description of what is fixed or changed

The code rewrite the numerical evaluation used as a short cut in Expr.is_constant to take care of free symbols assumptions.

#### Other comments

The code is verbose on purpose to be easier to maintain, read and understand. Some history of the code can be found in my comments of #30048. More over the patch set fix few related tests.

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* core
  * Improve Expr.is_constant to take care of assumptions

<!-- END RELEASE NOTES -->
