### PR TITLE
Add manualintegrate rule for x*csc(a*x + b) using polylogs

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1386,6 +1386,7 @@ Richard Samuel <samuelrichard214@gmail.com>
 Rick Muller <rpmuller@gmail.com>
 Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
 Riley Britten <nrb1324@hotmail.com>
+RjyavardhanSingh <rajyavardhansing2003@gmail.com> Snail <114798341+RjyavardhanSingh@users.noreply.github.com>
 Rimi <rimibis@umich.edu>
 Rishabh Chordiya <rishabh.arceus@gmail.com> <96073601+rishabhc33@users.noreply.github.com>
 Rishabh Daal <rishabhdaal@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1386,7 +1386,6 @@ Richard Samuel <samuelrichard214@gmail.com>
 Rick Muller <rpmuller@gmail.com>
 Rikard Nordgren <rikard.nordgren@farmaci.uu.se>
 Riley Britten <nrb1324@hotmail.com>
-RjyavardhanSingh <rajyavardhansing2003@gmail.com> Snail <114798341+RjyavardhanSingh@users.noreply.github.com>
 Rimi <rimibis@umich.edu>
 Rishabh Chordiya <rishabh.arceus@gmail.com> <96073601+rishabhc33@users.noreply.github.com>
 Rishabh Daal <rishabhdaal@gmail.com>
@@ -1403,6 +1402,7 @@ Ritu Raj Singh <RituRajSingh878@gmail.com> Ritu Raj Singh <riturajsingh878@gmail
 Ritu Raj Singh <RituRajSingh878@gmail.com> RituRajSingh878 <RituRajSingh878@gmail.com>
 Riyan Dhiman <Riyandhiman14@gmail.com> Riyan <43529842+Ryand1234@users.noreply.github.com>
 Rizgar Mella <rizgar.mella@gmail.com> <RizgarMella rizgar.mella@gmail.com>
+RjyavardhanSingh <rajyavardhansing2003@gmail.com> Snail <114798341+RjyavardhanSingh@users.noreply.github.com>
 Rob Drynkin <rob.drynkin@gmail.com>
 Rob Zinkov <rob@zinkov.com>
 Robert <average.programmer@gmail.com>

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -36,7 +36,7 @@ from sympy.core.containers import Dict
 from sympy.core.function import Derivative
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
-from sympy.core.numbers import Integer, Number, E
+from sympy.core.numbers import Integer, Number, E, I
 from sympy.core.power import Pow
 from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import S
@@ -1018,6 +1018,28 @@ class PolylogRule(AtomicRule):
     def eval(self) -> Expr:
         return polylog(self.b + 1, self.a * self.variable)
 
+class PolylogTrigRule(AtomicRule):
+    """integrate(x*csc(a*x + b), x) using complex exponentials"""
+
+    __slots__ = ("a", "b")
+
+    a: Expr
+    b: Expr
+
+    def __init__(
+        self, integrand: Expr, variable: Symbol, a: Expr, b: Expr
+    ) -> None:
+        super().__init__(integrand, variable)
+        self.a = a
+        self.b = b
+
+    def eval(self) -> Expr:
+        a, b, x = self.a, self.b, self.variable
+        u = a*x + b
+        return (
+            I*(polylog(2, -exp(I*u)) - polylog(2, exp(I*u)))/a**2 +
+            x*(log(1 - exp(I*u)) - log(1 + exp(I*u)))/a
+        )
 
 class UpperGammaRule(AtomicRule):
 
@@ -1861,6 +1883,25 @@ def trig_cmplx_exp_rule(integral: IntegralInfo):
         steps = integral_steps(rewritten, symbol)
         return RewriteRule(integrand, symbol, rewritten, steps)
 
