### PR TITLE
[GSoC] test_manual: update test cases for owens_t for extended piecewise

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1379,18 +1379,21 @@ _symbol = Dummy('x')
 def special_function_rule(integral):
     integrand, symbol = integral
     if not _special_function_patterns:
-        a = Wild('a', exclude=[_symbol], properties=[lambda x: not x.is_zero])
+        # Wild cards set to non-zero should only be used when the result is not
+        # valid e.g. Integral * 1/a
+        a_nonzero = Wild('a', exclude=[_symbol], properties=[lambda x: not x.is_zero])
         b = Wild('b', exclude=[_symbol])
         c = Wild('c', exclude=[_symbol])
-        d = Wild('d', exclude=[_symbol], properties=[lambda x: not x.is_zero])
-        e = Wild('e', exclude=[_symbol], properties=[
+        d_nonzero = Wild('d', exclude=[_symbol], properties=[lambda x: not x.is_zero])
+        e_nonnegative_integer = Wild('e', exclude=[_symbol], properties=[
             lambda x: not (x.is_nonnegative and x.is_integer)])
-        _wilds.extend((a, b, c, d, e))
+        y = Wild('y', exclude=[_symbol])
+        _wilds.extend((a_nonzero, b, c, d_nonzero, e_nonnegative_integer, y))
         # patterns consist of a SymPy class, a wildcard expr, an optional
         # condition coded as a lambda (when Wild properties are not enough),
         # followed by an applicable rule
-        linear_pattern = a*_symbol + b
-        quadratic_pattern = a*_symbol**2 + b*_symbol + c
+        linear_pattern = a_nonzero*_symbol + b
+        quadratic_pattern = a_nonzero*_symbol**2 + b*_symbol + c
         _special_function_patterns.extend((
             (Mul, exp(linear_pattern, evaluate=False)/_symbol, None, EiRule),
             (Mul, cos(linear_pattern, evaluate=False)/_symbol, None, CiRule),
@@ -1399,18 +1402,18 @@ def special_function_rule(integral):
             (Mul, sinh(linear_pattern, evaluate=False)/_symbol, None, ShiRule),
             (Pow, 1/log(linear_pattern, evaluate=False), None, LiRule),
             (exp, exp(quadratic_pattern, evaluate=False), None, ErfRule),
-            (Mul, exp(-(linear_pattern)**2, evaluate=False) * erf(d*(linear_pattern)),
-                lambda a, b, d: d != 1 and d != -1, OwensTRule),
+            (Mul, exp(-(linear_pattern)**2, evaluate=False) * erf(y*(linear_pattern)),
+                lambda a, b, y: y != 1 and y != -1, OwensTRule),
             (sin, sin(quadratic_pattern, evaluate=False), None, FresnelSRule),
             (cos, cos(quadratic_pattern, evaluate=False), None, FresnelCRule),
-            (Mul, _symbol**e*exp(a*_symbol, evaluate=False), None, UpperGammaRule),
-            (Mul, polylog(b, a*_symbol, evaluate=False)/_symbol, None, PolylogRule),
-            (Pow, 1/sqrt(a - d*sin(_symbol, evaluate=False)**2),
+            (Mul, _symbol**e_nonnegative_integer*exp(a_nonzero*_symbol, evaluate=False), None, UpperGammaRule),
+            (Mul, polylog(b, a_nonzero*_symbol, evaluate=False)/_symbol, None, PolylogRule),
+            (Pow, 1/sqrt(a_nonzero - d_nonzero*sin(_symbol, evaluate=False)**2),
                 lambda a, d: a != d, EllipticFRule),
-            (Pow, sqrt(a - d*sin(_symbol, evaluate=False)**2),
+            (Pow, sqrt(a_nonzero - d_nonzero*sin(_symbol, evaluate=False)**2),
                 lambda a, d: a != d, EllipticERule),
         ))
-    a_wild, _, _, d_wild, _ = _wilds
+    a_wild, _, _, d_wild, _, _ = _wilds
     _integrand = integrand.subs(symbol, _symbol)
     for type_, pattern, constraint, rule in _special_function_patterns:
         if isinstance(_integrand, type_):

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -470,16 +470,16 @@ def test_manualintegrate_parts_special():
 
 def test_manualintegrate_owent():
     f = exp(-x**2)*erf(y*x)
-    F = Piecewise((-2*sqrt(pi)*owens_t(sqrt(2)*x, y), Ne(y, 0)), (0, True))
+    F = -2*sqrt(pi)*owens_t(sqrt(2)*x, y)
     assert_is_integral_of(f, F)
 
     f = exp(-(3*x+2)**2)*erf(y*(3*x+2))
-    F = Piecewise((-2*sqrt(pi)*owens_t(sqrt(2)*(3*x + 2), y)/3, Ne(y, 0)), (0, True))
+    F = -2*sqrt(pi)*owens_t(sqrt(2)*(3*x + 2), y)/3
     assert_is_integral_of(f, F)
 
     f = owens_t(x, y)
-    F = x*owens_t(x, y) + sqrt(2)*(sqrt(2)*y*Piecewise((sqrt(pi)*erfi(x*(-y**2 - 1)/(2*sqrt(-y**2/2 - S.One/2)))/(2*sqrt(-y**2/2 - S.One/2)), Ne(y**2, -1)), (Integral(exp(-x**2*y**2/2 - x**2/2), x), True))/sqrt(pi) - exp(-x**2/2)*erf(sqrt(2)*x*y/2))/(4*sqrt(pi))
-    assert_is_integral_of(f, F)
+    F = x*owens_t(x, y) + sqrt(2)*(sqrt(2)*y*Piecewise((sqrt(pi)*erfi(x*(-y**2 - 1)/(2*sqrt(-y**2/2 - S.One/2)))/(2*sqrt(-y**2/2 - S.One/2)), Ne(y**2, - 1)), (Integral(exp(-x**2*y**2/2 - x**2/2), x), True))/sqrt(pi) - exp(-x**2/2)*erf(sqrt(2)*x*y/2))/(4*sqrt(pi))
+    assert manualintegrate(f, x) == F
 
     f = exp(-x**2)*erf(2*x)
     F = -2*sqrt(pi)*owens_t(sqrt(2)*x, 2)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -470,24 +470,21 @@ def test_manualintegrate_parts_special():
 
 def test_manualintegrate_owent():
     f = exp(-x**2)*erf(y*x)
-    F = -2*sqrt(pi)*owens_t(sqrt(2)*x, y)
+    F = Piecewise((-2*sqrt(pi)*owens_t(sqrt(2)*x, y), Ne(y, 0)), (0, True))
     assert_is_integral_of(f, F)
 
     f = exp(-(3*x+2)**2)*erf(y*(3*x+2))
-    F = -2*sqrt(pi)*owens_t(sqrt(2)*(3*x + 2), y)/3
+    F = Piecewise((-2*sqrt(pi)*owens_t(sqrt(2)*(3*x + 2), y)/3, Ne(y, 0)), (0, True))
     assert_is_integral_of(f, F)
 
     f = owens_t(x, y)
-    F = x*owens_t(x, y) + sqrt(2)*(sqrt(2)*y*erfi(x*(-y**2 - 1)/(2*sqrt(-y**2/2 - S.One/2)))/(2*sqrt(-y**2/2 - S.One/2)) - exp(-x**2/2)*erf(sqrt(2)*x*y/2))/(4*sqrt(pi))
+    F = x*owens_t(x, y) + sqrt(2)*(sqrt(2)*y*Piecewise((sqrt(pi)*erfi(x*(-y**2 - 1)/(2*sqrt(-y**2/2 - S.One/2)))/(2*sqrt(-y**2/2 - S.One/2)), Ne(y**2, -1)), (Integral(exp(-x**2*y**2/2 - x**2/2), x), True))/sqrt(pi) - exp(-x**2/2)*erf(sqrt(2)*x*y/2))/(4*sqrt(pi))
     assert_is_integral_of(f, F)
 
-    # numeric coefficient on the erf argument, not just a bare symbol
     f = exp(-x**2)*erf(2*x)
     F = -2*sqrt(pi)*owens_t(sqrt(2)*x, 2)
     assert_is_integral_of(f, F)
 
-    # y = 1 and y = -1 are excluded: erf(x)**2 has the nicer closed form
-    # produced by the parts path, not owens_t(..., 1)
     f = exp(-x**2)*erf(x)
     F = sqrt(pi)*erf(x)**2/4
     assert_is_integral_of(f, F)


### PR DESCRIPTION
…ditions

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
- #30143
- #30165

#### Brief description of what is fixed or changed
Fixes failing tests after merging both PRs. 

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
