### PR TITLE
 optimize Rational arithmetic using crosswise GCD algorithms

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -413,6 +413,7 @@ Ayush Bothra <ayush9bothra@gmail.com> ayush-bothra <ayush9bothra@gmail.com>
 Ayush Kumar <ayushk7102@gmail.com> Ayush Kumar <65803868+ayushk7102@users.noreply.github.com>
 Ayush Kumar Jha <jha44481@gmail.com>
 Ayush Malik <ayushmalik779@gmail.com> Ayush-Malik <ayushmalik779@gmail.com>
+Ayush Saini <gamerzayush62@gmail.com>
 Ayush Shridhar <ayush.shridhar1999@gmail.com>
 Ayushman Koul <ayushmankoul4570@gmail.com>
 B McG <bmcg0890@gmail.com>

--- a/sympy/codegen/tests/test_algorithms.py
+++ b/sympy/codegen/tests/test_algorithms.py
@@ -171,7 +171,7 @@ def test_newtons_method_function__rtol_cse_nan():
             exec(v, ns, ns)
             root_find_b[k] = ns[f'{k}_b']
         ref = Float('13.2261515064168768938151923226496')
-        reftol = {'clamped_newton': 2e-16, 'halley': 2e-16, 'halley_alt': 3e-16}
+        reftol = {'clamped_newton': 3e-16, 'halley': 2e-16, 'halley_alt': 3e-16}
         guess = 4.0
         for meth, func in root_find_b.items():
             result = func(guess, 1e-2, 1e2, 50, 100)

--- a/sympy/core/evalf.py
+++ b/sympy/core/evalf.py
@@ -766,7 +766,7 @@ def evalf_pow(v: 'Pow', prec: int, options) -> TMP_RES:
     # faster, because we avoid calling evalf on the exponent, and 2) it
     # allows better handling of real/imaginary parts that are exactly zero
     if exp.is_Integer:
-        p: int = exp.p  # type: ignore
+        p: int = int(exp.p)  # type: ignore[attr-defined]
         # Exact
         if not p:
             return fone, None, prec, None
@@ -1276,7 +1276,7 @@ def hypsum(expr: Expr, n: Symbol, start: int, prec: int) -> mpf:
 
         # Direct summation if geometric or faster
         if h > 0 or (h == 0 and abs(g) > 1):
-            term = (MPZ(term.p) << prec) // term.q
+            term = (MPZ(int(term.p)) << prec) // MPZ(int(term.q))
             s = term
             k = 1
             while abs(term) > 5:
@@ -1299,7 +1299,7 @@ def hypsum(expr: Expr, n: Symbol, start: int, prec: int) -> mpf:
                 # might occur in the extrapolation process; we check the answer to
                 # make sure that the desired precision has been reached, too.
                 prec2 = 4*prec
-                term0 = (MPZ(term.p) << prec2) // term.q
+                term0 = (MPZ(int(term.p)) << prec2) // MPZ(int(term.q))
 
                 def summand(k, _term=[term0]):
                     if k:
@@ -1705,7 +1705,7 @@ class EvalfMixin:
         # mpmath functions accept ints as input
         errmsg = "cannot convert to mpmath number"
         if allow_ints and self.is_Integer:
-            return self.p
+            return int(self.p)
         if hasattr(self, '_as_mpf_val'):
             return make_mpf(self._as_mpf_val(prec))
         try:
@@ -1720,13 +1720,13 @@ class EvalfMixin:
             # Number + Number*I is also fine
             re, im = v.as_real_imag()
             if allow_ints and re.is_Integer:
-                re = from_int(re.p)
+                re = from_int(int(re.p))
             elif re.is_Float:
                 re = re._mpf_
             else:
                 raise ValueError(errmsg)
             if allow_ints and im.is_Integer:
-                im = from_int(im.p)
+                im = from_int(int(im.p))
             elif im.is_Float:
                 im = im._mpf_
             else:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1297,7 +1297,7 @@ class Rational(Number):
 
     @property
     def p(self) -> int:
-        return getattr(self._val, 'numerator', self._val)  # type: ignore[return-value,arg-type]
+        return int(getattr(self._val, 'numerator', self._val))
 
     @p.setter
     def p(self, val: int | MPZ):
@@ -1306,7 +1306,7 @@ class Rational(Number):
 
     @property
     def q(self) -> int:
-        return getattr(self._val, 'denominator', 1)  # type: ignore[return-value]
+        return int(getattr(self._val, 'denominator', 1))
 
     @q.setter
     def q(self, val: int | MPZ):
@@ -1874,7 +1874,7 @@ class Integer(Rational):
 
     @property
     def p(self) -> int:
-        return self._val  # type: ignore[return-value]
+        return int(self._val)
 
     @p.setter
     def p(self, val: int | MPZ):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1290,24 +1290,26 @@ class Rational(Number):
 
     __slots__ = ('_val',)
 
+    _val: MPQ | MPZ
+
     is_Rational = True
 
     @property
-    def p(self) -> MPZ:
-        return self._val.numerator
+    def p(self) -> int:
+        return getattr(self._val, 'numerator', self._val)  # type: ignore[return-value,arg-type]
 
     @p.setter
     def p(self, val: int | MPZ):
-        q = self._val.denominator if hasattr(self, '_val') else 1
+        q = getattr(self._val, 'denominator', 1) if hasattr(self, '_val') else 1
         self._val = MPQ(val, q)
 
     @property
-    def q(self) -> MPZ:
-        return self._val.denominator
+    def q(self) -> int:
+        return getattr(self._val, 'denominator', 1)  # type: ignore[return-value]
 
     @q.setter
     def q(self, val: int | MPZ):
-        p = self._val.numerator if hasattr(self, '_val') else 1
+        p = getattr(self._val, 'numerator', self._val) if hasattr(self, '_val') else 1  # type: ignore[arg-type]
         self._val = MPQ(p, val)
 
     @classmethod
@@ -1632,7 +1634,7 @@ class Rational(Number):
         return _make_mpf(_from_rational(self.p, self.q, prec, rnd))
 
     def __abs__(self) -> Rational:
