### PR TITLE
simplify floor/ceiling sums that cancel

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1430,6 +1430,7 @@ Rom le Clair <jacen.guardian@gmail.com>
 Roman Inflianskas <infroma@gmail.com>
 Ronan Lamy <ronan.lamy@gmail.com> <Ronan.Lamy@normalesup.org>
 Rudr Tiwari <rudrtiwari@gmail.com>
+Rudra Dudhat <contact.rdudhat@gmail.com>
 Rupesh Harode <rupeshharode@gmail.com>
 Rushabh Mehta <mehtarushabh2005@gmail.com> Rushabh Mehta <139112780+RushabhMehta2005@users.noreply.github.com>
 Ruslan Pisarev <rpisarev@cloudlinux.com> <ruslan@rpisarev.org.ua>

--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -24,7 +24,7 @@ from sympy.functions.combinatorial.factorials import CombinatorialFunction
 from sympy.functions.elementary.complexes import unpolarify, Abs, sign
 from sympy.functions.elementary.exponential import ExpBase
 from sympy.functions.elementary.hyperbolic import HyperbolicFunction
-from sympy.functions.elementary.integers import ceiling
+from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.piecewise import (Piecewise, piecewise_fold,
                                                   piecewise_simplify)
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
@@ -719,6 +719,13 @@ def simplify(expr, ratio=1.7, measure=count_ops, rational=False, inverse=False, 
 
     if expr.has(TrigonometricFunction, HyperbolicFunction):
         expr = trigsimp(expr, deep=True)
+
+    if expr.has(floor, ceiling):
+        # ceiling(x) == -floor(-x) exactly, so rewriting to a single function
+        # lets Add/Mul collect terms that cancel, e.g.
+        # floor(x) + ceiling(-x) -> 0. `shorter` keeps the rewrite only when
+        # it is actually simpler, so lone ceilings are left alone.
+        expr = shorter(expr, expr.rewrite(floor))
 
     if expr.has(log):
         expr = shorter(expand_log(expr, deep=True), logcombine(expr))

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -15,6 +15,7 @@ from sympy.functions.combinatorial.factorials import (binomial, factorial)
 from sympy.functions.elementary.complexes import (Abs, sign)
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import (cosh, csch, sinh)
+from sympy.functions.elementary.integers import (ceiling, floor, frac)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, asin, atan, cos, sin, sinc, tan)
@@ -1124,3 +1125,18 @@ def test_issue_14269():
     root = (sqrt(2) - 1)**Rational(1, 3) - (sqrt(2) + 1)**Rational(1, 3)
     expr = (x**3 + 3*x + 2).subs(x, root)
     assert simplify(expr) == 0
+
+
+def test_issue_30300():
+    x, y = symbols('x y', real=True)
+    # ceiling(x) == -floor(-x), so these cancel exactly
+    assert simplify(floor(x) + ceiling(-x)) == 0
+    assert simplify(ceiling(x) + floor(-x)) == 0
+    assert simplify(floor(2*x) + ceiling(-2*x)) == 0
+    assert simplify(floor(sin(x)) + ceiling(-sin(x))) == 0
+    assert simplify(floor(x) + ceiling(-x) + y) == y
+    # nothing cancels here, so the expressions are left alone
+    assert simplify(ceiling(x)) == ceiling(x)
+    assert simplify(floor(x)) == floor(x)
+    assert simplify(frac(x)) == frac(x)
+    assert simplify(ceiling(x) + floor(x)) == ceiling(x) + floor(x)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30300

#### Brief description of what is fixed or changed

Fixes #30300, details are there. tldr sympy already knows `ceiling(x) == -floor(-x)` but `simplify` never used it, so the terms stayed as different functions and `Add` had nothing to collect. Now `simplify` rewrites to one function and lets `shorter` decide, so `floor(x) + ceiling(-x)` gives 0 and things that don't cancel (`ceiling(x)`, `frac(x)`) are left alone.

#### Other comments

1986 tests pass across simplify, functions/elementary, solvers, series, calculus and sets. Checked the new test fails without the change as well. 

#### AI Generation Disclosure

Claude wrote the change in `simplify.py` and the `test_issue_30300` test, and found the bug that I filed as #30300. I caught its maths error on the way (it first mixed this up with `floor(x) + floor(-x)`, which is -1 for non-integers,
not the exact identity we're using here). although i can defend every line of the code and the logic behind the same.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* simplify
  * `simplify` now cancels `floor`/`ceiling` terms that sum to zero, e.g.
    `floor(x) + ceiling(-x)` gives `0`.
<!-- END RELEASE NOTES -->
