### PR TITLE
Preserve precision in numerical evaluation of owens_t and Li

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -927,6 +927,7 @@ KJaybhaye <krushnajaybhaye01@gmail.com> KJaybhaye <80618101+KJaybhaye@users.nore
 KJaybhaye <krushnajaybhaye01@gmail.com> KJaybhaye <krushnajaybhaye01@gmail.com>
 KJaybhaye <krushnajaybhaye01@gmail.com> Krushna Jaybhaye <80618101+KJaybhaye@users.noreply.github.com>
 Ka Yi <chua.kayi@yahoo.com.sg>
+Kadir Barut <kadirrbrtt@gmail.com> Kadir Barut <34428205+kadirb4rut@users.noreply.github.com>
 Kaifeng Zhu <cafeeee@gmail.com>
 Kalevi Suominen <jksuom@gmail.com> <kalevi.suominen@helsinki.fi>
 Kamlesh Joshi <72374645+kamleshjoshi8102@users.noreply.github.com>

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -21,6 +21,7 @@ from sympy.functions.elementary.exponential import exp, log, exp_polar
 from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.trigonometric import cos, sin, sinc, atan
 from sympy.functions.special.hyper import hyper, meijerg
+from sympy.external.mpmath import prec_to_dps
 
 # TODO series expansions
 # TODO see the "Note:" in Ei
@@ -2927,7 +2928,7 @@ class owens_t(DefinedFunction):
 
     def _eval_evalf(self, prec):
         from sympy.integrals.integrals import Integral
-        return self.rewrite(Integral)._eval_evalf(prec)
+        return self.rewrite(Integral).evalf(n=prec_to_dps(prec))
 
 
 ###############################################################################

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -1751,7 +1751,7 @@ class Li(DefinedFunction):
             raise ArgumentIndexError(self, argindex)
 
     def _eval_evalf(self, prec):
-        return self.rewrite(li)._eval_evalf(prec)
+        return self.rewrite(li).evalf(n=prec_to_dps(prec))
 
     def _eval_rewrite_as_li(self, z, **kwargs):
         return li(z) - li(2)

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -608,6 +608,12 @@ def test_Li():
     raises(ArgumentIndexError, lambda: Li(z).fdiff(2))
 
 
+def test_Li_evalf_cancellation():
+    result = Li(2 + Rational(1, 10**20)).evalf()
+    expected = Float('1.442695040888963407354721258549378e-20', 50)
+    assert abs(result - expected) < 1e-34
+
+
 def test_si():
     assert Si(I*x) == I*Shi(x)
     assert Shi(I*x) == I*Si(x)

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -1098,3 +1098,16 @@ def test_owent_evalf():
     # Symmetry should hold numerically too
     assert abs(owens_t(-1, 2).evalf() - owens_t(1, 2).evalf()) < 1E-10
     assert abs(owens_t(1, -2).evalf() + owens_t(1, 2).evalf()) < 1E-10
+
+
+def test_owent_evalf_cancellation():
+    h, a = -6, 2
+    expr = erf(sqrt(2)*h/2)/2 + S.Half - 2*owens_t(h, a)
+
+    # The default precision must be propagated into the numerical integral so
+    # that Add can recover the cancellation in this left-tail probability.
+    result = expr.evalf()
+    # Independent 100-digit mpmath quadrature gives this reference value.
+    expected = Float('7.1180791906932412294852794865326e-43', 50)
+    assert result.is_Float
+    assert abs(result - expected) < 1e-55


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #30345

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

owens_t might give an incorrect result when it is computed as part of an expression involving serious cancellation.

The new evaluation process does not use the internal evaluation method inside owens_t, but instead passes the required precision to the rewritten integral.

I also created a regression test for the cancellation condition mentioned in #30345.

There was also a similar precision/cancellation issue in `Li._eval_evalf`. This was fixed by propagating the required precision through the public `evalf` method and adding the regression test `test_Li_evalf_cancellation`.

#### Other comments


#### AI Generation Disclosure

I worked on understanding the reason behind the numerical accuracy problem and used OpenAI Codex to help develop the fix. AI assistance was used for the changes in owens_t._eval_evalf, including prec_to_dps, and for the regression test test_owent_evalf_cancellation. AI assistance was also used for the changes in Li._eval_evalf and for the regression test test_Li_evalf_cancellation. I reviewed the changes and tested them locally before submitting my pull request.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Refined numerical calculation for owens_t and Li in cases of strong cancellation where loss of accuracy can become significant.
<!-- END RELEASE NOTES -->