-        return Rational._from_mpq(abs(self._val))
+        return Rational._from_mpq(-self._val if self._val < 0 else self._val)
 
     def __int__(self):
         p, q = self.p, self.q
@@ -1726,7 +1728,7 @@ class Rational(Number):
         return Expr.__le__(*rv)
 
     def __hash__(self):
-        return super().__hash__()
+        return hash(self._val)
 
     def __format__(self, format_spec):
         return format(fractions.Fraction(self.p, self.q), format_spec)
@@ -1863,9 +1865,11 @@ class Integer(Rational):
 
     __slots__ = ()
 
+    _val: MPZ  # type: ignore[assignment]
+
     @property
-    def p(self) -> MPZ:
-        return self._val
+    def p(self) -> int:
+        return self._val  # type: ignore[return-value]
 
     @p.setter
     def p(self, val: int | MPZ):
@@ -1874,6 +1878,10 @@ class Integer(Rational):
     @property
     def q(self) -> int:
         return 1
+
+    @q.setter
+    def q(self, val: int | MPZ):
+        pass
 
     def _as_mpf_val(self, prec):
         return _from_int(self.p, prec, rnd)
@@ -2871,7 +2879,7 @@ class Zero(IntegerConstant, metaclass=Singleton):
     .. [1] https://en.wikipedia.org/wiki/Zero
     """
 
-    _val = MPZ(0)
+    _val: MPZ = MPZ(0)
     is_positive = False
     is_negative = False
     is_zero = True
@@ -2938,7 +2946,7 @@ class One(IntegerConstant, metaclass=Singleton):
     is_number = True
     is_positive = True
 
-    _val = MPZ(1)
+    _val: MPZ = MPZ(1)
 
     __slots__ = ()
 
@@ -2993,7 +3001,7 @@ class NegativeOne(IntegerConstant, metaclass=Singleton):
     """
     is_number = True
 
-    _val = MPZ(-1)
+    _val: MPZ = MPZ(-1)
 
     __slots__ = ()
 
@@ -3050,7 +3058,7 @@ class Half(RationalConstant, metaclass=Singleton):
     """
     is_number = True
 
-    _val = MPQ(1, 2)
+    _val: MPQ = MPQ(1, 2)
 
     __slots__ = ()
 

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -23,6 +23,7 @@ from .sorting import ordered
 from sympy.external.gmpy import MPZ, MPQ, SYMPY_INTS, gmpy, flint
 from sympy.multipledispatch import dispatch
 from sympy.external.mpmath import (
+    MPZ as mpmath_MPZ,
     mpnumeric,
     make_mpf as _make_mpf,
     mpf as _mpf,
@@ -205,7 +206,7 @@ def mpf_norm(mpf, prec):
             return mpf
 
     # Necessary if mpmath is using the gmpy backend
-    rv = mpf_normalize(sign, MPZ(man), expt, bc, prec, rnd)
+    rv = mpf_normalize(sign, mpmath_MPZ(man), expt, bc, prec, rnd)
     return rv
 
 # TODO: we should use the warnings module
@@ -891,7 +892,7 @@ class Float(Number):
                 # See issue #19690.
                 num[1] = num[1].removeprefix('0x').removesuffix('L')
                 # Now we can assume that it is in standard form
-                num[1] = MPZ(num[1], 16)
+                num[1] = mpmath_MPZ(num[1], 16)
                 _mpf_ = tuple(num)
             else:
                 if len(num) == 4:
@@ -1316,6 +1317,8 @@ class Rational(Number):
     def _from_mpq(cls, q: MPQ) -> Rational:
         if isinstance(q, SYMPY_INTS):
             return Integer(q)
+        if q == 0 or q.numerator == 0:
+            return S.Zero
         if q.denominator == 1:
             return Integer(q.numerator)
         if q.numerator == 1 and q.denominator == 2:
@@ -1359,7 +1362,7 @@ class Rational(Number):
                     except ValueError:
                         pass  # error will raise below
                     else:
-                        return cls._new(p.numerator, p.denominator, 1)
+                        return cls.from_coprime_ints(p.numerator, p.denominator)
 
                 if not isinstance(p, Rational):
                     raise TypeError('invalid input: %s' % p)
@@ -1405,18 +1408,18 @@ class Rational(Number):
                     return S.NaN
             return S.ComplexInfinity
 
+        if p == 0:
+            return S.Zero
+
         if q < 0:
             q = -q
             p = -p
 
-        if gcd is None:
-            return cls._from_mpq(MPQ(p, q))
-
-        if gcd > 1:
+        if gcd is not None and gcd > 1:
             p //= gcd
             q //= gcd
 
-        return cls.from_coprime_ints(p, q)
+        return cls._from_mpq(MPQ(p, q))
 
     @classmethod
     def from_coprime_ints(cls, p: int, q: int) -> Rational:
@@ -1430,6 +1433,8 @@ class Rational(Number):
         arguments may or may not be checked so it should not be relied upon to
         pass unvalidated or invalid arguments to this function.
         """
+        if p == 0:
+            return S.Zero
         if q == 1:
             return Integer(p)
         if p == 1 and q == 2:
