### PR TITLE
fix(polys): terminate subresultants_pg sequences on zero remainder

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1861,6 +1861,7 @@ mao8 <thisisma08@gmail.com>
 mohajain <mohajain99@gmail.com> mohajain <45903778+mohajain@users.noreply.github.com>
 mohammedouahman <simofun85@gmail.com>
 mohit <39158356+mohitacecode@users.noreply.github.com> mohit <42018918+mohitshah3111999@users.noreply.github.com>
+morluto <76467478+morluto@users.noreply.github.com>
 naelsondouglas <naelson17@gmail.com>
 noam simcha finkelstein <noam.finkelstein@protonmail.com>
 numbermaniac <5206120+numbermaniac@users.noreply.github.com>

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -1433,53 +1433,53 @@ def modified_subresultants_pg(p, q, x):
     a2 = - rem(a0, a1, domain=QQ)             # first remainder
 
     if a2 == 0:                               # q | p; sequence terminates
-        d2 = S.Zero                           # with the pair (p, q)
+        return subres_l                       # with the pair (p, q)
+
+    rho2 =  LC(a2, x)                         # leading coeff of a2
+    d2 =  degree(a2, x)                       # actual degree of a2
+    deg_diff_new = exp_deg - d2               # expected - actual degree
+    del1 = d1 - d2                            # degree difference
+
+    # mul_fac is the factor by which a2 is multiplied to
+    # get integer coefficients
+    mul_fac_old = rho1**(del0 + del1 - deg_diff_new)
+
+    # update Pell-Gordon variables
+    p_list.append(1 + deg_diff_new)              # deg_diff_new is 0 for complete seq
+
+    # apply Pell-Gordon formula (7) in second reference
+    num = 1                                     # numerator of fraction
+    for u in u_list:
+        num *= (-1)**u
+    num = num * (-1)**v
+
+    # denominator depends on complete / incomplete seq
+    if deg_diff_new == 0:                        # complete seq
+        den = 1
+        for k in range(len(rho_list)):
+            den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+        den = den * rho_list_minus_1
+    else:                                       # incomplete seq
+        den = 1
+        for k in range(len(rho_list)-1):
+            den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+        den = den * rho_list_minus_1
+        expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
+        den = den * rho_list[len(rho_list) - 1]**expo
+
+    # the sign of the determinant depends on sg(num / den)
+    if  sign(num / den) > 0:
+        subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
     else:
-        rho2 =  LC(a2, x)                     # leading coeff of a2
-        d2 =  degree(a2, x)                   # actual degree of a2
-        deg_diff_new = exp_deg - d2           # expected - actual degree
-        del1 = d1 - d2                        # degree difference
+        subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
 
-        # mul_fac is the factor by which a2 is multiplied to
-        # get integer coefficients
-        mul_fac_old = rho1**(del0 + del1 - deg_diff_new)
-
-        # update Pell-Gordon variables
-        p_list.append(1 + deg_diff_new)              # deg_diff_new is 0 for complete seq
-
-        # apply Pell-Gordon formula (7) in second reference
-        num = 1                                     # numerator of fraction
-        for u in u_list:
-            num *= (-1)**u
-        num = num * (-1)**v
-
-        # denominator depends on complete / incomplete seq
-        if deg_diff_new == 0:                        # complete seq
-            den = 1
-            for k in range(len(rho_list)):
-                den *= rho_list[k]**(p_list[k] + p_list[k + 1])
-            den = den * rho_list_minus_1
-        else:                                       # incomplete seq
-            den = 1
-            for k in range(len(rho_list)-1):
-                den *= rho_list[k]**(p_list[k] + p_list[k + 1])
-            den = den * rho_list_minus_1
-            expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
-            den = den * rho_list[len(rho_list) - 1]**expo
-
-        # the sign of the determinant depends on sg(num / den)
-        if  sign(num / den) > 0:
-            subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
-        else:
-            subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
-
-        # update Pell-Gordon variables
-        k = var('k')
-        rho_list.append( sign(rho2))
-        u =  summation(k, (k, 1, p_list[len(p_list) - 1]))
-        u_list.append(u)
-        v = sum(p_list)
-        deg_diff_old=deg_diff_new
+    # update Pell-Gordon variables
+    k = var('k')
+    rho_list.append( sign(rho2))
+    u =  summation(k, (k, 1, p_list[len(p_list) - 1]))
+    u_list.append(u)
+    v = sum(p_list)
+    deg_diff_old=deg_diff_new
 
     # main loop
     while d2 > 0:

