### PR TITLE
Fix apply_finite_diff to accept map/iterator inputs for x_list and y_list

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1165,6 +1165,7 @@ Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
 MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@users.noreply.github.com>
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
+Muhammad Usaid <shkusaid910@gmail.com> shkusaid <shkusaid910@gmail.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Musab Kasbati <musab16000@gmail.com> Musab Kasbati <43878981+Musab1Blaser@users.noreply.github.com>
 Musab Kasbati <musab16000@gmail.com> Musab1Blaser <musab16000@gmail.com>

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -227,7 +227,7 @@ def apply_finite_diff(order, x_list, y_list, x0=S.Zero):
     >>> from sympy import apply_finite_diff
     >>> cube = lambda arg: (1.0*arg)**3
     >>> xlist = range(-3,3+1)
-    >>> apply_finite_diff(2, xlist, map(cube, xlist), 2) - 12 # doctest: +SKIP
+    >>> apply_finite_diff(2, xlist, map(cube, xlist), 2) - 12
     -3.55271367880050e-15
 
     we see that the example above only contain rounding errors.
@@ -268,7 +268,8 @@ def apply_finite_diff(order, x_list, y_list, x0=S.Zero):
     # In the original paper the following holds for the notation:
     # M = order
     # N = len(x_list) - 1
-
+    x_list = list(x_list)
+    y_list = list(y_list)
     N = len(x_list) - 1
     if len(x_list) != len(y_list):
         raise ValueError("x_list and y_list not equal in length.")


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Related to #6572


#### Brief description of what is fixed or changed

While I was solving and finding best contribution for my first open source contribution which was removing Skip comments from issue #6572. I noticed another type of error in my testing of code. I noticed that apply_finite_diff's function is called with a  map object  y_list and which cause the error "TypeError: object of type 'map' has no len()" that was happening because the y_list is a map object and it doesn't support any len() or indexes.
I fixed this issue by converting x_list and y_list into lists at the start of function so that iterable works.
I also delete the # doctest: +SKIP commented line from the code. 

#### Other comments
After changing the lines of code and delete the comment I ran through bin/doctest and also through the bin/tests from sympy/calculus/tests/test_finite_diff.py
both passed and I also checked other call sited of apply_finite_diff function via git command of git grep -n "apply_finite_diff("
none of them rely on x_list and y_list as an iterator so I changed them both.

#### AI Generation Disclosure

This is my first PR, and I used AI to help me understand terminal/git commands.


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* calculus
  * Fixed apply_finite_diff raising TypeError when x_list or y_list
    is a map object or other non-list iterable.
<!-- END RELEASE NOTES -->
