### PR TITLE
ArrayTensorProduct: extract scalar coefficients of matrix arguments

### DIFF
--- a/sympy/matrices/expressions/tests/test_derivatives.py
+++ b/sympy/matrices/expressions/tests/test_derivatives.py
@@ -96,9 +96,9 @@ def test_matrix_derivative_non_matrix_result():
     AdA = PermuteDims(ArrayTensorProduct(I, I), Permutation(3)(1, 2))
     assert A.diff(A) == AdA
     assert A.T.diff(A) == PermuteDims(ArrayTensorProduct(I, I), Permutation(3)(1, 2, 3))
-    assert (2*A).diff(A) == PermuteDims(ArrayTensorProduct(2*I, I), Permutation(3)(1, 2))
+    assert (2*A).diff(A) == PermuteDims(ArrayTensorProduct(2, I, I), Permutation(3)(1, 2))
     # The two identical addend derivatives are collected:
-    assert MatAdd(A, A).diff(A) == PermuteDims(ArrayTensorProduct(2*I, I), Permutation(3)(1, 2))
+    assert MatAdd(A, A).diff(A) == PermuteDims(ArrayTensorProduct(2, I, I), Permutation(3)(1, 2))
     assert (A + B).diff(A) == AdA
 
 
@@ -243,7 +243,7 @@ def test_matrix_derivatives_of_traces():
 
     expr = Trace(A)*A
     I = Identity(k)
