### PR TITLE
faster recurrenceless implementation of univariate Bell (Touchard) polynomial

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -697,8 +697,9 @@ class bell(DefinedFunction):
         # root occupies tree[0]
         tree[0]=[0]*(n-1)+[1]
         def divmod(p,q):
-            _divmod=lambda r,p: (r,p) if len(p)<len(q) else _divmod([p[-1]]+r,p[:-len(q)]+[a-p[-1]*b for a,b in zip(p[-len(q):-1],q[:-1])])
-            return _divmod([],p)
+            r=[]
+            while len(p)>=len(q): r,p=[p[-1]]+r,p[:-len(q)]+[a-p[-1]*b for a,b in zip(p[-len(q):-1],q[:-1])]
+            return (r,p)
         # split forwards through each branch
         for d in range(L):
             for j in range(1<<d,0,-1):

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -33,7 +33,7 @@ from sympy.ntheory.generate import _primepi
 from sympy.ntheory.partitions_ import _partition, _partition_rec
 from sympy.ntheory.primetest import isprime, is_square
 from sympy.polys.appellseqs import bernoulli_poly, euler_poly, genocchi_poly
-from sympy.polys.polytools import cancel
+from sympy.polys.polytools import cancel, Poly
 from sympy.utilities.enumerative import MultisetPartitionTraverser
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import multiset, multiset_derangements, iterable
@@ -681,14 +681,30 @@ class bell(DefinedFunction):
         return s
 
     @staticmethod
-    @recurrence_memo([S.One, _sym])
-    def _bell_poly(n, prev):
-        s = 1
-        a = 1
-        for k in range(2, n + 1):
-            a = a * (n - k + 1) // (k - 1)
-            s += a * prev[k - 1]
-        return expand_mul(_sym * s)
+    def _bell_poly(n):
+        if n==0: return S.One
+
+        L = n.bit_length()
+
+        # initially, tree[k] = x-k; at each height, tree[boundary(j)-1] is the product of the x-k's for k in [boundary(j-1)..boundary(j))
+        tree = [(-k,1) for k in reversed(range(1,n+1))]
+
+        mul=lambda a,b: [sum(a[j]*b[i-j] for j in range(max(i+1-len(b),0),min(i+1,len(a)))) for i in range(len(a)+len(b)-1)]
+        for d in range(L - 1, 0, -1):
+            for j in range(1,1<<d):
+                if (j-1)*n>>d < (m:=(2*j-1)*n>>d+1) < (b:=j*n>>d): tree[-b] = mul(tree[-b],tree[-m])
+
+        # root occupies tree[0]
+        tree[0]=[0]*(n-1)+[1]
+        def divmod(p,q):
+            _divmod=lambda r,p: (r,p) if len(p)<len(q) else _divmod([p[-1]]+r,p[:-len(q)]+[a-p[-1]*b for a,b in zip(p[-len(q):-1],q[:-1])])
+            return _divmod([],p)
+        # split forwards through each branch
+        for d in range(L):
+            for j in range(1<<d,0,-1):
+                if (j-1)*n>>d < (m:=(2*j-1)*n>>d+1) < (b:=j*n>>d): tree[-b],tree[-m] = divmod(tree[-b],tree[-m])
+
+        return Poly.from_list([tree[k][0] for k in range(n)]+[0],_sym).as_expr()
 
     @staticmethod
     def _bell_incomplete_poly(n, k, symbols):


### PR DESCRIPTION
#### References to other Issues or PRs
not applicable

#### Brief description of what is fixed or changed
using the fact that the Stirling numbers of the second kind are the coefficients in the decomposition of x**n into the basis of falling powers `ff(x,k)=x*(x-1)*...*(x-k+1)`, we can perform it iteratively by taking `coeff[ff(x,0)] = x**n%x`, `coeff[ff(x,1)] = x**n//x%(x-1)`, `coeff[ff(x,2)] = x**n//x//(x-1)%(x-2)`, etc., which allows us to reuse the previous computation by doing only one divmod for each coeff. (This is essentially https://en.wikipedia.org/wiki/Horner's_method in reverse)

this commit performs that with binary splitting; you wouldn't imagine this to make much difference since SymPy uses only schoolbook multiplication, not Karatsuba/FFTs, but for very large n, splitting keeps the size of the coefficients in the intermediate steps small which reduces overhead significantly.

#### Other comments
i suspect the existing implementation to be leaky in some way someone more well-versed than i would probably be able to identify, since the speedup is considerably greater than i would expect.

here is my little testing script:
```python
from sympy import Symbol,Poly,poly,symbols
from sympy.functions.combinatorial.numbers import stirling
from sympy.core import S
_sym = Symbol('x')

@staticmethod
def touchard(n):
    if n==0: return Poly(S.One,_sym)

    L = n.bit_length()

    # initially, tree[k] = x-k; at each height, tree[boundary(j)-1] is the product of the x-k's for k in [boundary(j-1)..boundary(j))
    tree = [(-k,1) for k in reversed(range(1,n+1))]

    mul=lambda a,b: [sum(a[j]*b[i-j] for j in range(max(i+1-len(b),0),min(i+1,len(a)))) for i in range(len(a)+len(b)-1)]
    for d in range(L - 1, 0, -1):
        for j in range(1,1<<d):
            if (j-1)*n>>d < (m:=(2*j-1)*n>>d+1) < (b:=j*n>>d): tree[-b] = mul(tree[-b],tree[-m])

    # root occupies tree[0]
    tree[0]=[0]*(n-1)+[1]
    def divmod(p,q):
        r=[]
        while len(p)>=len(q): r,p=[p[-1]]+r,p[:-len(q)]+[a-p[-1]*b for a,b in zip(p[-len(q):-1],q[:-1])]
        return (r,p)
    # split forwards through each branch
    for d in range(L):
        for j in range(1<<d,0,-1):
            if (j-1)*n>>d < (m:=(2*j-1)*n>>d+1) < (b:=j*n>>d): tree[-b],tree[-m] = divmod(tree[-b],tree[-m])

    return Poly.from_list([tree[k][0] for k in range(n)]+[0],_sym)

assert all(touchard(n).as_list()==[stirling(n,k) for k in reversed(range(n+1))] for n in range(64))
from time import time
x=symbols('x')
n=400;print(f'generating bell({n},x):')
t=time();print('new',hash(tuple(touchard(n).as_list())),time()-t)
from sympy import bell
t=time();print('old',hash(tuple(poly(bell(n,x),x).as_list())),time()-t)
```
and it returns
```python
generating bell(400,x):
new 4009177897965104914 0.08361387252807617
old 4009177897965104914 3.897909164428711
```
*[this part was updated after the acceptance of PR #30478; previously it was 9177 times faster at `bell(100,x)` but now only 46 times faster at `bell(400,x)`]*

#### AI Generation Disclosure
all code was done humanifically; i learned of the idea from https://scholars.iwu.edu/ws/portalfiles/portal/39727279/fulltext.pdf (which is a more formal explanation that gives some surrounding discussion). A google search dates that paper to ≤ 2012 so they had no (non-time-travelling) AI either

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * Replace `_bell_poly` (univariate Bell/Touchard polynomial) in `functions.combinatorial.numbers.bell` with a much faster version that avoids caching by using Horner's method in reverse instead of a recurrence.
<!-- END RELEASE NOTES -->