--- a/sympy/polys/subresultants_qq_zz.py
+++ b/sympy/polys/subresultants_qq_zz.py
@@ -1431,51 +1431,55 @@ def modified_subresultants_pg(p, q, x):
     # first remainder
     exp_deg = d1 - 1                          # expected degree of a2
     a2 = - rem(a0, a1, domain=QQ)             # first remainder
-    rho2 =  LC(a2, x)                         # leading coeff of a2
-    d2 =  degree(a2, x)                       # actual degree of a2
-    deg_diff_new = exp_deg - d2               # expected - actual degree
-    del1 = d1 - d2                            # degree difference
 
-    # mul_fac is the factor by which a2 is multiplied to
-    # get integer coefficients
-    mul_fac_old = rho1**(del0 + del1 - deg_diff_new)
-
-    # update Pell-Gordon variables
-    p_list.append(1 + deg_diff_new)              # deg_diff_new is 0 for complete seq
-
-    # apply Pell-Gordon formula (7) in second reference
-    num = 1                                     # numerator of fraction
-    for u in u_list:
-        num *= (-1)**u
-    num = num * (-1)**v
-
-    # denominator depends on complete / incomplete seq
-    if deg_diff_new == 0:                        # complete seq
-        den = 1
-        for k in range(len(rho_list)):
-            den *= rho_list[k]**(p_list[k] + p_list[k + 1])
-        den = den * rho_list_minus_1
-    else:                                       # incomplete seq
-        den = 1
-        for k in range(len(rho_list)-1):
-            den *= rho_list[k]**(p_list[k] + p_list[k + 1])
-        den = den * rho_list_minus_1
-        expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
-        den = den * rho_list[len(rho_list) - 1]**expo
-
-    # the sign of the determinant depends on sg(num / den)
-    if  sign(num / den) > 0:
-        subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
+    if a2 == 0:                               # q | p; sequence terminates
+        d2 = S.Zero                           # with the pair (p, q)
     else:
-        subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
+        rho2 =  LC(a2, x)                     # leading coeff of a2
+        d2 =  degree(a2, x)                   # actual degree of a2
+        deg_diff_new = exp_deg - d2           # expected - actual degree
+        del1 = d1 - d2                        # degree difference
 
