### PR TITLE
Prevent infinite loop in heurisch() for high degree trig denominators

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1169,6 +1169,7 @@ Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@
 Musab Kasbati <musab16000@gmail.com> Musab Kasbati <43878981+Musab1Blaser@users.noreply.github.com>
 Musab Kasbati <musab16000@gmail.com> Musab1Blaser <musab16000@gmail.com>
 Muskan Kumar <31043527+muskanvk@users.noreply.github.com>
+Márk Király <mark.kiraly.hu@gmail.com>
 Nabanita Dash <dashnabanita@gmail.com> Naba7 <dashnabanita@gmail.com>
 Nabanita Dash <dashnabanita@gmail.com> Nabanita Dash <31562743+Naba7@users.noreply.github.com>
 Naman Gera <namangera15@gmail.com> Naman Gera <43007653+namannimmo10@users.noreply.github.com>

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -10,6 +10,7 @@ from sympy.core.mul import Mul
 from sympy.core.symbol import Wild, Dummy, Symbol
 from sympy.core.basic import sympify
 from sympy.core.numbers import Rational, pi, I
+from sympy.core.power import Pow
 from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import S
 from sympy.core.sorting import ordered
@@ -24,6 +25,7 @@ from sympy.functions.elementary.complexes import Abs, re, im, sign, arg
 from sympy.functions.elementary.exponential import LambertW
 from sympy.functions.elementary.integers import floor, ceiling
 from sympy.functions.elementary.piecewise import Piecewise
+from sympy.functions.elementary.trigonometric import TrigonometricFunction
 from sympy.functions.special.delta_functions import Heaviside, DiracDelta
 
 from sympy.simplify.radsimp import collect
@@ -392,6 +394,14 @@ def heurisch(f, x, rewrite=False, hints=None, mappings=None, retries=3,
         indep, f = f.as_independent(x)
     else:
         indep = S.One
+
+    numer, denom = f.as_numer_denom()
+    if denom.has(Add) and not numer.has(TrigonometricFunction):
+        for pow_expr in denom.find(Pow):
+            pow_base, pow_exp = pow_expr.as_base_exp()
+            if isinstance(pow_base, TrigonometricFunction) and pow_exp.is_number and pow_exp >= 4:
+                raise NotImplementedError(
+                    "High degree (n>=4) trigonometric sum in denominator is not supported without trig numerator.")
 
     rewritables = {
         (sin, cos, cot): tan,


### PR DESCRIPTION
<!-- Closes #30309 -->

## Summary
Add a guard clause at the start of `heurisch()` to raise `NotImplementedError` when denominators contain trigonometric sums with powers `>= 4` AND the numerator does not contain any trigonometric functions.

This prevents combinatorial explosions and CPU hangs in polynomial solvers for unresolvable integrals, while allowing expressions with trigonometric numerators (which can often be solved via substitution) to proceed normally, ensuring existing tests pass.

**Raises:**
`NotImplementedError`: *"High degree (n>=4) trigonometric sum in denominator is not supported without trig numerator."*

## Checklist
- [x] I have read the [Contributing Guide](https://github.com/sympy/sympy/wiki/Contributing)
- [x] I have added/modified tests to cover the changes (N/A - Existing tests successfully pass with the refined guard clause)
- [x] The title of the pull request is a short summary of the changes
- [x] All formatting checks and tests pass locally

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Prevent infinite loop in heurisch() for high degree trig denominators.
<!-- END RELEASE NOTES -->