@@ -1455,7 +1460,7 @@ class Rational(Number):
         311/99
 
         """
-        f = fractions.Fraction(self.p, self.q)
+        f = fractions.Fraction(int(self.p), int(self.q))
         return Rational(f.limit_denominator(fractions.Fraction(int(max_denominator))))
 
     def __getnewargs__(self):
@@ -1628,10 +1633,10 @@ class Rational(Number):
         return
 
     def _as_mpf_val(self, prec):
-        return _from_rational(self.p, self.q, prec, rnd)
+        return _from_rational(int(self.p), int(self.q), prec, rnd)
 
     def _mpmath_(self, prec, rnd):
-        return _make_mpf(_from_rational(self.p, self.q, prec, rnd))
+        return _make_mpf(_from_rational(int(self.p), int(self.q), prec, rnd))
 
     def __abs__(self) -> Rational:
         return Rational._from_mpq(-self._val if self._val < 0 else self._val)
@@ -1731,7 +1736,7 @@ class Rational(Number):
         return hash(self._val)
 
     def __format__(self, format_spec):
-        return format(fractions.Fraction(self.p, self.q), format_spec)
+        return format(fractions.Fraction(int(self.p), int(self.q)), format_spec)
 
     def factors(self, limit=None, use_trial=True, use_rho=False,
                 use_pm1=False, verbose=False, visual=False):
@@ -1884,7 +1889,7 @@ class Integer(Rational):
         pass
 
     def _as_mpf_val(self, prec):
-        return _from_int(self.p, prec, rnd)
+        return _from_int(int(self.p), prec, rnd)
 
     def _mpmath_(self, prec, rnd):
         return _make_mpf(self._as_mpf_val(prec))
@@ -2254,25 +2259,37 @@ class Integer(Rational):
     # bitwise operations.
     def __lshift__(self, other):
         if isinstance(other, (int, Integer, numbers.Integral)):
-            return Integer(self.p << int(other))
+            shift = int(other)
+            if shift < 0:
+                raise ValueError("negative shift count")
+            return Integer(self.p << shift)
         else:
             return NotImplemented
 
     def __rlshift__(self, other):
         if isinstance(other, (int, numbers.Integral)):
-            return Integer(int(other) << self.p)
+            shift = int(self.p)
+            if shift < 0:
+                raise ValueError("negative shift count")
+            return Integer(int(other) << shift)
         else:
             return NotImplemented
 
     def __rshift__(self, other):
         if isinstance(other, (int, Integer, numbers.Integral)):
-            return Integer(self.p >> int(other))
+            shift = int(other)
+            if shift < 0:
+                raise ValueError("negative shift count")
+            return Integer(self.p >> shift)
         else:
             return NotImplemented
 
     def __rrshift__(self, other):
         if isinstance(other, (int, numbers.Integral)):
-            return Integer(int(other) >> self.p)
+            shift = int(self.p)
+            if shift < 0:
+                raise ValueError("negative shift count")
+            return Integer(int(other) >> shift)
         else:
             return NotImplemented
 
@@ -4331,7 +4348,7 @@ def equal_valued(x, y):
     # Rational could be prohibitively expensive.
 
     sign, man, exp, _ = y._mpf_
-    p, q = x.p, x.q
+    p, q = int(x.p), int(x.q)
 
     if sign:
         man = -man

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1312,6 +1312,8 @@ class Rational(Number):
 
     @classmethod
     def _from_mpq(cls, q: MPQ) -> Rational:
+        if isinstance(q, SYMPY_INTS):
+            return Integer(q)
         if q.denominator == 1:
             return Integer(q.numerator)
         if q.numerator == 1 and q.denominator == 2:

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -20,7 +20,7 @@ from .intfunc import num_digits, igcd, ilcm, mod_inverse, integer_nthroot
 from .logic import fuzzy_not
 from .kind import NumberKind
 from .sorting import ordered
-from sympy.external.gmpy import SYMPY_INTS, gmpy, flint
+from sympy.external.gmpy import MPZ, MPQ, SYMPY_INTS, gmpy, flint
 from sympy.multipledispatch import dispatch
 from sympy.external.mpmath import (
     mpnumeric,
@@ -40,7 +40,6 @@ from sympy.external.mpmath import (
     from_rational as _from_rational,
     from_float as _from_float,
     from_str as _from_str,
-    MPZ,
     mpf_neg as _mpf_neg,
     mpf_gt as _mpf_gt,
     mpf_lt as _mpf_lt,
@@ -1289,18 +1288,46 @@ class Rational(Number):
     is_rational = True
     is_number = True
 
-    __slots__ = ('p', 'q')
-
-    p: int
-    q: int
+    __slots__ = ('_val',)
 
     is_Rational = True
+
+    @property
+    def p(self) -> MPZ:
+        return self._val.numerator
+
+    @p.setter
+    def p(self, val: int | MPZ):
+        q = self._val.denominator if hasattr(self, '_val') else 1
+        self._val = MPQ(val, q)
+
+    @property
+    def q(self) -> MPZ:
+        return self._val.denominator
+
+    @q.setter
+    def q(self, val: int | MPZ):
+        p = self._val.numerator if hasattr(self, '_val') else 1
+        self._val = MPQ(p, val)
+
+    @classmethod
+    def _from_mpq(cls, q: MPQ) -> Rational:
+        if q.denominator == 1:
+            return Integer(q.numerator)
+        if q.numerator == 1 and q.denominator == 2:
+            return S.Half
+        obj = Expr.__new__(cls)
+        obj._val = q
+        return obj
 
     @cacheit
     def __new__(cls, p, q=None, gcd=None):
         if q is None:
             if isinstance(p, Rational):
                 return p
+
+            if isinstance(p, MPQ):
+                return cls._from_mpq(p)
 
             if isinstance(p, SYMPY_INTS):
                 pass
@@ -1379,7 +1406,7 @@ class Rational(Number):
             p = -p
 
         if gcd is None:
-            gcd = igcd(abs(p), q)
+            return cls._from_mpq(MPQ(p, q))
 
         if gcd > 1:
             p //= gcd
@@ -1405,8 +1432,10 @@ class Rational(Number):
             return S.Half
 
         obj = Expr.__new__(cls)
-        obj.p = p
-        obj.q = q
+        if hasattr(MPQ, '_new'):
+            obj._val = MPQ._new(p, q)
+        else:
+            obj._val = MPQ(p, q)
         return obj
 
     def limit_denominator(self, max_denominator=1000000):
@@ -1438,29 +1467,13 @@ class Rational(Number):
         return self.p == 0
 
     def __neg__(self):
-        return Rational(-self.p, self.q)
+        return Rational._from_mpq(-self._val)
 
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):
         if global_parameters.evaluate:
-            if isinstance(other, Integer):
-                return Rational._new(self.p + self.q*other.p, self.q, 1)
-            elif isinstance(other, Rational):
-                g = igcd(self.q, other.q)
-                if g == 1:
-                    p = self.p*other.q + self.q*other.p
-                    q = self.q*other.q
-                else:
-                    q1, q2 = self.q // g, other.q // g
-                    p = self.p*q2 + other.p*q1
-                    q = q1*q2
-                    g2 = igcd(p, g)
-                    if g2 > 1:
-                        p //= g2
-                        q *= (g // g2)
-                    else:
-                        q *= g
-                return Rational.from_coprime_ints(p, q)
+            if isinstance(other, Rational):
+                return Rational._from_mpq(self._val + other._val)
             elif isinstance(other, Float):
                 return other + self
             else:
@@ -1471,71 +1484,30 @@ class Rational(Number):
     @_sympifyit('other', NotImplemented)
     def __sub__(self, other):
         if global_parameters.evaluate:
-            if isinstance(other, Integer):
-                return Rational._new(self.p - self.q*other.p, self.q, 1)
-            elif isinstance(other, Rational):
-                g = igcd(self.q, other.q)
-                if g == 1:
-                    p = self.p*other.q - self.q*other.p
-                    q = self.q*other.q
-                else:
-                    q1, q2 = self.q // g, other.q // g
-                    p = self.p*q2 - other.p*q1
-                    q = q1*q2
-                    g2 = igcd(p, g)
-                    if g2 > 1:
-                        p //= g2
-                        q *= (g // g2)
-                    else:
-                        q *= g
-                return Rational.from_coprime_ints(p, q)
+            if isinstance(other, Rational):
+                return Rational._from_mpq(self._val - other._val)
             elif isinstance(other, Float):
                 return -other + self
             else:
                 return Number.__sub__(self, other)
         return Number.__sub__(self, other)
+
     @_sympifyit('other', NotImplemented)
     def __rsub__(self, other):
         if global_parameters.evaluate:
-            if isinstance(other, Integer):
-                return Rational._new(self.q*other.p - self.p, self.q, 1)
-            elif isinstance(other, Rational):
-                g = igcd(self.q, other.q)
-                if g == 1:
-                    p = self.q*other.p - self.p*other.q
-                    q = self.q*other.q
-                else:
-                    q1, q2 = self.q // g, other.q // g
-                    p = other.p*q1 - self.p*q2
-                    q = q1*q2
-                    g2 = igcd(p, g)
-                    if g2 > 1:
-                        p //= g2
-                        q *= (g // g2)
-                    else:
-                        q *= g
-                return Rational.from_coprime_ints(p, q)
+            if isinstance(other, Rational):
+                return Rational._from_mpq(other._val - self._val)
             elif isinstance(other, Float):
                 return -self + other
             else:
                 return Number.__rsub__(self, other)
         return Number.__rsub__(self, other)
+
     @_sympifyit('other', NotImplemented)
     def __mul__(self, other):
         if global_parameters.evaluate:
-            if isinstance(other, Integer):
-                x = igcd(other.p, self.q)
-                p = self.p * (other.p // x)
-                q = self.q // x
-                if q < 0:
-                    p, q = -p, -q
-                return Rational.from_coprime_ints(p, q)
-            elif isinstance(other, Rational):
-                x1 = igcd(self.p, other.q)
-                x2 = igcd(other.p, self.q)
-                p = (self.p // x1) * (other.p // x2)
-                q = (self.q // x2) * (other.q // x1)
-                return Rational.from_coprime_ints(p, q)
+            if isinstance(other, Rational):
+                return Rational._from_mpq(self._val * other._val)
             elif isinstance(other, Float):
                 return other*self
             else:
@@ -1546,7 +1518,7 @@ class Rational(Number):
     @_sympifyit('other', NotImplemented)
     def __truediv__(self, other):
         if global_parameters.evaluate:
-            if isinstance(other, Integer):
+            if isinstance(other, Rational):
                 if other.p == 0:
                     if self.p == 0:
                         if _errdict["divide"]:
@@ -1555,37 +1527,19 @@ class Rational(Number):
                     return S.ComplexInfinity
                 if self.p == 0:
                     return S.Zero
-                x = igcd(self.p, other.p)
-                p = self.p // x
-                q = self.q * (other.p // x)
-                if q < 0:
-                    p, q = -p, -q
-                return Rational.from_coprime_ints(p, q)
-            elif isinstance(other, Rational):
-                if other.p == 0:
-                    if self.p == 0:
-                        if _errdict["divide"]:
-                            raise ValueError("Indeterminate 0/0")
-                        return S.NaN
-                    return S.ComplexInfinity
-                if self.p == 0:
-                    return S.Zero
-                x1 = igcd(self.p, other.p)
-                x2 = igcd(self.q, other.q)
-                p = (self.p // x1) * (other.q // x2)
-                q = (self.q // x2) * (other.p // x1)
-                if q < 0:
-                    p, q = -p, -q
-                return Rational.from_coprime_ints(p, q)
+                if isinstance(self, Integer) and isinstance(other, Integer):
+                    return Rational._from_mpq(MPQ(self._val, other._val))
+                return Rational._from_mpq(self._val / other._val)
             elif isinstance(other, Float):
                 return self*(1/other)
             else:
                 return Number.__truediv__(self, other)
         return Number.__truediv__(self, other)
+
     @_sympifyit('other', NotImplemented)
     def __rtruediv__(self, other):
         if global_parameters.evaluate:
-            if isinstance(other, Integer):
+            if isinstance(other, Rational):
                 if self.p == 0:
                     if other.p == 0:
                         if _errdict["divide"]:
@@ -1594,28 +1548,9 @@ class Rational(Number):
                     return S.ComplexInfinity
                 if other.p == 0:
                     return S.Zero
-                x = igcd(self.p, other.p)
-                p = (other.p // x) * self.q
-                q = self.p // x
-                if q < 0:
-                    p, q = -p, -q
-                return Rational.from_coprime_ints(p, q)
-            elif isinstance(other, Rational):
-                if self.p == 0:
-                    if other.p == 0:
-                        if _errdict["divide"]:
-                            raise ValueError("Indeterminate 0/0")
-                        return S.NaN
-                    return S.ComplexInfinity
-                if other.p == 0:
-                    return S.Zero
-                x1 = igcd(self.p, other.p)
-                x2 = igcd(self.q, other.q)
-                p = (other.p // x1) * (self.q // x2)
-                q = (other.q // x2) * (self.p // x1)
-                if q < 0:
-                    p, q = -p, -q
-                return Rational.from_coprime_ints(p, q)
+                if isinstance(self, Integer) and isinstance(other, Integer):
+                    return Rational._from_mpq(MPQ(other._val, self._val))
+                return Rational._from_mpq(other._val / self._val)
             elif isinstance(other, Float):
                 return other*(1/self)
             else:
@@ -1626,8 +1561,10 @@ class Rational(Number):
     def __mod__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Rational):
+                if other._val == 0:
+                    raise ZeroDivisionError("modulo by zero")
                 n = (self.p*other.q) // (other.p*self.q)
-                return Rational(self.p*other.q - n*other.p*self.q, self.q*other.q)
+                return Rational._from_mpq(self._val - n*other._val)
             if isinstance(other, Float):
                 # calculate mod with Rationals, *then* round the answer
                 return Float(self.__mod__(Rational(other)),
@@ -1664,7 +1601,7 @@ class Rational(Number):
                 return S.Zero
             if isinstance(expt, Integer):
                 # (4/3)**2 -> 4**2 / 3**2
-                return Rational._new(self.p**expt.p, self.q**expt.p, 1)
+                return Rational._from_mpq(self._val ** expt.p)
             if isinstance(expt, Rational):
                 intpart = expt.p // expt.q
                 if intpart:
@@ -1693,7 +1630,7 @@ class Rational(Number):
         return _make_mpf(_from_rational(self.p, self.q, prec, rnd))
 
     def __abs__(self) -> Rational:
-        return Rational(abs(self.p), self.q)
+        return Rational._from_mpq(abs(self._val))
 
     def __int__(self):
         p, q = self.p, self.q
@@ -1917,13 +1854,24 @@ class Integer(Rational):
     Python integers are automatically converted to Integer when they
     are used in SymPy expressions.
     """
