### PR TITLE
 Add type annotations to euler_equations

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1218,6 +1218,7 @@ Nirmal Sarswat <nirmalsarswat400@gmail.com>
 Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
 Nishant Nikhil <nishantiam@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
+Nishkarsh Jain <87063934+nishkarshj@users.noreply.github.com>
 Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>

--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -3,6 +3,7 @@ This module implements a method to find
 Euler-Lagrange Equations for given Lagrangian.
 """
 from __future__ import annotations
+from collections.abc import Iterable
 from itertools import combinations_with_replacement
 from typing import TYPE_CHECKING
 
@@ -11,11 +12,9 @@ from sympy.core.relational import Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
-from sympy.utilities.iterables import iterable
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
+    from sympy.core.basic import Basic
     from sympy.core.expr import Expr
 
 
@@ -81,7 +80,11 @@ def euler_equations(
 
     """
 
-    funcs_tuple: tuple[Function, ...] = tuple(funcs) if iterable(funcs) else (funcs,)  # type: ignore[arg-type, assignment]
+    funcs_tuple: tuple[Function, ...]
+    if isinstance(funcs, Iterable):
+        funcs_tuple = tuple(funcs)
+    else:
+        funcs_tuple = (funcs,)
 
     if not funcs_tuple:
         funcs_tuple = tuple(L.atoms(Function))
@@ -90,12 +93,16 @@ def euler_equations(
             if not isinstance(f, Function):
                 raise TypeError('Function expected, got: %s' % f)
 
-    vars_tuple: tuple[Symbol, ...] = tuple(vars) if iterable(vars) else (vars,)  # type: ignore[arg-type, assignment]
+    vars_tuple: tuple[Basic, ...]
+    if isinstance(vars, Iterable):
+        vars_tuple = tuple(vars)
+    else:
+        vars_tuple = (vars,)
 
     if not vars_tuple:
-        vars_tuple = funcs_tuple[0].args  # type: ignore[assignment]
+        vars_tuple = funcs_tuple[0].args
     else:
-        vars_tuple = tuple(sympify(var) for var in vars_tuple)  # type: ignore[misc]
+        vars_tuple = tuple(sympify(var) for var in vars_tuple)
 
     if not all(isinstance(v, Symbol) for v in vars_tuple):
         raise TypeError('Variables are not symbols, got %s' % vars_tuple)

--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -4,6 +4,8 @@ Euler-Lagrange Equations for given Lagrangian.
 """
 from __future__ import annotations
 from itertools import combinations_with_replacement
+from typing import TYPE_CHECKING
+
 from sympy.core.function import (Derivative, Function, diff)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
@@ -11,8 +13,17 @@ from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.utilities.iterables import iterable
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
-def euler_equations(L, funcs=(), vars=()):
+    from sympy.core.expr import Expr
+
+
+def euler_equations(
+    L: Expr,
+    funcs: Function | Iterable[Function] = (),
+    vars: Symbol | Iterable[Symbol] = (),
+) -> list[Eq]:
     r"""
     Find the Euler-Lagrange equations [1]_ for a given Lagrangian.
 
@@ -70,37 +81,37 @@ def euler_equations(L, funcs=(), vars=()):
 
     """
 
-    funcs = tuple(funcs) if iterable(funcs) else (funcs,)
+    funcs_tuple: tuple[Function, ...] = tuple(funcs) if iterable(funcs) else (funcs,)  # type: ignore[arg-type, assignment]
 
-    if not funcs:
-        funcs = tuple(L.atoms(Function))
+    if not funcs_tuple:
+        funcs_tuple = tuple(L.atoms(Function))
     else:
-        for f in funcs:
+        for f in funcs_tuple:
             if not isinstance(f, Function):
                 raise TypeError('Function expected, got: %s' % f)
 
-    vars = tuple(vars) if iterable(vars) else (vars,)
+    vars_tuple: tuple[Symbol, ...] = tuple(vars) if iterable(vars) else (vars,)  # type: ignore[arg-type, assignment]
 
-    if not vars:
-        vars = funcs[0].args
+    if not vars_tuple:
+        vars_tuple = funcs_tuple[0].args  # type: ignore[assignment]
     else:
-        vars = tuple(sympify(var) for var in vars)
+        vars_tuple = tuple(sympify(var) for var in vars_tuple)  # type: ignore[misc]
 
-    if not all(isinstance(v, Symbol) for v in vars):
-        raise TypeError('Variables are not symbols, got %s' % vars)
+    if not all(isinstance(v, Symbol) for v in vars_tuple):
+        raise TypeError('Variables are not symbols, got %s' % vars_tuple)
 
-    for f in funcs:
-        if not vars == f.args:
-            raise ValueError("Variables %s do not match args: %s" % (vars, f))
+    for f in funcs_tuple:
+        if not vars_tuple == f.args:
+            raise ValueError("Variables %s do not match args: %s" % (vars_tuple, f))
 
     order = max([len(d.variables) for d in L.atoms(Derivative)
-                        if d.expr in funcs] + [0])
+                        if d.expr in funcs_tuple] + [0])
 
-    eqns = []
-    for f in funcs:
+    eqns: list[Eq] = []
+    for f in funcs_tuple:
         eq = diff(L, f)
         for i in range(1, order + 1):
-            for p in combinations_with_replacement(vars, i):
+            for p in combinations_with_replacement(vars_tuple, i):
                 eq = eq + S.NegativeOne**i*diff(L, diff(f, *p), *p)
         new_eq = Eq(eq, 0)
         if isinstance(new_eq, Eq):


### PR DESCRIPTION
#### References to other Issues or PRs

See #28806

#### Brief description of what is fixed or changed

Added type annotations to `euler_equations` in `sympy/calculus/euler.py`.

#### Other comments

Ran `ruff check`, `mypy`, and `pyright` on the file. All pass.
Also ran `sympy/calculus/tests/test_euler.py`, and the tests pass.

The changes were written with assistance from OpenCode.

#### AI Generation Disclosure

The code in this PR was written with assistance from an AI coding tool (OpenCode).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
