### PR TITLE
logic: add `assume()` to `dpll2`

### DIFF
--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -156,6 +156,7 @@ class SATSolver:
         self._status = IpasirStatus.UNKNOWN
         self._models = None
         self._clause_buffer = []
+        self._assumptions = []
 
     def _initialize_variables(self, variables):
         """Set up the variable data structures needed."""
@@ -221,6 +222,27 @@ class SATSolver:
         if self.is_unsatisfied:
             return
 
+        # The assumptions are decisions the search cannot take back. Failing
+        # one rules out models, not the clauses themselves.
+        for assumed_lit in self._assumptions:
+            if assumed_lit in self.var_settings:
+                continue
+
+            if -assumed_lit not in self.var_settings:
+                self.levels.append(Level(assumed_lit))
+                self._assign_literal(assumed_lit)
+                self._simplify()
+                if not self.is_unsatisfied:
+                    continue
+                self.is_unsatisfied = False
+
+            while len(self.levels) > 1:
+                self._undo()
+            return
+
+        # Undoing an assumption would answer a different question.
+        assumption_level = len(self.levels)
+
         # While the theory still has clauses remaining
         while True:
             # Perform cleanup / fixup at regular intervals
@@ -260,7 +282,7 @@ class SATSolver:
                         # Backtrack until reaching a level with one of the conflict causing literals.
                         inconsistent_literals = [-lit for lit in res[1]]
                         while True:
-                            if len(self.levels) == 1:
+                            if len(self.levels) == assumption_level:
                                 # If theory-inconsistent literals were set right off the bat
                                 # at level 0, the formula is unsat.
                                 return
@@ -271,7 +293,7 @@ class SATSolver:
 
                     while self._current_level.flipped:
                         self._undo()
-                    if len(self.levels) == 1:
+                    if len(self.levels) == assumption_level:
                         return
                     flip_lit = -self._current_level.decision
                     self._undo()
@@ -298,8 +320,12 @@ class SATSolver:
                     self._undo()
 
                     # If we've unrolled all the way, the theory is unsat
-                    if 1 == len(self.levels):
+                    if assumption_level == len(self.levels):
                         return
+
+                # The literal to flip would be an assumption, not ours to flip.
+                if assumption_level == len(self.levels):
+                    return
 
                 # Detect and add a learned clause
                 self.add_learned_clause(self.compute_conflict())
@@ -321,9 +347,9 @@ class SATSolver:
     """
     A subset of the IPASIR standard for incremental SAT solving, using the
     names that CaDiCaL gives them in its C++ API. Only the parts needed to
-    inspect the root level before searching and to keep solving after new
-    clauses have been added are implemented so far; assumptions and
-    ``failed`` are not supported yet.
+    inspect the root level before searching, to keep solving after new
+    clauses have been added and to solve under assumptions are implemented so
+    far; ``failed`` is not supported yet.
 
     # https://github.com/arminbiere/cadical/blob/master/src/cadical.hpp
     """
@@ -387,11 +413,21 @@ class SATSolver:
                 "clauses have been added with add() or clause(), as "
                 "restarting the same search is not implemented yet.")
 
+        while len(self.levels) > 1:
+            self._undo()
+
+        assumed = bool(self._assumptions)
+
         self._models = self._find_model()
         if next(self._models, None) is None:
             self._status = IpasirStatus.UNSATISFIABLE
         else:
             self._status = IpasirStatus.SATISFIABLE
+
+        # Asking again without them is a different question, not a restart.
+        if assumed:
+            self._assumptions = []
+            self._models = None
 
         return self._status
 
@@ -409,6 +445,38 @@ class SATSolver:
         if -lit in self.var_settings:
             return -lit
         return 0
