### PR TITLE
exponentiation by squaring for fibonacci polynomials and tribonacci

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -33,7 +33,7 @@ from sympy.ntheory.generate import _primepi
 from sympy.ntheory.partitions_ import _partition, _partition_rec
 from sympy.ntheory.primetest import isprime, is_square
 from sympy.polys.appellseqs import bernoulli_poly, euler_poly, genocchi_poly
-from sympy.polys.polytools import cancel
+from sympy.polys.polytools import cancel, Poly
 from sympy.utilities.enumerative import MultisetPartitionTraverser
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import multiset, multiset_derangements, iterable
@@ -231,10 +231,20 @@ class fibonacci(DefinedFunction):
     def _fib(n):
         return _ifib(n)
 
-    @staticmethod
-    @recurrence_memo([None, S.One, _sym])
-    def _fibpoly(n, prev):
-        return (prev[-2] + _sym*prev[-1]).expand()
+    @classmethod
+    @cacheit
+    def __fibpoly(cls,n):
+        if n<2:
+            z=Poly(S.Zero,_sym);o=Poly(S.One,_sym)
+            return [z,o] if n else [o,z]
+        def mul(a,b):
+            a0,a1=a
+            b0,b1=b
+            c=a1*b1
+            return [a0*b0+c,a0*b1+a1*b0+_sym*c]
+        return mul(cls.__fibpoly(p:=1<<n.bit_length()-1),cls.__fibpoly(n-p)) if n&n-1 else mul(t:=cls.__fibpoly(n>>1),t)
+    @classmethod
+    def _fibpoly(cls,n): return cls.__fibpoly(n+1)[0].as_expr()
 
     @classmethod
     def eval(cls, n, sym=None):
