### PR TITLE
Fix order of besseli in the generic airyaiprime rewrite

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1496,6 +1496,8 @@ Sarwar Chahal <chahal.sarwar98@gmail.com>
 Satya Prakash Dwibedi <akash581050@gmail.com>
 Saurabh Agarwal <shourabh.agarwal@gmail.com>
 Saurabh Jha <saurabh.jhaa@gmail.com>
+SaxdaAnhalta <rompa2006@gmail.com>
+SaxdaAnhalta <rompa2006@gmail.com> Roman Weller <149398693+SaxdaAnhalta@users.noreply.github.com>
 Sayan Goswami <Sayan98@users.noreply.github.com>
 Sayan Mitra <ee18b156@smail.iitm.ac.in>
 Sayandip Halder <sayandiph4@gmail.com> Sayandip <sayandiph4@gmail.com>

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -1844,7 +1844,7 @@ class airyaiprime(AiryBase):
             a = Pow(z, Rational(3, 2))
             b = Pow(a, tt)
             c = Pow(a, -tt)
-            return ot * (z**2*c*besseli(tt, tt*a) - b*besseli(-ot, tt*a))
+            return ot * (z**2*c*besseli(tt, tt*a) - b*besseli(-tt, tt*a))
 
     def _eval_rewrite_as_hyper(self, z, **kwargs):
         pf1 = z**2 / (2*3**Rational(2, 3)*gamma(Rational(2, 3)))

--- a/sympy/functions/special/tests/test_bessel.py
+++ b/sympy/functions/special/tests/test_bessel.py
@@ -717,7 +717,9 @@ def test_airyaiprime():
                   besselj(Rational(1, 3), 2*(-t)**Rational(3, 2)/3))/3)
     assert airyaiprime(z).rewrite(besseli) == (
         z**2*besseli(Rational(2, 3), 2*z**Rational(3, 2)/3)/(3*(z**Rational(3, 2))**Rational(2, 3)) -
-        (z**Rational(3, 2))**Rational(2, 3)*besseli(Rational(-1, 3), 2*z**Rational(3, 2)/3)/3)
+        (z**Rational(3, 2))**Rational(2, 3)*besseli(Rational(-2, 3), 2*z**Rational(3, 2)/3)/3)
+    # issue 30349
+    assert tn(airyaiprime(z), airyaiprime(z).rewrite(besseli), z)
     assert airyaiprime(p).rewrite(besseli) == (
         p*(-besseli(Rational(-2, 3), 2*p**Rational(3, 2)/3) + besseli(Rational(2, 3), 2*p**Rational(3, 2)/3))/3)
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30349

#### Brief description of what is fixed or changed

For a generic `z`, `airyaiprime(z).rewrite(besseli)` used `besseli(-1/3, ...)`
instead of the correct `besseli(-2/3, ...)` ([DLMF 9.6.3](https://dlmf.nist.gov/9.6#E3)),
so the result disagreed with `airyaiprime` everywhere (at `z = 1` it gave
-0.2266 instead of -0.1591; at `z = -1` it even gave a complex value). Only
the generic branch was affected — the `Re(z) > 0` branch and the counterpart
`airybiprime` already used the correct order.

One-line fix in `airyaiprime._eval_rewrite_as_besseli`; the corrected formula
was checked numerically against mpmath at 18 points across all complex
sectors (relative errors < 1e-13). The expected form in `test_airyaiprime` is
updated and a numerical regression test is added.

#### Other comments

#### AI Generation Disclosure

The bug search and the patch were created with Claude Code. However, I
reviewed the changes and tests manually.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
    * Fixed the order of `besseli` in `airyaiprime(z).rewrite(besseli)` for generic arguments (was `-1/3` instead of `-2/3`).
<!-- END RELEASE NOTES -->