+
+def trig_polylog_rule(integral: IntegralInfo):
+    """Integrate x*csc(a*x + b) using complex exponentials and polylogs."""
+    original_integrand, symbol = integral
+    integrand = _rewrite_to_reciprocal(original_integrand, sin, csc)
+
+    m = Wild('m', exclude=[symbol], properties=[lambda m: not m.is_zero])
+    n = Wild('n', exclude=[symbol])
+    a = Wild('a', exclude=[symbol, 0])
+    b = Wild('b', exclude=[symbol])
+
+    match = integrand.match((m*symbol + n)*csc(a*symbol + b))
+    if not match:
+        return
+
+    step: Rule = PolylogTrigRule(integrand, symbol, match[a], match[b])
+    if integrand != original_integrand:
+        return RewriteRule(original_integrand, symbol, integrand, step)
+    return step
 
 def quadratic_denom_rule(integral):
     integrand, symbol = integral
@@ -3166,6 +3207,7 @@ def integral_steps(integrand, symbol, **options):
             Add: add_rule,
             Mul: do_one(null_safe(mul_rule),
                         null_safe(trig_powers_products_rule),
+                        null_safe(trig_polylog_rule),
                         null_safe(heaviside_rule), null_safe(quadratic_denom_rule),
                         null_safe(sqrt_quadratic_rule),
                         null_safe(sqrt_fractional_linear_rule),

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -120,6 +120,19 @@ def test_manualintegrate_trigonometry():
     assert (F.diff(x) - f).rewrite(exp).simplify() == 0
 
 
+def test_manualintegrate_trig_polylog():
+    # integrate(x*csc(x), x) via complex exponentials and polylogs
+    F = I*(polylog(2, -exp(I*x)) - polylog(2, exp(I*x))) + \
+        x*(log(1 - exp(I*x)) - log(1 + exp(I*x)))
+    assert manualintegrate(x/sin(x), x) == F
+    assert manualintegrate(x*csc(x), x) == F
+    # equals() returns None for these expressions, so verify symbolically
+    # using polylog(1, z) = -log(1 - z)
+    d = manualintegrate(x*csc(a*x + b), x).diff(x) - x*csc(a*x + b)
+    assert d.rewrite(exp).replace(
+        polylog, lambda s, z: -log(1 - z)).simplify() == 0
+
+
 @slow
 def test_manualintegrate_trigpowers():
     assert manualintegrate(sin(x)**2 * cos(x), x) == sin(x)**3 / 3


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30309

#### Brief description of what is fixed or changed

manualintegrate could not evaluate integrate(x/sin(x), x): the integrand fell
through every rule, so an unevaluated Integral was returned. Integration by
parts also fails because dv = sin(x)**(-1) is not recognized as integrable.

This adds PolylogTrigRule, an AtomicRule for integrals of x*csc(a*x + b),
together with a finder trig_polylog_rule that normalizes sin(arg)**(-1) to
csc(arg) using _rewrite_to_reciprocal and matches linear*csc(linear). The rule
is registered in the Mul branch of integral_steps and returns

    I*(polylog(2,-exp(I*u)) - polylog(2,exp(I*u)))/a**2
        + x*(log(1-exp(I*u)) - log(1+exp(I*u)))/a,   u = a*x + b

A test is added in test_manual.py covering x/sin(x), x*csc(x) and the general
x*csc(a*x + b) case. Plain csc(x) keeps its previous result.

#### Other comments

.equals() returns None for these complex log/polylog expressions, so the test
verifies the derivative symbolically via polylog(1, z) = -log(1 - z).

#### AI Generation Disclosure

This PR was developed with assistance from an AI coding agent (opencode,
CLI-based). AI assisted with analyzing manualintegrate.py, deriving the
antiderivative formula, drafting PolylogTrigRule, trig_polylog_rule, the
dispatcher registration, and the test in test_manual.py. I applied, reviewed
and tested the changes myself (bin/test, doctest, numerical verification) and
typed part of the code manually.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* integrals
  * Added a manualintegrate rule for integrals of the form x*csc(a*x + b),
    so integrate(x/sin(x), x) now evaluates using polylogs.

<!-- END RELEASE NOTES -->