### PR TITLE
Fix minimum Python version error messages in setup.py and __init__.py…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1927,3 +1927,4 @@ zzj <29055749+zjzh@users.noreply.github.com>
 Łukasz Pankowski <lukpank@o2.pl>
 彭于斌 <1931127624@qq.com>
 袁野 (Yuan Ye) <yuanyelele@tutanota.com>
+SHIVANSH-ux-ys <singaser78@gmail.com>

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extra_kwargs = {
 
 # Keep in sync with sympy/__init__.py and python_requires below
 if sys.version_info < (3, 10):
-    print("SymPy requires Python 3.9 or newer. Python %d.%d detected"
+    print("SymPy requires Python 3.10 or newer. Python %d.%d detected"
           % sys.version_info[:2])
     sys.exit(-1)
 

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -15,8 +15,8 @@ See the webpage for more information and documentation:
 
 # Keep this in sync with setup.py/pyproject.toml
 import sys
-if sys.version_info < (3, 9):
-    raise ImportError("Python version 3.9 or above is required for SymPy.")
+if sys.version_info < (3, 10):
+    raise ImportError("Python version 3.10 or above is required for SymPy.")
 del sys
 
 


### PR DESCRIPTION
Fixes #30257

<!-- BEGIN RELEASE NOTES -->
* packaging
  * Fixed minimum Python version error messages in `setup.py` and `sympy/__init__.py` to correctly require Python 3.10.
<!-- END RELEASE NOTES -->