### PR TITLE
calculus: fix incorrect open bound in function_range

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -207,6 +207,7 @@ Abdullah Javed Nesar <abduljaved1994@gmail.com>
 Abhay_Dhiman <abhaysdhimans@gmail.com>
 Abhi58 <abhijithbharadwaj58@gmail.com>
 Abhigyan Khaund <mail@abhigyan.xyz>
+Abhijay <abhijaymovva@gmail.com> <65919828+amovva11@users.noreply.github.com>
 Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
 Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
 Abhinav Agarwal <abhinavagarwal1996@gmail.com>

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -68,6 +68,15 @@ def test_function_range():
         sin(x)/2, x, S.Naturals))
 
 
+def test_function_range_attained_bounds():
+    # issue 30293
+    assert function_range(x*exp(-x), x, Interval(0, oo)
+        ) == Interval(0, exp(-1))
+    assert function_range(-x*exp(-x), x, Interval(0, oo)
+        ) == Interval(-exp(-1), 0)
+    assert function_range(exp(x), x, S.Reals) == Interval.open(0, oo)
+
+
 @slow
 def test_function_range1():
     assert function_range(tan(x)**2 + tan(3*x)**2 + 1, x, S.Reals) == Interval(1,oo)

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -247,16 +247,17 @@ def function_range(f, symbol, domain):
                     range_int += FiniteSet(f.subs(symbol, singleton))
         elif isinstance(interval, Interval):
             vals = S.EmptySet
-            critical_values = S.EmptySet
+            attained_values = S.EmptySet
             bounds = ((interval.left_open, interval.inf, '+'),
                    (interval.right_open, interval.sup, '-'))
 
             for is_open, limit_point, direction in bounds:
                 if is_open:
-                    critical_values += FiniteSet(limit(f, symbol, limit_point, direction))
-                    vals += critical_values
+                    vals += FiniteSet(limit(f, symbol, limit_point, direction))
                 else:
-                    vals += FiniteSet(f.subs(symbol, limit_point))
+                    endpoint_value = f.subs(symbol, limit_point)
+                    vals += FiniteSet(endpoint_value)
+                    attained_values += FiniteSet(endpoint_value)
 
             critical_points = solveset(f.diff(symbol), symbol, interval)
 
@@ -268,16 +269,12 @@ def function_range(f, symbol, domain):
                         'Infinite number of critical points for {}'.format(f))
 
             for critical_point in critical_points:
-                vals += FiniteSet(f.subs(symbol, critical_point))
+                critical_point_value = f.subs(symbol, critical_point)
+                vals += FiniteSet(critical_point_value)
+                attained_values += FiniteSet(critical_point_value)
 
-            left_open, right_open = False, False
-
-            if critical_values is not S.EmptySet:
-                if critical_values.inf == vals.inf:
-                    left_open = True
-
-                if critical_values.sup == vals.sup:
-                    right_open = True
+            left_open = vals.inf not in attained_values
+            right_open = vals.sup not in attained_values
 
             range_int += Interval(vals.inf, vals.sup, left_open, right_open)
         else:


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30293

#### Brief description of what is fixed or changed

`function_range` marked an interval bound as open whenever the extreme value
equaled a limit taken at an open endpoint, even when that same value is
actually attained on the interval (at a closed endpoint or a critical point).

```python
>>> from sympy import function_range, exp, Interval, oo, Symbol
>>> x = Symbol('x')
>>> function_range(x*exp(-x), x, Interval(0, oo))
Interval.Lopen(0, exp(-1))   # (0, exp(-1)] -- wrong
```

The minimum value `0` is attained at `x = 0`, so the lower bound should be
closed; it was reported open only because `x*exp(-x) -> 0` as `x -> oo`.

This PR tracks the values the function actually attains (closed endpoints and
critical points) separately from values reached only as a limit, and opens a
bound only when the extreme value is reached solely as a limit:

```python
>>> function_range(x*exp(-x), x, Interval(0, oo))
Interval(0, exp(-1))         # [0, exp(-1)] -- correct
```

Cases where a bound genuinely is open (e.g. `function_range(exp(x), x,
S.Reals)` -> `Interval.open(0, oo)`) are unchanged.

#### Other comments

Added a regression test in `sympy/calculus/tests/test_util.py`. All existing
tests in `test_util.py` and the doctests pass with zero failures.

#### AI Disclosure

As a new contributor, I used an AI coding assistant to help me learn the codebase.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Fixed `function_range` incorrectly returning an open interval bound when the extreme value is also attained at a closed endpoint or critical point.
<!-- END RELEASE NOTES -->
