### PR TITLE
 Added strict type hints to sympy.utilities.misc

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -217,6 +217,7 @@ Abhinav Cillanki <abhinavcillanki@kgpian.iitkgp.ac.in> JebronLames32 <abhinavcil
 Abhishek <uchiha@pop-os.localdomain>
 Abhishek Chaudhary <ac5003@columbia.edu>
 Abhishek Garg <abhishekgarg119@gmail.com>
+Abhishek Joshi <157949438+abhishekjoshi13@users.noreply.github.com>
 Abhishek Kumar <abhishek.nitdelhi@gmail.com> ABHISHEK KUMAR <140839576+abhiphile@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> ABHISHEK PATIDAR <95904102+1e9abhi1e10@users.noreply.github.com>
 Abhishek Patidar <1e9abhi1e10@gmail.com> Abhishek Patidar <2311abhiptdr@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -906,6 +906,7 @@ Joseph Mehdiyev <yusifmehdiyev55@gmail.com> Joseph Mehdiyev <157145635+JosephMeh
 Joseph Rance <56409230+Joseph-Rance@users.noreply.github.com>
 Joseph Redfern <joseph@redfern.me>
 Josh Burkart <jburkart@gmail.com>
+Joshi <abhkjoshi13@gmail.com>
 José Senart <jose.senart@gmail.com>
 João Bravo <joaocgbravo@tecnico.ulisboa.pt>
 João Moura <operte@gmail.com>

--- a/sympy/utilities/misc.py
+++ b/sympy/utilities/misc.py
@@ -38,7 +38,7 @@ def filldedent(s: str, w: int = 70, **kwargs: Any) -> str:
     return '\n' + fill(dedent(str(s)).strip('\n'), width=w, **kwargs)
 
 
-def strlines(s, c=64, short=False):
+def strlines(s: str, c: int = 64, short: bool = False) -> str:
     """Return a cut-and-pastable string that, when printed, is
     equivalent to the input.  The lines will be surrounded by
     parentheses and no line will be longer than c (default 64)
@@ -72,14 +72,14 @@ def strlines(s, c=64, short=False):
     if '\n' in s:
         return rawlines(s)
     q = '"' if repr(s).startswith('"') else "'"
-    q = (q,)*2
+    qq = (q,)*2
     if '\\' in s:  # use r-string
-        m = '(\nr%s%%s%s\n)' % q
-        j = '%s\nr%s' % q
+        m = '(\nr%s%%s%s\n)' % qq
+        j = '%s\nr%s' % qq
         c -= 3
     else:
-        m = '(\n%s%%s%s\n)' % q
-        j = '%s\n%s' % q
+        m = '(\n%s%%s%s\n)' % qq
+        j = '%s\n%s' % qq
         c -= 2
     out = []
     while s:
@@ -90,7 +90,7 @@ def strlines(s, c=64, short=False):
     return m % j.join(out)
 
 
-def rawlines(s):
+def rawlines(s: str) -> str:
     """Return a cut-and-pastable string that, when printed, is equivalent
     to the input. Use this when there is more than one line in the
     string. The string returned is formatted so it can be indented
@@ -166,11 +166,11 @@ def rawlines(s):
                 rv.append(repr(li))
         return '(\n    %s\n)' % '\n    '.join(rv)
     else:
-        rv = '\n    '.join(lines)
+        rv_str = '\n    '.join(lines)
         if triple[0]:
-            return 'dedent("""\\\n    %s""")' % rv
+            return 'dedent("""\\\n    %s""")' % rv_str
         else:
-            return "dedent('''\\\n    %s''')" % rv
+            return "dedent('''\\\n    %s''')" % rv_str
 
 ARCH = str(struct.calcsize('P') * 8) + "-bit"
 
@@ -190,14 +190,14 @@ def debug_decorator(func: _CallableT) -> _CallableT:
     if not SYMPY_DEBUG:
         return func
 
