### PR TITLE
Fix `refine` for strict inequalities under finite-sign assumptions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1627,7 +1627,7 @@ Sushant Hiray <hiraysushant@gmail.com>
 Susumu Ishizuka <susumu.ishizuka@kii.com>
 Swapnil Agarwal <swapnilag29@gmail.com>
 Szymon Mieszczak <szymon.mieszczak@gmail.com>
-TaeHo Kim <tkim602@gatech.edu>
+TaeHo Kim <tkim602@gatech.edu> TaeHo Kim <thkim210414@gmail.com>
 Takafumi Arakaki <aka.tkf@gmail.com>
 Takumasa Nakamura <n.takumasa@gmail.com>
 Tanay Agrawal <tanay_agrawal@hotmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1627,6 +1627,7 @@ Sushant Hiray <hiraysushant@gmail.com>
 Susumu Ishizuka <susumu.ishizuka@kii.com>
 Swapnil Agarwal <swapnilag29@gmail.com>
 Szymon Mieszczak <szymon.mieszczak@gmail.com>
+TaeHo Kim <tkim602@gatech.edu>
 Takafumi Arakaki <aka.tkf@gmail.com>
 Takumasa Nakamura <n.takumasa@gmail.com>
 Tanay Agrawal <tanay_agrawal@hotmail.com>

--- a/sympy/assumptions/lra_satask.py
+++ b/sympy/assumptions/lra_satask.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from sympy.assumptions.cnf import CNF, EncodedCNF
-from sympy.assumptions.ask import Q
+from sympy.assumptions.ask import Q, _ask_recursive
 from sympy.logic.inference import satisfiable
 from sympy.logic.algorithms.lra_theory import UnhandledInput, ALLOWED_PRED
 from sympy.matrices.kind import MatrixKind
@@ -23,10 +23,11 @@ def lra_satask(proposition, assumptions=True):
     _props = CNF.from_prop(~proposition)
 
     cnf = CNF.from_prop(assumptions)
-    assumptions = EncodedCNF()
-    assumptions.from_cnf(cnf)
+    encoded_assumptions = EncodedCNF()
+    encoded_assumptions.from_cnf(cnf)
 
-    return check_satisfiability(props, _props, assumptions)
+    return check_satisfiability(
+        props, _props, encoded_assumptions, assumptions)
 
 # Some predicates such as Q.prime can't be handled by lra_satask.
 # For example, (x > 0) & (x < 1) & Q.prime(x) is unsat but lra_satask would think it was sat.
@@ -37,7 +38,7 @@ WHITE_LIST = ALLOWED_PRED.keys() | {Q.positive, Q.negative, Q.zero, Q.nonzero, Q
                                     Q.positive_infinite}
 
 
-def check_satisfiability(prop, _prop, factbase):
+def check_satisfiability(prop, _prop, factbase, assumptions=True):
     sat_true = factbase.copy()
     sat_false = factbase.copy()
     sat_true.add_from_cnf(prop)
@@ -56,7 +57,7 @@ def check_satisfiability(prop, _prop, factbase):
 
     # convert old assumptions into predicates and add them to sat_true and sat_false
     # also check for unhandled predicates
-    for assm in extract_pred_from_old_assum(all_exprs):
+    for assm in extract_pred_from_old_assum(all_exprs, assumptions):
         n = len(sat_true.encoding)
         if assm not in sat_true.encoding:
             sat_true.encoding[assm] = n+1
@@ -217,10 +218,13 @@ def get_all_pred_and_expr_from_enc_cnf(enc_cnf):
 
     return all_pred, all_exprs
 
-def extract_pred_from_old_assum(all_exprs):
+def extract_pred_from_old_assum(all_exprs, assumptions=True):
     """
     Returns a list of relevant new assumption predicate
     based on any old assumptions.
+
+    The optional assumptions are also used to establish that expressions
+    are real when this is not known from the old assumptions.
 
     Raises an UnhandledInput exception if any of the assumptions are
     unhandled.
@@ -251,10 +255,21 @@ def extract_pred_from_old_assum(all_exprs):
         if len(expr.free_symbols) == 0:
             continue
 
-        if expr.is_real is not True:
+        if expr.is_real is False:
+            raise UnhandledInput(f"LRASolver: {expr} must be real")
+        if (expr.is_real is None
+                and (assumptions is True or assumptions is S.true
+                    or _ask_recursive(Q.real(expr), assumptions) is not True)):
             raise UnhandledInput(f"LRASolver: {expr} must be real")
         # test for I times imaginary variable; such expressions are considered real
-        if isinstance(expr, Mul) and any(arg.is_real is not True for arg in expr.args):
+        if isinstance(expr, Mul) and any(
+                arg.is_real is False
+                or (
+                    arg.is_real is None
+                    and (assumptions is True or assumptions is S.true
+                        or _ask_recursive(Q.real(arg), assumptions) is not True)
+                )
+                for arg in expr.args):
             raise UnhandledInput(f"LRASolver: {expr} must be real")
 
         if expr.is_integer == True and expr.is_zero != True:

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -354,3 +354,8 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+
+def test_refine_issue_30324():
+    assumptions = Q.nonnegative(x) & Q.negative(y)
+    assert refine(x - y > 0, assumptions) is S.true

--- a/sympy/assumptions/tests/test_rel_queries.py
+++ b/sympy/assumptions/tests/test_rel_queries.py
@@ -85,6 +85,28 @@ def test_rel_queries():
     assert ask(x > z, (x > y) & (y > z)) is True
 
 
+
+def test_lra_satask_finite_sign_assumptions():
+    u, v = symbols("u v")
+    assumptions = Q.nonnegative(u) & Q.negative(v)
+    assert lra_satask(u - v > 0, assumptions) is True
+
+    boundary_assumptions = Q.nonnegative(u) & Q.nonpositive(v)
+    assert lra_satask(u - v >= 0, boundary_assumptions) is True
+    assert lra_satask(u - v > 0, boundary_assumptions) is None
+
+    assert lra_satask(2*u > 0, Q.positive(u)) is True
+
+    nonreal = Symbol("nonreal", real=False)
+    raises(UnhandledInput, lambda: lra_satask(Q.gt(nonreal, 0), Q.positive(nonreal)))
+
+    extended_assumptions = Q.extended_positive(u) & Q.extended_positive(v)
+    raises(
+        UnhandledInput,
+        lambda: lra_satask(u + v > u, extended_assumptions),
+    )
+
+
 def test_unhandled_queries():
     X = MatrixSymbol("X", 2, 2)
     assert ask(Q.lt(X, 2) & Q.gt(X, 3)) is None


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30324.

#### Brief description of what is fixed or changed

Previously

```python
refine(x - y > 0, Q.nonnegative(x) & Q.negative(y))
```

returned `x - y > 0` instead of `True`.

The fix:

- keeps the original assumptions available inside `lra_satask`
- uses `_ask_recursive(Q.real(...), assumptions)` when `.is_real` is unknown
- still rejects explicitly non-real and extended-real cases

Regression tests were added for the reported case (`refine`) and the underlying `lra_satask` behavior.

#### Other comments

Relevant assumptions, relational, doctest, and code-quality checks pass locally.

#### AI Generation Disclosure

GPT-5.6 Sol assisted with investigating the LRA realness path and parts of the related fix and tests. I reviewed and validated the final changes locally.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * Fixed refinement of strict inequalities under finite-sign assumptions.

<!-- END RELEASE NOTES -->
