### PR TITLE
evalf: fix floor of log evalf when chop=True

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -254,6 +254,8 @@ Akshansh Bhatt <akshansh@tuta.io>
 Akshansh Bhatt <akshansh@tuta.io> <53227127+akshanshbhatt@users.noreply.github.com>
 Akshat Jain <akshat.jain@students.iiit.ac.in>
 Akshat Maheshwari <akshat14714@gmail.com>
+Akshat Raj <akshatraj287@gmail.com> <48322760+Akshat-Raj@users.noreply.github.com>
+Akshat Raj <akshatraj287@gmail.com> Akshat-Raj <akshatraj287@gmail.com>
 Akshat Sood <68052998+akshatsood2249@users.noreply.github.com>
 Akshay <akshaynukala95@gmail.com>
 Akshay <akshaynukala95@gmail.com> <akshayah3@users.noreply.github.com>

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -414,6 +414,8 @@ def get_integer_part(expr: Expr, no: int, options: OPT_DICT, return_ints=False) 
             ire, iim, ire_acc, iim_acc = evalf(
                 re_im - nint, 10, options)  # don't need much precision
             assert not iim
+            if ire in [None, fzero]: #if ire = 0, then nexpr is an integer already, therefore floor=ceil=nint.
+                return from_int(nint), INF
             size = -fastlog(ire) + 2  # -ve b/c ire is less than 1
             if size > prec:
                 ire, iim, ire_acc, iim_acc = evalf(

--- a/sympy/core/tests/test_evalf.py
+++ b/sympy/core/tests/test_evalf.py
@@ -748,3 +748,15 @@ def test_issue_28280():
     assert x > 20
     y = 20 + log(1 + S(10)**-9)
     assert y > 20
+
+
+def test_issue_30297():
+    from sympy import log, floor, Integer
+    from sympy.abc import x
+
+    # This test shows evalf working for floor(log(x, 2)) with chop = True
+    expr = floor(log(x, 5))
+    result1 = expr.evalf(chop=True, subs={x: Integer(5)})
+    result2 = expr.evalf(subs={x: Integer(5)})
+    assert result1 == 1.
+    assert result2 == 1.


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #30297

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

This PR fixes a bug in the `evalf()` function, as detailed in the issue `exprtest.evalf(chop=True, subs={x: Integer(2)})` was causing a crash specefically for when chop=True. 

So the `evalf_floor()` works by calling the `get_integer_part()` function, which works by calculating the nearest integer(`nint`) to the input, subtracting it from the original to get the `ire`, which is the remainder. It then calculates the `size = -fastlog(ire) + 2`, the crash occured because when `chop=True` then `log(2,2)` returns exactly 1.0, which results in `ire` being 0, so then `fastlog(0)` returns a -inf, so `size = inf`.Then in the next step it calls `evalf(re_im, size, options)` which crashes because now size is infinite. 

This PR applies an early return safetycheck, before the functions tries to calculate `fastlog(ire)`,  it checks if ire is 0, if it is then simply return nint.

#### Other comments


#### AI Generation Disclosure

Gemini was used to debug and summerise parts of the codebase, the code is handwritten.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a bug in evalf where calculating the floor of an exact integer with chop=True caused a crash.
<!-- END RELEASE NOTES -->