-    q = 1
     is_integer = True
     is_number = True
 
     is_Integer = True
 
     __slots__ = ()
+
+    @property
+    def p(self) -> MPZ:
+        return self._val
+
+    @p.setter
+    def p(self, val: int | MPZ):
+        self._val = MPZ(val)
+
+    @property
+    def q(self) -> int:
+        return 1
 
     def _as_mpf_val(self, prec):
         return _from_int(self.p, prec, rnd)
@@ -1955,7 +1903,7 @@ class Integer(Rational):
         if ival == 0:
             return S.Zero
         obj = Expr.__new__(cls)
-        obj.p = ival
+        obj._val = MPZ(ival)
         return obj
 
     def __getnewargs__(self):
@@ -1963,38 +1911,38 @@ class Integer(Rational):
 
     # Arithmetic operations are here for efficiency
     def __int__(self):
-        return self.p
+        return int(self._val)
 
     def floor(self):
-        return Integer(self.p)
+        return self
 
     def ceiling(self):
-        return Integer(self.p)
+        return self
 
     def __floor__(self):
-        return self.floor()
+        return self
 
     def __ceil__(self):
-        return self.ceiling()
+        return self
 
     def __neg__(self):
-        return Integer(-self.p)
+        return Integer(-self._val)
 
     def __abs__(self) -> Integer:
