### PR TITLE
[GSoC] Add SkewNormal distribution to sympy.stats

### DIFF
--- a/doc/src/modules/stats.rst
+++ b/doc/src/modules/stats.rst
@@ -74,6 +74,7 @@ Continuous Types
 .. autofunction:: Reciprocal
 .. autofunction:: StudentT
 .. autofunction:: ShiftedGompertz
+.. autofunction:: SkewNormal
 .. autofunction:: Trapezoidal
 .. autofunction:: Triangular
 .. autofunction:: Uniform

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -1643,6 +1643,10 @@ def test_sympy__stats__crv_types__ShiftedGompertzDistribution():
     from sympy.stats.crv_types import ShiftedGompertzDistribution
     assert _test_args(ShiftedGompertzDistribution(1, 1))
 
+def test_sympy__stats__crv_types__SkewNormalDistribution():
+    from sympy.stats.crv_types import SkewNormalDistribution
+    assert _test_args(SkewNormalDistribution(0, 1, 1))
+
 def test_sympy__stats__crv_types__StudentTDistribution():
     from sympy.stats.crv_types import StudentTDistribution
     assert _test_args(StudentTDistribution(1))

--- a/sympy/stats/__init__.py
+++ b/sympy/stats/__init__.py
@@ -119,7 +119,7 @@ __all__ = [
     'FisherZ', 'Frechet', 'Gamma', 'GammaInverse', 'Gompertz', 'Gumbel',
     'Kumaraswamy', 'Laplace', 'Levy', 'Logistic','LogCauchy', 'LogLogistic', 'LogitNormal', 'LogNormal', 'Lomax',
     'Moyal', 'Maxwell', 'Nakagami', 'Normal', 'GaussianInverse', 'Pareto', 'PowerFunction',
-    'QuadraticU', 'RaisedCosine', 'Rayleigh','Reciprocal', 'StudentT', 'ShiftedGompertz',
+    'QuadraticU', 'RaisedCosine', 'Rayleigh','Reciprocal', 'SkewNormal', 'StudentT', 'ShiftedGompertz',
     'Trapezoidal', 'Triangular', 'Uniform', 'UniformSum', 'VonMises', 'Wald',
     'Weibull', 'WignerSemicircle', 'ContinuousDistributionHandmade',
 
@@ -169,7 +169,7 @@ from .crv_types import (ContinuousRV, Arcsin, Benini, Beta, BetaNoncentral,
         Gompertz, Gumbel, Kumaraswamy, Laplace, Levy, Logistic, LogCauchy,
         LogLogistic, LogitNormal, LogNormal, Lomax, Maxwell, Moyal, Nakagami,
         Normal, Pareto, QuadraticU, RaisedCosine, Rayleigh, Reciprocal,
-        StudentT, PowerFunction, ShiftedGompertz, Trapezoidal, Triangular,
+        SkewNormal, StudentT, PowerFunction, ShiftedGompertz, Trapezoidal, Triangular,
         Uniform, UniformSum, VonMises, Wald, Weibull, WignerSemicircle,
         ContinuousDistributionHandmade)
 

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -4012,6 +4012,7 @@ class SkewNormalDistribution(SingleContinuousDistribution):
     @staticmethod
     def check(xi, omega, alpha):
         _value_check(omega > 0, "Scale parameter must be positive")
+        _value_check(alpha.is_real != False, "Shape parameter alpha must be real.")
 
     def pdf(self, x):
         xi, omega, alpha = self.xi, self.omega, self.alpha

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -4075,10 +4075,8 @@ def SkewNormal(name, xi, omega, alpha):
     Setting :math:`\alpha = 0` reduces to a Normal distribution:
 
     >>> from sympy.stats import Normal
-    >>> from sympy import simplify
-    >>> simplify(density(SkewNormal("x", xi, omega, 0))(x) -
-    ...          density(Normal("x", xi, omega))(x))
-    0
+    >>> density(SkewNormal("x", xi, omega, 0))(x) == density(Normal("x", xi, omega))(x)
+    True
 
     References
     ==========

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -46,6 +46,7 @@ RaisedCosine
 Rayleigh
 Reciprocal
 ShiftedGompertz
+SkewNormal
 StudentT
 Trapezoidal
 Triangular
@@ -80,7 +81,7 @@ from sympy.functions.elementary.integers import floor
 from sympy.functions.elementary.miscellaneous import sqrt, Max, Min
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import asin
-from sympy.functions.special.error_functions import (erf, erfc, erfi, erfinv, expint)
+from sympy.functions.special.error_functions import (erf, erfc, erfi, erfinv, expint, owens_t)
 from sympy.functions.special.gamma_functions import (gamma, lowergamma, uppergamma)
 from sympy.functions.special.zeta_functions import zeta
 from sympy.functions.special.hyper import hyper
@@ -137,6 +138,7 @@ __all__ = ['ContinuousRV',
 'RaisedCosine',
 'Rayleigh',
 'Reciprocal',
+'SkewNormal',
 'StudentT',
 'ShiftedGompertz',
 'Trapezoidal',
@@ -3997,6 +3999,96 @@ def ShiftedGompertz(name, b, eta):
 
     """
     return rv(name, ShiftedGompertzDistribution, (b, eta))
+
+#-------------------------------------------------------------------------------
+# SkewNormal distribution -------------------------------------------------------
+
+
+class SkewNormalDistribution(SingleContinuousDistribution):
+    _argnames = ('xi', 'omega', 'alpha')
+
+    set = Interval(-oo, oo)
+
+    @staticmethod
+    def check(xi, omega, alpha):
+        _value_check(omega > 0, "Scale parameter must be positive")
+
+    def pdf(self, x):
+        xi, omega, alpha = self.xi, self.omega, self.alpha
+        z = (x - xi)/omega
+        return exp(-z**2/2)*(1 + erf(alpha*z/sqrt(2)))/(sqrt(2*pi)*omega)
+
+    def _cdf(self, x):
+        xi, omega, alpha = self.xi, self.omega, self.alpha
+        z = (x - xi)/omega
+        return erf(sqrt(2)*z/2)/2 + S.Half - 2*owens_t(z, alpha)
+
+
+def SkewNormal(name, xi, omega, alpha):
+    r"""
+    Create a continuous random variable with a Skew Normal distribution.
+
+    Explanation
+    ===========
+
+    The density of the Skew Normal distribution is given by
+
+    .. math::
+        f(x) := \frac{2}{\omega} \phi\left(\frac{x-\xi}{\omega}\right)
+                \Phi\left(\alpha\frac{x-\xi}{\omega}\right)
+
+    where $\phi$ and $\Phi$ are the standard normal PDF and CDF,
+    respectively.
+
+    Parameters
+    ==========
+
+    xi : Real number, the location
+    omega : Real number, `\omega > 0`, a scale
+    alpha : Real number, the shape parameter
+
+    Returns
+    =======
+
+    RandomSymbol
+
+    Examples
+    ========
+
+    >>> from sympy.stats import SkewNormal, density, cdf
+    >>> from sympy import Symbol
+
+    >>> xi = Symbol("xi")
+    >>> omega = Symbol("omega", positive=True)
+    >>> alpha = Symbol("alpha")
+    >>> x = Symbol("x")
+
+    >>> X = SkewNormal("x", xi, omega, alpha)
+
+    >>> density(X)(x)
+    sqrt(2)*(erf(sqrt(2)*alpha*(x - xi)/(2*omega)) + 1)*exp(-(x - xi)**2/(2*omega**2))/(2*sqrt(pi)*omega)
+
+    >>> cdf(X)(x)
+    erf(sqrt(2)*(x - xi)/(2*omega))/2 - 2*owens_t((x - xi)/omega, alpha) + 1/2
+
+    Setting :math:`\alpha = 0` reduces to a Normal distribution:
+
+    >>> from sympy.stats import Normal
+    >>> from sympy import simplify
+    >>> simplify(density(SkewNormal("x", xi, omega, 0))(x) -
+    ...          density(Normal("x", xi, omega))(x))
+    0
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Skew_normal_distribution
+    .. [2] Azzalini, A. (1985). A class of distributions which includes
+           the normal ones. Scandinavian Journal of Statistics, 171-178.
+
+    """
+
+    return rv(name, SkewNormalDistribution, (xi, omega, alpha))
 
 #-------------------------------------------------------------------------------
 # StudentT distribution --------------------------------------------------------

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -4007,8 +4007,6 @@ def ShiftedGompertz(name, b, eta):
 class SkewNormalDistribution(SingleContinuousDistribution):
     _argnames = ('xi', 'omega', 'alpha')
 
-    set = Interval(-oo, oo)
-
     @staticmethod
     def check(xi, omega, alpha):
         _value_check(omega > 0, "Scale parameter must be positive")

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1179,6 +1179,7 @@ def test_skewnormal():
 
     raises(ValueError, lambda: SkewNormal('x', 0, -1, 1))
     raises(ValueError, lambda: SkewNormal('x', 0, 0, 1))
+    raises(ValueError, lambda: SkewNormal('x', 0, 1, I))
 
 
 def test_studentt():

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1524,6 +1524,7 @@ def test_long_precomputed_cdf():
             Laplace("LA", -5, 4),
             Logistic("L", -6, 7),
             Nakagami("N", 2, 7),
+            SkewNormal("SN", -2, 3, 4),
             StudentT("S", 4)
             ]
     for distr in distribs:

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -1168,10 +1168,8 @@ def test_skewnormal():
     assert cdf(X)(x) == erf(sqrt(2)*z/2)/2 + S.Half - 2*owens_t(z, alpha)
 
     # alpha = 0 reduces to a Normal distribution
-    assert simplify(density(SkewNormal("x", xi, omega, 0))(x) -
-                     density(Normal("x", xi, omega))(x)) == 0
-    assert simplify(cdf(SkewNormal("x", xi, omega, 0))(x) -
-                     cdf(Normal("x", xi, omega))(x)) == 0
+    assert density(SkewNormal("x", xi, omega, 0))(x) == density(Normal("x", xi, omega))(x)
+    assert cdf(SkewNormal("x", xi, omega, 0))(x) == cdf(Normal("x", xi, omega))(x)
 
     # -X ~ SkewNormal(-xi, omega, -alpha)
     Y = SkewNormal("y", -xi, omega, -alpha)

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -17,7 +17,7 @@ from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (asin, atan, cos, sin, tan)
 from sympy.functions.special.bessel import (besseli, besselj, besselk)
 from sympy.functions.special.beta_functions import beta
-from sympy.functions.special.error_functions import (erf, erfc, erfi, expint)
+from sympy.functions.special.error_functions import (erf, erfc, erfi, expint, owens_t)
 from sympy.functions.special.gamma_functions import (gamma, lowergamma, uppergamma)
 from sympy.functions.special.zeta_functions import zeta
 from sympy.functions.special.hyper import hyper
@@ -36,7 +36,8 @@ from sympy.stats import (P, E, where, density, variance, covariance, skewness, k
                          Exponential, ExponentialPower, FDistribution, FisherZ, Frechet, Gamma,
                          GammaInverse, Gompertz, Gumbel, Kumaraswamy, Laplace, Levy, Logistic, LogCauchy,
                          LogLogistic, LogitNormal, LogNormal, Maxwell, Moyal, Nakagami, Normal, GaussianInverse,
-                         Pareto, PowerFunction, QuadraticU, RaisedCosine, Rayleigh, Reciprocal, ShiftedGompertz, StudentT,
+                         Pareto, PowerFunction, QuadraticU, RaisedCosine, Rayleigh, Reciprocal, ShiftedGompertz,
+                         SkewNormal, StudentT,
                          Trapezoidal, Triangular, Uniform, UniformSum, VonMises, Weibull, coskewness,
                          WignerSemicircle, Wald, correlation, moment, cmoment, smoment, quantile,
                          Lomax, BoundedPareto)
@@ -1154,6 +1155,30 @@ def test_shiftedgompertz():
     eta = Symbol("eta", positive=True)
     X = ShiftedGompertz("x", b, eta)
     assert density(X)(x) == b*(eta*(1 - exp(-b*x)) + 1)*exp(-b*x)*exp(-eta*exp(-b*x))
+
+
+def test_skewnormal():
+    xi = Symbol("xi", real=True)
+    omega = Symbol("omega", positive=True)
+    alpha = Symbol("alpha", real=True)
+
+    X = SkewNormal("x", xi, omega, alpha)
+    z = (x - xi)/omega
+    assert density(X)(x) == exp(-z**2/2)*(1 + erf(alpha*z/sqrt(2)))/(sqrt(2*pi)*omega)
+    assert cdf(X)(x) == erf(sqrt(2)*z/2)/2 + S.Half - 2*owens_t(z, alpha)
+
+    # alpha = 0 reduces to a Normal distribution
+    assert simplify(density(SkewNormal("x", xi, omega, 0))(x) -
+                     density(Normal("x", xi, omega))(x)) == 0
+    assert simplify(cdf(SkewNormal("x", xi, omega, 0))(x) -
+                     cdf(Normal("x", xi, omega))(x)) == 0
+
+    # -X ~ SkewNormal(-xi, omega, -alpha)
+    Y = SkewNormal("y", -xi, omega, -alpha)
+    assert simplify(density(X)(x) - density(Y)(-x)) == 0
+
+    raises(ValueError, lambda: SkewNormal('x', 0, -1, 1))
+    raises(ValueError, lambda: SkewNormal('x', 0, 0, 1))
 
 
 def test_studentt():


### PR DESCRIPTION
#### References to other Issues or PRs

Follow-up to #30143, which added `sympy.functions.special.error_functions.owens_t`
specifically as a prerequisite for this. From that PR's review:

> Future consumer: sympy.stats has no skew-normal distribution yet; if one
> is added, its CDF is $\Phi(x) - 2T(x, \alpha)$, so this function is the
> prerequisite.
>
> — https://github.com/sympy/sympy/pull/30143#issuecomment-5208541829

Closes #30251.
Closes #30345.

#### Brief description of what is fixed or changed

Adds a `SkewNormal` distribution to `sympy.stats`, alongside the existing
`Normal`. With location $\xi$, scale $\omega > 0$, and shape $\alpha$:

$$f(x) = \frac{2}{\omega}\,\varphi\!\left(\frac{x-\xi}{\omega}\right)\Phi\!\left(\alpha\frac{x-\xi}{\omega}\right)$$

* `pdf` is elementary (`erf`/`exp`), following the pattern of
  `NormalDistribution.pdf`.
* `_cdf` is $\Phi(z) - 2T(z, \alpha)$ where $T$ is Owen's T function
  (`owens_t`), following the pattern of `NormalDistribution._cdf`.
* Parameter validation: $\omega > 0$ via `_value_check`; $\alpha$ is
  unconstrained.

It reduces to `Normal(xi, omega)` when `alpha = 0`, and satisfies
`-X ~ SkewNormal(-xi, omega, -alpha)`; both are checked in
`test_skewnormal` (`sympy/stats/tests/test_continuous_rv.py`), along with
direct checks of the `pdf`/`cdf` formulas and of the `omega > 0`
validation.

```pycon
>>> from sympy.stats import SkewNormal, density, cdf
>>> from sympy import Symbol
>>> xi = Symbol("xi")
>>> omega = Symbol("omega", positive=True)
>>> alpha = Symbol("alpha")
>>> x = Symbol("x")
>>> X = SkewNormal("x", xi, omega, alpha)
>>> density(X)(x)
sqrt(2)*(erf(sqrt(2)*alpha*(x - xi)/(2*omega)) + 1)*exp(-(x - xi)**2/(2*omega**2))/(2*sqrt(pi)*omega)
>>> cdf(X)(x)
erf(sqrt(2)*(x - xi)/(2*omega))/2 - 2*owens_t((x - xi)/omega, alpha) + 1/2
```

#### Other comments

Moments and the characteristic function have known closed forms but are
left for a follow-up, since they aren't needed to make the distribution
usable and would add scope to this PR.

#### AI Generation Disclosure

This PR was written with Claude Code (Anthropic). All code, docstrings,
and tests in this PR (`sympy/stats/crv_types.py`, `sympy/stats/__init__.py`,
`sympy/stats/tests/test_continuous_rv.py`, `doc/src/modules/stats.rst`)
were AI-generated, based on the distribution definition and scope
described in the linked issue. Correctness was checked by running the
full `sympy/stats` test suite and the `crv_types.py` doctests (both
passing), and by cross-checking the `_cdf` formula against direct
numerical integration of the `pdf`, the `alpha=0` reduction to `Normal`,
and the `-X ~ SkewNormal(-xi, omega, -alpha)` sign identity.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* stats
  * Added the `SkewNormal` distribution, with `pdf` given in terms of
    `erf` and `_cdf` given in terms of Owen's T function (`owens_t`).
<!-- END RELEASE NOTES -->
