### PR TITLE
Type hints for sympy/calculus/finite_diff.py for apply_finite_diff()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -635,6 +635,7 @@ Ethan Ward <etkewa@gmail.com> eward <eward@sunbelt-medical.com>
 Eva Charlotte Mayer <eva-charlotte.mayer@posteo.de>
 Eva Tiwari <eva.tiwari@gmail.com> Eva <eva.tiwari@gmail.com>
 Evan <guaguajinchina@gmail.com> Wang 6 <wang6@Wangdebijibendiannao.local>
+Evan Palskoi <epalskoi@gmail.com> Evan Palskoi <143654283+EvanPalskoi@users.noreply.github.com>
 Evandro Bernardes <evbernardes@gmail.com> Evandro <15084103+evbernardes@users.noreply.github.com>
 Evandro Bernardes <evbernardes@gmail.com> Evandro Bernardes <s.evandro@hotmail.com>
 Evandro Bernardes <evbernardes@gmail.com> evbernardes <s.evandro@hotmail.com>
@@ -1927,4 +1928,3 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
-Evan Palskoi <epalskoi@gmail.com> Evan Palskoi <143654283+EvanPalskoi@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1927,3 +1927,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+Evan Palskoi <epalskoi@gmail.com> Evan Palskoi <143654283+EvanPalskoi@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1509,3 +1509,4 @@ Benjamin A. Beasley <code@musicinmybrain.net>
 Henry <henrybrewer00@gmail.com>
 Matthew M <mmythen@gmail.com>
 Sreekant Baheti <60787859+Sreekant13@users.noreply.github.com>
+Evan Palskoi <epalskoi@gmail.com>

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -24,10 +24,13 @@ from sympy.core.function import Subs
 from sympy.core.traversal import preorder_traversal
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable
+from collections.abc import Sequence
+from sympy.core.expr import Expr
+from sympy.core.symbol import Symbol
 
+from typing import cast
 
-
-def finite_diff_weights(order, x_list, x0=S.One):
+def finite_diff_weights(order: int | Expr, x_list: Sequence[Expr | int | float], x0: Expr = S.One) -> list[list[list[Expr]]]:
     """
     Calculates the finite difference weights for an arbitrarily spaced
     one-dimensional grid (``x_list``) for derivatives at ``x0`` of order
@@ -164,7 +167,7 @@ def finite_diff_weights(order, x_list, x0=S.One):
     """
     # The notation below closely corresponds to the one used in the paper.
     order = S(order)
-    if not order.is_number:
+    if not isinstance(order, int) and not order.is_number:
         raise ValueError("Cannot handle symbolic order.")
     if order < 0:
         raise ValueError("Negative derivative order illegal.")
@@ -172,7 +175,7 @@ def finite_diff_weights(order, x_list, x0=S.One):
         raise ValueError("Non-integer order illegal")
     M = order
     N = len(x_list) - 1
