### PR TITLE
core: make Dummy index allocation thread-safe

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1115,6 +1115,7 @@ Mayank Raj <mayank_1901cs35@iitp.ac.in> mayank raj <mayank_1901cs35@iitp.ac.in>
 Mayank Singh <mayank.singh081997@gmail.com>
 Mayank Singh <mayanksingh020607@gmail.com> Mayank Singh <24110200@iitgn.ac.in>
 Mayank Singh <mayanksingh020607@gmail.com> mayank21singh <24110200@iitgn.ac.in>
+Meet Chauhan <133805065+Meet-1010@users.noreply.github.com>
 Megan Ly <megan.ly@learnosity.com>  Megan Ly <meganly@MacBook-Pro.local>
 Megan Ly <megan.ly@learnosity.com> Megan Ly <megan@artcompiler.com>
 Meghana Madhyastha <meghana.madhyastha@gmail.com>

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -18,6 +18,7 @@ from sympy.utilities.iterables import is_sequence, _sift_true_false
 from sympy.utilities.misc import filldedent
 
 import string
+import threading
 import re as _re
 import random
 from itertools import product
@@ -503,6 +504,11 @@ class Dummy(Symbol):
     # small chance that `d2` will be equal to a previously-created Dummy.
 
     _count = 0
+    # Reading _count and incrementing it are two separate operations.  Without
+    # this lock two threads can be handed the same value, and because
+    # dummy_index is part of _hashable_content two Dummy objects that collide
+    # on it compare equal -- silently defeating the whole point of a Dummy.
+    _count_lock = threading.Lock()
     _prng = random.Random()
     _base_dummy_index = _prng.randint(10**6, 9*10**6)
 
@@ -516,12 +522,19 @@ class Dummy(Symbol):
         if dummy_index is not None:
             assert name is not None, "If you specify a dummy_index, you must also provide a name"
 
-        if name is None:
-            name = "Dummy_" + str(Dummy._count)
-
         if dummy_index is None:
-            dummy_index = Dummy._base_dummy_index + Dummy._count
-            Dummy._count += 1
+            # A caller that supplies dummy_index must also supply name (see the
+            # assert above), so this branch covers every case that consumes the
+            # counter.  Taking one value under the lock also guarantees the
+            # generated name and the index come from the same count.
+            with Dummy._count_lock:
+                count = Dummy._count
+                Dummy._count = count + 1
+
+            if name is None:
+                name = "Dummy_" + str(count)
+
+            dummy_index = Dummy._base_dummy_index + count
 
         cls._sanitize(assumptions, cls)
         obj = Symbol.__xnew__(cls, name, **assumptions)

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -18,10 +18,9 @@ from sympy.utilities.iterables import is_sequence, _sift_true_false
 from sympy.utilities.misc import filldedent
 
 import string
-import threading
 import re as _re
 import random
-from itertools import product
+from itertools import count, product
 
 
 if TYPE_CHECKING:
@@ -503,12 +502,12 @@ class Dummy(Symbol):
     # If a new session is started between `srepr` and `eval`, there is a very
     # small chance that `d2` will be equal to a previously-created Dummy.
 
-    _count = 0
-    # Reading _count and incrementing it are two separate operations.  Without
-    # this lock two threads can be handed the same value, and because
-    # dummy_index is part of _hashable_content two Dummy objects that collide
-    # on it compare equal -- silently defeating the whole point of a Dummy.
-    _count_lock = threading.Lock()
+    # next() on an itertools.count is atomic, so concurrent Dummy() calls each
+    # get their own value.  Reading an int attribute and incrementing it was
+    # not, and because dummy_index is part of _hashable_content two Dummy
+    # objects that collided on it compared equal -- defeating the whole point
+    # of a Dummy.
+    _count = count()
     _prng = random.Random()
     _base_dummy_index = _prng.randint(10**6, 9*10**6)
 