-    def maketree(f, *args, **kw):
+    def maketree(f: Callable[..., Any], *args: Any, **kw: Any) -> Any:
         global _debug_tmp, _debug_iter
         oldtmp = _debug_tmp
         _debug_tmp = []
         _debug_iter += 1
 
-        def tree(subtrees):
-            def indent(s, variant=1):
+        def tree(subtrees: list[str]) -> str:
+            def indent(s: str, variant: int = 1) -> str:
                 x = s.split("\n")
                 r = "+-%s\n" % x[0]
                 for a in x[1:]:
@@ -236,13 +236,13 @@ def debug_decorator(func: _CallableT) -> _CallableT:
             _debug_tmp = []
         return r
 
-    def decorated(*args, **kwargs):
+    def decorated(*args: Any, **kwargs: Any) -> Any:
         return maketree(func, *args, **kwargs)
 
     return decorated  # type: ignore
 
 
-def debug(*args):
+def debug(*args: Any) -> None:
     """
     Print ``*args`` if SYMPY_DEBUG is True, else do nothing.
     """
@@ -251,7 +251,7 @@ def debug(*args):
         print(*args, file=sys.stderr)
 
 
-def debugf(string, args):
+def debugf(string: str, args: Any) -> None:
     """
     Print ``string%args`` if SYMPY_DEBUG is True, else do nothing. This is
     intended for debug messages using formatted strings.
@@ -261,7 +261,7 @@ def debugf(string, args):
         print(string%args, file=sys.stderr)
 
 
-def find_executable(executable, path=None):
+def find_executable(executable: str, path: str | None = None) -> str | None:
     """Try to find 'executable' in the directories listed in 'path' (a
     string listing directories separated by 'os.pathsep'; defaults to
     os.environ['PATH']).  Returns the complete filename or None if not
@@ -343,7 +343,7 @@ def func_name(x: Any, short: bool = False) -> str:
     return rv
 
 
-def _replace(reps):
+def _replace(reps: dict[str, str]) -> Callable[[str], str]:
     """Return a function that can make the replacements, given in
     ``reps``, on a string. The replacements should be given as mapping.
 
@@ -366,7 +366,7 @@ def _replace(reps):
     return lambda string: pattern.sub(D, string)
 
 
-def replace(string, *reps):
+def replace(string: str, *reps: Any) -> str:
     """Return ``string`` with all keys in ``reps`` replaced with
     their corresponding values, longer strings first, irrespective
     of the order they are given.  ``reps`` may be passed as tuples
@@ -400,15 +400,15 @@ def replace(string, *reps):
     if len(reps) == 1:
         kv = reps[0]
         if isinstance(kv, dict):
-            reps = kv
+            reps_dict = kv
         else:
             return string.replace(*kv)
     else:
-        reps = dict(reps)
-    return _replace(reps)(string)
+        reps_dict = dict(reps)
+    return _replace(reps_dict)(string)
 
 
-def translate(s, a, b=None, c=None):
+def translate(s: str, a: Any, b: Any = None, c: Any = None) -> str:
     """Return ``s`` where characters have been replaced or deleted.
 
     SYNTAX


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

See #28806 

#### Brief description of what is fixed or changed
This PR adds missing type hints to 'sympy/utilities/misc.py' to make the file strictly typed. While doing this, I also had to fix a couple of variable shadowing issues where variables were changing types mid-function. Like 'q' was being reassigned from a string to a tuple, and 'reps' was changing from a tuple to a dict. Mypy was giving errors for these so I renamed the variables to 'qq' and 'reps_dict' to keep the types consistent throughout the functions.

#### Other comments

I ran the strict checks locally using 'mypy --disalllow-untyped-defs sympy/utilities/misc.py' and it now successfully passed with 0 errors.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used Gemini to help me understand what some of the specific mypy assignment errors meant like the variables shadowing and to check the correct typing syntax. I manually applied, reviewed, and tested all the code changes locally.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* utilities
  * Added strict type hints to misc.py  
<!-- END RELEASE NOTES -->