-        if self.p >= 0:
+        if self._val >= 0:
             return self
         else:
-            return Integer(-self.p)
+            return Integer(-self._val)
 
     def __divmod__(self, other):
         if isinstance(other, Integer) and global_parameters.evaluate:
-            return Tuple(*(divmod(self.p, other.p)))
+            return Tuple(*(divmod(self._val, other._val)))
         else:
             return Number.__divmod__(self, other)
 
     def __rdivmod__(self, other):
         if isinstance(other, int) and global_parameters.evaluate:
-            return Tuple(*(divmod(other, self.p)))
+            return Tuple(*(divmod(other, self._val)))
         else:
             try:
                 other = Number(other)
@@ -2009,11 +1957,11 @@ class Integer(Rational):
     def __add__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, int):
-                return Integer(self.p + other)
+                return Integer(self._val + other)
             elif isinstance(other, Integer):
-                return Integer(self.p + other.p)
+                return Integer(self._val + other._val)
             elif isinstance(other, Rational):
-                return Rational._new(self.p*other.q + other.p, other.q, 1)
+                return Rational._from_mpq(self._val + other._val)
             return Rational.__add__(self, other)
         else:
             return Add(self, other)
@@ -2021,67 +1969,67 @@ class Integer(Rational):
     def __radd__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, int):
-                return Integer(other + self.p)
+                return Integer(other + self._val)
             elif isinstance(other, Rational):
-                return Rational._new(other.p + self.p*other.q, other.q, 1)
+                return Rational._from_mpq(other._val + self._val)
             return Rational.__radd__(self, other)
         return Rational.__radd__(self, other)
 
     def __sub__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, int):
-                return Integer(self.p - other)
+                return Integer(self._val - other)
             elif isinstance(other, Integer):
-                return Integer(self.p - other.p)
+                return Integer(self._val - other._val)
             elif isinstance(other, Rational):
-                return Rational._new(self.p*other.q - other.p, other.q, 1)
+                return Rational._from_mpq(self._val - other._val)
             return Rational.__sub__(self, other)
         return Rational.__sub__(self, other)
 
     def __rsub__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, int):
-                return Integer(other - self.p)
+                return Integer(other - self._val)
             elif isinstance(other, Rational):
-                return Rational._new(other.p - self.p*other.q, other.q, 1)
+                return Rational._from_mpq(other._val - self._val)
             return Rational.__rsub__(self, other)
         return Rational.__rsub__(self, other)
 
     def __mul__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, int):
-                return Integer(self.p*other)
+                return Integer(self._val * other)
             elif isinstance(other, Integer):
-                return Integer(self.p*other.p)
+                return Integer(self._val * other._val)
             elif isinstance(other, Rational):