-    assert expr.diff(A) == ArrayAdd(ArrayTensorProduct(I, A), PermuteDims(ArrayTensorProduct(Trace(A)*I, I), Permutation(3)(1, 2)))
+    assert expr.diff(A) == ArrayAdd(ArrayTensorProduct(I, A), PermuteDims(ArrayTensorProduct(Trace(A), I, I), Permutation(3)(1, 2)))
     assert expr[i, j].diff(A[m, n]).doit() == (
         KDelta(i, m)*KDelta(j, n)*Trace(A) +
         KDelta(m, n)*A[i, j]
@@ -407,7 +407,7 @@ def test_mixed_deriv_mixed_expressions():
 
     expr = Trace(A)*A
     I = Identity(k)
-    assert expr.diff(A) == ArrayAdd(ArrayTensorProduct(I, A), PermuteDims(ArrayTensorProduct(Trace(A)*I, I), Permutation(3)(1, 2)))
+    assert expr.diff(A) == ArrayAdd(ArrayTensorProduct(I, A), PermuteDims(ArrayTensorProduct(Trace(A), I, I), Permutation(3)(1, 2)))
 
     expr = Trace(Trace(A)*A)
     assert expr.diff(A) == (2*Trace(A))*Identity(k)
@@ -672,7 +672,7 @@ def test_issue_15667():
     # https://github.com/sympy/sympy/issues/15667
     expr = Trace(A) * A
     I = Identity(k)
-    assert expr.diff(A) == ArrayAdd(ArrayTensorProduct(I, A), PermuteDims(ArrayTensorProduct(Trace(A)*I, I), Permutation(3)(1, 2)))
+    assert expr.diff(A) == ArrayAdd(ArrayTensorProduct(I, A), PermuteDims(ArrayTensorProduct(Trace(A), I, I), Permutation(3)(1, 2)))
 
 
 def test_matpow_derivative():

--- a/sympy/tensor/array/expressions/array_expressions.py
+++ b/sympy/tensor/array/expressions/array_expressions.py
@@ -320,17 +320,28 @@ class ArrayTensorProduct(_CodegenArrayAbstract):
         # ArrayTensorProduct(x*y, A, B).  The scalar is kept as a rank-0
         # argument (instead of returning Mul(coefficient, ...)) so that
         # the result remains a valid array expression with a well-defined
-        # shape.  Scalar coefficients inside MatrixExpr arguments (e.g.
-        # ArrayTensorProduct(2*M, N) with M a MatrixSymbol) are NOT
-        # extracted, as the matrix-recognition machinery in
-        # from_array_to_matrix relies on matrix arguments keeping their
-        # coefficients; use _split_scalar_coefficient to compare
-        # arguments modulo their scalar coefficient.
+        # shape.  Scalar coefficients of MatrixExpr arguments (e.g.
+        # ArrayTensorProduct(2*M, N) with M a MatrixSymbol) are extracted
+        # as well; the matrix recognition in from_array_to_matrix absorbs
+        # the leading coefficient back into its matrix result.
         def _is_plain_scalar(arg):
             # Rank-0 array expressions (e.g. full contractions) are not
             # merged: the branches below lift them into the expression.
             return (get_shape(arg) == () and
                     not isinstance(arg, (_ArrayExpr, _CodegenArrayAbstract)))
+
+        # Extract the scalar coefficients of matrix arguments, e.g.
+        # ArrayTensorProduct(2*M, N) becomes ArrayTensorProduct(2, M, N):
+        split_args = []
+        for arg in args:
+            if isinstance(arg, MatrixExpr):
+                coeff, array = _split_scalar_coefficient(arg)
+                if coeff is not S.One:
+                    split_args.append(coeff)
+                split_args.append(array)
+            else:
+                split_args.append(arg)
+        args = split_args
 
         scalars = [arg for arg in args if _is_plain_scalar(arg)]
         if scalars:

--- a/sympy/tensor/array/expressions/from_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/from_array_to_matrix.py
@@ -22,7 +22,7 @@ from sympy.tensor.array.expressions.array_expressions import PermuteDims, ArrayD
     ArrayTensorProduct, OneArray, get_ndim, _get_sub_ndim, ZeroArray, ArrayContraction, \
     ArrayAdd, _CodegenArrayAbstract, get_shape, ArrayElementwiseApplyFunc, _ArrayExpr, _EditArrayContraction, _ArgE, \
     ArrayElement, _array_tensor_product, _array_contraction, _array_diagonal, _array_add, _permute_dims, ArraySum, \
-    _get_sub_ndim_list
+    _get_sub_ndim_list, _array_term_as_coeff_arrays
 from sympy.tensor.array.expressions.utils import _get_mapping_from_sub_ndim_list
 
 
@@ -71,6 +71,22 @@ def _insert_candidate_into_editor(editor: _EditArrayContraction, arg_with_ind: _
     editor.args_with_ind.remove(candidate)
     new_arge = _ArgE(new_element)
     return new_arge, other_index
+
+
+def _a2m_absorb_scalars(expr):
+    """Turn a tensor product of scalar coefficients and a single matrix
+    expression into the matrix expression multiplied by the coefficients.
+
+    ``ArrayTensorProduct`` canonicalizes ``2*M`` to ``ArrayTensorProduct(2,
+    M)``; when a matrix expression is expected the coefficient has to be
+    absorbed back into the matrix.
+    """
+    if isinstance(expr, ArrayTensorProduct):
+        coeff, arrays = _array_term_as_coeff_arrays(expr)
+        if len(arrays) == 1 and isinstance(arrays[0], MatrixExpr) and \
+                coeff.is_commutative is not False:
+            return coeff*arrays[0]
+    return expr
 
 
 def _support_function_tp1_recognize(contraction_indices, args):
@@ -128,7 +144,7 @@ def _support_function_tp1_recognize(contraction_indices, args):
             break
 
     editor.refresh_indices()
-    return editor.to_array_contraction()
+    return _a2m_absorb_scalars(editor.to_array_contraction())
 
 
 def _find_trivial_matrices_rewrite(expr: ArrayTensorProduct):
@@ -211,7 +227,7 @@ def _(expr: ArrayTensorProduct):
 
 @_array2matrix.register(ArraySum)
 def _(expr: ArraySum):
-    new_function = _array2matrix(expr.function)
+    new_function = _a2m_absorb_scalars(_array2matrix(expr.function))
     output = expr.func(new_function, *expr.limits).simplify()
     if isinstance(output, ZeroArray) and get_ndim(output) == 2:
         return ZeroMatrix(*output.shape)
@@ -303,20 +319,26 @@ def _(expr: PermuteDims):
         mat_mul_lines = _array2matrix(expr.expr)
         if not isinstance(mat_mul_lines, ArrayTensorProduct):
             return _permute_dims(mat_mul_lines, expr.permutation)
-        # TODO: this assumes that all arguments are matrices, it may not be the case:
-        permutation = Permutation(2*len(mat_mul_lines.args)-1)*expr.permutation
-        permuted = [permutation(i) for i in range(2*len(mat_mul_lines.args))]
-        args_array = [None for i in mat_mul_lines.args]
-        for i in range(len(mat_mul_lines.args)):
+        # Rank-0 arguments (scalar coefficients) carry no axes, so the
+        # permutation only acts on the matrix arguments:
+        ndims = [get_ndim(arg) for arg in mat_mul_lines.args]
+        if any(ndim not in (0, 2) for ndim in ndims):
+            return _permute_dims(mat_mul_lines, expr.permutation)
+        scalars = [arg for arg, ndim in zip(mat_mul_lines.args, ndims) if ndim == 0]
+        matrices = [arg for arg, ndim in zip(mat_mul_lines.args, ndims) if ndim == 2]
+        permutation = Permutation(2*len(matrices)-1)*expr.permutation
+        permuted = [permutation(i) for i in range(2*len(matrices))]
+        args_array = [None for i in matrices]
+        for i in range(len(matrices)):
             p1 = permuted[2*i]
             p2 = permuted[2*i+1]
             if p1 // 2 != p2 // 2:
                 return _permute_dims(mat_mul_lines, permutation)
             if p1 > p2:
-                args_array[i] = _a2m_transpose(mat_mul_lines.args[p1 // 2])
+                args_array[i] = _a2m_transpose(matrices[p1 // 2])
             else:
-                args_array[i] = mat_mul_lines.args[p1 // 2]
-        return _a2m_tensor_product(*args_array)
+                args_array[i] = matrices[p1 // 2]
+        return _a2m_tensor_product(*scalars, *args_array)
     else:
         return expr
 
@@ -657,9 +679,9 @@ def convert_array_to_matrix(expr):
 
     The two lines have free indices at axes 0, 3 and 4, 7, respectively.
     """
-    rec = _array2matrix(expr)
+    rec = _a2m_absorb_scalars(_array2matrix(expr))
     rec, removed = _remove_trivial_dims(rec)
-    return rec
+    return _a2m_absorb_scalars(rec)
 
 
 def _array_diag2contr_diagmatrix(expr: ArrayDiagonal):
@@ -752,6 +774,11 @@ def _a2m_tensor_product(*args):
             arrays = [scalar] + arrays
         else:
             arrays[0] *= scalar
+    if len(arrays) == 1:
+        # Return the (possibly coefficient-carrying) matrix expression as
+        # is: canonicalizing it as a tensor product would extract the
+        # coefficient again into a leading rank-0 argument.
+        return arrays[0]
     return _array_tensor_product(*arrays)
 
 

--- a/sympy/tensor/array/expressions/tests/test_array_expressions.py
+++ b/sympy/tensor/array/expressions/tests/test_array_expressions.py
@@ -259,9 +259,10 @@ def test_arrayexpr_tensor_product_scalar_coefficients():
     assert tp.doit() == ArrayTensorProduct(2, M, N)
     assert ArrayTensorProduct(x*y*M, N).doit() == ArrayTensorProduct(x*y, M, N)
 
-    # Scalar coefficients of MatrixExpr arguments are kept in place, as
-    # the matrix-recognition machinery relies on them:
-    assert ArrayTensorProduct(2*Ms, Ns).doit() == ArrayTensorProduct(2*Ms, Ns)
+    # Scalar coefficients of MatrixExpr arguments are extracted as well:
+    assert ArrayTensorProduct(2*Ms, Ns).doit() == ArrayTensorProduct(2, Ms, Ns)
+    assert ArrayTensorProduct(2*Ms, 3*Ns).doit() == ArrayTensorProduct(6, Ms, Ns)
+    assert ArrayTensorProduct(x*Ms*Ns, y*Ns).doit() == ArrayTensorProduct(x*y, Ms*Ns, Ns)
 
     # Rank-0 array expressions (e.g. full contractions) are not merged
     # into the scalar coefficient:
@@ -877,19 +878,19 @@ def test_array_sum():
     assert expr.doit() == 5*X
 
     expr = ArrayTensorProduct(ArraySum(X, (i, 1, 5)), Y)
-    assert expr.doit() == ArrayTensorProduct(5*X, Y)
+    assert expr.doit() == ArrayTensorProduct(5, X, Y)
 
     expr = ArrayTensorProduct(A, ArraySum(X, (i, 1, j)), B, ArraySum(Y, (i, 1, m)), C)
-    assert expr.doit() == ArrayTensorProduct(A, j*X, B, m*Y, C)
+    assert expr.doit() == ArrayTensorProduct(j*m, A, X, B, Y, C)
 
     expr = ArrayTensorProduct(A, ArraySum(X*sin(i), (i, 1, j)), B, ArraySum(Y*sin(i), (i, 1, m)), C)
-    assert expr.doit().dummy_eq(ArraySum(ArrayTensorProduct(A, sin(i)*X, B, sin(n)*Y, C), (i, 1, j), (n, 1, m)))
+    assert expr.doit().dummy_eq(ArraySum(ArrayTensorProduct(sin(i)*sin(n), A, X, B, Y, C), (i, 1, j), (n, 1, m)))
 
     expr = ArrayTensorProduct(ArraySum(X**sin(i), (i, 1, j)), Y)
     assert expr.doit().dummy_eq(ArraySum(ArrayTensorProduct(X**sin(i), Y), (i, 1, j)))
 
     expr = ArrayTensorProduct(ArraySum(X**sin(i), (i, 1, j)), i*Y)
-    assert expr.doit().dummy_eq(ArraySum(ArrayTensorProduct(X**sin(m), i*Y), (m, 1, j)))
+    assert expr.doit().dummy_eq(ArraySum(ArrayTensorProduct(i, X**sin(m), Y), (m, 1, j)))
 
     expr = ArrayContraction(ArraySum(X, (i, 0, j)), (0, 1))
     assert expr.doit() == ArrayContraction((j + 1)*X, (0, 1))

--- a/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_array_to_matrix.py
@@ -16,7 +16,8 @@ from sympy.matrices.expressions.diagonal import DiagMatrix, DiagonalMatrix
 from sympy.matrices import Trace, MatMul, Transpose
 from sympy.tensor.array.expressions.array_expressions import ZeroArray, OneArray, \
     ArrayElement, ArraySymbol, ArrayElementwiseApplyFunc, _array_tensor_product, _array_contraction, \
-    _array_diagonal, _permute_dims, PermuteDims, ArrayAdd, ArrayDiagonal, ArrayContraction, ArrayTensorProduct, ArraySum
+    _array_diagonal, _permute_dims, PermuteDims, ArrayAdd, ArrayDiagonal, ArrayContraction, ArrayTensorProduct, ArraySum, \
+    _array_add
 from sympy.testing.pytest import raises
 
 
@@ -747,3 +748,36 @@ def test_array_sum_conversion():
 
     expr = ArraySum(X, (i, 1, 10))
     assert convert_array_to_matrix(expr) == 10*X
+
+
+def test_arrayexpr_convert_array_to_matrix_scalar_coefficients():
+    # Scalar coefficients of matrix arguments are extracted by the
+    # canonicalization of ArrayTensorProduct into a leading rank-0 argument
+    # (see issue #30387); the matrix recognition has to absorb them back.
+    x, y = symbols("x y")
+
+    cg = _array_contraction(_array_tensor_product(2*M, N), (1, 2))
+    assert cg == _array_contraction(_array_tensor_product(2, M, N), (1, 2))
+    assert convert_array_to_matrix(cg) == 2*M*N
+
+    cg = _array_contraction(_array_tensor_product(x*M, y*N, P), (1, 2), (3, 4))
+    assert convert_array_to_matrix(cg) == x*y*M*N*P
+
+    cg = _array_contraction(_array_tensor_product(3*M), (0, 1))
+    assert convert_array_to_matrix(cg) == 3*Trace(M)
+
+    assert convert_array_to_matrix(_array_tensor_product(2*M, 3*N)) == ArrayTensorProduct(6, M, N)
+    assert convert_array_to_matrix(_array_add(_array_tensor_product(2*M, N), _array_tensor_product(M, 3*N))) == \
+        ArrayTensorProduct(5, M, N)
+
+    # Permutations act on the matrix axes only, the coefficient has none:
+    cg = PermuteDims(_array_tensor_product(2*M, N), Permutation([2, 3, 0, 1]))
+    assert convert_array_to_matrix(cg) == ArrayTensorProduct(2, N, M)
+
+    cg = PermuteDims(_array_contraction(_array_tensor_product(3*M, N, P), (1, 2)), Permutation([1, 0, 3, 2]))
+    assert convert_array_to_matrix(cg) == ArrayTensorProduct(3, N.T*M.T, P.T)
+
+    cg = PermuteDims(_array_contraction(_array_tensor_product(3*M, N, P), (1, 2)), Permutation([2, 3, 0, 1]))
+    assert convert_array_to_matrix(cg) == ArrayTensorProduct(3, P, M*N)
+
+    assert _support_function_tp1_recognize([(1, 2)], [2*M, N]) == 2*M*N

--- a/sympy/tensor/array/expressions/tests/test_simplification.py
+++ b/sympy/tensor/array/expressions/tests/test_simplification.py
@@ -111,4 +111,4 @@ def test_array_add_collect_derivative_regression():
     Ak = MatrixSymbol("Ak", k, k)
     I = Identity(k)
     assert MatAdd(Ak, Ak).diff(Ak) == \
-        PermuteDims(ArrayTensorProduct(2*I, I), Permutation(3)(1, 2))
+        PermuteDims(ArrayTensorProduct(2, I, I), Permutation(3)(1, 2))


### PR DESCRIPTION
This is a follow-up from a previous merge. Claude had been unable to extract scalars from `ArrayTensorProduct` because it was breaking the conversion algorithm `convert_array_to_matrix`.

This should fix it (hopefully!)

#### References to other Issues or PRs

Fixes #30387. Follow-up of #30275.

#### Brief description of what is fixed or changed

The canonicalization of `ArrayTensorProduct` now also extracts the scalar coefficients of `MatrixExpr` arguments into the leading rank-0 argument, consistently with what #30275 does for plain scalar arguments:

```python
>>> ArrayTensorProduct(2*M, N).doit()
ArrayTensorProduct(2, M, N)
>>> ArrayTensorProduct(2*M, 3*N).doit()
ArrayTensorProduct(6, M, N)
```

`from_array_to_matrix` is adapted to the leading coefficient, which is what blocked this in #30275:

- `_a2m_tensor_product` returns a single matrix result directly instead of canonicalizing it as a tensor product (which would extract the coefficient it has just absorbed);
- the recognition of permuted matrix-multiplication lines assigns axes to the matrix arguments only, skipping rank-0 ones (a leading coefficient would otherwise shift the axes and transpose the result);
- the recognizer, the `ArraySum` conversion and the top-level `convert_array_to_matrix` absorb a leading coefficient into a single matrix result, so that `2*M*N` is returned rather than `ArrayTensorProduct(2, M*N)`.

Test expectations are updated to the new canonical form (e.g. matrix derivatives now show `ArrayTensorProduct(2, I, I)` instead of `ArrayTensorProduct(2*I, I)`). New tests in `test_array_expressions.py` and `test_convert_array_to_matrix.py` cover the extraction and the conversion back to matrices for contracted, permuted, summed and traced products; every converted result was checked against the explicit arrays.

#### Other comments

The doctests of `doc/src/explanation/modules/matrices/matrixderivatives.rst` and the `sympy/tensor`, `sympy/matrices`, `sympy/printing` and `sympy/codegen` test suites pass locally.

#### AI Generation Disclosure

Claude Code (Claude Fable 5.1), working under the direction of the author, who reviewed the changes.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* tensor
  * `ArrayTensorProduct` now extracts the scalar coefficients of its `MatrixExpr` arguments into a leading scalar argument, e.g. `ArrayTensorProduct(2*M, N)` becomes `ArrayTensorProduct(2, M, N)`; `convert_array_to_matrix` absorbs such coefficients back into the matrix expressions it recognizes.
<!-- END RELEASE NOTES -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XigkSxBiMvAFEY8S2yYyP4
