### PR TITLE
[GSoC 2026] Fix docstring of the character table class

### DIFF
--- a/sympy/combinatorics/character_table.py
+++ b/sympy/combinatorics/character_table.py
@@ -45,14 +45,14 @@ class CharacterTable(DefaultPrinting):
     ========
 
     The character table of a permutation group is computed by calling the
-    `character_table` method on the group.
+    ``character_table`` method on the group.
 
     >>> from sympy.combinatorics import SymmetricGroup, AlternatingGroup
     >>> M = SymmetricGroup(4).character_table()
     >>> type(M)
     <class 'sympy.combinatorics.character_table.CharacterTable'>
 
-    Calling `.as_matrix()` on the character table returns a matrix.
+    Calling ``.as_matrix()`` on the character table returns a matrix.
 
     >>> M.as_matrix()
     Matrix([
@@ -64,7 +64,7 @@ class CharacterTable(DefaultPrinting):
 
     The character table builds upon DomainMatrix, from which users can access the
     the values of the characters as domain elements. The domain of a character table is
-    either ZZ or a cyclotomic field.
+    either :ref:`ZZ` or a cyclotomic field :ref:`QQ(zeta_n)`.
 
     >>> M = AlternatingGroup(4).character_table()
     >>> M.as_matrix()
@@ -79,7 +79,7 @@ class CharacterTable(DefaultPrinting):
     3
 
     The order of the columns matches the order of the conjugacy classes,
-    which can be accessed with the method `conjugacy_class_reps`.
+    which can be accessed with the method ``conjugacy_class_reps``.
 
     >>> M.conjugacy_class_reps() # doctest: +SKIP
     [(3), (0 3 1), (3)(0 2 1), (0 3)(1 2)]
@@ -138,7 +138,7 @@ class CharacterTable(DefaultPrinting):
         >>> AlternatingGroup(5).character_table().zeta_order
         5
 
-        It returns 1 if the character table is over ZZ.
+        It returns 1 if the character table is over :ref:`ZZ`.
 
         >>> from sympy.combinatorics import SymmetricGroup
         >>> SymmetricGroup(4).character_table().zeta_order


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

Fixes the docstring of the CharacterTable class to make them display properly in the documentation page.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