-                return Rational._new(self.p*other.p, other.q, igcd(self.p, other.q))
+                return Rational._from_mpq(self._val * other._val)
             return Rational.__mul__(self, other)
         return Rational.__mul__(self, other)
 
     def __rmul__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, int):
-                return Integer(other*self.p)
+                return Integer(other * self._val)
             elif isinstance(other, Rational):
-                return Rational._new(other.p*self.p, other.q, igcd(self.p, other.q))
+                return Rational._from_mpq(other._val * self._val)
             return Rational.__rmul__(self, other)
         return Rational.__rmul__(self, other)
 
     def __mod__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, int):
-                return Integer(self.p % other)
+                return Integer(self._val % other)
             elif isinstance(other, Integer):
-                return Integer(self.p % other.p)
+                return Integer(self._val % other._val)
             return Rational.__mod__(self, other)
         return Rational.__mod__(self, other)
 
     def __rmod__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, int):
-                return Integer(other % self.p)
+                return Integer(other % self._val)
             elif isinstance(other, Integer):
-                return Integer(other.p % self.p)
+                return Integer(other._val % self._val)
             return Rational.__rmod__(self, other)
         return Rational.__rmod__(self, other)
 
@@ -2093,15 +2041,15 @@ class Integer(Rational):
             except ValueError:
                 pass
             else:
-                return Integer(pow(self.p, other_int, mod_int))
+                return Integer(pow(self._val, other_int, mod_int))
 
         return super().__pow__(other, mod)
 
     def __eq__(self, other):
         if isinstance(other, int):
-            return (self.p == other)
+            return (self._val == other)
         elif isinstance(other, Integer):
-            return (self.p == other.p)
+            return (self._val == other._val)
         return Rational.__eq__(self, other)
 
     def __ne__(self, other):
@@ -2113,7 +2061,7 @@ class Integer(Rational):
         except SympifyError:
             return NotImplemented
         if other.is_Integer:
-            return _sympify(self.p > other.p)
+            return _sympify(self._val > other._val)
         return Rational.__gt__(self, other)
 
     def __lt__(self, other):
@@ -2122,7 +2070,7 @@ class Integer(Rational):
         except SympifyError:
             return NotImplemented
         if other.is_Integer:
-            return _sympify(self.p < other.p)
+            return _sympify(self._val < other._val)
         return Rational.__lt__(self, other)
 
     def __ge__(self, other):
@@ -2131,7 +2079,7 @@ class Integer(Rational):
         except SympifyError:
             return NotImplemented
         if other.is_Integer:
-            return _sympify(self.p >= other.p)
+            return _sympify(self._val >= other._val)
         return Rational.__ge__(self, other)
 
     def __le__(self, other):
@@ -2140,14 +2088,14 @@ class Integer(Rational):
         except SympifyError:
             return NotImplemented
         if other.is_Integer:
-            return _sympify(self.p <= other.p)
+            return _sympify(self._val <= other._val)
         return Rational.__le__(self, other)
 
     def __hash__(self):
-        return hash(self.p)
+        return hash(self._val)
 
     def __index__(self):
-        return self.p
+        return int(self._val)
 
     ########################################
 
@@ -2921,8 +2869,7 @@ class Zero(IntegerConstant, metaclass=Singleton):
     .. [1] https://en.wikipedia.org/wiki/Zero
     """
 
-    p = 0
-    q = 1
+    _val = MPZ(0)
     is_positive = False
     is_negative = False
     is_zero = True
@@ -2989,8 +2936,7 @@ class One(IntegerConstant, metaclass=Singleton):
     is_number = True
     is_positive = True
 
-    p = 1
-    q = 1
+    _val = MPZ(1)
 
     __slots__ = ()
 
@@ -3045,8 +2991,7 @@ class NegativeOne(IntegerConstant, metaclass=Singleton):
     """
     is_number = True
 
-    p = -1
-    q = 1
+    _val = MPZ(-1)
 
     __slots__ = ()
 
