### PR TITLE
fix(polys): correct the sign of resultant when deg(f) < deg(g)

### DIFF
--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -346,18 +346,27 @@ def dup_inner_subresultants(f: dup[Er], g: dup[Er], K: Domain[Er]):
            ACM Transaction of Mathematical Software 4 (1978) 237-249
 
     """
+    R, S, _ = _dup_inner_subresultants(f, g, K)
+    return R, S
+
+
+def _dup_inner_subresultants(f, g, K):
     n = dup_degree(f)
     m = dup_degree(g)
 
-    if n < m:
+    swapped = n < m
+
+    if swapped:
         f, g = g, f
         n, m = m, n
 
     if not f:
-        return [], []
+        return [], [], False
 
     if not g:
-        return [f], [K.one]
+        return [f], [K.one], False
+
+    negate = swapped and (n*m) % 2
 
     R = [f, g]
     d = n - m
@@ -395,7 +404,7 @@ def dup_inner_subresultants(f: dup[Er], g: dup[Er], K: Domain[Er]):
 
         S.append(-c)
 
-    return R, S
+    return R, S, negate
 
 
 def dup_subresultants(f, g, K):
@@ -432,12 +441,17 @@ def dup_prs_resultant(f, g, K):
     if not f or not g:
         return (K.zero, [])
 
-    R, S = dup_inner_subresultants(f, g, K)
+    R, S, negate = _dup_inner_subresultants(f, g, K)
 
     if dup_degree(R[-1]) > 0:
         return (K.zero, R)
 
-    return S[-1], R
+    res = S[-1]
+
+    if negate:
+        res = -res
+
+    return res, R
 
 
 def dup_resultant(f, g, K, includePRS=False):
@@ -482,22 +496,31 @@ def dmp_inner_subresultants(f, g, u, K):
     True
 
     """
+    R, S, _ = _dmp_inner_subresultants(f, g, u, K)
+    return R, S
+
+
+def _dmp_inner_subresultants(f, g, u, K):
     if not u:
-        return dup_inner_subresultants(f, g, K)
+        return _dup_inner_subresultants(f, g, K)
 
     n = dmp_degree(f, u)
     m = dmp_degree(g, u)
 
-    if n < m:
+    swapped = n < m
+
+    if swapped:
         f, g = g, f
         n, m = m, n
 
     if dmp_zero_p(f, u):
-        return [], []
+        return [], [], False
 
     v = u - 1
     if dmp_zero_p(g, u):
-        return [f], [dmp_ground(K.one, v, K)]
+        return [f], [dmp_ground(K.one, v, K)], False
+
+    negate = swapped and (n*m) % 2
 
     R = [f, g]
     d = n - m
@@ -536,7 +559,7 @@ def dmp_inner_subresultants(f, g, u, K):
 
         S.append(dmp_neg(c, v, K))
 
-    return R, S
+    return R, S, negate
 
 
 def dmp_subresultants(f, g, u, K):
@@ -594,12 +617,17 @@ def dmp_prs_resultant(f, g, u, K):
     if dmp_zero_p(f, u) or dmp_zero_p(g, u):
         return (dmp_zero(u - 1, K), [])
 
-    R, S = dmp_inner_subresultants(f, g, u, K)
+    R, S, negate = _dmp_inner_subresultants(f, g, u, K)
 
     if dmp_degree(R[-1], u) > 0:
         return (dmp_zero(u - 1, K), R)
 
-    return S[-1], R
+    res = S[-1]
+
+    if negate:
+        res = dmp_neg(res, u - 1, K)
+
+    return res, R
 
 
 def dmp_zz_modular_resultant(f, g, p, u, K):

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -122,6 +122,16 @@ def test_dup_subresultants():
 
     assert R.dup_resultant(f, g) == 0
 
+    # Res(f, g) == (-1)**(deg(f)*deg(g))*Res(g, f), see #10666
+    assert R.dup_resultant(x + 2, x**3) == -8
+    assert R.dup_resultant(x**3, x + 2) == 8
+
+    f = 3*x + 3
+    g = 5*x**3 - 5*x**2 + 4*x + 5
+
+    assert R.dup_resultant(f, g) == -243
+    assert R.dup_resultant(g, f) == 243
+
     f = 3*x**3 - x
     g = 5*x**2 + 1
 
@@ -198,6 +208,24 @@ def test_dmp_subresultants():
     assert R.dmp_prs_resultant(f, g)[0] == r
     assert R.dmp_zz_collins_resultant(f, g) == r
     assert R.dmp_qq_collins_resultant(f, g) == r
