### PR TITLE
functions: Add Jacobi elliptic functions

### DIFF
--- a/doc/src/modules/functions/special.rst
+++ b/doc/src/modules/functions/special.rst
@@ -185,10 +185,16 @@ Elliptic integrals
 .. autoclass:: elliptic_pi
    :members:
 
-Jacobi theta functions
-----------------------
+Jacobi elliptic and theta functions
+-----------------------------------
 .. module:: sympy.functions.special.elliptic_functions
 
+.. autoclass:: jacobisn
+   :members:
+.. autoclass:: jacobicn
+   :members:
+.. autoclass:: jacobidn
+   :members:
 .. autoclass:: jtheta
    :members:
 

--- a/doc/src/modules/functions/special.rst
+++ b/doc/src/modules/functions/special.rst
@@ -189,11 +189,11 @@ Jacobi elliptic and theta functions
 -----------------------------------
 .. module:: sympy.functions.special.elliptic_functions
 
-.. autoclass:: jacobisn
+.. autoclass:: jacobi_sn
    :members:
-.. autoclass:: jacobicn
+.. autoclass:: jacobi_cn
    :members:
-.. autoclass:: jacobidn
+.. autoclass:: jacobi_dn
    :members:
 .. autoclass:: jtheta
    :members:

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -137,8 +137,9 @@ from .functions import (factorial, factorial2, rf, ff, binomial,
         legendre, assoc_legendre, hermite, hermite_prob, chebyshevt, chebyshevu,
         chebyshevu_root, chebyshevt_root, laguerre, assoc_laguerre, gegenbauer,
         jacobi, jacobi_normalized, Ynm, Ynm_c, Znm, elliptic_k, elliptic_f,
-        elliptic_e, elliptic_pi, jtheta, beta, mathieus, mathieuc, mathieusprime,
-        mathieucprime, riemann_xi, betainc, betainc_regularized)
+        elliptic_e, elliptic_pi, jtheta, jacobisn, jacobicn, jacobidn, beta,
+        mathieus, mathieuc, mathieusprime, mathieucprime, riemann_xi, betainc,
+        betainc_regularized)
 
 from .ntheory import (nextprime, prevprime, prime, primerange,
         randprime, Sieve, sieve, primorial, cycle_length, composite,
@@ -366,8 +367,9 @@ __all__ = [
     'chebyshevt', 'chebyshevu', 'chebyshevu_root', 'chebyshevt_root',
     'laguerre', 'assoc_laguerre', 'gegenbauer', 'jacobi', 'jacobi_normalized',
     'Ynm', 'Ynm_c', 'Znm', 'elliptic_k', 'elliptic_f', 'elliptic_e',
-    'elliptic_pi', 'jtheta', 'beta', 'mathieus', 'mathieuc', 'mathieusprime',
-    'mathieucprime', 'riemann_xi','betainc', 'betainc_regularized',
+    'elliptic_pi', 'jtheta', 'jacobisn', 'jacobicn', 'jacobidn', 'beta',
+    'mathieus', 'mathieuc', 'mathieusprime', 'mathieucprime', 'riemann_xi',
+    'betainc', 'betainc_regularized',
 
     # sympy.ntheory
     'nextprime', 'prevprime', 'prime', 'primerange', 'randprime',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -137,7 +137,7 @@ from .functions import (factorial, factorial2, rf, ff, binomial,
         legendre, assoc_legendre, hermite, hermite_prob, chebyshevt, chebyshevu,
         chebyshevu_root, chebyshevt_root, laguerre, assoc_laguerre, gegenbauer,
         jacobi, jacobi_normalized, Ynm, Ynm_c, Znm, elliptic_k, elliptic_f,
-        elliptic_e, elliptic_pi, jtheta, jacobisn, jacobicn, jacobidn, beta,
+        elliptic_e, elliptic_pi, jtheta, jacobi_sn, jacobi_cn, jacobi_dn, beta,
         mathieus, mathieuc, mathieusprime, mathieucprime, riemann_xi, betainc,
         betainc_regularized)
 
@@ -367,7 +367,7 @@ __all__ = [
     'chebyshevt', 'chebyshevu', 'chebyshevu_root', 'chebyshevt_root',
     'laguerre', 'assoc_laguerre', 'gegenbauer', 'jacobi', 'jacobi_normalized',
     'Ynm', 'Ynm_c', 'Znm', 'elliptic_k', 'elliptic_f', 'elliptic_e',
-    'elliptic_pi', 'jtheta', 'jacobisn', 'jacobicn', 'jacobidn', 'beta',
+    'elliptic_pi', 'jtheta', 'jacobi_sn', 'jacobi_cn', 'jacobi_dn', 'beta',
     'mathieus', 'mathieuc', 'mathieusprime', 'mathieucprime', 'riemann_xi',
     'betainc', 'betainc_regularized',
 

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2566,6 +2566,26 @@ def test_sympy__functions__special__elliptic_functions__jtheta():
     assert _test_args(jtheta(1, x, y, 2))
 
 
+def test_sympy__functions__special__elliptic_functions__JacobiEllipticBase():
+    from sympy.functions.special.elliptic_functions import JacobiEllipticBase
+    assert _test_args(JacobiEllipticBase(x, y))
+
+
+def test_sympy__functions__special__elliptic_functions__jacobisn():
+    from sympy.functions.special.elliptic_functions import jacobisn
+    assert _test_args(jacobisn(x, y))
+
+
+def test_sympy__functions__special__elliptic_functions__jacobicn():
+    from sympy.functions.special.elliptic_functions import jacobicn
+    assert _test_args(jacobicn(x, y))
+
+
+def test_sympy__functions__special__elliptic_functions__jacobidn():
+    from sympy.functions.special.elliptic_functions import jacobidn
+    assert _test_args(jacobidn(x, y))
+
+
 def test_sympy__functions__special__delta_functions__DiracDelta():
     from sympy.functions.special.delta_functions import DiracDelta
     assert _test_args(DiracDelta(x, 1))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -2571,19 +2571,19 @@ def test_sympy__functions__special__elliptic_functions__JacobiEllipticBase():
     assert _test_args(JacobiEllipticBase(x, y))
 
 
-def test_sympy__functions__special__elliptic_functions__jacobisn():
-    from sympy.functions.special.elliptic_functions import jacobisn
-    assert _test_args(jacobisn(x, y))
+def test_sympy__functions__special__elliptic_functions__jacobi_sn():
+    from sympy.functions.special.elliptic_functions import jacobi_sn
+    assert _test_args(jacobi_sn(x, y))
 
 
-def test_sympy__functions__special__elliptic_functions__jacobicn():
-    from sympy.functions.special.elliptic_functions import jacobicn
-    assert _test_args(jacobicn(x, y))
+def test_sympy__functions__special__elliptic_functions__jacobi_cn():
+    from sympy.functions.special.elliptic_functions import jacobi_cn
+    assert _test_args(jacobi_cn(x, y))
 
 
-def test_sympy__functions__special__elliptic_functions__jacobidn():
-    from sympy.functions.special.elliptic_functions import jacobidn
-    assert _test_args(jacobidn(x, y))
+def test_sympy__functions__special__elliptic_functions__jacobi_dn():
+    from sympy.functions.special.elliptic_functions import jacobi_dn
+    assert _test_args(jacobi_dn(x, y))
 
 
 def test_sympy__functions__special__delta_functions__DiracDelta():

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -47,7 +47,8 @@ from sympy.functions.special.polynomials import (legendre, assoc_legendre,
 from sympy.functions.special.spherical_harmonics import Ynm, Ynm_c, Znm
 from sympy.functions.special.elliptic_integrals import (elliptic_k,
         elliptic_f, elliptic_e, elliptic_pi)
-from sympy.functions.special.elliptic_functions import jtheta
+from sympy.functions.special.elliptic_functions import (jacobicn, jacobidn,
+        jacobisn, jtheta)
 from sympy.functions.special.beta_functions import beta, betainc, betainc_regularized
 from sympy.functions.special.mathieu_functions import (mathieus, mathieuc,
         mathieusprime, mathieucprime)
@@ -111,7 +112,7 @@ __all__ = [
 
     'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi',
 
-    'jtheta',
+    'jtheta', 'jacobisn', 'jacobicn', 'jacobidn',
 
     'beta', 'betainc', 'betainc_regularized',
 

--- a/sympy/functions/__init__.py
+++ b/sympy/functions/__init__.py
@@ -47,8 +47,8 @@ from sympy.functions.special.polynomials import (legendre, assoc_legendre,
 from sympy.functions.special.spherical_harmonics import Ynm, Ynm_c, Znm
 from sympy.functions.special.elliptic_integrals import (elliptic_k,
         elliptic_f, elliptic_e, elliptic_pi)
-from sympy.functions.special.elliptic_functions import (jacobicn, jacobidn,
-        jacobisn, jtheta)
+from sympy.functions.special.elliptic_functions import (jacobi_cn, jacobi_dn,
+        jacobi_sn, jtheta)
 from sympy.functions.special.beta_functions import beta, betainc, betainc_regularized
 from sympy.functions.special.mathieu_functions import (mathieus, mathieuc,
         mathieusprime, mathieucprime)
@@ -112,7 +112,7 @@ __all__ = [
 
     'elliptic_k', 'elliptic_f', 'elliptic_e', 'elliptic_pi',
 
-    'jtheta', 'jacobisn', 'jacobicn', 'jacobidn',
+    'jtheta', 'jacobi_sn', 'jacobi_cn', 'jacobi_dn',
 
     'beta', 'betainc', 'betainc_regularized',
 

--- a/sympy/functions/special/elliptic_functions.py
+++ b/sympy/functions/special/elliptic_functions.py
@@ -2,9 +2,14 @@
 from __future__ import annotations
 
 from sympy.core import Add, S
+from sympy.core.expr import Expr
 from sympy.core.function import ArgumentIndexError, DefinedFunction
 from sympy.core.numbers import pi
+from sympy.external.mpmath import local_workprec
+from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.hyperbolic import sech, tanh
 from sympy.functions.elementary.trigonometric import cos, sin
+from sympy.functions.special.elliptic_integrals import elliptic_k
 
 
 class jtheta(DefinedFunction):
@@ -261,3 +266,339 @@ class jtheta(DefinedFunction):
         # Expand the finite nome series in x because q and z can depend on x.
         # The explicit Order accounts for the omitted theta-series terms.
         return series._eval_nseries(x, n, logx, cdir) + Order(x**n, x)
+
+
+def _jacobi_theta_parameters(u, m):
+    """Return the nome and theta argument for Jacobi elliptic functions."""
+    q = exp(-pi*elliptic_k(1 - m)/elliptic_k(m))
+    return q, u/jtheta(3, 0, q)**2
+
+
+class JacobiEllipticBase(DefinedFunction):
+    """Base class for the Jacobi elliptic functions."""
+
+    nargs = 2
+    _kind = ''
+
+    @property
+    def argument(self):
+        """The argument of the Jacobi elliptic function."""
+        return self.args[0]
+
+    @property
+    def parameter(self):
+        """The parameter of the Jacobi elliptic function."""
+        return self.args[1]
+
+    def _eval_evalf(self, prec):
+        if all(arg.is_number for arg in self.args):
+            u = self.argument._to_mpmath(prec)
+            m = self.parameter._to_mpmath(prec)
+            with local_workprec(prec) as ctx:
+                result = ctx.ellipfun(self._kind, u, m)
+            return Expr._from_mpmath(result, prec)
+
+
+class jacobisn(JacobiEllipticBase):
+    r"""
+    The Jacobi elliptic sine function ``jacobisn(u, m)``.
+
+    Explanation
+    ===========
+
+    ``jacobisn(u, m)`` is the Jacobi elliptic function
+    :math:`\operatorname{sn}(u\mathrel{|}m)`, with argument $u$ and
+    parameter $m = k^2$, where $k$ is the elliptic modulus. If
+    $u = F(\phi\mathrel{|}m)$, where $F$ is the incomplete elliptic
+    integral of the first kind represented in SymPy by
+    :class:`~.elliptic_f`, then
+
+    .. math::
+
+        \operatorname{sn}(u\mathrel{|}m) = \sin(\phi).
+
+    As a function of $u$, ``jacobisn`` is doubly periodic. Writing $K(m)$
+    for the complete elliptic integral of the first kind, represented by
+    :class:`~.elliptic_k`, a pair of periods is
+
+    .. math::
+
+        4K(m), \qquad 2iK(1-m).
+
+    The function is meromorphic in both $u$ and $m$.
+
+    Together with ``jacobicn`` and ``jacobidn``, this function belongs to a
+    system closed under differentiation with respect to $u$. It can also be
+    rewritten in terms of :class:`~.jtheta`. With
+
+    .. math::
+
+        q = \exp\left(-\pi\frac{K(1-m)}{K(m)}\right), \qquad
+        v = \frac{u}{\vartheta_3(0,q)^2},
+
+    the relation is
+
+    .. math::
+
+        \operatorname{sn}(u\mathrel{|}m)
+        = \frac{\vartheta_3(0,q)\vartheta_1(v,q)}
+        {\vartheta_2(0,q)\vartheta_4(v,q)}.
+
+    The parameter convention agrees with :class:`~.elliptic_k`,
+    :class:`~.elliptic_f`, and mpmath's ``ellipfun``.
+
+    Examples
+    ========
+
+    >>> from sympy import jacobisn, jtheta
+    >>> from sympy.abc import m, u
+    >>> jacobisn(0, m)
+    0
+    >>> jacobisn(u, 0)
+    sin(u)
+    >>> jacobisn(u, 1)
+    tanh(u)
+    >>> jacobisn(u, m).diff(u)
+    jacobicn(u, m)*jacobidn(u, m)
+    >>> jacobisn(u, m).rewrite(jtheta).has(jtheta)
+    True
+
+    See Also
+    ========
+
+    jacobicn, jacobidn, jtheta, elliptic_f, elliptic_k
+
+    References
+    ==========
+
+    .. [1] https://dlmf.nist.gov/22
+    .. [2] https://mpmath.org/doc/current/functions/elliptic.html#ellipfun
+
+    """
+
+    _kind = 'sn'
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_zero:
+            return S.Zero
+        if m.is_zero:
+            return sin(u)
+        if m is S.One:
+            return tanh(u)
+        if u.could_extract_minus_sign():
+            return -cls(-u, m)
+
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return jacobicn(u, m)*jacobidn(u, m)
+        raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_jtheta(self, u, m, **kwargs):
+        q, v = _jacobi_theta_parameters(u, m)
+        return (jtheta(3, 0, q)*jtheta(1, v, q)
+                / (jtheta(2, 0, q)*jtheta(4, v, q)))
+
+
+class jacobicn(JacobiEllipticBase):
+    r"""
+    The Jacobi elliptic cosine function ``jacobicn(u, m)``.
+
+    Explanation
+    ===========
+
+    ``jacobicn(u, m)`` is the Jacobi elliptic function
+    :math:`\operatorname{cn}(u\mathrel{|}m)`, with argument $u$ and
+    parameter $m = k^2$, where $k$ is the elliptic modulus. If
+    $u = F(\phi\mathrel{|}m)$, where $F$ is the incomplete elliptic
+    integral of the first kind represented in SymPy by
+    :class:`~.elliptic_f`, then
+
+    .. math::
+
+        \operatorname{cn}(u\mathrel{|}m) = \cos(\phi).
+
+    As a function of $u$, ``jacobicn`` is doubly periodic. Writing $K(m)$
+    for the complete elliptic integral of the first kind, represented by
+    :class:`~.elliptic_k`, a pair of periods is
+
+    .. math::
+
+        4K(m), \qquad 2K(m) + 2iK(1-m).
+
+    The function is meromorphic in both $u$ and $m$.
+
+    Together with ``jacobisn`` and ``jacobidn``, this function belongs to a
+    system closed under differentiation with respect to $u$. It can also be
+    rewritten in terms of :class:`~.jtheta`. With
+
+    .. math::
+
+        q = \exp\left(-\pi\frac{K(1-m)}{K(m)}\right), \qquad
+        v = \frac{u}{\vartheta_3(0,q)^2},
+
+    the relation is
+
+    .. math::
+
+        \operatorname{cn}(u\mathrel{|}m)
+        = \frac{\vartheta_4(0,q)\vartheta_2(v,q)}
+        {\vartheta_2(0,q)\vartheta_4(v,q)}.
+
+    The parameter convention agrees with :class:`~.elliptic_k`,
+    :class:`~.elliptic_f`, and mpmath's ``ellipfun``.
+
+    Examples
+    ========
+
+    >>> from sympy import jacobicn, jtheta
+    >>> from sympy.abc import m, u
+    >>> jacobicn(0, m)
+    1
+    >>> jacobicn(u, 0)
+    cos(u)
+    >>> jacobicn(u, 1)
+    sech(u)
+    >>> jacobicn(u, m).diff(u)
+    -jacobidn(u, m)*jacobisn(u, m)
+    >>> jacobicn(u, m).rewrite(jtheta).has(jtheta)
+    True
+
+    See Also
+    ========
+
+    jacobisn, jacobidn, jtheta, elliptic_f, elliptic_k
+
+    References
+    ==========
+
+    .. [1] https://dlmf.nist.gov/22
+    .. [2] https://mpmath.org/doc/current/functions/elliptic.html#ellipfun
+
+    """
+
+    _kind = 'cn'
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_zero:
+            return S.One
+        if m.is_zero:
+            return cos(u)
+        if m is S.One:
+            return sech(u)
+        if u.could_extract_minus_sign():
+            return cls(-u, m)
+
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return -jacobisn(u, m)*jacobidn(u, m)
+        raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_jtheta(self, u, m, **kwargs):
+        q, v = _jacobi_theta_parameters(u, m)
+        return (jtheta(4, 0, q)*jtheta(2, v, q)
+                / (jtheta(2, 0, q)*jtheta(4, v, q)))
+
+
+class jacobidn(JacobiEllipticBase):
+    r"""
+    The Jacobi delta amplitude function ``jacobidn(u, m)``.
+
+    Explanation
+    ===========
+
+    ``jacobidn(u, m)`` is the Jacobi elliptic function
+    :math:`\operatorname{dn}(u\mathrel{|}m)`, with argument $u$ and
+    parameter $m = k^2$, where $k$ is the elliptic modulus. If
+    $u = F(\phi\mathrel{|}m)$, where $F$ is the incomplete elliptic
+    integral of the first kind represented in SymPy by
+    :class:`~.elliptic_f`, then
+
+    .. math::
+
+        \operatorname{dn}(u\mathrel{|}m)
+        = \sqrt{1 - m\sin^2(\phi)}.
+
+    As a function of $u$, ``jacobidn`` is doubly periodic. Writing $K(m)$
+    for the complete elliptic integral of the first kind, represented by
+    :class:`~.elliptic_k`, a pair of periods is
+
+    .. math::
+
+        2K(m), \qquad 4iK(1-m).
+
+    The function is meromorphic in both $u$ and $m$.
+
+    Together with ``jacobisn`` and ``jacobicn``, this function belongs to a
+    system closed under differentiation with respect to $u$. It can also be
+    rewritten in terms of :class:`~.jtheta`. With
+
+    .. math::
+
+        q = \exp\left(-\pi\frac{K(1-m)}{K(m)}\right), \qquad
+        v = \frac{u}{\vartheta_3(0,q)^2},
+
+    the relation is
+
+    .. math::
+
+        \operatorname{dn}(u\mathrel{|}m)
+        = \frac{\vartheta_4(0,q)\vartheta_3(v,q)}
+        {\vartheta_3(0,q)\vartheta_4(v,q)}.
+
+    The parameter convention agrees with :class:`~.elliptic_k`,
+    :class:`~.elliptic_f`, and mpmath's ``ellipfun``.
+
+    Examples
+    ========
+
+    >>> from sympy import jacobidn, jtheta
+    >>> from sympy.abc import m, u
+    >>> jacobidn(0, m)
+    1
+    >>> jacobidn(u, 0)
+    1
+    >>> jacobidn(u, 1)
+    sech(u)
+    >>> jacobidn(u, m).diff(u)
+    -m*jacobicn(u, m)*jacobisn(u, m)
+    >>> jacobidn(u, m).rewrite(jtheta).has(jtheta)
+    True
+
+    See Also
+    ========
+
+    jacobisn, jacobicn, jtheta, elliptic_f, elliptic_k
+
+    References
+    ==========
+
+    .. [1] https://dlmf.nist.gov/22
+    .. [2] https://mpmath.org/doc/current/functions/elliptic.html#ellipfun
+
+    """
+
+    _kind = 'dn'
+
+    @classmethod
+    def eval(cls, u, m):
+        if u.is_zero or m.is_zero:
+            return S.One
+        if m is S.One:
+            return sech(u)
+        if u.could_extract_minus_sign():
+            return cls(-u, m)
+
+    def fdiff(self, argindex=1):
+        u, m = self.args
+        if argindex == 1:
+            return -m*jacobisn(u, m)*jacobicn(u, m)
+        raise ArgumentIndexError(self, argindex)
+
+    def _eval_rewrite_as_jtheta(self, u, m, **kwargs):
+        q, v = _jacobi_theta_parameters(u, m)
+        return (jtheta(4, 0, q)*jtheta(3, v, q)
+                / (jtheta(3, 0, q)*jtheta(4, v, q)))

--- a/sympy/functions/special/elliptic_functions.py
+++ b/sympy/functions/special/elliptic_functions.py
@@ -291,7 +291,10 @@ class JacobiEllipticBase(DefinedFunction):
         return self.args[1]
 
     def _eval_evalf(self, prec):
-        if all(arg.is_number for arg in self.args):
+        if any(arg is S.NaN for arg in self.args):
+            return S.NaN
+        if all(arg.is_number and arg.is_finite is not False
+                for arg in self.args):
             u = self.argument._to_mpmath(prec)
             m = self.parameter._to_mpmath(prec)
             with local_workprec(prec) as ctx:
@@ -299,14 +302,14 @@ class JacobiEllipticBase(DefinedFunction):
             return Expr._from_mpmath(result, prec)
 
 
-class jacobisn(JacobiEllipticBase):
+class jacobi_sn(JacobiEllipticBase):
     r"""
-    The Jacobi elliptic sine function ``jacobisn(u, m)``.
+    The Jacobi elliptic sine function ``jacobi_sn(u, m)``.
 
     Explanation
     ===========
 
-    ``jacobisn(u, m)`` is the Jacobi elliptic function
+    ``jacobi_sn(u, m)`` is the Jacobi elliptic function
     :math:`\operatorname{sn}(u\mathrel{|}m)`, with argument $u$ and
     parameter $m = k^2$, where $k$ is the elliptic modulus. If
     $u = F(\phi\mathrel{|}m)$, where $F$ is the incomplete elliptic
@@ -317,7 +320,7 @@ class jacobisn(JacobiEllipticBase):
 
         \operatorname{sn}(u\mathrel{|}m) = \sin(\phi).
 
-    As a function of $u$, ``jacobisn`` is doubly periodic. Writing $K(m)$
+    As a function of $u$, ``jacobi_sn`` is doubly periodic. Writing $K(m)$
     for the complete elliptic integral of the first kind, represented by
     :class:`~.elliptic_k`, a pair of periods is
 
@@ -327,7 +330,7 @@ class jacobisn(JacobiEllipticBase):
 
     The function is meromorphic in both $u$ and $m$.
 
-    Together with ``jacobicn`` and ``jacobidn``, this function belongs to a
+    Together with ``jacobi_cn`` and ``jacobi_dn``, this function belongs to a
     system closed under differentiation with respect to $u$. It can also be
     rewritten in terms of :class:`~.jtheta`. With
 
@@ -350,23 +353,24 @@ class jacobisn(JacobiEllipticBase):
     Examples
     ========
 
-    >>> from sympy import jacobisn, jtheta
-    >>> from sympy.abc import m, u
-    >>> jacobisn(0, m)
+    >>> from sympy import elliptic_k, exp, jacobi_sn, jtheta, pi
+    >>> from sympy.abc import m, q, u
+    >>> jacobi_sn(0, m)
     0
-    >>> jacobisn(u, 0)
+    >>> jacobi_sn(u, 0)
     sin(u)
-    >>> jacobisn(u, 1)
+    >>> jacobi_sn(u, 1)
     tanh(u)
-    >>> jacobisn(u, m).diff(u)
-    jacobicn(u, m)*jacobidn(u, m)
-    >>> jacobisn(u, m).rewrite(jtheta).has(jtheta)
-    True
+    >>> jacobi_sn(u, m).diff(u)
+    jacobi_cn(u, m)*jacobi_dn(u, m)
+    >>> nome = exp(-pi*elliptic_k(1 - m)/elliptic_k(m))
+    >>> jacobi_sn(u, m).rewrite(jtheta).subs(nome, q)
+    jtheta(1, u/jtheta(3, 0, q)**2, q)*jtheta(3, 0, q)/(jtheta(2, 0, q)*jtheta(4, u/jtheta(3, 0, q)**2, q))
 
     See Also
     ========
 
-    jacobicn, jacobidn, jtheta, elliptic_f, elliptic_k
+    jacobi_cn, jacobi_dn, jtheta, elliptic_f, elliptic_k
 
     References
     ==========
@@ -380,6 +384,8 @@ class jacobisn(JacobiEllipticBase):
 
     @classmethod
     def eval(cls, u, m):
+        if u is S.NaN or m is S.NaN:
+            return S.NaN
         if u.is_zero:
             return S.Zero
         if m.is_zero:
@@ -392,7 +398,7 @@ class jacobisn(JacobiEllipticBase):
     def fdiff(self, argindex=1):
         u, m = self.args
         if argindex == 1:
-            return jacobicn(u, m)*jacobidn(u, m)
+            return jacobi_cn(u, m)*jacobi_dn(u, m)
         raise ArgumentIndexError(self, argindex)
 
     def _eval_rewrite_as_jtheta(self, u, m, **kwargs):
@@ -401,14 +407,14 @@ class jacobisn(JacobiEllipticBase):
                 / (jtheta(2, 0, q)*jtheta(4, v, q)))
 
 
-class jacobicn(JacobiEllipticBase):
+class jacobi_cn(JacobiEllipticBase):
     r"""
-    The Jacobi elliptic cosine function ``jacobicn(u, m)``.
+    The Jacobi elliptic cosine function ``jacobi_cn(u, m)``.
 
     Explanation
     ===========
 
-    ``jacobicn(u, m)`` is the Jacobi elliptic function
+    ``jacobi_cn(u, m)`` is the Jacobi elliptic function
     :math:`\operatorname{cn}(u\mathrel{|}m)`, with argument $u$ and
     parameter $m = k^2$, where $k$ is the elliptic modulus. If
     $u = F(\phi\mathrel{|}m)$, where $F$ is the incomplete elliptic
@@ -419,7 +425,7 @@ class jacobicn(JacobiEllipticBase):
 
         \operatorname{cn}(u\mathrel{|}m) = \cos(\phi).
 
-    As a function of $u$, ``jacobicn`` is doubly periodic. Writing $K(m)$
+    As a function of $u$, ``jacobi_cn`` is doubly periodic. Writing $K(m)$
     for the complete elliptic integral of the first kind, represented by
     :class:`~.elliptic_k`, a pair of periods is
 
@@ -429,7 +435,7 @@ class jacobicn(JacobiEllipticBase):
 
     The function is meromorphic in both $u$ and $m$.
 
-    Together with ``jacobisn`` and ``jacobidn``, this function belongs to a
+    Together with ``jacobi_sn`` and ``jacobi_dn``, this function belongs to a
     system closed under differentiation with respect to $u$. It can also be
     rewritten in terms of :class:`~.jtheta`. With
 
@@ -452,23 +458,24 @@ class jacobicn(JacobiEllipticBase):
     Examples
     ========
 
-    >>> from sympy import jacobicn, jtheta
-    >>> from sympy.abc import m, u
-    >>> jacobicn(0, m)
+    >>> from sympy import elliptic_k, exp, jacobi_cn, jtheta, pi
+    >>> from sympy.abc import m, q, u
+    >>> jacobi_cn(0, m)
     1
-    >>> jacobicn(u, 0)
+    >>> jacobi_cn(u, 0)
     cos(u)
-    >>> jacobicn(u, 1)
+    >>> jacobi_cn(u, 1)
     sech(u)
-    >>> jacobicn(u, m).diff(u)
-    -jacobidn(u, m)*jacobisn(u, m)
-    >>> jacobicn(u, m).rewrite(jtheta).has(jtheta)
-    True
+    >>> jacobi_cn(u, m).diff(u)
+    -jacobi_dn(u, m)*jacobi_sn(u, m)
+    >>> nome = exp(-pi*elliptic_k(1 - m)/elliptic_k(m))
+    >>> jacobi_cn(u, m).rewrite(jtheta).subs(nome, q)
+    jtheta(2, u/jtheta(3, 0, q)**2, q)*jtheta(4, 0, q)/(jtheta(2, 0, q)*jtheta(4, u/jtheta(3, 0, q)**2, q))
 
     See Also
     ========
 
-    jacobisn, jacobidn, jtheta, elliptic_f, elliptic_k
+    jacobi_sn, jacobi_dn, jtheta, elliptic_f, elliptic_k
 
     References
     ==========
@@ -482,6 +489,8 @@ class jacobicn(JacobiEllipticBase):
 
     @classmethod
     def eval(cls, u, m):
+        if u is S.NaN or m is S.NaN:
+            return S.NaN
         if u.is_zero:
             return S.One
         if m.is_zero:
@@ -494,7 +503,7 @@ class jacobicn(JacobiEllipticBase):
     def fdiff(self, argindex=1):
         u, m = self.args
         if argindex == 1:
-            return -jacobisn(u, m)*jacobidn(u, m)
+            return -jacobi_sn(u, m)*jacobi_dn(u, m)
         raise ArgumentIndexError(self, argindex)
 
     def _eval_rewrite_as_jtheta(self, u, m, **kwargs):
@@ -503,14 +512,14 @@ class jacobicn(JacobiEllipticBase):
                 / (jtheta(2, 0, q)*jtheta(4, v, q)))
 
 
-class jacobidn(JacobiEllipticBase):
+class jacobi_dn(JacobiEllipticBase):
     r"""
-    The Jacobi delta amplitude function ``jacobidn(u, m)``.
+    The Jacobi delta amplitude function ``jacobi_dn(u, m)``.
 
     Explanation
     ===========
 
-    ``jacobidn(u, m)`` is the Jacobi elliptic function
+    ``jacobi_dn(u, m)`` is the Jacobi elliptic function
     :math:`\operatorname{dn}(u\mathrel{|}m)`, with argument $u$ and
     parameter $m = k^2$, where $k$ is the elliptic modulus. If
     $u = F(\phi\mathrel{|}m)$, where $F$ is the incomplete elliptic
@@ -522,7 +531,7 @@ class jacobidn(JacobiEllipticBase):
         \operatorname{dn}(u\mathrel{|}m)
         = \sqrt{1 - m\sin^2(\phi)}.
 
-    As a function of $u$, ``jacobidn`` is doubly periodic. Writing $K(m)$
+    As a function of $u$, ``jacobi_dn`` is doubly periodic. Writing $K(m)$
     for the complete elliptic integral of the first kind, represented by
     :class:`~.elliptic_k`, a pair of periods is
 
@@ -532,7 +541,7 @@ class jacobidn(JacobiEllipticBase):
 
     The function is meromorphic in both $u$ and $m$.
 
-    Together with ``jacobisn`` and ``jacobicn``, this function belongs to a
+    Together with ``jacobi_sn`` and ``jacobi_cn``, this function belongs to a
     system closed under differentiation with respect to $u$. It can also be
     rewritten in terms of :class:`~.jtheta`. With
 
@@ -555,23 +564,24 @@ class jacobidn(JacobiEllipticBase):
     Examples
     ========
 
-    >>> from sympy import jacobidn, jtheta
-    >>> from sympy.abc import m, u
-    >>> jacobidn(0, m)
+    >>> from sympy import elliptic_k, exp, jacobi_dn, jtheta, pi
+    >>> from sympy.abc import m, q, u
+    >>> jacobi_dn(0, m)
     1
-    >>> jacobidn(u, 0)
+    >>> jacobi_dn(u, 0)
     1
-    >>> jacobidn(u, 1)
+    >>> jacobi_dn(u, 1)
     sech(u)
-    >>> jacobidn(u, m).diff(u)
-    -m*jacobicn(u, m)*jacobisn(u, m)
-    >>> jacobidn(u, m).rewrite(jtheta).has(jtheta)
-    True
+    >>> jacobi_dn(u, m).diff(u)
+    -m*jacobi_cn(u, m)*jacobi_sn(u, m)
+    >>> nome = exp(-pi*elliptic_k(1 - m)/elliptic_k(m))
+    >>> jacobi_dn(u, m).rewrite(jtheta).subs(nome, q)
+    jtheta(3, u/jtheta(3, 0, q)**2, q)*jtheta(4, 0, q)/(jtheta(3, 0, q)*jtheta(4, u/jtheta(3, 0, q)**2, q))
 
     See Also
     ========
 
-    jacobisn, jacobicn, jtheta, elliptic_f, elliptic_k
+    jacobi_sn, jacobi_cn, jtheta, elliptic_f, elliptic_k
 
     References
     ==========
@@ -585,6 +595,8 @@ class jacobidn(JacobiEllipticBase):
 
     @classmethod
     def eval(cls, u, m):
+        if u is S.NaN or m is S.NaN:
+            return S.NaN
         if u.is_zero or m.is_zero:
             return S.One
         if m is S.One:
@@ -595,7 +607,7 @@ class jacobidn(JacobiEllipticBase):
     def fdiff(self, argindex=1):
         u, m = self.args
         if argindex == 1:
-            return -m*jacobisn(u, m)*jacobicn(u, m)
+            return -m*jacobi_sn(u, m)*jacobi_cn(u, m)
         raise ArgumentIndexError(self, argindex)
 
     def _eval_rewrite_as_jtheta(self, u, m, **kwargs):

--- a/sympy/functions/special/tests/test_elliptic_functions.py
+++ b/sympy/functions/special/tests/test_elliptic_functions.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from sympy.core import S
+from sympy.core.function import Derivative
 from sympy.core.numbers import Float, I, Rational, pi
 from sympy.core.symbol import Symbol
 from sympy.functions.elementary.exponential import exp
+from sympy.functions.elementary.hyperbolic import sech, tanh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import cos, sin
-from sympy.functions.special.elliptic_functions import jtheta
+from sympy.functions.special.elliptic_functions import (
+    jacobicn, jacobidn, jacobisn, jtheta)
+from sympy.functions.special.elliptic_integrals import elliptic_k
 from sympy.series.order import O
 from sympy.testing.pytest import raises
 
@@ -19,6 +23,186 @@ d = Symbol('d', integer=True, nonnegative=True)
 
 def _assert_close(left, right, tolerance=S(10)**-25):
     assert abs((left - right).evalf(30)) < tolerance
+
+
+def test_jacobi_elliptic_definition():
+    for func in (jacobisn, jacobicn, jacobidn):
+        assert func(z, q).args == (z, q)
+
+
+def test_jacobi_elliptic_special_values():
+    # DLMF 22.5.1, 22.5.3, and 22.5.4:
+    # https://dlmf.nist.gov/22.5.T1
+    # https://dlmf.nist.gov/22.5.T3
+    # https://dlmf.nist.gov/22.5.T4
+    assert jacobisn(0, q) == 0
+    assert jacobicn(0, q) == 1
+    assert jacobidn(0, q) == 1
+
+    assert jacobisn(z, 0) == sin(z)
+    assert jacobicn(z, 0) == cos(z)
+    assert jacobidn(z, 0) == 1
+
+    assert jacobisn(z, 1) == tanh(z)
+    assert jacobicn(z, 1) == sech(z)
+    assert jacobidn(z, 1) == sech(z)
+
+
+def test_jacobi_elliptic_parity():
+    # This follows from the theta representations in DLMF 22.2.4--22.2.6
+    # and the theta-function parity in DLMF 20.2.1--20.2.4:
+    # https://dlmf.nist.gov/22.2.E4
+    # https://dlmf.nist.gov/22.2.E5
+    # https://dlmf.nist.gov/22.2.E6
+    assert jacobisn(-z, q) == -jacobisn(z, q)
+    assert jacobicn(-z, q) == jacobicn(z, q)
+    assert jacobidn(-z, q) == jacobidn(z, q)
+
+
+def test_jacobi_elliptic_diff():
+    # DLMF 22.13.1:
+    # https://dlmf.nist.gov/22.13.T1
+    assert jacobisn(z, q).diff(z) == jacobicn(z, q)*jacobidn(z, q)
+    assert jacobicn(z, q).diff(z) == -jacobisn(z, q)*jacobidn(z, q)
+    assert jacobidn(z, q).diff(z) == -q*jacobisn(z, q)*jacobicn(z, q)
+
+    assert jacobisn(z, q).diff(q) == Derivative(jacobisn(z, q), q)
+    assert jacobicn(z, q).diff(q) == Derivative(jacobicn(z, q), q)
+    assert jacobidn(z, q).diff(q) == Derivative(jacobidn(z, q), q)
+
+
+def test_jacobi_elliptic_series():
+    # DLMF 22.10.1--22.10.3, with the modulus k replaced by the parameter
+    # m = k**2 used by SymPy:
+    # https://dlmf.nist.gov/22.10.E1
+    # https://dlmf.nist.gov/22.10.E2
+    # https://dlmf.nist.gov/22.10.E3
+    assert jacobisn(z, q).series(z, 0, 6) == (
+        z + (-q/6 - S.One/6)*z**3
+        + (q**2/120 + 7*q/60 + S.One/120)*z**5 + O(z**6))
+    assert jacobicn(z, q).series(z, 0, 6) == (
+        1 - z**2/2 + (q/6 + S.One/24)*z**4 + O(z**6))
+    assert jacobidn(z, q).series(z, 0, 6) == (
+        1 - q*z**2/2 + (q**2/24 + q/6)*z**4 + O(z**6))
+
+
+def test_jacobi_elliptic_rewrite_as_jtheta():
+    # DLMF 22.2.4--22.2.6:
+    # https://dlmf.nist.gov/22.2.E4
+    # https://dlmf.nist.gov/22.2.E5
+    # https://dlmf.nist.gov/22.2.E6
+    nome = exp(-pi*elliptic_k(1 - q)/elliptic_k(q))
+    theta_argument = z/jtheta(3, 0, nome)**2
+
+    assert jacobisn(z, q).rewrite(jtheta) == (
+        jtheta(3, 0, nome)*jtheta(1, theta_argument, nome)
+        / (jtheta(2, 0, nome)*jtheta(4, theta_argument, nome)))
+    assert jacobicn(z, q).rewrite(jtheta) == (
+        jtheta(4, 0, nome)*jtheta(2, theta_argument, nome)
+        / (jtheta(2, 0, nome)*jtheta(4, theta_argument, nome)))
+    assert jacobidn(z, q).rewrite(jtheta) == (
+        jtheta(4, 0, nome)*jtheta(3, theta_argument, nome)
+        / (jtheta(3, 0, nome)*jtheta(4, theta_argument, nome)))
+
+    for func in (jacobisn, jacobicn, jacobidn):
+        value = func(Rational(1, 3), Rational(2, 5))
+        _assert_close(value, value.rewrite(jtheta))
+
+
+def test_jacobi_elliptic_evalf():
+    # Reference values from the mpmath ellipfun documentation and tests:
+    # https://mpmath.org/doc/current/functions/elliptic.html#ellipfun
+    references = (
+        (jacobisn, '0.24615967096986145833'),
+        (jacobicn, '0.96922928989378439337'),
+        (jacobidn, '0.98473484156599474563'),
+    )
+    for func, reference in references:
+        value = func(Rational(1, 4), Rational(1, 2)).evalf(25)
+        assert abs(value - Float(reference, 25)) < S(10)**-19
+
+    argument = Rational(1, 3) + I/7
+    parameter = Rational(2, 5) + I/9
+    sn = jacobisn(argument, parameter)
+    cn = jacobicn(argument, parameter)
+    dn = jacobidn(argument, parameter)
+    # DLMF 22.6.1, with m = k**2:
+    # https://dlmf.nist.gov/22.6.E1
+    _assert_close(sn**2 + cn**2, 1)
+    _assert_close(dn**2 + parameter*sn**2, 1)
+
+
+def test_jacobi_elliptic_double_argument_identities():
+    # DLMF 22.6.5--22.6.7, with the modulus k replaced by the parameter
+    # m = k**2 used by SymPy.
+    # https://dlmf.nist.gov/22.6.E5
+    # https://dlmf.nist.gov/22.6.E6
+    # https://dlmf.nist.gov/22.6.E7
+    argument = Rational(1, 3) + I/7
+    parameter = Rational(2, 5) + I/9
+    sn = jacobisn(argument, parameter)
+    cn = jacobicn(argument, parameter)
+    dn = jacobidn(argument, parameter)
+    denominator = 1 - parameter*sn**4
+
+    _assert_close(
+        jacobisn(2*argument, parameter),
+        2*sn*cn*dn/denominator,
+    )
+    _assert_close(
+        jacobicn(2*argument, parameter),
+        (cn**2 - sn**2*dn**2)/denominator,
+    )
+    _assert_close(
+        jacobidn(2*argument, parameter),
+        (dn**2 - parameter*sn**2*cn**2)/denominator,
+    )
+
+
+def test_jacobi_elliptic_half_argument_identities():
+    # DLMF 22.6.19--22.6.21. These squared forms avoid choosing branches of
+    # square roots. Here 1 - parameter is the complementary parameter k'**2.
+    # https://dlmf.nist.gov/22.6.E19
+    # https://dlmf.nist.gov/22.6.E20
+    # https://dlmf.nist.gov/22.6.E21
+    argument = Rational(1, 3) + I/7
+    parameter = Rational(2, 5) + I/9
+    cn = jacobicn(argument, parameter)
+    dn = jacobidn(argument, parameter)
+    complementary_parameter = 1 - parameter
+
+    _assert_close(
+        jacobisn(argument/2, parameter)**2,
+        (1 - cn)/(1 + dn),
+    )
+    _assert_close(
+        jacobicn(argument/2, parameter)**2,
+        (-complementary_parameter + dn + parameter*cn)
+        / (parameter*(1 + cn)),
+    )
+    _assert_close(
+        jacobidn(argument/2, parameter)**2,
+        (parameter*cn + dn + complementary_parameter)/(1 + dn),
+    )
+
+
+def test_jacobi_elliptic_periodicity():
+    # DLMF 22.4.1, with K = K(m) and K' = K(1 - m).
+    # https://dlmf.nist.gov/22.4.T1
+    argument = Rational(1, 3) + I/7
+    parameter = Rational(2, 5)
+    complete = elliptic_k(parameter)
+    complementary = elliptic_k(1 - parameter)
+
+    periods = (
+        (jacobisn, (4*complete, 2*I*complementary)),
+        (jacobicn, (4*complete, 2*complete + 2*I*complementary)),
+        (jacobidn, (2*complete, 4*I*complementary)),
+    )
+    for func, function_periods in periods:
+        value = func(argument, parameter)
+        for period in function_periods:
+            _assert_close(func(argument + period, parameter), value)
 
 
 def test_jtheta_definition():

--- a/sympy/functions/special/tests/test_elliptic_functions.py
+++ b/sympy/functions/special/tests/test_elliptic_functions.py
@@ -4,15 +4,17 @@ from sympy.core import S
 from sympy.core.function import Derivative
 from sympy.core.numbers import Float, I, Rational, pi
 from sympy.core.symbol import Symbol
+from sympy.external import mpmath
 from sympy.functions.elementary.exponential import exp
 from sympy.functions.elementary.hyperbolic import sech, tanh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import cos, sin
 from sympy.functions.special.elliptic_functions import (
-    jacobicn, jacobidn, jacobisn, jtheta)
+    jacobi_cn, jacobi_dn, jacobi_sn, jtheta)
 from sympy.functions.special.elliptic_integrals import elliptic_k
 from sympy.series.order import O
 from sympy.testing.pytest import raises
+from sympy.utilities.lambdify import lambdify
 
 
 n = Symbol('n', integer=True)
@@ -26,7 +28,7 @@ def _assert_close(left, right, tolerance=S(10)**-25):
 
 
 def test_jacobi_elliptic_definition():
-    for func in (jacobisn, jacobicn, jacobidn):
+    for func in (jacobi_sn, jacobi_cn, jacobi_dn):
         assert func(z, q).args == (z, q)
 
 
@@ -35,17 +37,23 @@ def test_jacobi_elliptic_special_values():
     # https://dlmf.nist.gov/22.5.T1
     # https://dlmf.nist.gov/22.5.T3
     # https://dlmf.nist.gov/22.5.T4
-    assert jacobisn(0, q) == 0
-    assert jacobicn(0, q) == 1
-    assert jacobidn(0, q) == 1
+    assert jacobi_sn(0, q) == 0
+    assert jacobi_cn(0, q) == 1
+    assert jacobi_dn(0, q) == 1
 
-    assert jacobisn(z, 0) == sin(z)
-    assert jacobicn(z, 0) == cos(z)
-    assert jacobidn(z, 0) == 1
+    assert jacobi_sn(z, 0) == sin(z)
+    assert jacobi_cn(z, 0) == cos(z)
+    assert jacobi_dn(z, 0) == 1
 
-    assert jacobisn(z, 1) == tanh(z)
-    assert jacobicn(z, 1) == sech(z)
-    assert jacobidn(z, 1) == sech(z)
+    assert jacobi_sn(z, 1) == tanh(z)
+    assert jacobi_cn(z, 1) == sech(z)
+    assert jacobi_dn(z, 1) == sech(z)
+
+    for func in (jacobi_sn, jacobi_cn, jacobi_dn):
+        assert func(S.NaN, q) is S.NaN
+        assert func(z, S.NaN) is S.NaN
+        assert func(S.NaN, 0) is S.NaN
+        assert func(0, S.NaN) is S.NaN
 
 
 def test_jacobi_elliptic_parity():
@@ -54,21 +62,21 @@ def test_jacobi_elliptic_parity():
     # https://dlmf.nist.gov/22.2.E4
     # https://dlmf.nist.gov/22.2.E5
     # https://dlmf.nist.gov/22.2.E6
-    assert jacobisn(-z, q) == -jacobisn(z, q)
-    assert jacobicn(-z, q) == jacobicn(z, q)
-    assert jacobidn(-z, q) == jacobidn(z, q)
+    assert jacobi_sn(-z, q) == -jacobi_sn(z, q)
+    assert jacobi_cn(-z, q) == jacobi_cn(z, q)
+    assert jacobi_dn(-z, q) == jacobi_dn(z, q)
 
 
 def test_jacobi_elliptic_diff():
     # DLMF 22.13.1:
     # https://dlmf.nist.gov/22.13.T1
-    assert jacobisn(z, q).diff(z) == jacobicn(z, q)*jacobidn(z, q)
-    assert jacobicn(z, q).diff(z) == -jacobisn(z, q)*jacobidn(z, q)
-    assert jacobidn(z, q).diff(z) == -q*jacobisn(z, q)*jacobicn(z, q)
+    assert jacobi_sn(z, q).diff(z) == jacobi_cn(z, q)*jacobi_dn(z, q)
+    assert jacobi_cn(z, q).diff(z) == -jacobi_sn(z, q)*jacobi_dn(z, q)
+    assert jacobi_dn(z, q).diff(z) == -q*jacobi_sn(z, q)*jacobi_cn(z, q)
 
-    assert jacobisn(z, q).diff(q) == Derivative(jacobisn(z, q), q)
-    assert jacobicn(z, q).diff(q) == Derivative(jacobicn(z, q), q)
-    assert jacobidn(z, q).diff(q) == Derivative(jacobidn(z, q), q)
+    assert jacobi_sn(z, q).diff(q) == Derivative(jacobi_sn(z, q), q)
+    assert jacobi_cn(z, q).diff(q) == Derivative(jacobi_cn(z, q), q)
+    assert jacobi_dn(z, q).diff(q) == Derivative(jacobi_dn(z, q), q)
 
 
 def test_jacobi_elliptic_series():
@@ -77,12 +85,12 @@ def test_jacobi_elliptic_series():
     # https://dlmf.nist.gov/22.10.E1
     # https://dlmf.nist.gov/22.10.E2
     # https://dlmf.nist.gov/22.10.E3
-    assert jacobisn(z, q).series(z, 0, 6) == (
+    assert jacobi_sn(z, q).series(z, 0, 6) == (
         z + (-q/6 - S.One/6)*z**3
         + (q**2/120 + 7*q/60 + S.One/120)*z**5 + O(z**6))
-    assert jacobicn(z, q).series(z, 0, 6) == (
+    assert jacobi_cn(z, q).series(z, 0, 6) == (
         1 - z**2/2 + (q/6 + S.One/24)*z**4 + O(z**6))
-    assert jacobidn(z, q).series(z, 0, 6) == (
+    assert jacobi_dn(z, q).series(z, 0, 6) == (
         1 - q*z**2/2 + (q**2/24 + q/6)*z**4 + O(z**6))
 
 
@@ -94,17 +102,17 @@ def test_jacobi_elliptic_rewrite_as_jtheta():
     nome = exp(-pi*elliptic_k(1 - q)/elliptic_k(q))
     theta_argument = z/jtheta(3, 0, nome)**2
 
-    assert jacobisn(z, q).rewrite(jtheta) == (
+    assert jacobi_sn(z, q).rewrite(jtheta) == (
         jtheta(3, 0, nome)*jtheta(1, theta_argument, nome)
         / (jtheta(2, 0, nome)*jtheta(4, theta_argument, nome)))
-    assert jacobicn(z, q).rewrite(jtheta) == (
+    assert jacobi_cn(z, q).rewrite(jtheta) == (
         jtheta(4, 0, nome)*jtheta(2, theta_argument, nome)
         / (jtheta(2, 0, nome)*jtheta(4, theta_argument, nome)))
-    assert jacobidn(z, q).rewrite(jtheta) == (
+    assert jacobi_dn(z, q).rewrite(jtheta) == (
         jtheta(4, 0, nome)*jtheta(3, theta_argument, nome)
         / (jtheta(3, 0, nome)*jtheta(4, theta_argument, nome)))
 
-    for func in (jacobisn, jacobicn, jacobidn):
+    for func in (jacobi_sn, jacobi_cn, jacobi_dn):
         value = func(Rational(1, 3), Rational(2, 5))
         _assert_close(value, value.rewrite(jtheta))
 
@@ -113,9 +121,9 @@ def test_jacobi_elliptic_evalf():
     # Reference values from the mpmath ellipfun documentation and tests:
     # https://mpmath.org/doc/current/functions/elliptic.html#ellipfun
     references = (
-        (jacobisn, '0.24615967096986145833'),
-        (jacobicn, '0.96922928989378439337'),
-        (jacobidn, '0.98473484156599474563'),
+        (jacobi_sn, '0.24615967096986145833'),
+        (jacobi_cn, '0.96922928989378439337'),
+        (jacobi_dn, '0.98473484156599474563'),
     )
     for func, reference in references:
         value = func(Rational(1, 4), Rational(1, 2)).evalf(25)
@@ -123,13 +131,36 @@ def test_jacobi_elliptic_evalf():
 
     argument = Rational(1, 3) + I/7
     parameter = Rational(2, 5) + I/9
-    sn = jacobisn(argument, parameter)
-    cn = jacobicn(argument, parameter)
-    dn = jacobidn(argument, parameter)
+    sn = jacobi_sn(argument, parameter)
+    cn = jacobi_cn(argument, parameter)
+    dn = jacobi_dn(argument, parameter)
     # DLMF 22.6.1, with m = k**2:
     # https://dlmf.nist.gov/22.6.E1
     _assert_close(sn**2 + cn**2, 1)
     _assert_close(dn**2 + parameter*sn**2, 1)
+
+    for func in (jacobi_sn, jacobi_cn, jacobi_dn):
+        for nonfinite in (S.Infinity, S.NegativeInfinity,
+                S.ComplexInfinity):
+            value = func(nonfinite, S.Half)
+            assert value.evalf() == value
+            value = func(S.Half, nonfinite)
+            assert value.evalf() == value
+        assert func(S.NaN, S.Half, evaluate=False).evalf() is S.NaN
+        assert func(S.Half, S.NaN, evaluate=False).evalf() is S.NaN
+
+
+def test_jacobi_elliptic_lambdify_mpmath():
+    references = (
+        (jacobi_sn, '0.24615967096986145833'),
+        (jacobi_cn, '0.96922928989378439337'),
+        (jacobi_dn, '0.98473484156599474563'),
+    )
+    with mpmath.mp.workdps(30):
+        for func, reference in references:
+            numerical = lambdify((z, q), func(z, q), 'mpmath')
+            value = numerical(mpmath.mpf(1)/4, mpmath.mpf(1)/2)
+            assert abs(value - mpmath.mpf(reference)) < mpmath.mpf('1e-19')
 
 
 def test_jacobi_elliptic_double_argument_identities():
@@ -140,21 +171,21 @@ def test_jacobi_elliptic_double_argument_identities():
     # https://dlmf.nist.gov/22.6.E7
     argument = Rational(1, 3) + I/7
     parameter = Rational(2, 5) + I/9
-    sn = jacobisn(argument, parameter)
-    cn = jacobicn(argument, parameter)
-    dn = jacobidn(argument, parameter)
+    sn = jacobi_sn(argument, parameter)
+    cn = jacobi_cn(argument, parameter)
+    dn = jacobi_dn(argument, parameter)
     denominator = 1 - parameter*sn**4
 
     _assert_close(
-        jacobisn(2*argument, parameter),
+        jacobi_sn(2*argument, parameter),
         2*sn*cn*dn/denominator,
     )
     _assert_close(
-        jacobicn(2*argument, parameter),
+        jacobi_cn(2*argument, parameter),
         (cn**2 - sn**2*dn**2)/denominator,
     )
     _assert_close(
-        jacobidn(2*argument, parameter),
+        jacobi_dn(2*argument, parameter),
         (dn**2 - parameter*sn**2*cn**2)/denominator,
     )
 
@@ -167,21 +198,21 @@ def test_jacobi_elliptic_half_argument_identities():
     # https://dlmf.nist.gov/22.6.E21
     argument = Rational(1, 3) + I/7
     parameter = Rational(2, 5) + I/9
-    cn = jacobicn(argument, parameter)
-    dn = jacobidn(argument, parameter)
+    cn = jacobi_cn(argument, parameter)
+    dn = jacobi_dn(argument, parameter)
     complementary_parameter = 1 - parameter
 
     _assert_close(
-        jacobisn(argument/2, parameter)**2,
+        jacobi_sn(argument/2, parameter)**2,
         (1 - cn)/(1 + dn),
     )
     _assert_close(
-        jacobicn(argument/2, parameter)**2,
+        jacobi_cn(argument/2, parameter)**2,
         (-complementary_parameter + dn + parameter*cn)
         / (parameter*(1 + cn)),
     )
     _assert_close(
-        jacobidn(argument/2, parameter)**2,
+        jacobi_dn(argument/2, parameter)**2,
         (parameter*cn + dn + complementary_parameter)/(1 + dn),
     )
 
@@ -195,9 +226,9 @@ def test_jacobi_elliptic_periodicity():
     complementary = elliptic_k(1 - parameter)
 
     periods = (
-        (jacobisn, (4*complete, 2*I*complementary)),
-        (jacobicn, (4*complete, 2*complete + 2*I*complementary)),
-        (jacobidn, (2*complete, 4*I*complementary)),
+        (jacobi_sn, (4*complete, 2*I*complementary)),
+        (jacobi_cn, (4*complete, 2*complete + 2*I*complementary)),
+        (jacobi_dn, (2*complete, 4*I*complementary)),
     )
     for func, function_periods in periods:
         value = func(argument, parameter)

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1268,6 +1268,23 @@ class LatexPrinter(Printer):
             return r"\left(%s\right)^{%s}" % (tex, exp)
         return tex
 
+    def _print_jacobi_elliptic(self, expr, name, exp=None):
+        u, m = expr.args
+        tex = r"\operatorname{%s}" % name
+        if exp is not None:
+            tex += r"^{%s}" % exp
+        return tex + r"\left(%s\middle| %s\right)" % (
+            self._print(u), self._print(m))
+
+    def _print_jacobisn(self, expr, exp=None):
+        return self._print_jacobi_elliptic(expr, "sn", exp)
+
+    def _print_jacobicn(self, expr, exp=None):
+        return self._print_jacobi_elliptic(expr, "cn", exp)
+
+    def _print_jacobidn(self, expr, exp=None):
+        return self._print_jacobi_elliptic(expr, "dn", exp)
+
     def _print_beta(self, expr, exp=None):
         x = expr.args[0]
         # Deal with unevaluated single argument beta

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1276,13 +1276,13 @@ class LatexPrinter(Printer):
         return tex + r"\left(%s\middle| %s\right)" % (
             self._print(u), self._print(m))
 
-    def _print_jacobisn(self, expr, exp=None):
+    def _print_jacobi_sn(self, expr, exp=None):
         return self._print_jacobi_elliptic(expr, "sn", exp)
 
-    def _print_jacobicn(self, expr, exp=None):
+    def _print_jacobi_cn(self, expr, exp=None):
         return self._print_jacobi_elliptic(expr, "cn", exp)
 
-    def _print_jacobidn(self, expr, exp=None):
+    def _print_jacobi_dn(self, expr, exp=None):
         return self._print_jacobi_elliptic(expr, "dn", exp)
 
     def _print_beta(self, expr, exp=None):

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1938,6 +1938,22 @@ class PrettyPrinter(Printer):
         pform.prettyArgs = pretty_args
         return pform
 
+    def _print_jacobi_elliptic(self, e, name):
+        argument = self._print(e.args[0])
+        parameter = self._print(e.args[1])
+        pform = self._hprint_vseparator(argument, parameter)
+        pform = prettyForm(*pform.parens())
+        return prettyForm(*pform.left(name))
+
+    def _print_jacobisn(self, e):
+        return self._print_jacobi_elliptic(e, 'sn')
+
+    def _print_jacobicn(self, e):
+        return self._print_jacobi_elliptic(e, 'cn')
+
+    def _print_jacobidn(self, e):
+        return self._print_jacobi_elliptic(e, 'dn')
+
     def _print_GoldenRatio(self, expr):
         if self._use_unicode:
             return prettyForm(pretty_symbol('phi'))

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1945,13 +1945,13 @@ class PrettyPrinter(Printer):
         pform = prettyForm(*pform.parens())
         return prettyForm(*pform.left(name))
 
-    def _print_jacobisn(self, e):
+    def _print_jacobi_sn(self, e):
         return self._print_jacobi_elliptic(e, 'sn')
 
-    def _print_jacobicn(self, e):
+    def _print_jacobi_cn(self, e):
         return self._print_jacobi_elliptic(e, 'cn')
 
-    def _print_jacobidn(self, e):
+    def _print_jacobi_dn(self, e):
         return self._print_jacobi_elliptic(e, 'dn')
 
     def _print_GoldenRatio(self, expr):

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -50,9 +50,9 @@ from sympy.functions import (Abs, Chi, Ci, Ei, KroneckerDelta,
     Piecewise, Shi, Si, atan2, beta, binomial, catalan, ceiling, cos,
     euler, exp, expint, factorial, factorial2, floor, gamma, hyper, log,
     meijerg, sin, sqrt, subfactorial, tan, uppergamma, lerchphi, polylog,
-    elliptic_k, elliptic_f, elliptic_e, elliptic_pi, jtheta, DiracDelta, bell,
-    bernoulli, fibonacci, tribonacci, lucas, stieltjes, mathieuc, mathieus,
-    mathieusprime, mathieucprime)
+    elliptic_k, elliptic_f, elliptic_e, elliptic_pi, jacobicn, jacobidn,
+    jacobisn, jtheta, DiracDelta, bell, bernoulli, fibonacci, tribonacci, lucas,
+    stieltjes, mathieuc, mathieus, mathieusprime, mathieucprime)
 
 from sympy.matrices import (Adjoint, Inverse, MatAdd, MatrixSymbol, Transpose,
                             KroneckerProduct, BlockMatrix, OneMatrix, ZeroMatrix)
@@ -6595,6 +6595,11 @@ Pi|3; -|6|\n\
     expr = jtheta(1, z, y, 2)
     assert pretty(expr) == "      (2)      \ntheta    (z, y)\n     1         "
     assert upretty(expr) == "  (2)      \n\u03d1    (z, y)\n 1         "
+
+    for func, name in ((jacobisn, 'sn'), (jacobicn, 'cn'), (jacobidn, 'dn')):
+        expr = func(z, y)
+        assert pretty(expr) == f"{name}(z|y)"
+        assert upretty(expr) == f"{name}(z\u2502y)"
 
 
 def test_RandomDomain():

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -50,8 +50,8 @@ from sympy.functions import (Abs, Chi, Ci, Ei, KroneckerDelta,
     Piecewise, Shi, Si, atan2, beta, binomial, catalan, ceiling, cos,
     euler, exp, expint, factorial, factorial2, floor, gamma, hyper, log,
     meijerg, sin, sqrt, subfactorial, tan, uppergamma, lerchphi, polylog,
-    elliptic_k, elliptic_f, elliptic_e, elliptic_pi, jacobicn, jacobidn,
-    jacobisn, jtheta, DiracDelta, bell, bernoulli, fibonacci, tribonacci, lucas,
+    elliptic_k, elliptic_f, elliptic_e, elliptic_pi, jacobi_cn, jacobi_dn,
+    jacobi_sn, jtheta, DiracDelta, bell, bernoulli, fibonacci, tribonacci, lucas,
     stieltjes, mathieuc, mathieus, mathieusprime, mathieucprime)
 
 from sympy.matrices import (Adjoint, Inverse, MatAdd, MatrixSymbol, Transpose,
@@ -6596,7 +6596,7 @@ Pi|3; -|6|\n\
     assert pretty(expr) == "      (2)      \ntheta    (z, y)\n     1         "
     assert upretty(expr) == "  (2)      \n\u03d1    (z, y)\n 1         "
 
-    for func, name in ((jacobisn, 'sn'), (jacobicn, 'cn'), (jacobidn, 'dn')):
+    for func, name in ((jacobi_sn, 'sn'), (jacobi_cn, 'cn'), (jacobi_dn, 'dn')):
         expr = func(z, y)
         assert pretty(expr) == f"{name}(z|y)"
         assert upretty(expr) == f"{name}(z\u2502y)"

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -820,6 +820,11 @@ class MpmathPrinter(PythonCodePrinter):
         return '{}({})'.format(
             self._module_format('mpmath.log1p'), self._print(e.args[0]))
 
+    def _print_JacobiEllipticBase(self, e):
+        return "{}({!r}, {}, {})".format(
+            self._module_format('mpmath.ellipfun'), e._kind,
+            self._print(e.args[0]), self._print(e.args[1]))
+
     def _print_Pow(self, expr, rational=False):
         return self._hprint_Pow(expr, rational=rational, sqrt='mpmath.sqrt')
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -32,7 +32,8 @@ from sympy.functions.elementary.trigonometric import (acsc, asin, cos, cot, sin,
 from sympy.functions.special.beta_functions import beta
 from sympy.functions.special.delta_functions import (DiracDelta, Heaviside)
 from sympy.functions.special.elliptic_integrals import (elliptic_e, elliptic_f, elliptic_k, elliptic_pi)
-from sympy.functions.special.elliptic_functions import jtheta
+from sympy.functions.special.elliptic_functions import (
+    jacobicn, jacobidn, jacobisn, jtheta)
 from sympy.functions.special.error_functions import (Chi, Ci, Ei, Shi, Si, expint)
 from sympy.functions.special.gamma_functions import (gamma, uppergamma)
 from sympy.functions.special.hyper import (hyper, meijerg)
@@ -719,6 +720,14 @@ def test_latex_functions():
         r"\vartheta_{n}^{(2)}\left(x, y\right)"
     assert latex(jtheta(n, x, y, 2)**3) == \
         r"\left(\vartheta_{n}^{(2)}\left(x, y\right)\right)^{3}"
+    assert latex(jacobisn(x, y)) == \
+        r"\operatorname{sn}\left(x\middle| y\right)"
+    assert latex(jacobicn(x, y)) == \
+        r"\operatorname{cn}\left(x\middle| y\right)"
+    assert latex(jacobidn(x, y)) == \
+        r"\operatorname{dn}\left(x\middle| y\right)"
+    assert latex(jacobisn(x, y)**2) == \
+        r"\operatorname{sn}^{2}\left(x\middle| y\right)"
 
     assert latex(Ei(x)) == r'\operatorname{Ei}{\left(x \right)}'
     assert latex(Ei(x)**2) == r'\operatorname{Ei}^{2}{\left(x \right)}'

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -33,7 +33,7 @@ from sympy.functions.special.beta_functions import beta
 from sympy.functions.special.delta_functions import (DiracDelta, Heaviside)
 from sympy.functions.special.elliptic_integrals import (elliptic_e, elliptic_f, elliptic_k, elliptic_pi)
 from sympy.functions.special.elliptic_functions import (
-    jacobicn, jacobidn, jacobisn, jtheta)
+    jacobi_cn, jacobi_dn, jacobi_sn, jtheta)
 from sympy.functions.special.error_functions import (Chi, Ci, Ei, Shi, Si, expint)
 from sympy.functions.special.gamma_functions import (gamma, uppergamma)
 from sympy.functions.special.hyper import (hyper, meijerg)
@@ -720,13 +720,13 @@ def test_latex_functions():
         r"\vartheta_{n}^{(2)}\left(x, y\right)"
     assert latex(jtheta(n, x, y, 2)**3) == \
         r"\left(\vartheta_{n}^{(2)}\left(x, y\right)\right)^{3}"
-    assert latex(jacobisn(x, y)) == \
+    assert latex(jacobi_sn(x, y)) == \
         r"\operatorname{sn}\left(x\middle| y\right)"
-    assert latex(jacobicn(x, y)) == \
+    assert latex(jacobi_cn(x, y)) == \
         r"\operatorname{cn}\left(x\middle| y\right)"
-    assert latex(jacobidn(x, y)) == \
+    assert latex(jacobi_dn(x, y)) == \
         r"\operatorname{dn}\left(x\middle| y\right)"
-    assert latex(jacobisn(x, y)**2) == \
+    assert latex(jacobi_sn(x, y)**2) == \
         r"\operatorname{sn}^{2}\left(x\middle| y\right)"
 
     assert latex(Ei(x)) == r'\operatorname{Ei}{\left(x \right)}'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -24,6 +24,8 @@ from sympy.tensor import IndexedBase, Idx
 from sympy.tensor.array.expressions.array_expressions import ArraySymbol, ArrayDiagonal, ArrayContraction, ZeroArray, OneArray
 from sympy.external import import_module
 from sympy.functions.special.gamma_functions import loggamma
+from sympy.functions.special.elliptic_functions import (
+    jacobi_cn, jacobi_dn, jacobi_sn)
 
 
 
@@ -141,6 +143,9 @@ def test_MpmathPrinter():
     assert p.doprint(S.Infinity) == 'mpmath.inf'
     assert p.doprint(S.NegativeInfinity) == 'mpmath.ninf'
     assert p.doprint(loggamma(x)) == 'mpmath.loggamma(x)'
+    assert p.doprint(jacobi_sn(x, y)) == "mpmath.ellipfun('sn', x, y)"
+    assert p.doprint(jacobi_cn(x, y)) == "mpmath.ellipfun('cn', x, y)"
+    assert p.doprint(jacobi_dn(x, y)) == "mpmath.ellipfun('dn', x, y)"
 
 
 def test_NumPyPrinter():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #24494 by adding the three fundamental Jacobi elliptic functions `jacobisn`, `jacobicn`, and `jacobidn`.

This follows #30205, which added the Jacobi theta functions used by the explicit theta-function rewrites in this PR.

This work supersedes the abandoned approach in #22778 and incorporates feedback from its design discussion.

#### Brief description of what is fixed or changed

Adds the three fundamental Jacobi elliptic functions `jacobisn`, `jacobicn`, and `jacobidn`, including symbolic differentiation, special values, series expansions, numerical evaluation, theta-function rewrites, printing, documentation, and tests.

#### Other comments

Relates to ongoing work in discussion #30211

#### AI Generation Disclosure

- I used OpenAI GPT-5.6 Sol, with high reasoning effort, through the Codex VS Code extension.
- After I provided relevant references and discussed the desired criteria and functionality, we established an implementation plan. AI then assisted with most of the code in this PR, including the implementation, tests, documentation, printer integration, and export changes.
- I reviewed DLMF for various identities to include in tests and we iterated on this to expand testing.
- I personally reviewed, understood, tested, and iterated on every submitted line, including by importing into a notebook to use it as intended.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

- functions
  - Added Jacobi elliptic functions with symbolic differentiation and mpmath-backed numerical evaluation.

<!-- END RELEASE NOTES -->
