### PR TITLE
Fix wrong sign of spherical Bessel functions on the negative real axis

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1496,6 +1496,8 @@ Sarwar Chahal <chahal.sarwar98@gmail.com>
 Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>
 Saurabh Jha <saurabh.jhaa@gmail.com>
+SaxdaAnhalta <rompa2006@gmail.com>
+SaxdaAnhalta <rompa2006@gmail.com> Roman Weller <149398693+SaxdaAnhalta@users.noreply.github.com>
 Sayan Goswami <Sayan98@users.noreply.github.com>
 Sayan Mitra <ee18b156@smail.iitm.ac.in>
 Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -1184,7 +1184,7 @@ class hn1(SphericalHankelBase):
     >>> hn1(nu, z).rewrite(yn)
     (-1)**nu*yn(-nu - 1, z) + I*yn(nu, z)
     >>> hn1(nu, z).rewrite(hankel1)
-    sqrt(2)*sqrt(pi)*hankel1(nu, z)/(2*sqrt(z))
+    sqrt(2)*sqrt(pi)*hankel1(nu + 1/2, z)/(2*sqrt(z))
 
     See Also
     ========
@@ -1202,7 +1202,7 @@ class hn1(SphericalHankelBase):
 
     @assume_integer_order
     def _eval_rewrite_as_hankel1(self, nu, z, **kwargs):
-        return sqrt(pi/2)/sqrt(z)*hankel1(nu, z)
+        return sqrt(pi/2)/sqrt(z)*hankel1(nu + S.Half, z)
 
 
 class hn2(SphericalHankelBase):
@@ -1236,7 +1236,7 @@ class hn2(SphericalHankelBase):
     >>> print(expand_func(hn2(1, z)))
     I*sin(z)/z - cos(z)/z + sin(z)/z**2 + I*cos(z)/z**2
     >>> hn2(nu, z).rewrite(hankel2)
-    sqrt(2)*sqrt(pi)*hankel2(nu, z)/(2*sqrt(z))
+    sqrt(2)*sqrt(pi)*hankel2(nu + 1/2, z)/(2*sqrt(z))
     >>> hn2(nu, z).rewrite(jn)
     -(-1)**(nu + 1)*I*jn(-nu - 1, z) + jn(nu, z)
     >>> hn2(nu, z).rewrite(yn)
@@ -1258,7 +1258,7 @@ class hn2(SphericalHankelBase):
 
     @assume_integer_order
     def _eval_rewrite_as_hankel2(self, nu, z, **kwargs):
-        return sqrt(pi/2)/sqrt(z)*hankel2(nu, z)
+        return sqrt(pi/2)/sqrt(z)*hankel2(nu + S.Half, z)
 
 
 def jn_zeros(n, k, method="sympy", dps=15):

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -979,11 +979,11 @@ class jn(SphericalBesselBase):
     >>> expand_func(jn(3, z))
     (-6/z**2 + 15/z**4)*sin(z) + (1/z - 15/z**3)*cos(z)
     >>> jn(nu, z).rewrite(besselj)
-    sqrt(2)*sqrt(pi)*sqrt(1/z)*besselj(nu + 1/2, z)/2
+    sqrt(2)*sqrt(pi)*besselj(nu + 1/2, z)/(2*sqrt(z))
     >>> jn(nu, z).rewrite(bessely)
-    (-1)**nu*sqrt(2)*sqrt(pi)*sqrt(1/z)*bessely(-nu - 1/2, z)/2
+    (-1)**nu*sqrt(2)*sqrt(pi)*bessely(-nu - 1/2, z)/(2*sqrt(z))
     >>> jn(2, 5.2+0.3j).evalf(20)
-    0.099419756723640344491 - 0.054525080242173562897*I
+    0.099419756723640345986 - 0.054525080242173563452*I
 
     See Also
     ========
@@ -1010,10 +1010,10 @@ class jn(SphericalBesselBase):
             return S.Zero
 
     def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
-        return sqrt(pi/(2*z)) * besselj(nu + S.Half, z)
+        return sqrt(pi/2)/sqrt(z) * besselj(nu + S.Half, z)
 
     def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
-        return S.NegativeOne**nu * sqrt(pi/(2*z)) * bessely(-nu - S.Half, z)
+        return S.NegativeOne**nu * sqrt(pi/2)/sqrt(z) * bessely(-nu - S.Half, z)
 
     def _eval_rewrite_as_yn(self, nu, z, **kwargs):
         return S.NegativeOne**(nu) * yn(-nu - 1, z)
@@ -1056,11 +1056,11 @@ class yn(SphericalBesselBase):
     >>> expand_func(yn(1, z)) == -cos(z)/z**2-sin(z)/z
     True
     >>> yn(nu, z).rewrite(besselj)
-    (-1)**(nu + 1)*sqrt(2)*sqrt(pi)*sqrt(1/z)*besselj(-nu - 1/2, z)/2
+    (-1)**(nu + 1)*sqrt(2)*sqrt(pi)*besselj(-nu - 1/2, z)/(2*sqrt(z))
     >>> yn(nu, z).rewrite(bessely)