+
+    # Res(f, g) == (-1)**(deg(f)*deg(g))*Res(g, f), see #10666 (degrees
+    # are taken with respect to the generator being eliminated)
+    f = x + y
+    g = x**3 + y
+
+    ye = y.as_expr()
+
+    assert R.dmp_resultant(f, g).as_expr() == ye - ye**3
+    assert R.dmp_resultant(g, f).as_expr() == ye**3 - ye
+    assert R.dmp_prs_resultant(f, g)[0].as_expr() == ye - ye**3
+    assert R.dmp_prs_resultant(g, f)[0].as_expr() == ye**3 - ye
+    assert R.dmp_zz_modular_resultant(f, g, 5).as_expr() == ye - ye**3
+    assert R.dmp_zz_modular_resultant(g, f, 5).as_expr() == ye**3 - ye
+    assert R.dmp_zz_collins_resultant(f, g).as_expr() == ye - ye**3
+    assert R.dmp_zz_collins_resultant(g, f).as_expr() == ye**3 - ye
+    assert R.dmp_qq_collins_resultant(f, g).as_expr() == ye - ye**3
+    assert R.dmp_qq_collins_resultant(g, f).as_expr() == ye**3 - ye
 
     R, x, y, z, u, v = ring("x,y,z,u,v", ZZ)
 

--- a/sympy/polys/tests/test_polytools.py
+++ b/sympy/polys/tests/test_polytools.py
@@ -2155,6 +2155,22 @@ def test_resultant():
     assert resultant(f, g, polys=True) == H
     assert resultant(F, G, polys=False) == h
 
+    f, g, h = x + a, x**3, -a**3
+
+    assert resultant(f, g, x) == h
+    assert resultant(g, f, x) == a**3
+    assert resultant(x + a, x**5, x) == -a**5
+    assert Poly(x + a, x).resultant(Poly(x**3, x)) == -a**3
+    assert Poly(x + 2, x).rep.resultant(Poly(x**3, x).rep) == -8
+
+    f, g = 2*x - 4, 3*x**3 + 3*x**2 + 4*x + 4
+
+    assert resultant(f, g, x) == 384
+    assert resultant(g, f, x) == -384
+
+    assert resultant(x*y + 3, x*y**3 + 5, y) == 5*x**3 - 27*x
+    assert resultant(x*y**3 + 5, x*y + 3, y) == 27*x - 5*x**3
+
     raises(ComputationFailed, lambda: resultant(4, 2))
 
 

--- a/sympy/polys/tests/test_rings.py
+++ b/sympy/polys/tests/test_rings.py
@@ -2001,6 +2001,8 @@ def test_PolyElement_resultant():
     f, g, h = x**2 - 2*x + 1, x**2 - 1, 0
 
     assert f.resultant(g) == h
+    assert (x + 2).resultant(x**3) == -8
+    assert (x**3).resultant(x + 2) == 8
 
 
 def test_PolyElement_discriminant():


### PR DESCRIPTION

• #### References to other Issues or PRs

  Fixes #10666.
  Closes #25406.

  #### Brief description of what is fixed or changed

  Fixes the sign returned by resultant when the lower-degree polynomial is given first and both polynomial degrees are odd.

  The subresultant PRS orders its inputs by degree. When this reverses the arguments, the resultant must be corrected using

  Res(f, g) = (-1)**(deg(f)*deg(g)) * Res(g, f).

  For example:

  resultant(x + 2, x**3, x)

  This previously returned 8; it now returns -8.

  The PRS cores now propagate the required sign correction to the resultant wrappers without repeating degree or PRS computation. Their existing (R, S) return contract is unchanged. Shared PRS base cases carry the fix to the top-level, Poly, PolyElement, DMP, modular, and Collins resultant paths.

  #### Other comments

  subresultants() continues to return the sequence for the degree-ordered pair. Zero-resultant and common-factor behavior is unchanged.

  discriminant() is unaffected because it passes the degree-n polynomial before its degree-n - 1 derivative, so the PRS does not reorder those inputs.

  Regression tests cover both the argument orders for odd-degree univariate and the multivariate polynomials. On the      affected base revision, the new assertions fail with the opposite sign.

  Validation on the final rebased tree:

  - python -m pytest sympy/polys -q — 2520 passed, 14 deselected, 6 xfailed
  - bin/doctest sympy/polys/euclidtools.py — 45 passed

  #### AI Generation Disclosure

  Codex materially assisted with the private-core design, implementation, mathematical verification, regression tests,    and code review.

  The materially assisted implementation is located in:

  - sympy/polys/euclidtools.py: lines 349–369, 407, 444–454, 499–523, 562, and 620–630

  The materially assisted regression tests are located in:

  - sympy/polys/tests/test_euclidtools.py: lines 125–133 and 212–228
  - sympy/polys/tests/test_polytools.py: lines 2158–2172
  - sympy/polys/tests/test_rings.py: lines 2004–2005

  #### Release Notes
  <!-- BEGIN RELEASE NOTES -->

  - polys
      - Fixed resultant returning the wrong sign when both polynomial degrees were odd and the lower-degree argument was supplied first.
  <!-- END RELEASE NOTES -->
