### PR TITLE
Fix sign errors in li(z).rewrite(Shi)/Chi and erfi(z).rewrite(expint)

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -642,7 +642,7 @@ class erfi(DefinedFunction):
         return sqrt(-z**2)/z*(uppergamma(S.Half, -z**2)/sqrt(pi) - S.One)
 
     def _eval_rewrite_as_expint(self, z, **kwargs):
-        return sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(pi)
+        return -sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(pi)
 
     def _eval_expand_func(self, **hints):
         return self.rewrite(erf)
@@ -1576,9 +1576,9 @@ class li(DefinedFunction):
     >>> li(z).rewrite(Ci)
     -log(I*log(z)) - log(1/log(z))/2 + log(log(z))/2 + Ci(I*log(z)) + Shi(log(z))
     >>> li(z).rewrite(Shi)
-    -log(1/log(z))/2 + log(log(z))/2 + Chi(log(z)) - Shi(log(z))
+    -log(1/log(z))/2 - log(log(z))/2 + Chi(log(z)) + Shi(log(z))
     >>> li(z).rewrite(Chi)
-    -log(1/log(z))/2 + log(log(z))/2 + Chi(log(z)) - Shi(log(z))
+    -log(1/log(z))/2 - log(log(z))/2 + Chi(log(z)) + Shi(log(z))
 
     See Also
     ========
@@ -1645,7 +1645,7 @@ class li(DefinedFunction):
     _eval_rewrite_as_Ci = _eval_rewrite_as_Si
 
     def _eval_rewrite_as_Shi(self, z, **kwargs):
-        return (Chi(log(z)) - Shi(log(z)) - S.Half*(log(S.One/log(z)) - log(log(z))))
+        return (Chi(log(z)) + Shi(log(z)) - S.Half*(log(S.One/log(z)) + log(log(z))))
 
     _eval_rewrite_as_Chi = _eval_rewrite_as_Shi
 

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -248,7 +248,7 @@ def test_erfi():
     assert erfi(z).rewrite('uppergamma') == (sqrt(-z**2)/z*(uppergamma(S.Half,
         -z**2)/sqrt(S.Pi) - S.One))
     assert erfi(z).rewrite('expint') == -sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(S.Pi)
-    for zval in (Rational(3, 4), 2, I, 1 + I, -1 + I, -2 - I):
+    for zval in (Rational(3, 4), 2, -2, I, -2*I, 1 + I, -1 + I, -2 - I):
         r = erfi(z).rewrite(expint).subs(z, zval)
         assert abs(r.evalf(15) - erfi(zval).evalf(15)) < 1e-13
     assert erfi(z).rewrite('tractable') == -I*(-_erfs(I*z)*exp(z**2) + 1)

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -587,7 +587,8 @@ def test_li():
                                   Chi(log(z)) + Shi(log(z)))
     # the rewrites must agree with li numerically for 0 < z < 1, z > 1
     # and complex z in all quadrants
-    for zval in (Rational(1, 4), Rational(9, 8), 3, 1 + 2*I, -1 + I, -2 - 3*I):
+    for zval in (Rational(1, 4), Rational(9, 8), 3, -2, 2*I, -2*I,
+                 1 + 2*I, -1 + I, -2 - 3*I):
         for target in (Si, Ci, Shi, Chi):
             r = li(z).rewrite(target).subs(z, zval)
             assert abs(r.evalf(15) - li(zval).evalf(15)) < 1e-13

--- a/sympy/functions/special/tests/test_error_functions.py
+++ b/sympy/functions/special/tests/test_error_functions.py
@@ -247,7 +247,10 @@ def test_erfi():
     assert erfi(z).rewrite('meijerg') == z*meijerg([S.Half], [], [0], [Rational(-1, 2)], -z**2)/sqrt(pi)
     assert erfi(z).rewrite('uppergamma') == (sqrt(-z**2)/z*(uppergamma(S.Half,
         -z**2)/sqrt(S.Pi) - S.One))
