### PR TITLE
Fix asech derivative for x < -1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1497,6 +1497,7 @@ Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>
 Saurabh Jha <saurabh.jhaa@gmail.com>
 SaxdaAnhalta <rompa2006@gmail.com>
+SaxdaAnhalta <rompa2006@gmail.com> Roman Weller <149398693+SaxdaAnhalta@users.noreply.github.com>
 Sayan Goswami <Sayan98@users.noreply.github.com>
 Sayan Mitra <ee18b156@smail.iitm.ac.in>
 Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1496,6 +1496,7 @@ Sarwar Chahal <chahal.sarwar98@gmail.com>
 Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>
 Saurabh Jha <saurabh.jhaa@gmail.com>
+SaxdaAnhalta <rompa2006@gmail.com>
 Sayan Goswami <Sayan98@users.noreply.github.com>
 Sayan Mitra <ee18b156@smail.iitm.ac.in>
 Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1937,7 +1937,7 @@ class asech(InverseHyperbolicFunction):
     >>> from sympy import asech, sqrt, S
     >>> from sympy.abc import x
     >>> asech(x).diff(x)
-    -1/(x**2*sqrt(-1 + 1/x)*sqrt(1 + 1/x))
+    -sqrt(1/(x + 1))/(x*sqrt(1 - x))
     >>> asech(1).diff(x)
     0
     >>> asech(1)
@@ -1968,11 +1968,8 @@ class asech(InverseHyperbolicFunction):
 
     def fdiff(self, argindex=1):
         if argindex == 1:
-            # Chain rule through asech(z) = acosh(1/z); like acosh, the
-            # square roots must stay separate to give the correct branch
-            # for all complex z (issue #30335).
             z = self.args[0]
-            return -1/(z**2*sqrt(1/z - 1)*sqrt(1/z + 1))
+            return -sqrt(1/(z + 1))/(z*sqrt(1 - z))
         else:
             raise ArgumentIndexError(self, argindex)
 

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1937,7 +1937,7 @@ class asech(InverseHyperbolicFunction):
     >>> from sympy import asech, sqrt, S
     >>> from sympy.abc import x
     >>> asech(x).diff(x)
-    -1/(x*sqrt(1 - x**2))
+    -1/(x**2*sqrt(-1 + 1/x)*sqrt(1 + 1/x))
     >>> asech(1).diff(x)
     0
     >>> asech(1)
@@ -1968,8 +1968,11 @@ class asech(InverseHyperbolicFunction):
 
     def fdiff(self, argindex=1):
         if argindex == 1:
+            # Chain rule through asech(z) = acosh(1/z); like acosh, the
+            # square roots must stay separate to give the correct branch
+            # for all complex z (issue #30335).
             z = self.args[0]
-            return -1/(z*sqrt(1 - z**2))
+            return -1/(z**2*sqrt(1/z - 1)*sqrt(1/z + 1))
         else:
             raise ArgumentIndexError(self, argindex)
 

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -894,10 +894,10 @@ def test_asech_nseries():
     17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
     assert asech(-I*x + 3)._eval_nseries(x, 4, None) == asech(3) + sqrt(2)*x/12 + \
     17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
