### PR TITLE
fix is_monotonic misclassifying monotonic functions with stationary points

### DIFF
--- a/sympy/calculus/singularities.py
+++ b/sympy/calculus/singularities.py
@@ -511,8 +511,6 @@ def is_monotonic(
     .. [2] https://en.wikipedia.org/wiki/Monotonic_function
 
     """
-    from sympy.solvers.solveset import solveset
-
     expression = sympify(expression)
 
     free = expression.free_symbols
@@ -534,5 +532,5 @@ def is_monotonic(
             if interior_sings != S.EmptySet:
                 return False
 
-    turning_points = solveset(expression.diff(variable), variable, interval)
-    return interval.intersection(turning_points) is S.EmptySet
+    return (is_increasing(expression, interval, variable)
+            or is_decreasing(expression, interval, variable))

--- a/sympy/calculus/tests/test_singularities.py
+++ b/sympy/calculus/tests/test_singularities.py
@@ -120,6 +120,12 @@ def test_is_monotonic():
     raises(NotImplementedError, lambda: is_monotonic(x**2 + y + 1))
 
 
+def test_issue_28571():
+    assert is_monotonic(x**3, S.Reals)
+    assert is_monotonic(1, S.Reals)
+    assert not is_monotonic(x**4, S.Reals)
+
+
 def test_issue_23401():
     x = Symbol('x')
     expr = (x + 1)/(-1.0e-3*x**2 + 0.1*x + 0.1)


### PR DESCRIPTION
Fixes #28571.

is_monotonic(x**3, Interval(-10, 10)) returned False even though x**3 is
strictly increasing on all of R. the last check in the function is

    turning_points = solveset(expression.diff(variable), variable, interval)
    return interval.intersection(turning_points) is S.EmptySet

for x**3 the derivative is 3*x**2 and solveset gives {0}, so the
intersection is {0} and we return False. that conflates "the derivative
has a zero somewhere" with "the derivative flips sign somewhere". for
differentiable expressions, isolated zeros of the derivative do not break
monotonicity. x**3 is the simplest example: its derivative vanishes at 0
but is nonnegative everywhere.

is_monotonic is documented as "increasing or decreasing", and
is_increasing/is_decreasing already implement exactly the derivative-sign
criterion (solveset of derivative >= 0 and <= 0 respectively). so instead
of patching the turning-point rule, this PR drops the duplicate algorithm
and reuses the two helpers. the constant function case (is_monotonic(5))
now returns True as well, since constant functions are both increasing and
decreasing.

no claim is made about non-differentiable expressions: the piecewise
jump case is untouched (the old code misclassifies those too, and fixing
that is a different issue).

tested x**3, x**4, a constant, and all existing docstring examples
(x**3 - 3*x**2 + 4*x, tan, 1/x, the 1/(x**2-3*x) family) against 1.14.0
locally — all come out as expected; the new regression test
test_issue_28571 covers the stationary-point and constant cases.