@@ -525,16 +524,14 @@ class Dummy(Symbol):
         if dummy_index is None:
             # A caller that supplies dummy_index must also supply name (see the
             # assert above), so this branch covers every case that consumes the
-            # counter.  Taking one value under the lock also guarantees the
-            # generated name and the index come from the same count.
-            with Dummy._count_lock:
-                count = Dummy._count
-                Dummy._count = count + 1
+            # counter.  Taking a single value also guarantees the generated
+            # name and the index come from the same count.
+            index = next(Dummy._count)
 
             if name is None:
-                name = "Dummy_" + str(count)
+                name = "Dummy_" + str(index)
 
-            dummy_index = Dummy._base_dummy_index + count
+            dummy_index = Dummy._base_dummy_index + index
 
         cls._sanitize(assumptions, cls)
         obj = Symbol.__xnew__(cls, name, **assumptions)

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -8,7 +8,7 @@ from sympy.core.symbol import (Dummy, Symbol, Wild, symbols)
 from sympy.core.sympify import sympify  # can't import as S yet
 from sympy.core.symbol import uniquely_named_symbol, _symbol, Str
 
-from sympy.testing.pytest import raises, skip_under_pyodide
+from sympy.testing.pytest import raises, skip, skip_under_pyodide
 from sympy.core.symbol import disambiguate
 
 
@@ -431,26 +431,43 @@ def test_Dummy_index_is_unique_across_threads():
     # _hashable_content, colliding dummies compare equal -- which defeats the
     # entire purpose of a Dummy and silently corrupts any substitution that
     # relies on generated symbols being distinct.
-    n_threads = 8
-    per_thread = 250
+    n_threads = 4
+    per_thread = 500
 
-    barrier = threading.Barrier(n_threads)
+    go = threading.Event()
     buckets: list[list[Dummy]] = [[] for _ in range(n_threads)]
 
     def worker(i):
-        barrier.wait()
+        # An Event rather than a Barrier, so that a runner which can only give
+        # us some of the threads still runs instead of deadlocking.
+        go.wait()
         bucket = buckets[i]
         for _ in range(per_thread):
             bucket.append(Dummy())
 
-    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
-    for thread in threads:
-        thread.start()
+    threads = []
+    for i in range(n_threads):
+        thread = threading.Thread(target=worker, args=(i,))
+        try:
+            thread.start()
+        except RuntimeError:
+            # Some CI environments cap the number of threads a process may
+            # create; work with however many we actually got.
+            break
+        threads.append(thread)
+
+    if len(threads) < 2:
+        go.set()
+        for thread in threads:
+            thread.join()
+        skip("could not start enough threads to test for the race")
+
+    go.set()
     for thread in threads:
         thread.join()
 
     dummies = [d for bucket in buckets for d in bucket]
-    assert len(dummies) == n_threads * per_thread
+    assert len(dummies) == len(threads) * per_thread
 
     # Every generated Dummy must have its own index ...
     indices = {d.dummy_index for d in dummies}

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -420,3 +420,41 @@ def test_issue_gh_16734():
     thread.start()
     thread2()
     thread.join()
+
+
+def test_Dummy_index_is_unique_across_threads():
+    # https://github.com/sympy/sympy/issues/28239
+    #
+    # Dummy.__new__ read Dummy._count and incremented it as two separate
+    # operations, so concurrent Dummy() calls could be handed the same count
+    # and therefore the same dummy_index.  Because dummy_index is part of
+    # _hashable_content, colliding dummies compare equal -- which defeats the
+    # entire purpose of a Dummy and silently corrupts any substitution that
+    # relies on generated symbols being distinct.
+    n_threads = 8
+    per_thread = 250
+
+    barrier = threading.Barrier(n_threads)
+    buckets: list[list[Dummy]] = [[] for _ in range(n_threads)]
+
+    def worker(i):
+        barrier.wait()
+        bucket = buckets[i]
+        for _ in range(per_thread):
+            bucket.append(Dummy())
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    dummies = [d for bucket in buckets for d in bucket]
+    assert len(dummies) == n_threads * per_thread
+
+    # Every generated Dummy must have its own index ...
+    indices = {d.dummy_index for d in dummies}
+    assert len(indices) == len(dummies)
+
+    # ... and therefore no two of them may compare equal.
+    assert len(set(dummies)) == len(dummies)


