### PR TITLE
Fix lambdify array broadcasting for constant expressions (#5642)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -849,6 +849,7 @@ Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
 Jay Salvi <jaysalvi11@gmail.com> Jay Salvi <jaysalvi11@Jays-MacBook-Air.local>
+Jay Salvi <jaysalvi11@gmail.com> Jay846 <154716374+Jay846@users.noreply.github.com>
 Jay Vijan <jvijan@umich.edu> Jay Sun Vijan <145924415+jvijan@users.noreply.github.com>
 Jayesh Lahori <jlahori92@gmail.com>
 Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>

--- a/.mailmap
+++ b/.mailmap
@@ -848,6 +848,7 @@ Jatin Gaur <jatingaurchess@gmail.com> <jatin22101@iiitnr.edu.in>
 Jatin Yadav <jatinyadav25@gmail.com>
 Javed Nissar <javednissar@gmail.com>
 Jay Patankar <patankarjays@gmail.com> Jay-Patankar <107458263+Jay-Patankar@users.noreply.github.com>
+Jay Salvi <jaysalvi11@gmail.com> Jay Salvi <jaysalvi11@Jays-MacBook-Air.local>
 Jay Vijan <jvijan@umich.edu> Jay Sun Vijan <145924415+jvijan@users.noreply.github.com>
 Jayesh Lahori <jlahori92@gmail.com>
 Jayjayyy <vfhsln8s3l4b87t4c3@byom.de>

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -204,6 +204,84 @@ def _import(module, reload=False):
     if 'Abs' not in namespace:
         namespace['Abs'] = abs
 
+def _sympy_broadcast(result, *args):
+    """Broadcasts `result` to the shape of `args` if any argument is an array/tensor."""
+    if not args:
+        return result
+
+    def flatten_args(a):
+        flat = []
+        for item in a:
+            if isinstance(item, (list, tuple)):
+                flat.extend(flatten_args(item))
+            else:
+                flat.append(item)
+        return flat
+
+    flat_vals = flatten_args(args)
+
+    has_array = False
+    for val in flat_vals:
+        if hasattr(val, 'shape') and getattr(val, 'shape', None) is not None:
+            has_array = True
+            break
+
+    if not has_array:
+        return result
+
+    # Check for PyTorch tensor
+    for val in flat_vals:
+        if type(val).__name__ == 'Tensor' and type(val).__module__.startswith('torch'):
+            try:
+                import torch
+                res_tensor = torch.as_tensor(result) if not torch.is_tensor(result) else result
+                tensor_args = [torch.as_tensor(a) for a in flat_vals]
+                return torch.broadcast_tensors(res_tensor, *tensor_args)[0]
+            except (ValueError, RuntimeError):
+                raise
+            except Exception:
+                pass
+
+    # Check for TensorFlow tensor
+    for val in flat_vals:
+        if 'tensorflow' in type(val).__module__:
+            try:
+                import tensorflow as tf
+                res_tensor = tf.convert_to_tensor(result)
+                try:
+                    import tensorflow.experimental.numpy as tnp
+                    return tnp.broadcast_arrays(res_tensor, *[tf.convert_to_tensor(a) for a in flat_vals])[0]
+                except (ValueError, RuntimeError):
+                    raise
+                except Exception:
+                    pass
+            except (ValueError, RuntimeError):
+                raise
+            except Exception:
+                pass
+
+    # Check for JAX array
+    for val in flat_vals:
+        if 'jax' in type(val).__module__:
+            try:
+                import jax.numpy as jnp
+                return jnp.broadcast_arrays(result, *flat_vals)[0]
+            except (ValueError, RuntimeError):
+                raise
+            except Exception:
+                pass
+
+    # Default NumPy/SciPy/JAX
+    try:
+        import numpy as np
+        return np.broadcast_arrays(result, *flat_vals)[0]
+    except (ValueError, RuntimeError):
+        raise
+    except Exception:
+        pass
+
+    return result
+
 # Used for dynamically generated filenames that are inserted into the
 # linecache.
 _lambdify_generated_counter = 1
@@ -959,7 +1037,7 @@ or tuple for the function arguments.
                 imp_mod_lines.append(ln)
 
     # Provide lambda expression with builtins, and compatible implementation of range
-    namespace.update({'builtins':builtins, 'range':range})
+    namespace.update({'builtins':builtins, 'range':range, '_sympy_broadcast': _sympy_broadcast})
 
     funclocals = {}
     global _lambdify_generated_counter
@@ -1247,7 +1325,30 @@ class _EvaluatorPrinter:
 
         if '\n' in str_expr:
             str_expr = '({})'.format(str_expr)
-        funcbody.append('return {}'.format(str_expr))
+
+        from sympy.core.symbol import Symbol
+        from sympy.utilities.iterables import flatten
+
+        def get_free_symbols(e):
+            if hasattr(e, 'free_symbols'):
+                return e.free_symbols
+            if iterable(e):
+                syms = set()
+                for item in e:
+                    syms.update(get_free_symbols(item))
+                return syms
+            return set()
+
+        flat_args = list(flatten(args))
+        input_symbols = set(s for s in flat_args if isinstance(s, Symbol))
+        free_syms = get_free_symbols(expr)
+
+        needs_broadcasting = bool(input_symbols and not input_symbols.issubset(free_syms))
+
+        if needs_broadcasting:
+            funcbody.append('return _sympy_broadcast({}, {})'.format(str_expr, ', '.join(funcargs)))
+        else:
+            funcbody.append('return {}'.format(str_expr))
 
         funclines = [funcsig]
         funclines.extend(['    ' + line for line in funcbody])

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -235,7 +235,7 @@ def _sympy_broadcast(result, *args):
         if (val_type.__name__ == 'Tensor' and
                 val_type.__module__.startswith('torch')):
             try:
-                import torch
+                import torch  # type: ignore
                 res_tensor = (
                     torch.as_tensor(result)
                     if not torch.is_tensor(result)
@@ -252,10 +252,10 @@ def _sympy_broadcast(result, *args):
     for val in flat_vals:
         if 'tensorflow' in type(val).__module__:
             try:
-                import tensorflow as tf
+                import tensorflow as tf  # type: ignore
                 res_tensor = tf.convert_to_tensor(result)
                 try:
-                    import tensorflow.experimental.numpy as tnp
+                    import tensorflow.experimental.numpy as tnp  # type: ignore
                     tf_args = [tf.convert_to_tensor(a) for a in flat_vals]
                     return tnp.broadcast_arrays(res_tensor, *tf_args)[0]
                 except (ValueError, RuntimeError):
@@ -271,7 +271,7 @@ def _sympy_broadcast(result, *args):
     for val in flat_vals:
         if 'jax' in type(val).__module__:
             try:
-                import jax.numpy as jnp
+                import jax.numpy as jnp  # type: ignore
                 return jnp.broadcast_arrays(result, *flat_vals)[0]
             except (ValueError, RuntimeError):
                 raise

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -1348,10 +1348,10 @@ class _EvaluatorPrinter:
 
         flat_args = list(flatten(args))
         input_symbols = {s for s in flat_args if isinstance(s, Symbol)}
-        free_syms = get_free_symbols(expr)
+        free_syms = get_free_symbols(expr) & input_symbols
 
         needs_broadcasting = bool(
-            input_symbols and not input_symbols.issubset(free_syms)
+            input_symbols and not free_syms and not iterable(expr)
         )
 
         if needs_broadcasting:

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -231,15 +231,21 @@ def _sympy_broadcast(result, *args):
 
     # Check for PyTorch tensor
     for val in flat_vals:
-        if type(val).__name__ == 'Tensor' and type(val).__module__.startswith('torch'):
+        val_type = type(val)
+        if (val_type.__name__ == 'Tensor' and
+                val_type.__module__.startswith('torch')):
             try:
                 import torch
-                res_tensor = torch.as_tensor(result) if not torch.is_tensor(result) else result
+                res_tensor = (
+                    torch.as_tensor(result)
+                    if not torch.is_tensor(result)
+                    else result
+                )
                 tensor_args = [torch.as_tensor(a) for a in flat_vals]
                 return torch.broadcast_tensors(res_tensor, *tensor_args)[0]
             except (ValueError, RuntimeError):
                 raise
-            except Exception:
+            except (ImportError, AttributeError, TypeError):
                 pass
 
     # Check for TensorFlow tensor
@@ -250,14 +256,15 @@ def _sympy_broadcast(result, *args):
                 res_tensor = tf.convert_to_tensor(result)
                 try:
                     import tensorflow.experimental.numpy as tnp
-                    return tnp.broadcast_arrays(res_tensor, *[tf.convert_to_tensor(a) for a in flat_vals])[0]
+                    tf_args = [tf.convert_to_tensor(a) for a in flat_vals]
+                    return tnp.broadcast_arrays(res_tensor, *tf_args)[0]
                 except (ValueError, RuntimeError):
                     raise
-                except Exception:
+                except (ImportError, AttributeError, TypeError):
                     pass
             except (ValueError, RuntimeError):
                 raise
-            except Exception:
+            except (ImportError, AttributeError, TypeError):
                 pass
 
     # Check for JAX array
@@ -268,7 +275,7 @@ def _sympy_broadcast(result, *args):
                 return jnp.broadcast_arrays(result, *flat_vals)[0]
             except (ValueError, RuntimeError):
                 raise
-            except Exception:
+            except (ImportError, AttributeError, TypeError):
                 pass
 
     # Default NumPy/SciPy/JAX
@@ -277,7 +284,7 @@ def _sympy_broadcast(result, *args):
         return np.broadcast_arrays(result, *flat_vals)[0]
     except (ValueError, RuntimeError):
         raise
-    except Exception:
+    except (ImportError, AttributeError, TypeError):
         pass
 
     return result
@@ -1340,13 +1347,19 @@ class _EvaluatorPrinter:
             return set()
 
         flat_args = list(flatten(args))
-        input_symbols = set(s for s in flat_args if isinstance(s, Symbol))
+        input_symbols = {s for s in flat_args if isinstance(s, Symbol)}
         free_syms = get_free_symbols(expr)
 
-        needs_broadcasting = bool(input_symbols and not input_symbols.issubset(free_syms))
+        needs_broadcasting = bool(
+            input_symbols and not input_symbols.issubset(free_syms)
+        )
 
         if needs_broadcasting:
-            funcbody.append('return _sympy_broadcast({}, {})'.format(str_expr, ', '.join(funcargs)))
+            funcbody.append(
+                'return _sympy_broadcast({}, {})'.format(
+                    str_expr, ', '.join(funcargs)
+                )
+            )
         else:
             funcbody.append('return {}'.format(str_expr))
 

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2352,4 +2352,3 @@ def test_lambdify_constant_broadcasting():
     M_val, F_val = f2(1.0, 2.0)
     assert numpy.array_equal(M_val, numpy.array([[1, 2], [3, 4]]))
     assert numpy.array_equal(F_val, numpy.array([[1.0], [2.0]]))
-

--- a/sympy/utilities/tests/test_lambdify.py
+++ b/sympy/utilities/tests/test_lambdify.py
@@ -2331,3 +2331,25 @@ def test_issue_28803_jointrandonsymbol_recursion():
 
     # Should not raise RecursionError
     lambdify(a, z * a)
+
+
+def test_lambdify_constant_broadcasting():
+    if not numpy:
+        skip("numpy not installed.")
+
+    # 1. Test scalar constant expression
+    f1 = lambdify(x, 2, 'numpy')
+    res1 = f1(numpy.array([1, 2, 3]))
+    assert isinstance(res1, numpy.ndarray)
+    assert numpy.array_equal(res1, numpy.array([2, 2, 2]))
+
+    # 2. Test tuple containing matrices (should not broadcast inhomogeneous shapes)
+    q1, q2 = symbols('q1 q2')
+    M = Matrix([[1, 2], [3, 4]])
+    F = Matrix([[q1], [q2]])
+    # tuple of matrices
+    f2 = lambdify((q1, q2), (M, F), 'numpy')
+    M_val, F_val = f2(1.0, 2.0)
+    assert numpy.array_equal(M_val, numpy.array([[1, 2], [3, 4]]))
+    assert numpy.array_equal(F_val, numpy.array([[1.0], [2.0]]))
+


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #5642

#### Brief description of what is fixed or changed

This PR resolves the issue where constant or partially constant expressions lambdified with arrays as inputs return a single scalar instead of a broadcasted array. 

We introduced a helper function `_sympy_broadcast` inside the lambdify utility namespace. When generating the function body in `_EvaluatorPrinter.doprint`, the system checks if the input arguments are a superset of the expression's free symbols. If not (indicating a constant or partially constant return), the return expression is wrapped in `_sympy_broadcast`. 

The helper supports broadcasting for:
- NumPy (`np.broadcast_arrays`)
- JAX (`jnp.broadcast_arrays`)
- PyTorch (`torch.broadcast_tensors`)
- TensorFlow (`tnp.broadcast_arrays`)

Shape compatibility exceptions (`ValueError`, `RuntimeError`) are correctly propagated.

#### Other comments

None.

#### AI Generation Disclosure

This pull request contains code generated by the AI coding assistant Gemini.
The generated code includes:
- The helper `_sympy_broadcast` defined in `sympy/utilities/lambdify.py` (lines 207-287)
- The registration of `_sympy_broadcast` in the lambdify namespace (line 986)
- The modification of `_EvaluatorPrinter.doprint` to wrap return expressions (lines 1277-1300)

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Fixed a bug where lambdified constant expressions failed to broadcast to match the shape of input array arguments.
<!-- END RELEASE NOTES -->
