### PR TITLE
fix(printing.latex): escape leading/trailing underscores in symbol names

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1695,6 +1695,10 @@ class LatexPrinter(Printer):
             name, supers, subs = (name.replace('_', '\\_').replace('^', '\\^'), [], [])
         else:
             name, supers, subs = split_super_sub(name)
+            # A leading underscore is a literal part of the symbol name (there
+            # is no preceding name to attach a subscript to), so escape it
+            # instead of emitting it raw as an (empty) subscript.
+            name = name.replace('_', '\\_')
         name = translate(name)
         supers = [translate(sup) for sup in supers]
         subs = [translate(sub) for sub in subs]
@@ -1711,7 +1715,13 @@ class LatexPrinter(Printer):
         if supers:
             name += "^{%s}" % " ".join(supers)
         if subs:
-            name += "_{%s}" % " ".join(subs)
+            # A trailing underscore is split into an empty subscript. Render it
+            # as a literal escaped underscore after the real subscripts instead
+            # of an empty subscript group (e.g. ``x_`` -> ``x\_``, not ``x_{}``).
+            real_subs = [sub for sub in subs if sub]
+            if real_subs:
+                name += "_{%s}" % " ".join(real_subs)
+            name += "\\_" * (len(subs) - len(real_subs))
 
         return name
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -282,6 +282,22 @@ def test_latex_basic():
     assert latex(Pow(Rational(-1, 3), -1, evaluate=False)) == r'\frac{1}{- \frac{1}{3}}'
 
 
+def test_latex_underscore_symbols():
+    # Issue 14718: leading/trailing underscores must be escaped, while an
+    # underscore followed by digits must still render as a subscript.
+    assert latex(Symbol('_x')) == r"\_x"
+    assert latex(2*Symbol('_x')) == r"2 \_x"
+    assert latex(Symbol('x_')) == r"x\_"
+    assert latex(Symbol('_x_')) == r"\_x\_"
+    assert latex(Symbol('__x')) == r"\_\_x"
+    assert latex(sin(Symbol('_theta'))) == r"\sin{\left(\_theta \right)}"
+    # Subscript semantics are preserved.
+    assert latex(Symbol('x_1')) == r"x_{1}"
+    assert latex(Symbol('x_a')) == r"x_{a}"
+    # Mixed subscript plus trailing underscore keeps the correct order.
+    assert latex(Symbol('x_a_')) == r"x_{a}\_"
+
+
 def test_latex_builtins():
     assert latex(True) == r"\text{True}"
     assert latex(False) == r"\text{False}"


### PR DESCRIPTION
Symbol names with a leading underscore were printed raw (e.g. latex(2*Symbol('_x')) gave '2 _x') and a trailing underscore was turned into an empty subscript (latex(Symbol('x_')) gave 'x_{}'). Both are literal underscores that LaTeX must escape. Subscript semantics (x_1 -> x_{1}) are preserved.

Closes sympy/sympy#14718

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs
Fixes #14718
<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed
Symbol names with a leading underscore were printed unescaped (latex(2*Symbol('_x'))
gave '2 _x'), and a trailing underscore became an empty subscript (latex(Symbol('x_'))
gave 'x_{}'). Both are literal underscores that LaTeX must escape. This escapes leading
underscores and renders a trailing underscore as a literal \_, while preserving
subscript semantics (x_1 -> x_{1}).

#### Other comments
Added regression test test_latex_underscore_symbols covering leading, trailing,
doubled, and mixed underscore cases.

#### AI Generation Disclosure
AI-assisted: the code changes and test were drafted with the assistance of an
AI coding agent (DeepSeek), then reviewed and verified by the contributor against
SymPy's test suite.
<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a bug where leading and trailing underscores in symbol names were not escaped in LaTeX output.
<!-- END RELEASE NOTES -->