-    assert asech(I*x - 3)._eval_nseries(x, 4, None) == -asech(-3) - sqrt(2)*x/12 - \
-    17*sqrt(2)*I*x**2/576 + 443*sqrt(2)*x**3/41472 + O(x**4)
-    assert asech(-I*x - 3)._eval_nseries(x, 4, None) == asech(-3) - sqrt(2)*x/12 + \
-    17*sqrt(2)*I*x**2/576 + 443*sqrt(2)*x**3/41472 + O(x**4)
+    assert asech(I*x - 3)._eval_nseries(x, 4, None) == -asech(-3) + sqrt(2)*x/12 + \
+    17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
+    assert asech(-I*x - 3)._eval_nseries(x, 4, None) == asech(-3) + sqrt(2)*x/12 - \
+    17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
     # Tests concerning im(ndir) == 0
     assert asech(-I*x**2 + x - 2)._eval_nseries(x, 3, None) == 2*I*pi/3 + \
     x*(-sqrt(3) + 3*I)/(6*sqrt(3) + 6*I) + x**2*(36 + sqrt(3)*(7 - 12*I) + 21*I)/(72*sqrt(3) - \
@@ -1471,8 +1471,21 @@ def test_derivs():
     assert acosh(x).diff(x) == 1/(sqrt(x - 1)*sqrt(x + 1))
     assert acosh(x).diff(x) == acosh(x).rewrite(log).diff(x).together()
     assert atanh(x).diff(x) == 1/(-x**2 + 1)
-    assert asech(x).diff(x) == -1/(x*sqrt(1 - x**2))
+    assert asech(x).diff(x) == -1/(x**2*sqrt(1/x - 1)*sqrt(1/x + 1))
     assert acsch(x).diff(x) == -1/(x**2*sqrt(1 + x**(-2)))
+
+
+def test_asech_deriv_branch():
+    # issue 30335: the derivative of asech must be correct on the whole
+    # complex plane, in particular for x < -1 where the old formula
+    # -1/(x*sqrt(1 - x**2)) had the wrong sign.
+    x = Symbol('x')
+    deriv = asech(x).diff(x)
+    assert deriv.subs(x, -2) == sqrt(3)*I/6
+    logderiv = asech(x).rewrite(log).diff(x)
+    for pt in (-2, -S.Half, S.Half, 2, S.Half + I, -S.Half - I,
+               -2 + I/1000, -2 - I/1000, 2 + I/1000, 2 - I/1000):
+        assert (deriv.subs(x, pt) - logderiv.subs(x, pt)).evalf(chop=True) == 0
 
 
 def test_sinh_expansion():

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -1471,14 +1471,12 @@ def test_derivs():
     assert acosh(x).diff(x) == 1/(sqrt(x - 1)*sqrt(x + 1))
     assert acosh(x).diff(x) == acosh(x).rewrite(log).diff(x).together()
     assert atanh(x).diff(x) == 1/(-x**2 + 1)
-    assert asech(x).diff(x) == -1/(x**2*sqrt(1/x - 1)*sqrt(1/x + 1))
+    assert asech(x).diff(x) == -sqrt(1/(x + 1))/(x*sqrt(1 - x))
     assert acsch(x).diff(x) == -1/(x**2*sqrt(1 + x**(-2)))
 
 
 def test_asech_deriv_branch():
-    # issue 30335: the derivative of asech must be correct on the whole
-    # complex plane, in particular for x < -1 where the old formula
-    # -1/(x*sqrt(1 - x**2)) had the wrong sign.
+    # issue 30335
     x = Symbol('x')
     deriv = asech(x).diff(x)
     assert deriv.subs(x, -2) == sqrt(3)*I/6


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30335

#### Brief description of what is fixed or changed

I looked into the problem and prepared a fix.

**Cause of the problem:**
The previous derivative formula `-1/(x*sqrt(1 - x**2))` behaves incorrectly for `x < -1`, because combining the square root into `sqrt(1 - x**2)` loses information about the branch cut. At `x = -2` the old formula gives `-0.2887i`, while the correct value (checked against `mpmath`) is `+0.2887i`.

The problem is analogous to `acosh(z)`, where SymPy already uses the separated square-root representation `1/(sqrt(z - 1)*sqrt(z + 1))`.

**Solution:**
Using `asech(z) = acosh(1/z)` and applying the chain rule with separated square roots gives the correct derivative:

`-1/(z**2 * sqrt(1/z - 1) * sqrt(1/z + 1))`

With this formula the sign is correct on all parts of the complex plane (in particular for `x < -1`), which I verified numerically at various points against `mpmath`.

**Note on the tests:**
In `test_asech_nseries`, two test expectations for series expansions around `-3` were adjusted, since they still had the old (wrong) sign from the incorrect derivative baked in. With this, all SymPy tests and doctests pass completely again.

#### Other comments


#### AI Generation Disclosure

Everything in this patch was written by Claude Code. However, I reviewed it, understood it, and also checked the tests.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed derivative sign of ``asech(x)`` for ``x < -1`` by separating square roots.
<!-- END RELEASE NOTES -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhE29CRDj1vBZpVebp7Zfz