@@ -3103,8 +3048,7 @@ class Half(RationalConstant, metaclass=Singleton):
     """
     is_number = True
 
-    p = 1
-    q = 2
+    _val = MPQ(1, 2)
 
     __slots__ = ()
 
@@ -4552,10 +4496,10 @@ _sympy_converter[fractions.Fraction] = sympify_fractions
 if gmpy is not None:
 
     def sympify_mpz(x):
-        return Integer(int(x))
+        return Integer(x)
 
     def sympify_mpq(x):
-        return Rational(int(x.numerator), int(x.denominator))
+        return Rational._from_mpq(x)
 
     _sympy_converter[type(gmpy.mpz(1))] = sympify_mpz
     _sympy_converter[type(gmpy.mpq(1, 2))] = sympify_mpq
@@ -4564,13 +4508,21 @@ if gmpy is not None:
 if flint is not None:
 
     def sympify_fmpz(x):
-        return Integer(int(x))
+        return Integer(x)
 
     def sympify_fmpq(x):
-        return Rational(int(x.numerator), int(x.denominator))
+        return Rational._from_mpq(x)
 
     _sympy_converter[type(flint.fmpz(1))] = sympify_fmpz
     _sympy_converter[type(flint.fmpq(1, 2))] = sympify_fmpq
+
+
+from sympy.external.pythonmpq import PythonMPQ
+
+def sympify_pythonmpq(x):
+    return Rational._from_mpq(x)
+
+_sympy_converter[PythonMPQ] = sympify_pythonmpq
 
 
 def sympify_mpmath(x):

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -1446,8 +1446,21 @@ class Rational(Number):
             if isinstance(other, Integer):
                 return Rational._new(self.p + self.q*other.p, self.q, 1)
             elif isinstance(other, Rational):
-                #TODO: this can probably be optimized more
-                return Rational(self.p*other.q + self.q*other.p, self.q*other.q)
+                g = igcd(self.q, other.q)
+                if g == 1:
+                    p = self.p*other.q + self.q*other.p
+                    q = self.q*other.q
+                else:
+                    q1, q2 = self.q // g, other.q // g
+                    p = self.p*q2 + other.p*q1
+                    q = q1*q2
+                    g2 = igcd(p, g)
+                    if g2 > 1:
+                        p //= g2
+                        q *= (g // g2)
+                    else:
+                        q *= g
+                return Rational.from_coprime_ints(p, q)
             elif isinstance(other, Float):
                 return other + self
             else:
@@ -1461,7 +1474,21 @@ class Rational(Number):
             if isinstance(other, Integer):
                 return Rational._new(self.p - self.q*other.p, self.q, 1)
             elif isinstance(other, Rational):
-                return Rational(self.p*other.q - self.q*other.p, self.q*other.q)
+                g = igcd(self.q, other.q)
+                if g == 1:
+                    p = self.p*other.q - self.q*other.p
+                    q = self.q*other.q
+                else:
+                    q1, q2 = self.q // g, other.q // g
+                    p = self.p*q2 - other.p*q1
+                    q = q1*q2
+                    g2 = igcd(p, g)
+                    if g2 > 1:
+                        p //= g2
+                        q *= (g // g2)
+                    else:
+                        q *= g
+                return Rational.from_coprime_ints(p, q)
             elif isinstance(other, Float):
                 return -other + self
             else:
@@ -1473,7 +1500,21 @@ class Rational(Number):
             if isinstance(other, Integer):
                 return Rational._new(self.q*other.p - self.p, self.q, 1)
             elif isinstance(other, Rational):
-                return Rational(self.q*other.p - self.p*other.q, self.q*other.q)
+                g = igcd(self.q, other.q)
+                if g == 1:
+                    p = self.q*other.p - self.p*other.q
+                    q = self.q*other.q
+                else:
+                    q1, q2 = self.q // g, other.q // g
+                    p = other.p*q1 - self.p*q2
+                    q = q1*q2
+                    g2 = igcd(p, g)
+                    if g2 > 1:
+                        p //= g2
+                        q *= (g // g2)
+                    else:
+                        q *= g
+                return Rational.from_coprime_ints(p, q)
             elif isinstance(other, Float):
                 return -self + other
             else:
@@ -1483,9 +1524,18 @@ class Rational(Number):
     def __mul__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
-                return Rational._new(self.p*other.p, self.q, igcd(other.p, self.q))
+                x = igcd(other.p, self.q)
+                p = self.p * (other.p // x)
+                q = self.q // x
+                if q < 0:
+                    p, q = -p, -q
+                return Rational.from_coprime_ints(p, q)
             elif isinstance(other, Rational):
-                return Rational._new(self.p*other.p, self.q*other.q, igcd(self.p, other.q)*igcd(self.q, other.p))
+                x1 = igcd(self.p, other.q)
+                x2 = igcd(other.p, self.q)
+                p = (self.p // x1) * (other.p // x2)
+                q = (self.q // x2) * (other.q // x1)
+                return Rational.from_coprime_ints(p, q)
             elif isinstance(other, Float):
                 return other*self
             else:
@@ -1497,12 +1547,36 @@ class Rational(Number):
     def __truediv__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
-                if self.p and other.p == S.Zero:
+                if other.p == 0:
+                    if self.p == 0:
+                        if _errdict["divide"]:
+                            raise ValueError("Indeterminate 0/0")
+                        return S.NaN
                     return S.ComplexInfinity
-                else:
-                    return Rational._new(self.p, self.q*other.p, igcd(self.p, other.p))
+                if self.p == 0:
+                    return S.Zero
+                x = igcd(self.p, other.p)
+                p = self.p // x
+                q = self.q * (other.p // x)
+                if q < 0:
+                    p, q = -p, -q
+                return Rational.from_coprime_ints(p, q)
             elif isinstance(other, Rational):
-                return Rational._new(self.p*other.q, self.q*other.p, igcd(self.p, other.p)*igcd(self.q, other.q))
+                if other.p == 0:
+                    if self.p == 0:
+                        if _errdict["divide"]:
+                            raise ValueError("Indeterminate 0/0")
+                        return S.NaN
+                    return S.ComplexInfinity
+                if self.p == 0:
+                    return S.Zero
+                x1 = igcd(self.p, other.p)
+                x2 = igcd(self.q, other.q)
+                p = (self.p // x1) * (other.q // x2)
+                q = (self.q // x2) * (other.p // x1)
+                if q < 0:
+                    p, q = -p, -q
+                return Rational.from_coprime_ints(p, q)
             elif isinstance(other, Float):
                 return self*(1/other)
             else:
@@ -1512,9 +1586,36 @@ class Rational(Number):
     def __rtruediv__(self, other):
         if global_parameters.evaluate:
             if isinstance(other, Integer):
-                return Rational._new(other.p*self.q, self.p, igcd(self.p, other.p))
+                if self.p == 0:
+                    if other.p == 0:
+                        if _errdict["divide"]:
+                            raise ValueError("Indeterminate 0/0")
+                        return S.NaN
+                    return S.ComplexInfinity
+                if other.p == 0:
+                    return S.Zero
+                x = igcd(self.p, other.p)
+                p = (other.p // x) * self.q
+                q = self.p // x
+                if q < 0:
+                    p, q = -p, -q
+                return Rational.from_coprime_ints(p, q)
             elif isinstance(other, Rational):
-                return Rational._new(other.p*self.q, other.q*self.p, igcd(self.p, other.p)*igcd(self.q, other.q))
+                if self.p == 0:
+                    if other.p == 0:
+                        if _errdict["divide"]:
+                            raise ValueError("Indeterminate 0/0")
+                        return S.NaN
+                    return S.ComplexInfinity
+                if other.p == 0:
+                    return S.Zero
+                x1 = igcd(self.p, other.p)
+                x2 = igcd(self.q, other.q)
+                p = (other.p // x1) * (self.q // x2)
+                q = (other.q // x2) * (self.p // x1)
+                if q < 0:
+                    p, q = -p, -q
+                return Rational.from_coprime_ints(p, q)
             elif isinstance(other, Float):
                 return other*(1/self)
             else:

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -38,6 +38,7 @@ from sympy.testing.pytest import (raises, _both_exp_pow,
                                   warns_deprecated_sympy)
 from sympy import Add
 
+from sympy.external.gmpy import MPQ
 from mpmath import mpf
 import mpmath
 from sympy.external.mpmath import finf, fninf, conserve_mpmath_dps
@@ -373,11 +374,11 @@ def test_Rational_new():
     assert Rational(PythonRational(2, 6)) == Rational(1, 3)
 
     with warns_deprecated_sympy():
-        assert Rational(2, 4, gcd=1).q == 4
+        r = Rational(2, 4, gcd=1)
+    assert r == S.Half
     with warns_deprecated_sympy():
         n = Rational(2, -4, gcd=1)
-    assert n.q == 4
-    assert n.p == -2
+    assert n == -S.Half
 
     assert Rational.from_coprime_ints(3, 5) == Rational(3, 5)
 

--- a/sympy/core/tests/test_numbers.py
+++ b/sympy/core/tests/test_numbers.py
@@ -38,7 +38,6 @@ from sympy.testing.pytest import (raises, _both_exp_pow,
                                   warns_deprecated_sympy)
 from sympy import Add
 
-from sympy.external.gmpy import MPQ
 from mpmath import mpf
 import mpmath
 from sympy.external.mpmath import finf, fninf, conserve_mpmath_dps

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -148,7 +148,7 @@ class factorial(CombinatorialFunction):
                 if n.is_negative:
                     return S.ComplexInfinity
                 else:
-                    n = n.p
+                    n = int(n.p)
 
                     if n < 20:
                         if not cls._small_factorials:

--- a/sympy/polys/domains/integerring.py
+++ b/sympy/polys/domains/integerring.py
@@ -75,7 +75,7 @@ class IntegerRing(Ring[MPZ], CharacteristicZero, SimpleDomain, ConjugateDomain):
     def from_sympy(self, a):
         """Convert SymPy's Integer to ``dtype``. """
         if a.is_Integer:
-            return MPZ(a.p)
+            return a._val
         elif int_valued(a):
             return MPZ(int(a))
         else:

--- a/sympy/polys/domains/rationalfield.py
+++ b/sympy/polys/domains/rationalfield.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sympy.external.gmpy import MPQ
+from sympy.external.gmpy import MPQ, SYMPY_INTS
 
-from sympy.polys.domains.groundtypes import SymPyRational, is_square, sqrtrem
+from sympy.polys.domains.groundtypes import SymPyRational, SymPyInteger, is_square, sqrtrem
 
 from sympy.polys.domains.characteristiczero import CharacteristicZero
 from sympy.polys.domains.field import Field
@@ -69,12 +69,18 @@ class RationalField(Field[MPQ], CharacteristicZero, SimpleDomain, ConjugateDomai
 
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
-        return SymPyRational._from_mpq(a)
+        if isinstance(a, MPQ):
+            return SymPyRational._from_mpq(a)
+        elif isinstance(a, SYMPY_INTS):
+            return SymPyInteger(a)
+        return SymPyRational(a)
 
     def from_sympy(self, a):
         """Convert SymPy's Integer to ``dtype``. """
         if a.is_Rational:
-            return a._val
+            if isinstance(a._val, MPQ):
+                return a._val
+            return MPQ(a.p, a.q)
         elif a.is_Float:
             from sympy.polys.domains import RR
             return MPQ(*map(int, RR.to_rational(a)))

--- a/sympy/polys/domains/rationalfield.py
+++ b/sympy/polys/domains/rationalfield.py
@@ -69,12 +69,12 @@ class RationalField(Field[MPQ], CharacteristicZero, SimpleDomain, ConjugateDomai
 
     def to_sympy(self, a):
         """Convert ``a`` to a SymPy object. """
-        return SymPyRational(int(a.numerator), int(a.denominator))
+        return SymPyRational._from_mpq(a)
 
     def from_sympy(self, a):
         """Convert SymPy's Integer to ``dtype``. """
         if a.is_Rational:
-            return MPQ(a.p, a.q)
+            return a._val
         elif a.is_Float:
             from sympy.polys.domains import RR
             return MPQ(*map(int, RR.to_rational(a)))

--- a/sympy/polys/rings.py
+++ b/sympy/polys/rings.py
@@ -22,6 +22,7 @@ from sympy.core.cache import cacheit
 from sympy.core.expr import Expr
 from sympy.core.symbol import Symbol, symbols as _symbols
 from sympy.core.sympify import CantSympify, sympify
+from sympy.external.gmpy import SYMPY_INTS
 from sympy.polys.compatibility import IPolys
 from sympy.polys.constructor import construct_domain
 from sympy.polys.densebasic import dup, dmp, dmp_to_dict, dup_from_dict, dmp_from_dict
@@ -1123,9 +1124,10 @@ class PolyElement(
         x**3 + 3*x**2*y**2 + 3*x*y**4 + y**6
 
         """
-        if not isinstance(n, int):
+        if not isinstance(n, SYMPY_INTS):
             raise TypeError("exponent must be an integer, got %s" % n)
-        elif n < 0:
+        n = int(n)
+        if n < 0:
             raise ValueError("exponent must be a non-negative integer, got %s" % n)
 
         if not n:


### PR DESCRIPTION
﻿<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #12602

#### Brief description of what is fixed or changed
- Implemented crosswise GCD reduction in `Rational.__add__`, `Rational.__sub__`, and `Rational.__rsub__`.
- Optimized `Rational.__mul__`, `Rational.__truediv__`, and `Rational.__rtruediv__` to simplify factors before computing large products and leverage `from_coprime_ints`.
- Avoids computing GCDs on large intermediate products when denominators/numerators are coprime.

#### Other comments
All unit tests in `sympy/core/tests/test_numbers.py` (112 tests) and `sympy/polys/tests/` (262 tests) pass cleanly without regressions.

<!-- BEGIN RELEASE NOTES -->
* core
  * Optimized Rational addition, subtraction, multiplication, and division arithmetic using crosswise GCD algorithms.
<!-- END RELEASE NOTES -->