-    sqrt(2)*sqrt(pi)*sqrt(1/z)*bessely(nu + 1/2, z)/2
+    sqrt(2)*sqrt(pi)*bessely(nu + 1/2, z)/(2*sqrt(z))
     >>> yn(2, 5.2+0.3j).evalf(20)
-    0.18525034196069722536 + 0.014895573969924817587*I
+    0.1852503419606972279 + 0.014895573969924818173*I
 
     See Also
     ========
@@ -1075,11 +1075,11 @@ class yn(SphericalBesselBase):
     """
     @assume_integer_order
     def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
-        return S.NegativeOne**(nu+1) * sqrt(pi/(2*z)) * besselj(-nu - S.Half, z)
+        return S.NegativeOne**(nu+1) * sqrt(pi/2)/sqrt(z) * besselj(-nu - S.Half, z)
 
     @assume_integer_order
     def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
-        return sqrt(pi/(2*z)) * bessely(nu + S.Half, z)
+        return sqrt(pi/2)/sqrt(z) * bessely(nu + S.Half, z)
 
     def _eval_rewrite_as_jn(self, nu, z, **kwargs):
         return S.NegativeOne**(nu + 1) * jn(-nu - 1, z)
@@ -1097,20 +1097,20 @@ class SphericalHankelBase(SphericalBesselBase):
     @assume_integer_order
     def _eval_rewrite_as_besselj(self, nu, z, **kwargs):
         # jn +- I*yn
-        # jn as beeselj: sqrt(pi/(2*z)) * besselj(nu + S.Half, z)
-        # yn as besselj: (-1)**(nu+1) * sqrt(pi/(2*z)) * besselj(-nu - S.Half, z)
+        # jn as besselj: sqrt(pi/2)/sqrt(z) * besselj(nu + S.Half, z)
+        # yn as besselj: (-1)**(nu+1) * sqrt(pi/2)/sqrt(z) * besselj(-nu - S.Half, z)
         hks = self._hankel_kind_sign
-        return sqrt(pi/(2*z))*(besselj(nu + S.Half, z) +
-                               hks*I*S.NegativeOne**(nu+1)*besselj(-nu - S.Half, z))
+        return sqrt(pi/2)/sqrt(z)*(besselj(nu + S.Half, z) +
+                                   hks*I*S.NegativeOne**(nu+1)*besselj(-nu - S.Half, z))
 
     @assume_integer_order
     def _eval_rewrite_as_bessely(self, nu, z, **kwargs):
         # jn +- I*yn
-        # jn as bessely: (-1)**nu * sqrt(pi/(2*z)) * bessely(-nu - S.Half, z)
-        # yn as bessely: sqrt(pi/(2*z)) * bessely(nu + S.Half, z)
+        # jn as bessely: (-1)**nu * sqrt(pi/2)/sqrt(z) * bessely(-nu - S.Half, z)
+        # yn as bessely: sqrt(pi/2)/sqrt(z) * bessely(nu + S.Half, z)
         hks = self._hankel_kind_sign
-        return sqrt(pi/(2*z))*(S.NegativeOne**nu*bessely(-nu - S.Half, z) +
-                               hks*I*bessely(nu + S.Half, z))
+        return sqrt(pi/2)/sqrt(z)*(S.NegativeOne**nu*bessely(-nu - S.Half, z) +
+                                   hks*I*bessely(nu + S.Half, z))
 
     def _eval_rewrite_as_yn(self, nu, z, **kwargs):
         hks = self._hankel_kind_sign
@@ -1184,7 +1184,7 @@ class hn1(SphericalHankelBase):
     >>> hn1(nu, z).rewrite(yn)
     (-1)**nu*yn(-nu - 1, z) + I*yn(nu, z)
     >>> hn1(nu, z).rewrite(hankel1)
-    sqrt(2)*sqrt(pi)*sqrt(1/z)*hankel1(nu, z)/2
+    sqrt(2)*sqrt(pi)*hankel1(nu, z)/(2*sqrt(z))
 
     See Also
     ========
@@ -1202,7 +1202,7 @@ class hn1(SphericalHankelBase):
 
     @assume_integer_order
     def _eval_rewrite_as_hankel1(self, nu, z, **kwargs):
-        return sqrt(pi/(2*z))*hankel1(nu, z)
+        return sqrt(pi/2)/sqrt(z)*hankel1(nu, z)
 
 
 class hn2(SphericalHankelBase):
@@ -1236,7 +1236,7 @@ class hn2(SphericalHankelBase):
     >>> print(expand_func(hn2(1, z)))
     I*sin(z)/z - cos(z)/z + sin(z)/z**2 + I*cos(z)/z**2
     >>> hn2(nu, z).rewrite(hankel2)
-    sqrt(2)*sqrt(pi)*sqrt(1/z)*hankel2(nu, z)/2
+    sqrt(2)*sqrt(pi)*hankel2(nu, z)/(2*sqrt(z))
     >>> hn2(nu, z).rewrite(jn)
     -(-1)**(nu + 1)*I*jn(-nu - 1, z) + jn(nu, z)
     >>> hn2(nu, z).rewrite(yn)
@@ -1258,7 +1258,7 @@ class hn2(SphericalHankelBase):
 
     @assume_integer_order
     def _eval_rewrite_as_hankel2(self, nu, z, **kwargs):
-        return sqrt(pi/(2*z))*hankel2(nu, z)
+        return sqrt(pi/2)/sqrt(z)*hankel2(nu, z)
 
 
 def jn_zeros(n, k, method="sympy", dps=15):

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -261,8 +261,8 @@ def test_rewrite():
         assert hn1(order, z) == hn1(order, z).rewrite(f)
         assert hn2(order, z) == hn2(order, z).rewrite(f)
 
-    assert jn(order, z).rewrite(besselj) == sqrt(2)*sqrt(pi)*sqrt(1/z)*besselj(order + S.Half, z)/2
-    assert jn(order, z).rewrite(bessely) == (-1)**nu*sqrt(2)*sqrt(pi)*sqrt(1/z)*bessely(-order - S.Half, z)/2
+    assert jn(order, z).rewrite(besselj) == sqrt(2)*sqrt(pi)*besselj(order + S.Half, z)/(2*sqrt(z))
+    assert jn(order, z).rewrite(bessely) == (-1)**nu*sqrt(2)*sqrt(pi)*bessely(-order - S.Half, z)/(2*sqrt(z))
 
     # for integral orders rewriting SBFs w.r.t bessel[jy] is allowed
     N = Symbol('n', integer=True)
@@ -277,6 +277,17 @@ def test_rewrite():
     for func, refunc in product((yn, jn, hn1, hn2),
                                 (jn, yn, besselj, bessely)):
         assert tn(func(ri, z), func(ri, z).rewrite(refunc), z)
+
+
+def test_issue_23970():
+    # evalf gave the wrong sign on the negative real axis
+    assert jn(0, -2).evalf() > 0
+    for f in (jn, yn, hn1, hn2):
+        for order in (0, 1, 2):
+            for zval in (-2, Rational(-5, 2), -1 + I, -1 - I, 3):
+                got = f(order, zval).evalf(15)
+                ref = expand_func(f(order, x)).subs(x, zval).evalf(15)
+                assert abs(got - ref) < 1e-13
 
 
 def test_expand():

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -290,6 +290,18 @@ def test_issue_23970():
                 assert abs(got - ref) < 1e-13
 
 
+def test_hn_rewrite_hankel():
+    # the rewrites of hn1/hn2 in terms of hankel1/hankel2 used the order
+    # nu instead of nu + 1/2
+    for f, target in ((hn1, hankel1), (hn2, hankel2)):
+        for order in (0, 1, 2):
+            for zval in (-2, Rational(-5, 2), -1 + I, -1 - I, 3):
+                rewritten = f(order, x).rewrite(target)
+                reference = expand_func(f(order, x))
+                assert abs(rewritten.subs(x, zval).evalf(15)
+                           - reference.subs(x, zval).evalf(15)) < 1e-13
+
+
 def test_expand():
     assert expand_func(besselj(S.Half, z).rewrite(jn)) == \
         sqrt(2)*sin(z)/(sqrt(pi)*sqrt(z))


### PR DESCRIPTION
#### References to other Issues or PRs

See #23970: this addresses the spherical Bessel part of it (the lambdify
problem and the other non-spherical issues discussed there remain open,
so the issue should not be closed when this is merged).

Builds on the analysis in that issue and the draft #23980 by oscarbenjamin,
but is deliberately restricted to the spherical Bessel functions.

#### Brief description of what is fixed or changed

For integer orders the spherical Bessel functions `jn`, `yn`, `hn1` and `hn2`
are single-valued functions with no branch cut (e.g. `jn(0, z) == sin(z)/z`),
but `evalf` systematically gave the wrong sign on the negative real axis:

```python
>>> N(jn(0, -2))     # before
-0.454648713412841   # should be sin(-2)/(-2) = +0.454648713412841
```

The reason is the prefactor `sqrt(pi/(2*z))` in the rewrites in terms of
`besselj`/`bessely` (which `evalf` goes through): the branch of `sqrt(1/z)` on
the negative real axis does not match the branch cut orientation of `besselj`
there. Writing the prefactor as `sqrt(pi/2)/sqrt(z)` gives both factors the
same cut orientation, so the jumps cancel on the axis too; elsewhere the two
forms are identical. The change is applied to the 8 affected rewrite methods.

A regression test `test_issue_23970` checks all four functions on and off the
axis against `expand_func`. Two `evalf(20)` doctest values are updated; the
old values had rounding errors in the last digits.

#### Other comments

#### AI Generation Disclosure

The bug search and the patch were created with Claude Code. However, I
reviewed the changes and tests manually.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
    * Fixed the numerical evaluation of the spherical Bessel functions `jn`,
      `yn`, `hn1` and `hn2`, which gave the wrong sign on the negative real axis.
    * Fixed the order of the Hankel function in the rewrites of `hn1` and
      `hn2` in terms of `hankel1` and `hankel2`.
<!-- END RELEASE NOTES -->

