### PR TITLE
calculus: use intermediate value theorem in `function_range`

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -58,10 +58,10 @@ def test_function_range():
         ) == Interval(-1, 1)
     assert function_range(cos(x), x, S.EmptySet) == S.EmptySet
     assert function_range(x/sqrt(x**2+1), x, S.Reals) == Interval.open(-1,1)
+    assert function_range(sin(x) + x, x, S.Reals) == S.Reals  # issue 13273
+    assert function_range(x + 1/(x**2 + 1), x, S.Reals) == S.Reals
     raises(NotImplementedError, lambda : function_range(
         exp(x)*(sin(x) - cos(x))/2 - x, x, S.Reals))
-    raises(NotImplementedError, lambda : function_range(
-        sin(x) + x, x, S.Reals)) # issue 13273
     raises(NotImplementedError, lambda : function_range(
         log(x), x, S.Integers))
     raises(NotImplementedError, lambda : function_range(

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -184,13 +184,13 @@ def function_range(f, symbol, domain):
     >>> function_range(sin(x), x, Interval(0, 2*pi))
     Interval(-1, 1)
     >>> function_range(tan(x), x, Interval(-pi/2, pi/2))
-    Interval(-oo, oo)
+    Reals
     >>> function_range(1/x, x, S.Reals)
     Union(Interval.open(-oo, 0), Interval.open(0, oo))
     >>> function_range(exp(x), x, S.Reals)
     Interval.open(0, oo)
     >>> function_range(log(x), x, S.Reals)
-    Interval(-oo, oo)
+    Reals
     >>> function_range(sqrt(x), x, Interval(-5, 9))
     Interval(0, 3)
 
@@ -257,6 +257,10 @@ def function_range(f, symbol, domain):
                     vals += critical_values
                 else:
                     vals += FiniteSet(f.subs(symbol, limit_point))
+
+            if vals.inf == S.NegativeInfinity and vals.sup == S.Infinity:
+                range_int += S.Reals
+                continue
 
             critical_points = solveset(f.diff(symbol), symbol, interval)
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None.

#### Brief description of what is fixed or changed

Before the fix:

```python
In [1]: from sympy.calculus.util import function_range

In [2]: function_range(x + 1/(x**2 + 1), x, S.Reals)
---------------------------------------------------------------------------
TypeError 
```

After the fix:

```python
In [1]: from sympy.calculus.util import function_range

In [2]: function_range(x + 1/(x**2 + 1), x, S.Reals)
Out[2]: ℝ
```

#### Other comments

```python
In [1]: Interval(-oo, oo) == S.Reals
Out[1]: True
```

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->
I discussed where to add the code with DeepSeek.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* calculus
  * Use intermediate value theorem in `function_range`.
<!-- END RELEASE NOTES -->