### PR TITLE
test: add regression tests for inequalities

### DIFF
--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -2774,6 +2774,20 @@ def test_issue_11064():
         Interval.Lopen(sqrt(5), oo)
 
 
+def test_sqrt_inequality():
+    u = symbols('u')
+    epsilon_1 = (u + 1) / (2 * (2 * u + 1)) * (5 * u + 2 - sqrt(u * (17 * u + 8)))
+    epsilon_2 = (u + 1) / (2 * (2 * u + 1)) * (5 * u + 2 + sqrt(u * (17 * u + 8)))
+
+    assert solveset(epsilon_1 > 0, u, S.Reals) == \
+        Union(Interval.open(-1, -S.Half), Interval(0, oo))
+    assert solveset(epsilon_1 > 1, u, S.Reals) == \
+        Union(Interval.open(1 - sqrt(3), -S.Half),
+              Interval.open(1 + sqrt(3), oo))
+    assert solveset(epsilon_2 > 1, u, S.Reals) == \
+        Interval.open(0, oo)
+
+
 def test_issue_12478():
     eq = sqrt(x - 2) + 2
     soln = solveset_real(eq, x)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Related to gh-12471 and gh-21276.

#### Brief description of what is fixed or changed
Add regression tests for the inequalities fixed by gh-12471 and gh-21276.

#### Other comments 

`solveset(epsilon_1 > 0, u, S.Reals)` was fixed by https://github.com/sympy/sympy/commit/ce2375aedb8889484dc7855ad513762240564fbd from gh-12471.

Before https://github.com/sympy/sympy/commit/ce2375aedb8889484dc7855ad513762240564fbd,

```python
In [1]: u = symbols('u')

In [2]: epsilon_1 = (u + 1)/(2*(2*u + 1))*(5*u + 2 - sqrt(u*(17*u + 8)))

In [3]: solveset(epsilon_1 > 0, u, S.Reals)
```

output:

```math
\left(-1, -\frac{1}{2}\right) \cup \left(0, \infty\right)
```

expected result:

```math
\left(-1, -\frac{1}{2}\right) \cup \left[0, \infty\right)
```

After  https://github.com/sympy/sympy/commit/ce2375aedb8889484dc7855ad513762240564fbd,
The code above returns the expected result.

`solveset(epsilon_1 > 1, u, S.Reals)`, `solveset(epsilon_2 > 1, u, S.Reals)`
were fixed by 651595d137c2c4469d97be2458f469dfbdb2c9b9 from gh-21276.

Before 651595d137c2c4469d97be2458f469dfbdb2c9b9,

```python
In [1]: u = symbols('u')

In [2]: epsilon_1 = (u + 1)/(2*(2*u + 1))*(5*u + 2 - sqrt(u*(17*u + 8)))

In [3]: solveset(epsilon_1 > 1, u, S.Reals)
Out[3]: ConditionSet(u, (u + 1)*(5*u - sqrt(u*(17*u + 8)) + 2)/(4*u + 2) > 1, Reals)
expected result = (1 - √3, -1/2) ∪ (1 + √3, ∞)

In [4]: epsilon_2 = (u + 1)/(2*(2*u + 1))*(5*u + 2 + sqrt(u*(17*u + 8)))

In [5]: solveset(epsilon_2 > 1, u, S.Reals)
Out[5]: ConditionSet(u, (u + 1)*(5*u + sqrt(u*(17*u + 8)) + 2)/(4*u + 2) > 1, Reals)
expected result = (0, ∞)
```

After 651595d137c2c4469d97be2458f469dfbdb2c9b9, the code above returns the expected results.

#### AI Generation Disclosure
DeepSeek helped identify which commits fixed the issues.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
All code was written manually.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
