### PR TITLE
Fix plural agreement in MatrixExpr._iterable comment

### DIFF
--- a/sympy/matrices/expressions/matexpr.py
+++ b/sympy/matrices/expressions/matexpr.py
@@ -59,7 +59,7 @@ class MatrixExpr(Expr):
     __slots__: tuple[str, ...] = ()
 
     # Should not be considered iterable by the
-    # sympy.utilities.iterables.iterable function. Subclass that actually are
+    # sympy.utilities.iterables.iterable function. Subclasses that actually are
     # iterable (i.e., explicit matrices) should set this to True.
     _iterable = False
 


### PR DESCRIPTION
Small grammar fix in the internal doc comment for `MatrixExpr._iterable`:
"Subclass that actually are" -> "Subclasses that actually are".

No functional changes or logic alterations.