@@ -364,15 +374,39 @@ class tribonacci(DefinedFunction):
 
     """
 
-    @staticmethod
-    @recurrence_memo([S.Zero, S.One, S.One])
-    def _trib(n, prev):
-        return (prev[-3] + prev[-2] + prev[-1])
+    @classmethod
+    @cacheit
+    def __trib(cls,n):
+        if n<2: return [0,1,0] if n else [1,0,0]
+        def mul(a,b):
+            a0,a1,a2=a
+            b0,b1,b2=b
+            c=a1*b2+a2*b1
+            d=a2*b2
+            return [a0*b0+c+d,a0*b1+a1*b0+c+2*d,a0*b2+a1*b1+a2*b0+c+2*d]
+        return mul(cls.__trib(p:=1<<n.bit_length()-1),cls.__trib(n-p)) if n&n-1 else mul(t:=cls.__trib(n>>1),t)
+    @classmethod
+    def _trib(cls,n): return cls.__trib(n+2)[0]
 
-    @staticmethod
-    @recurrence_memo([S.Zero, S.One, _sym**2])
-    def _tribpoly(n, prev):
-        return (prev[-3] + _sym*prev[-2] + _sym**2*prev[-1]).expand()
+    @classmethod
+    @cacheit
+    def __tribpoly(cls,n):
+        z=Poly(S.Zero,_sym);o=Poly(S.One,_sym)
+        if n<2: return [z,o,z] if n else [o,z,z]
+
+        def mul(a,b):
+            x=_sym
+            a0,a1,a2=a
+            b0,b1,b2=b
+
+            c=a1*b2+a2*b1
+            d=a2*b2
+
+            return [a0*b0+c+x**2*d,a0*b1+a1*b0+x*c+(1+x**3)*d,a0*b2+a1*b1+a2*b0+x**2*c+(x+x**4)*d]
+
+        return mul(cls.__tribpoly(p:=1<<n.bit_length()-1),cls.__tribpoly(n-p)) if n&n-1 else mul(t:=cls.__tribpoly(n>>1),t)
+    @classmethod
+    def _tribpoly(cls,n): return cls.__tribpoly(n+2)[0].as_expr()
 
     @classmethod
     def eval(cls, n, sym=None):

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -233,7 +233,7 @@ class fibonacci(DefinedFunction):
 
     @classmethod
     @cacheit
-    def __fibpoly(cls,n):
+    def __fibpoly(cls,n:int):
         if n<2:
             z=Poly(S.Zero,_sym);o=Poly(S.One,_sym)
             return [z,o] if n else [o,z]
@@ -244,7 +244,7 @@ class fibonacci(DefinedFunction):
             return [a0*b0+c,a0*b1+a1*b0+_sym*c]
         return mul(cls.__fibpoly(p:=1<<n.bit_length()-1),cls.__fibpoly(n-p)) if n&n-1 else mul(t:=cls.__fibpoly(n>>1),t)
     @classmethod
-    def _fibpoly(cls,n): return cls.__fibpoly(n+1)[0].as_expr()
+    def _fibpoly(cls,n:int): return cls.__fibpoly(int(n)+1)[0].as_expr()
 
     @classmethod
     def eval(cls, n, sym=None):
@@ -376,7 +376,7 @@ class tribonacci(DefinedFunction):
 
     @classmethod
     @cacheit
-    def __trib(cls,n):
+    def __trib(cls,n:int):
         if n<2: return [0,1,0] if n else [1,0,0]
         def mul(a,b):
             a0,a1,a2=a
@@ -386,11 +386,11 @@ class tribonacci(DefinedFunction):
             return [a0*b0+c+d,a0*b1+a1*b0+c+2*d,a0*b2+a1*b1+a2*b0+c+2*d]
         return mul(cls.__trib(p:=1<<n.bit_length()-1),cls.__trib(n-p)) if n&n-1 else mul(t:=cls.__trib(n>>1),t)
     @classmethod
-    def _trib(cls,n): return cls.__trib(n+2)[0]
+    def _trib(cls,n): return cls.__trib(int(n)+2)[0]
 
     @classmethod
     @cacheit
-    def __tribpoly(cls,n):
+    def __tribpoly(cls,n:int):
         z=Poly(S.Zero,_sym);o=Poly(S.One,_sym)
         if n<2: return [z,o,z] if n else [o,z,z]
 
@@ -406,7 +406,7 @@ class tribonacci(DefinedFunction):
 
         return mul(cls.__tribpoly(p:=1<<n.bit_length()-1),cls.__tribpoly(n-p)) if n&n-1 else mul(t:=cls.__tribpoly(n>>1),t)
     @classmethod
-    def _tribpoly(cls,n): return cls.__tribpoly(n+2)[0].as_expr()
+    def _tribpoly(cls,n): return cls.__tribpoly(int(n)+2)[0].as_expr()
 
     @classmethod
     def eval(cls, n, sym=None):


### PR DESCRIPTION
#### References to other Issues or PRs
none that i can see

#### Brief description of what is changed
the present implementation iterates over (and caches) every term up to the one queried, taking quadratic time and space wrt `n` to compute a number that is only `Θ(n)` bits long! this is bad

i have [a little page](https://oeis.org/wiki/User:Natalia_L._Skirrow/linear_recurrence) about computing linear-recurrent sequences (note that the OEISwiki since updated the MediaWiki/LaTeX-extension versions which mangled one line somewhat). The method used here is the one mentioned at the end of the page (the `nthTerm` function) with the multiplications and modulos unravelled out for the particular o.g.f. denominators. I initially learned of it from from [this gist](https://gist.github.com/hepheir/6e1a830211829b4119797a4ca5b1a3de) which in turn is a Python port of [this gist](https://gist.github.com/koosaga/d4afc4434dbaa348d5bef0d60ac36aa4).

it is the same idea as i discussed in [this mathstodon thread](https://mathstodon.xyz/@peterluschny/116320199782572958) with Peter Luschny which to this prog for the n-th Fibonacci number
```python
A000045=lambda n: pow(2,(m:=n+1)*m,~(~0<<2*m|1<<m))&~(~0<<m)
```
essentially, you write the coefficient of `x^n` in the expansion of `p(x)/q(x)` about `x=0` (ascending powers) as the coefficient of `x^0` in `x^n * p(1/x)/q(1/x)` about `x=∞` (descending powers), then the actual steps in the big-endian long division are just repeating a convolve-and-modulo.

`pow` already does this with exponentiation by squaring, but storing polynomials packed into integers' binary expansions is slow because the `k`th of the `Θ(log(n))` steps requires the integers to have the full (`Θ(n)`) length instead of `Θ(2**k)`; the sum of all intermediate steps' time is [linearithmic](https://en.wiktionary.org/wiki/linearithmic) wrt of the last step instead of linear, so that golfy function takes `Θ(M(log(n))*log(log(n)))` time (where `M(l)` is the time of length-`l` integer mul) to compute `fibonacci(n)` instead of `Θ(M(log(n)))`.

note that this is a bit faster than the 'obvious' way to implement it (by exponentiating `x^deg(q)*q(1/x)`'s companion matrix), since it only multiplies polynomials instead of matrices!

#### Other comments
testing
```python
print(f'n={n}')
print('fibpoly')
t=time();print('new',hash(_fibpoly(n)),time()-t)
t=time();print('old',hash(fibold(n,x)),time()-t)
print('trib')
t=time();print('new',hash(_trib(n)),time()-t)
t=time();print('old',hash(tribold(n)),time()-t)
print('tribpoly')
t=time();print('new',hash(_tribpoly(n)),time()-t)
t=time();print('old',hash(tribold(n,x)),time()-t)
```
gives some nice results
```
n=64
fibpoly
new -6625529000866608950 0.006861209869384766
old -6625529000866608950 0.30802488327026367
trib
new 29120472094716576 2.6941299438476562e-05
old 29120472094716576 0.00023508071899414062
tribpoly
new -5339331448381513034 0.017297029495239258
old -5339331448381513034 0.6685609817504883
n=256
fibpoly
new -1244491013611592081 0.03415393829345703
old -1244491013611592081 6.608983755111694
trib
new 770993570957667723 8.606910705566406e-05
old 770993570957667723 0.0013852119445800781
tribpoly
new 5644479863304873029 0.1628739833831787
old 5644479863304873029 18.193758010864258
```

#### AI Generation Disclosure
NO AI USE (on account of it was very easy and enjoyable for one such as i).

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * Switch Fibonacci polynomials and Tribonacci numbers/polynomials from direct recurrence to polynomial exponentiation by squaring
<!-- END RELEASE NOTES -->
