### PR TITLE
assumptions: add refine handler for frac

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1441,7 +1441,6 @@ S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
-SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>
@@ -1546,6 +1545,8 @@ Shiyao Guo <mivikq@gmail.com> Mivik <54128043+Mivik@users.noreply.github.com>
 Shiyao Guo <mivikq@gmail.com> Mivik <mivikq@gmail.com>
 Shravas K Rao <shravas@gmail.com>
 Shreyash Mishra <72146041+Shreyash-cyber@users.noreply.github.com>
+Shrinivas <shrinivasbhong2428@gmail.com> BHONG SHRINIVAS MUKUND <183748734+SHRINIVAS-BHONG@users.noreply.github.com>
+Shrinivas <shrinivasbhong2428@gmail.com> SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com>
 Shruti Mangipudi <shruti2395@gmail.com>
 Shuai Zhou <shuaivzhou@berkeley.edu>
 Shubham Abhang <shubhamabhang77@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1441,6 +1441,7 @@ S. Hanko <suzy.hanko@gmail.com>
 S.Y. Lee <sylee957@gmail.com> (Lazard) S.Y. Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> Sangyub Lee <sylee957@gmail.com>
 S.Y. Lee <sylee957@gmail.com> sylee957 <sylee957@gmail.com>
+SHRINIVAS-BHONG <shrinivasbhong2428@gmail.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <50399005+Saanidhyavats@users.noreply.github.com>
 Saanidhya vats <saanidhyavats@gmail.com> Saanidhya <saanidhyavats@gmail.com>
 Sachin Agarwal <sachinagarwal0499@gmail.com> <sachin13agarwal@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1509,4 +1509,3 @@ Benjamin A. Beasley <code@musicinmybrain.net>
 Henry <henrybrewer00@gmail.com>
 Matthew M <mmythen@gmail.com>
 Sreekant Baheti <60787859+Sreekant13@users.noreply.github.com>
-Bhong Shrinivas Mukund <shrinivasbhong2428@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1509,3 +1509,4 @@ Benjamin A. Beasley <code@musicinmybrain.net>
 Henry <henrybrewer00@gmail.com>
 Matthew M <mmythen@gmail.com>
 Sreekant Baheti <60787859+Sreekant13@users.noreply.github.com>
+Bhong Shrinivas Mukund <shrinivasbhong2428@gmail.com>

--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -298,6 +298,53 @@ def refine_atan2(expr, assumptions):
         return expr
 
 
+def refine_frac(expr, assumptions):
+    """
+    Handler for the frac (fractional part) function.
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, refine, Q, frac
+    >>> x = Symbol('x')
+    >>> y = Symbol('y')
+    >>> refine(frac(x), Q.integer(x))
+    0
+    >>> refine(frac(x), Q.zero(x))
+    0
+    >>> refine(frac(x + y), Q.integer(x))
+    frac(y)
+    >>> refine(frac(frac(x)))
+    frac(x)
+    """
+    from sympy.functions.elementary.integers import frac
+    arg = expr.args[0]
+
+    # If the argument is an integer or zero, frac(arg) is 0
+    if ask(Q.integer(arg), assumptions) or ask(Q.zero(arg), assumptions):
+        return S.Zero
+
+    # frac(frac(x)) is frac(x)
+    if isinstance(arg, frac):
+        return arg
+
+    # If the argument is an addition (e.g. integer + non-integer)
+    if isinstance(arg, Add):
+        non_integer_terms = []
+        has_integer = False
+        for term in arg.args:
+            if ask(Q.integer(term), assumptions) or isinstance(term, frac):
+                has_integer = True
+                if isinstance(term, frac):
+                    non_integer_terms.append(term)
+            else:
+                non_integer_terms.append(term)
+        if has_integer:
+            return frac(Add(*non_integer_terms))
+
+    return expr
+
+
 def refine_re(expr, assumptions):
     """
     Handler for real part.
@@ -617,4 +664,5 @@ handlers_dict: dict[str, Callable[[Basic, Boolean | bool], Expr]] = {
     'Heaviside': refine_Heaviside,
     'floor': refine_floor_ceiling,
     'ceiling' : refine_floor_ceiling,
+    'frac': refine_frac,
 }

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -354,3 +354,14 @@ def test_Heaviside():
     assert refine(Heaviside(x, 1), Q.zero(x)) == 1
     assert refine(Heaviside(x, 1), Q.positive(x)) == 1
     assert refine(Heaviside(x, 1), Q.negative(x)) == 0
+
+
+def test_frac():
+    from sympy.functions.elementary.integers import frac
+    assert refine(frac(x), Q.integer(x)) == 0
+    assert refine(frac(x), Q.zero(x)) == 0
+    assert refine(frac(x), Q.real(x)) == frac(x)
+    assert refine(frac(x + y), Q.integer(x)) == frac(y)
+    assert refine(frac(x + y + z), Q.integer(x) & Q.integer(y)) == frac(z)
+    assert refine(frac(x + y - z), Q.integer(x)) == frac(y - z)
+    assert refine(frac(frac(x))) == frac(x)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Partially fixes #27888


#### Brief description of what is fixed or changed

Adds a `refine_frac` handler to `sympy.assumptions.refine` to simplify `frac` (fractional part) function under assumptions:
- `refine(frac(x), Q.integer(x))` -> `0`
- `refine(frac(x), Q.zero(x))` -> `0`
- `refine(frac(x + y), Q.integer(x))` -> `frac(y)`
- `refine(frac(frac(x)))` -> `frac(x)`


#### Other comments

All tests ran and passed locally (`pytest sympy/assumptions/tests/test_refine.py` and `python bin/doctest sympy/assumptions/refine.py`).


#### AI Generation Disclosure

An AI coding assistant was used for initial codebase exploration and drafting unit test templates. All code logic, mathematical rules, and tests were thoroughly reviewed, edited, and verified locally by me.


#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Added `refine` handler for `frac` function.
<!-- END RELEASE NOTES -->