### PR TITLE
Series annotations

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1218,6 +1218,7 @@ Nirmal Sarswat <nirmalsarswat400@gmail.com>
 Nisarg Chaudhari <54911392+Nisarg-Chaudhari@users.noreply.github.com>
 Nishant Nikhil <nishantiam@gmail.com>
 Nishith Shah <nishithshah.2211@gmail.com>
+Nishkarsh Jain <87063934+nishkarshj@users.noreply.github.com>
 Nitin Chaudhary <nitinmax1000@gmail.com>
 Nityananda Gohain <nityanandagohain@gmail.com>
 NotWearingPants <26556598+NotWearingPants@users.noreply.github.com>

--- a/sympy/calculus/euler.py
+++ b/sympy/calculus/euler.py
@@ -4,6 +4,8 @@ Euler-Lagrange Equations for given Lagrangian.
 """
 from __future__ import annotations
 from itertools import combinations_with_replacement
+from typing import TYPE_CHECKING
+
 from sympy.core.function import (Derivative, Function, diff)
 from sympy.core.relational import Eq
 from sympy.core.singleton import S
@@ -11,8 +13,17 @@ from sympy.core.symbol import Symbol
 from sympy.core.sympify import sympify
 from sympy.utilities.iterables import iterable
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
-def euler_equations(L, funcs=(), vars=()):
+    from sympy.core.expr import Expr
+
+
+def euler_equations(
+    L: Expr,
+    funcs: Function | Iterable[Function] = (),
+    vars: Symbol | Iterable[Symbol] = (),
+) -> list[Eq]:
     r"""
     Find the Euler-Lagrange equations [1]_ for a given Lagrangian.
 
@@ -70,37 +81,37 @@ def euler_equations(L, funcs=(), vars=()):
 
     """
 
-    funcs = tuple(funcs) if iterable(funcs) else (funcs,)
+    funcs_tuple: tuple[Function, ...] = tuple(funcs) if iterable(funcs) else (funcs,)  # type: ignore[arg-type, assignment]
 
-    if not funcs:
-        funcs = tuple(L.atoms(Function))
+    if not funcs_tuple:
+        funcs_tuple = tuple(L.atoms(Function))
     else:
-        for f in funcs:
+        for f in funcs_tuple:
             if not isinstance(f, Function):
                 raise TypeError('Function expected, got: %s' % f)
 
-    vars = tuple(vars) if iterable(vars) else (vars,)
+    vars_tuple: tuple[Symbol, ...] = tuple(vars) if iterable(vars) else (vars,)  # type: ignore[arg-type, assignment]
 
-    if not vars:
-        vars = funcs[0].args
+    if not vars_tuple:
+        vars_tuple = funcs_tuple[0].args  # type: ignore[assignment]
     else:
-        vars = tuple(sympify(var) for var in vars)
+        vars_tuple = tuple(sympify(var) for var in vars_tuple)  # type: ignore[misc]
 
-    if not all(isinstance(v, Symbol) for v in vars):
-        raise TypeError('Variables are not symbols, got %s' % vars)
+    if not all(isinstance(v, Symbol) for v in vars_tuple):
+        raise TypeError('Variables are not symbols, got %s' % vars_tuple)
 
-    for f in funcs:
-        if not vars == f.args:
-            raise ValueError("Variables %s do not match args: %s" % (vars, f))
+    for f in funcs_tuple:
+        if not vars_tuple == f.args:
+            raise ValueError("Variables %s do not match args: %s" % (vars_tuple, f))
 
     order = max([len(d.variables) for d in L.atoms(Derivative)
-                        if d.expr in funcs] + [0])
+                        if d.expr in funcs_tuple] + [0])
 
-    eqns = []
-    for f in funcs:
+    eqns: list[Eq] = []
+    for f in funcs_tuple:
         eq = diff(L, f)
         for i in range(1, order + 1):
-            for p in combinations_with_replacement(vars, i):
+            for p in combinations_with_replacement(vars_tuple, i):
                 eq = eq + S.NegativeOne**i*diff(L, diff(f, *p), *p)
         new_eq = Eq(eq, 0)
         if isinstance(new_eq, Eq):

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -2919,7 +2919,7 @@ class Expr(Basic, EvalfMixin):
     ##################### SERIES, LEADING TERM, LIMIT, ORDER METHODS ##################
     ###################################################################################
 
-    def series(self, x=None, x0=0, n=6, dir="+", logx=None, cdir=0):
+    def series(self, x=None, x0: Expr | int | float = 0, n=6, dir="+", logx=None, cdir=0):
         """
         Series expansion of "self" around ``x = x0`` yielding either terms of
         the series one by one (the lazy series given when n=None), else

--- a/sympy/series/series.py
+++ b/sympy/series/series.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from sympy.core.sympify import sympify
 
+if TYPE_CHECKING:
+    from sympy.core import Expr, Symbol
 
-def series(expr, x=None, x0=0, n=6, dir="+"):
+
+def series(
+    expr: Expr,
+    x: Symbol | None = None,
+    x0: Expr | int | float = 0,
+    n: int = 6,
+    dir: str = "+",
+) -> Expr:
     """Series expansion of expr around point `x = x0`.
 
     Parameters
@@ -61,4 +72,4 @@ def series(expr, x=None, x0=0, n=6, dir="+"):
     sympy.core.expr.Expr.series: See the docstring of Expr.series() for complete details of this wrapper.
     """
     expr = sympify(expr)
-    return expr.series(x, x0, n, dir)
+    return expr.series(x, x0, n, dir)  # pyright: ignore[reportArgumentType]

--- a/sympy/series/series.py
+++ b/sympy/series/series.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 from sympy.core.sympify import sympify
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from sympy.core import Expr, Symbol
 
 
@@ -13,7 +15,7 @@ def series(
     x0: Expr | int | float = 0,
     n: int = 6,
     dir: str = "+",
-) -> Expr:
+) -> Expr | Iterator[Expr]:
     """Series expansion of expr around point `x = x0`.
 
     Parameters
@@ -72,4 +74,4 @@ def series(
     sympy.core.expr.Expr.series: See the docstring of Expr.series() for complete details of this wrapper.
     """
     expr = sympify(expr)
-    return expr.series(x, x0, n, dir)  # pyright: ignore[reportArgumentType]
+    return expr.series(x, x0, n, dir)


### PR DESCRIPTION
#### References to other Issues or PRs

See #28806

#### Brief description of what is fixed or changed

Added type annotations to the `series` function in `sympy/series/series.py`.

#### Other comments

Local checks pass: `ruff check`, `mypy`, and `pyright` are clean on the
file, and `sympy/series/tests/test_series.py` runs green.

The changes were written with assistance from OpenCode.

#### AI Generation Disclosure

The code in this PR was written with assistance from an AI coding tool
(OpenCode).

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->