-    delta = [[[0 for nu in range(N+1)] for n in range(N+1)] for
+    delta = [[[S.Zero for nu in range(N+1)] for n in range(N+1)] for
              m in range(M+1)]
     delta[0][0][0] = S.One
     c1 = S.One
@@ -194,7 +197,7 @@ def finite_diff_weights(order, x_list, x0=S.One):
     return delta
 
 
-def apply_finite_diff(order, x_list, y_list, x0=S.Zero):
+def apply_finite_diff(order: int, x_list: Sequence[Expr | int | float], y_list: Sequence[Expr | int | float], x0: Expr = S.Zero) -> Expr:
     """
     Calculates the finite difference approximation of
     the derivative of requested order at ``x0`` from points
@@ -281,7 +284,7 @@ def apply_finite_diff(order, x_list, y_list, x0=S.Zero):
     return derivative
 
 
-def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
+def _as_finite_diff(derivative: Expr, points: Sequence[Expr] | Expr | int = 1, x0: Expr | None = None, wrt: Symbol | None = None) -> Expr:
     """
     Returns an approximation of a derivative of a function in
     the form of a finite difference formula. The expression is a
@@ -380,33 +383,31 @@ def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
     if x0 is None:
         x0 = wrt
 
+    points_seq: Sequence[Expr]
     if not iterable(points):
-        if getattr(points, 'is_Function', False) and wrt in points.args:
-            points = points.subs(wrt, x0)
-        # points is simply the step-size, let's make it a
-        # equidistant sequence centered around x0
-        if order % 2 == 0:
-            # even order => odd number of points, grid point included
-            points = [x0 + points*i for i
-                      in range(-order//2, order//2 + 1)]
-        else:
-            # odd order => even number of points, half-way wrt grid point
-            points = [x0 + points*S(i)/2 for i
-                      in range(-order, order + 1, 2)]
+        points_expr: Expr = cast(Expr, points)
+        if getattr(points_expr, "is_Function", False) and wrt in getattr(points_expr, "args", ()):
+            points_expr = points_expr.subs(wrt, x0) 
+            if order % 2 == 0:
+                points_seq = [x0 + points_expr * i for i in range(-order//2, order//2 + 1)]
+            else:
+                points_seq = [x0 + points_expr * S(i) / 2 for i in range(-order, order + 1, 2)]
+    else:
+        points_seq = cast(Sequence[Expr], points)
     others = [wrt, 0]
     for v in set(derivative.variables):
         if v == wrt:
             continue
         others += [v, derivative.variables.count(v)]
-    if len(points) < order+1:
+    if len(points_seq) < order+1:
         raise ValueError("Too few points for order %d" % order)
-    return apply_finite_diff(order, points, [
+    return apply_finite_diff(order, points_seq, [
         Derivative(derivative.expr.subs({wrt: x}), *others) for
-        x in points], x0)
+        x in points_seq], x0)
 
 
-def differentiate_finite(expr, *symbols,
-                         points=1, x0=None, wrt=None, evaluate=False):
+def differentiate_finite(expr: Expr, *symbols: Symbol | int,
+                         points: Sequence[Expr] | Expr | int = 1, x0: Expr | None = None, wrt: Symbol | None = None, evaluate: bool = False) -> Expr:
     r""" Differentiate expr and replace Derivatives with finite differences.
 
     Parameters

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -28,7 +28,9 @@ from collections.abc import Sequence
 from sympy.core.expr import Expr
 from sympy.core.symbol import Symbol
 
-from typing import cast
+from typing import TYPE_CHECKING, cast
+if TYPE_CHECKING:
+    from sympy.core.symbol import Symbol
 
 def finite_diff_weights(order: int | Expr, x_list: Sequence[Expr | int | float], x0: Expr = S.One) -> list[list[list[Expr]]]:
     """

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -27,11 +27,7 @@ from sympy.utilities.iterables import iterable
 from collections.abc import Sequence
 from sympy.core.expr import Expr
 
-from typing import TYPE_CHECKING, cast
-if TYPE_CHECKING:
-    from sympy.core.symbol import Symbol
-
-def finite_diff_weights(order: int | Expr, x_list: Sequence[Expr | int | float], x0: Expr = S.One) -> list[list[list[Expr]]]:
+def finite_diff_weights(order, x_list, x0=S.One):
     """
     Calculates the finite difference weights for an arbitrarily spaced
     one-dimensional grid (``x_list``) for derivatives at ``x0`` of order
@@ -168,7 +164,7 @@ def finite_diff_weights(order: int | Expr, x_list: Sequence[Expr | int | float],
     """
     # The notation below closely corresponds to the one used in the paper.
     order = S(order)
-    if not isinstance(order, int) and not order.is_number:
+    if not order.is_number:
         raise ValueError("Cannot handle symbolic order.")
     if order < 0:
         raise ValueError("Negative derivative order illegal.")
@@ -279,13 +275,13 @@ def apply_finite_diff(order: int, x_list: Sequence[Expr | int | float], y_list: 
 
     delta = finite_diff_weights(order, x_list, x0)
 
-    derivative = 0
+    derivative: Expr = S.Zero
     for nu in range(len(x_list)):
         derivative += delta[order][N][nu]*y_list[nu]
     return derivative
 
 
-def _as_finite_diff(derivative: Expr, points: Sequence[Expr] | Expr | int = 1, x0: Expr | None = None, wrt: Symbol | None = None) -> Expr:
+def _as_finite_diff(derivative, points=1, x0=None, wrt=None):
     """
     Returns an approximation of a derivative of a function in
     the form of a finite difference formula. The expression is a
@@ -384,31 +380,33 @@ def _as_finite_diff(derivative: Expr, points: Sequence[Expr] | Expr | int = 1, x
     if x0 is None:
         x0 = wrt
 
-    points_seq: Sequence[Expr]
     if not iterable(points):
-        points_expr: Expr = cast(Expr, points)
-        if getattr(points_expr, "is_Function", False) and wrt in getattr(points_expr, "args", ()):
-            points_expr = points_expr.subs(wrt, x0) 
-            if order % 2 == 0:
-                points_seq = [x0 + points_expr * i for i in range(-order//2, order//2 + 1)]
-            else:
-                points_seq = [x0 + points_expr * S(i) / 2 for i in range(-order, order + 1, 2)]
-    else:
-        points_seq = cast(Sequence[Expr], points)
+        if getattr(points, 'is_Function', False) and wrt in points.args:
+            points = points.subs(wrt, x0)
+        # points is simply the step-size, let's make it a
+        # equidistant sequence centered around x0
+        if order % 2 == 0:
+            # even order => odd number of points, grid point included
+            points = [x0 + points*i for i
+                      in range(-order//2, order//2 + 1)]
+        else:
+            # odd order => even number of points, half-way wrt grid point
+            points = [x0 + points*S(i)/2 for i
+                      in range(-order, order + 1, 2)]
     others = [wrt, 0]
     for v in set(derivative.variables):
         if v == wrt:
             continue
         others += [v, derivative.variables.count(v)]
-    if len(points_seq) < order+1:
+    if len(points) < order+1:
         raise ValueError("Too few points for order %d" % order)
-    return apply_finite_diff(order, points_seq, [
+    return apply_finite_diff(order, points, [
         Derivative(derivative.expr.subs({wrt: x}), *others) for
-        x in points_seq], x0)
+        x in points], x0)
 
 
-def differentiate_finite(expr: Expr, *symbols: Symbol | int,
-                         points: Sequence[Expr] | Expr | int = 1, x0: Expr | None = None, wrt: Symbol | None = None, evaluate: bool = False) -> Expr:
+def differentiate_finite(expr, *symbols,
+                         points=1, x0=None, wrt=None, evaluate=False):
     r""" Differentiate expr and replace Derivatives with finite differences.
 
     Parameters

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -26,7 +26,6 @@ from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable
 from collections.abc import Sequence
 from sympy.core.expr import Expr
-from sympy.core.symbol import Symbol
 
 from typing import TYPE_CHECKING, cast
 if TYPE_CHECKING:

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -24,8 +24,10 @@ from sympy.core.function import Subs
 from sympy.core.traversal import preorder_traversal
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import iterable
-from collections.abc import Sequence
-from sympy.core.expr import Expr
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from sympy.core.expr import Expr
 
 def finite_diff_weights(order, x_list, x0=S.One):
     """


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

See  #28806

#### Brief description of what is fixed or changed

added imports:

from collections.abc import Sequence
from sympy.core.expr import Expr

added type hints to the following functions:

def apply_finite_diff

modified line 190 to initialize delta with S.zero rather than the int 0 to fix mypy issue with assuming delta was an int.

#### Other comments

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