+
+    def assume(self, lit):
+        """Constrain the next call to ``solve()`` with *lit*, which it drops
+        again afterwards, letting one solver answer several questions.
+
+        TODO: ``failed()``, which reports the assumptions a search could not
+        satisfy, is not implemented yet.
+
+        Examples
+        ========
+
+        >>> from sympy.logic.algorithms.dpll2 import SATSolver, IpasirStatus
+        >>> l = SATSolver([{1, 2}, {-1, -2}], {1, 2}, set())
+        >>> l.assume(1)
+        >>> l.solve() == IpasirStatus.SATISFIABLE
+        True
+        >>> l.val(2)
+        -2
+
+        """
+        if lit == 0 or abs(lit) >= len(self.variable_set):
+            raise ValueError(f"{lit} is not a literal of one of the variables "
+                "the solver was created with.")
+
+        while len(self.levels) > 1:
+            self._undo()
+
+        self._models = None
+        if self._status == IpasirStatus.SATISFIABLE:
+            self._status = IpasirStatus.UNKNOWN
+
+        self._assumptions.append(lit)
 
     def add(self, lit):
         """Add *lit* to the clause being built, or add that clause to the

--- a/sympy/logic/tests/test_inference.py
+++ b/sympy/logic/tests/test_inference.py
@@ -218,6 +218,63 @@ def test_satsolver_solve_after_propagate():
     assert s.solve() == IpasirStatus.UNSATISFIABLE
 
 
+def test_satsolver_assume():
+    # The same solver answers both questions, one assumption at a time.
+    s = SATSolver([{1, 2}, {-1, -2}], {1, 2}, set())
+    s.assume(1)
+    assert s.solve() == IpasirStatus.SATISFIABLE
+    assert (s.val(1), s.val(2)) == (1, -2)
+    s.assume(-1)
+    assert s.solve() == IpasirStatus.SATISFIABLE
+    assert (s.val(1), s.val(2)) == (-1, 2)
+
+    # Assumptions constrain one search only, so dropping them makes the
+    # solver answer about the clauses on their own again.
+    s = SATSolver([{1, 2}], {1, 2}, set())
+    s.assume(-1)
+    s.assume(-2)
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
+    assert s.solve() == IpasirStatus.SATISFIABLE
+
+    # Assuming a literal the clauses contradict fails, and assuming one they
+    # imply changes nothing.
+    s = SATSolver([{1}, {-1, 2}], {1, 2}, set())
+    s.assume(-1)
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
+    s.assume(2)
+    assert s.solve() == IpasirStatus.SATISFIABLE
+    assert s.val(2) == 2
+
+    # Assumptions that contradict each other cannot be satisfied either.
+    s = SATSolver([{1, 2}], {1, 2}, set())
+    s.assume(1)
+    s.assume(-1)
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
+
+    # Selector variables, which is what assumptions are for: 3 guards the
+    # clause {1} and 4 guards {-1}, and assuming one activates it.
+    s = SATSolver([{1, -3}, {-1, -4}], {1, 2, 3, 4}, set())
+    s.assume(3)
+    assert s.solve() == IpasirStatus.SATISFIABLE
+    assert s.val(1) == 1
+    s.assume(4)
+    assert s.solve() == IpasirStatus.SATISFIABLE
+    assert s.val(1) == -1
+    s.assume(3)
+    s.assume(4)
+    assert s.solve() == IpasirStatus.UNSATISFIABLE
+
+    # Assumptions are not clauses, so the root level knows nothing of them.
+    s = SATSolver([{1, 2}], {1, 2}, set())
+    s.assume(1)
+    assert s.fixed(1) == 0
+    assert s.propagate() == IpasirStatus.UNKNOWN
+
+    # Only a literal of an existing variable can be assumed.
+    raises(ValueError, lambda: s.assume(0))
+    raises(ValueError, lambda: s.assume(9))
+
+
 def test_satsolver_interface_errors():
     # val() needs a model to read from.
     s = SATSolver([{1}, {-1, 2}], {1, 2}, set())


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes in part: #30314
Needed by #30265 
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Adds `assume(lit)` to the IPASIR interface of `SATSolver`. An assumption constrains the next `solve()` and is dropped afterwards, so one solver can answer several questions.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
The tests and documentation/comments were written down by Claude Code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