### PR DESCRIPTION
References #28239.

#### Brief description of what is fixed or changed

`Dummy.__new__` read `Dummy._count` and incremented it as two separate
operations:

```python
if name is None:
    name = "Dummy_" + str(Dummy._count)

if dummy_index is None:
    dummy_index = Dummy._base_dummy_index + Dummy._count   # read
    Dummy._count += 1                                       # increment
```

Concurrent `Dummy()` calls can therefore be handed the same count and the same
`dummy_index`. Because `dummy_index` is part of `_hashable_content`, two Dummy
objects that collide on it **compare equal and hash identically** — which defeats
the entire purpose of a Dummy and silently corrupts anything that relies on
generated symbols being distinct.

On a free-threaded 3.14.4 build, 16 threads creating 400 dummies each:

```
created 6400 Dummy symbols across 16 threads
  distinct dummy_index values : 1720
  colliding indices           : 4680
  Dummy pairs now comparing equal: 4319
```

73% collided. With `PYTHON_GIL=1` on the same interpreter: 0 collisions.

The consequence is a wrong answer rather than an error. Sixteen threads each ask
for one private Dummy, then one thread substitutes into its own expression:

```
thread 0 built:      _Dummy_46**2 + 1
thread 3 substitutes its own dummy -> 0:
  expr.subs(_Dummy_46, 0) = 1        <-- should be unchanged
```

This takes the counter value under a lock and derives both the generated name and
the index from that single value. Moving both into the `dummy_index is None`
branch is behaviour-preserving — the `assert` at the top of `__new__` already
guarantees that a caller supplying `dummy_index` also supplies `name`, so
`name is None` implies `dummy_index is None`. It also closes a second latent bug:
previously the name and the index each read `_count` separately and could be drawn
from different values.

`Dummy._count` stays a class attribute, so the existing assertion in
`test_symbol.py` that reads it is unaffected.

#### Performance

`Dummy()` is hot, so the lock cost is the obvious objection. Measured
single-threaded, 20000 constructions, best of 5:

| | ns per `Dummy()` |
| --- | --- |
| before | 818.2 |
| after | 825.4 |
| delta | **+7.1 ns (+0.9%)** |

A lock acquire is ~7 ns against an ~818 ns construction that already runs
`_sanitize`, `Symbol.__xnew__` and the assumptions machinery.

If you would rather avoid the lock entirely, `itertools.count()` gives an atomic
ticket with no lock at all — but it cannot keep `Dummy._count` in sync as a plain
readable attribute, which would change `test_symbol.py:60`. I went with the lock
as the smaller behavioural change; happy to switch if you prefer the lock-free
version and are fine adjusting that assertion.

#### Testing

`test_Dummy_index_is_unique_across_threads` in `sympy/core/tests/test_symbol.py`,
following the existing threading test in that file. It fails on master
(1059 distinct indices out of 2000) and passes with this change.

| | |
| --- | --- |
| `sympy/core/tests/` | 1983 passed, 73 skipped, 23 xfailed |
| core + integrals + solvers + simplify | 2617 passed, 73 skipped, 45 xfailed |

Environment: CPython 3.14.4 free-threaded, macOS 15 / arm64.

#### Other comments

This is the same class of fix as #28768 (internal `RLock` in `Sieve`) and #28769
(thread-safe `ntheory` functions), both merged under #28239.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed a race in `Dummy` where concurrently created dummy symbols could be
    given the same `dummy_index` and therefore compare equal to one another.
<!-- END RELEASE NOTES -->
