### PR TITLE
Fix Q.real and Q.complex for powers with zero base and negative exponent

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1496,6 +1496,8 @@ Sarwar Chahal <chahal.sarwar98@gmail.com>
 Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>
 Saurabh Jha <saurabh.jhaa@gmail.com>
+SaxdaAnhalta <rompa2006@gmail.com>
+SaxdaAnhalta <rompa2006@gmail.com> Roman Weller <149398693+SaxdaAnhalta@users.noreply.github.com>
 Sayan Goswami <Sayan98@users.noreply.github.com>
 Sayan Mitra <ee18b156@smail.iitm.ac.in>
 Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -353,6 +353,9 @@ def _(expr, assumptions):
         if _ask_recursive(Q.real(expr.exp), assumptions):
             if (expr.exp.is_Rational and
                     _ask_recursive(Q.even(expr.exp.q), assumptions)):
+                if expr.exp.is_negative:
+                    # A zero base gives complex infinity, which is not real
+                    return _ask_recursive(Q.positive(expr.base), assumptions)
                 return _ask_recursive(Q.nonnegative(expr.base), assumptions)
             base_is_zero = _ask_recursive(Q.zero(expr.base), assumptions)
             if base_is_zero or _ask_recursive(Q.integer(expr.exp), assumptions):
@@ -517,6 +520,11 @@ def _(expr, assumptions):
 def _(expr, assumptions):
     if expr.base == E:
         return True
+    if (_ask_recursive(Q.zero(expr.base), assumptions) and
+            _ask_recursive(Q.negative(expr.exp), assumptions)):
+        # A zero base with a negative exponent gives complex infinity,
+        # which is not complex
+        return False
     return test_closed_group(expr, assumptions, Q.complex)
 
 @ComplexPredicate.register_many(Determinant, MatrixElement, Trace) # type:ignore

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1300,6 +1300,13 @@ def test_complex():
     assert _ask_recursive(Q.complex(2**x), Q.odd(x)) is True
     assert _ask_recursive(Q.complex(x**y), Q.complex(x) & Q.complex(y)) is True
 
+    # https://github.com/sympy/sympy/issues/28150
+    # A zero base with a negative exponent gives zoo, which is not complex
+    assert ask(Q.complex(Pow(S.Zero, -1, evaluate=False))) is False
+    assert _ask_recursive(Q.complex(x**(-1)), Q.zero(x)) is False
+    assert _ask_recursive(Q.complex(x**(-2)), Q.zero(x)) is False
+    assert _ask_recursive(Q.complex(x**Rational(-1, 2)), Q.zero(x)) is False
+
     # trigonometric expressions
     assert _ask_recursive(Q.complex(sin(x))) is True
     assert _ask_recursive(Q.complex(sin(2*x + 1))) is True
@@ -2104,6 +2111,16 @@ def test_real_pow():
     assert _ask_recursive(Q.real(x**pi), Q.zero(x)) is True
     assert _ask_recursive(Q.real(x**sqrt(2)), Q.zero(x)) is True
     assert _ask_recursive(Q.real(x**Rational(1/2)), Q.zero(x)) is True
+
+    # https://github.com/sympy/sympy/issues/28150
+    # https://github.com/sympy/sympy/issues/28151
+    # A zero base with a negative exponent gives zoo, which is not real
+    assert ask(Q.real(Pow(S.Zero, -1, evaluate=False))) is False
+    assert ask(Q.real(Pow(S.Zero, S.Half, evaluate=False))) is True
+    assert _ask_recursive(Q.real(x**Rational(-1, 2)), Q.zero(x)) is False
+    assert _ask_recursive(Q.real(x**Rational(-3, 2)), Q.zero(x)) is False
+    assert _ask_recursive(Q.real(x**Rational(-1, 2)), Q.positive(x)) is True
+    assert _ask_recursive(Q.real(x**Rational(-1, 2)), Q.nonnegative(x)) is None
 
 
 @_both_exp_pow


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #28150
Fixes #28151

#### Brief description of what is fixed or changed

I looked into the edge cases in the `ask` system concerning division by zero in powers and prepared a fix.

**Cause of the problem:**
In `sympy/assumptions/handlers/sets.py` there were two gaps in the evaluation of powers with a zero base and negative exponents (which mathematically corresponds to `zoo` and is neither real nor complex):

1. For exponents with an even denominator (like `-1/2`), the real handler only checked `Q.nonnegative(base)`. With a negative exponent, however, a base of `0` leads to `zoo`.
2. The complex handler generally assumed that the complex numbers are closed under exponentiation, so `ask(Q.complex(Pow(0, -1, evaluate=False)))` wrongly returned `True`.

**Solution:**
- For negative exponents with an even denominator, the real handler now strictly checks `Q.positive(base)` instead of `Q.nonnegative(base)`. If the base could possibly be zero, `ask` now correctly answers `None` instead of `True`.
- The complex handler now first checks whether the base is provably zero and the exponent provably negative — in that case it directly returns `False`.

**Note on issues #28150 and #28151:**
The original minimal examples from both issues have already been fixed by earlier refactorings. This PR covers the remaining edge cases (fractional negative exponents & the complex evaluation) and adds comprehensive regression tests, so that both issues can finally be closed.

All 156 tests of the assumptions suite as well as all doctests pass locally.

#### Other comments


#### AI Generation Disclosure

Everything in this patch was written by Claude Code. However, I reviewed it, understood it, and also checked the tests.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed ``ask(Q.real(...))`` and ``ask(Q.complex(...))`` for powers with zero base and negative exponents.
<!-- END RELEASE NOTES -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhE29CRDj1vBZpVebp7Zfz