-    # update Pell-Gordon variables
-    k = var('k')
-    rho_list.append( sign(rho2))
-    u =  summation(k, (k, 1, p_list[len(p_list) - 1]))
-    u_list.append(u)
-    v = sum(p_list)
-    deg_diff_old=deg_diff_new
+        # mul_fac is the factor by which a2 is multiplied to
+        # get integer coefficients
+        mul_fac_old = rho1**(del0 + del1 - deg_diff_new)
+
+        # update Pell-Gordon variables
+        p_list.append(1 + deg_diff_new)              # deg_diff_new is 0 for complete seq
+
+        # apply Pell-Gordon formula (7) in second reference
+        num = 1                                     # numerator of fraction
+        for u in u_list:
+            num *= (-1)**u
+        num = num * (-1)**v
+
+        # denominator depends on complete / incomplete seq
+        if deg_diff_new == 0:                        # complete seq
+            den = 1
+            for k in range(len(rho_list)):
+                den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+            den = den * rho_list_minus_1
+        else:                                       # incomplete seq
+            den = 1
+            for k in range(len(rho_list)-1):
+                den *= rho_list[k]**(p_list[k] + p_list[k + 1])
+            den = den * rho_list_minus_1
+            expo = (p_list[len(rho_list) - 1] + p_list[len(rho_list)] - deg_diff_new)
+            den = den * rho_list[len(rho_list) - 1]**expo
+
+        # the sign of the determinant depends on sg(num / den)
+        if  sign(num / den) > 0:
+            subres_l.append( simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
+        else:
+            subres_l.append(- simplify(rho_1**degdif*a2* Abs(mul_fac_old) ) )
+
+        # update Pell-Gordon variables
+        k = var('k')
+        rho_list.append( sign(rho2))
+        u =  summation(k, (k, 1, p_list[len(p_list) - 1]))
+        u_list.append(u)
+        v = sum(p_list)
+        deg_diff_old=deg_diff_new
 
     # main loop
     while d2 > 0:
@@ -1483,6 +1487,10 @@ def modified_subresultants_pg(p, q, x):
         del0 = del1                          # update degree difference
         exp_deg = d1 - 1                     # new expected degree
         a2 = - rem(a0, a1, domain=QQ)        # new remainder
+
+        if a2 == 0:                          # exact division; sequence complete
+            break
+
         rho3 =  LC(a2, x)                    # leading coeff of a2
         d2 =  degree(a2, x)                  # actual degree of a2
         deg_diff_new = exp_deg - d2          # expected - actual degree

--- a/sympy/polys/tests/test_subresultants_qq_zz.py
+++ b/sympy/polys/tests/test_subresultants_qq_zz.py
@@ -346,3 +346,30 @@ def test_subresultants_vv_2():
     p = x**3 - 7*x + 7
     q = 3*x**2 - 7
     assert subresultants_vv_2(p, q, x) == euclid_amv(p, q, x)
+
+
+def test_subresultants_pg_common_factor():
+    # a zero pseudo-remainder must terminate the sequence instead of
+    # producing NaN in the Pell-Gordon variables
+    x = Symbol("x")
+
+    p = 4*x**3 + 3*x**2 + x + 2
+    q = x + 1
+
+    assert subresultants_pg(p, q, x) == [p, q]
+    assert modified_subresultants_pg(p, q, x) == [p, q]
+
+    p = 4*x**3 + 3*x**2 + x + 2
+    q = 2*x + 2
+
+    assert subresultants_pg(p, q, x) == subresultants(p, q, x)
+    assert modified_subresultants_pg(p, q, x) == subresultants(p, q, x)
+
+    p = x**3 - x
+    q = x**2 - x
+
+    r = [p, q]
+
+    assert subresultants_pg(p, q, x) == r
+    assert modified_subresultants_pg(p, q, x) == r
+    assert subresultants_pg(x**4 - 1, x**2 - 1, x) == [x**4 - 1, x**2 - 1]


### PR DESCRIPTION
Fixes #30330.

## Bug

`subresultants_pg` and `modified_subresultants_pg` crash whenever a pseudo-remainder is identically zero (`q | p`, or exact division later in the sequence):

```python
>>> from sympy import symbols
>>> from sympy.polys.subresultants_qq_zz import subresultants_pg, modified_subresultants_pg
>>> x = symbols('x')
>>> p = 4*x**3 + 3*x**2 + x + 2
>>> q = x + 1                      # p(-1) == 0, so the first remainder is 0
>>> subresultants_pg(p, q, x)
TypeError: Invalid NaN comparison
>>> modified_subresultants_pg(p, q, x)
TypeError: Invalid NaN comparison
```

Also later in the sequence:

| expression | master | this PR |
|---|---|---|
| `subresultants_pg(x**4 - 1, x**2 - 1, x)` | TypeError | `[x**4 - 1, x**2 - 1]` |
| `subresultants_pg(4*x**3 + 3*x**2 + x + 2, 2*x + 2, x)` | TypeError | matches `subresultants()` |

## Root cause (formal chain)

1. `a2 = -rem(p, q) = 0`
2. `d2 = degree(0, x) = -oo` ⟹ `deg_diff_new = exp_deg - d2 = oo`
3. `deg_diff_new == 0` is False → incomplete-sequence denominator gets exponent `oo`; every `rho_list` entry is ±1 and `(-1)**oo = nan` in SymPy → `den = nan`
4. `sign(num/den) = sign(nan)`, and `StrictGreaterThan(S.NaN, 0)` raises `TypeError: Invalid NaN comparison`

The existing trailing cleanup `if subres_l[m-1] == nan ...` was intended for this but can never fire since `Expr.__eq__(nan)` is always False.

## Fix

Skip the Pell-Gordon variable updates and terminate as soon as a remainder is zero — both at the first-remainder step and in the main loop. This makes the output convention identical to `sympy.polys.polytools.subresultants`:

```python
>>> subresultants_pg(4*x**3 + 3*x**2 + x + 2, x + 1, x)
[4*x**3 + 3*x**2 + x + 2, x + 1]
```

## Validation

- new regression tests (5 common-factor pairs, first-step and main-loop termination)
- randomized fuzz: 60 pairs with guaranteed common factors — `subresultants_pg` ≡ `polytools.subresultants` on all, 0 crashes
- full `sympy/polys` suite: 2364 passed

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a crash (``TypeError: Invalid NaN comparison``) in ``subresultants_pg`` and ``modified_subresultants_pg`` for polynomials having a common factor.
<!-- END RELEASE NOTES -->
