### PR TITLE
doc: fix broken 2013 tutorial link in introductory tutorial (#29023)

### DIFF
--- a/doc/src/tutorials/intro-tutorial/preliminaries.rst
+++ b/doc/src/tutorials/intro-tutorial/preliminaries.rst
@@ -25,7 +25,8 @@ Exercises
 =========
 
 This tutorial was the basis for a tutorial given at the 2013 SciPy conference
-in Austin, TX.  The website for that tutorial is `here
-<https://certik.github.io/scipy-2013-tutorial/html/index.html>`_. It has links
-to videos, materials, and IPython notebook exercises.  The IPython notebook
-exercises in particular are recommended to anyone going through this tutorial.
+in Austin, TX.  The original tutorial website (hosted at
+``certik.github.io/scipy-2013-tutorial``) is no longer maintained and its math
+rendering is broken due to a defunct MathJax CDN.  For historical reference,
+the source repository is available at
+`GitHub <https://github.com/certik/scipy-2013-tutorial>`_.


### PR DESCRIPTION
## Summary

Fixes #29023: The link in the "Exercises" section of the Introductory Tutorial points to a 2013 SciPy conference tutorial website that has broken math rendering due to a defunct MathJax CDN.

## Changes

- Replaced the broken link to `https://certik.github.io/scipy-2013-tutorial/html/index.html` with a note explaining the historical context
- Added a reference to the GitHub source repository (`https://github.com/certik/scipy-2013-tutorial`) for historical reference

## Verification

- The original link returns HTTP 200 but math rendering is broken (MathJax CDN `c328740.ssl.cf1.rackcdn.com` is defunct)
- Math expressions render as raw LaTeX (e.g., `\sqrt{8}` instead of √8)
- The GitHub source repository is still accessible and provides historical context

## AI Assistance

This fix was developed with AI assistance. The issue was independently verified by checking the linked website and confirming the MathJax CDN is no longer functional.