-    assert erfi(z).rewrite('expint') == sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(S.Pi)
+    assert erfi(z).rewrite('expint') == -sqrt(-z**2)/z - z*expint(S.Half, -z**2)/sqrt(S.Pi)
+    for zval in (Rational(3, 4), 2, I, 1 + I, -1 + I, -2 - I):
+        r = erfi(z).rewrite(expint).subs(z, zval)
+        assert abs(r.evalf(15) - erfi(zval).evalf(15)) < 1e-13
     assert erfi(z).rewrite('tractable') == -I*(-_erfs(I*z)*exp(z**2) + 1)
     assert expand_func(erfi(I*z)) == I*erf(z)
 
@@ -578,10 +581,16 @@ def test_li():
                                  log(log(z))/2 + Ci(I*log(z)) + Shi(log(z)))
     assert li(z).rewrite(Ci) == (-log(I*log(z)) - log(1/log(z))/2 +
                                  log(log(z))/2 + Ci(I*log(z)) + Shi(log(z)))
-    assert li(z).rewrite(Shi) == (-log(1/log(z))/2 + log(log(z))/2 +
-                                  Chi(log(z)) - Shi(log(z)))
-    assert li(z).rewrite(Chi) == (-log(1/log(z))/2 + log(log(z))/2 +
-                                  Chi(log(z)) - Shi(log(z)))
+    assert li(z).rewrite(Shi) == (-log(1/log(z))/2 - log(log(z))/2 +
+                                  Chi(log(z)) + Shi(log(z)))
+    assert li(z).rewrite(Chi) == (-log(1/log(z))/2 - log(log(z))/2 +
+                                  Chi(log(z)) + Shi(log(z)))
+    # the rewrites must agree with li numerically for 0 < z < 1, z > 1
+    # and complex z in all quadrants
+    for zval in (Rational(1, 4), Rational(9, 8), 3, 1 + 2*I, -1 + I, -2 - 3*I):
+        for target in (Si, Ci, Shi, Chi):
+            r = li(z).rewrite(target).subs(z, zval)
+            assert abs(r.evalf(15) - li(zval).evalf(15)) < 1e-13
     assert li(z).rewrite(hyper) ==(log(z)*hyper((1, 1), (2, 2), log(z)) -
                                    log(1/log(z))/2 + log(log(z))/2 + EulerGamma)
     assert li(z).rewrite(meijerg) == (-log(1/log(z))/2 - log(-log(z)) + log(log(z))/2 -


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30352

#### Brief description of what is fixed or changed

This PR fixes two sign bugs in `sympy/functions/special/error_functions.py`:

1. `li._eval_rewrite_as_Shi` / `Chi`: The formula used `- Shi(...)` instead of `+ Shi(...)`. Since `li(z) == Ei(log(z))` and `Ei(y) == Shi(y) + Chi(y)`, the `Shi` term must be added. The incorrect sign resulted in wrong numerical values across all test points (and introduced spurious imaginary components for real inputs like `z = 0.5`).
2. `erfi._eval_rewrite_as_expint`: The leading `sqrt(-z**2)/z` term was missing a minus sign. Fixing it to `-sqrt(-z**2)/z` brings it in line with `erfi(z).rewrite(uppergamma)` and removes an unwanted `+ 2.0*I` artifact when evaluating at `z = 2`.

Both rewrites now evaluate to the correct values when checked against `evalf`.

Changes:
- Corrected the signs in `_eval_rewrite_as_Shi` and `_eval_rewrite_as_Chi` for `li`.
- Added the missing minus sign to the leading term in `_eval_rewrite_as_expint` for `erfi`.
- Updated existing structural tests in `test_li` and `test_erfi`.
- Added multi-point numerical assertions against `evalf` for both functions.
- Updated affected doctests in `li`.

#### Other comments

#### AI Generation Disclosure

The bug search and the patch were created with Claude Code. However, I reviewed the changes and tests manually.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed incorrect signs in ``li(z).rewrite(Shi)``, ``li(z).rewrite(Chi)``, and ``erfi(z).rewrite(expint)``.
<!-- END RELEASE NOTES -->
