### PR TITLE
Set sort_key on NaN

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3454,7 +3454,7 @@ class NaN(Number, metaclass=Singleton):
 
     @cacheit
     def sort_key(self, order=None):
-        return self.class_key(), (0, ()), (), S.Zero
+        return self.class_key(), (0, ()), (), S.NegativeInfinity
 
     def floor(self):
         return self

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -3452,6 +3452,10 @@ class NaN(Number, metaclass=Singleton):
     def __truediv__(self, other):
         return self
 
+    @cacheit
+    def sort_key(self, order=None):
+        return self.class_key(), (0, ()), (), S.Zero
+
     def floor(self):
         return self
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1786,6 +1786,8 @@ def test_expr_sorting():
     a, b = exprs = [Dummy('x'), Dummy('x')]
     assert sorted([b, a], key=default_sort_key) == exprs
 
+    exprs = [f(nan), f(1)]
+    assert sorted(exprs, key=default_sort_key) == exprs
 
 def test_as_ordered_factors():
 

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1786,7 +1786,7 @@ def test_expr_sorting():
     a, b = exprs = [Dummy('x'), Dummy('x')]
     assert sorted([b, a], key=default_sort_key) == exprs
 
-    exprs = [f(nan), f(1)]
+    exprs = [f(nan), f(-1), f(1)]
     assert sorted(exprs, key=default_sort_key) == exprs
 
 def test_as_ordered_factors():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1297,3 +1297,7 @@ def test_printing_stats():
     assert z2._eval_is_commutative() == False
     assert z3._eval_is_commutative() == False
     assert z4._eval_is_commutative() == False
+
+def test_issue_30343():
+    f = Function('f')
+    assert str(f(nan) + f(1)) == "f(nan) + f(1)"


### PR DESCRIPTION
The default sort key implementation from Number uses self, but NaN raises an exception when compared with other numbers.

Fixes #30343

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

AI found the issue but the fix was entirely human generated. 

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- printing
  - Fix a crash that could happen printing expressions with `nan`.
<!-- END RELEASE NOTES -->
