### PR TITLE
owens_t: evaluate numerically by direct mpmath quadrature

### DIFF
--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2932,11 +2932,8 @@ class owens_t(DefinedFunction):
         if not (h.is_number and a.is_number):
             return None
         with local_workprec(prec + 10) as ctx:
-            try:
-                hm = ctx.convert(h._to_mpmath(prec + 10))
-                am = ctx.convert(a._to_mpmath(prec + 10))
-            except (ValueError, TypeError):
-                return None
+            hm = ctx.convert(h._to_mpmath(prec + 10))
+            am = ctx.convert(a._to_mpmath(prec + 10))
 
             def integrand(t):
                 s = 1 + t**2

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2,9 +2,13 @@
     of incomplete gamma functions. It should probably be renamed. """
 from __future__ import annotations
 
+import mpmath
+from mpmath import workprec
+
 from sympy.core import EulerGamma # Must be imported from core, not core.numbers
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
+from sympy.core.expr import Expr
 from sympy.core.function import DefinedFunction, ArgumentIndexError, expand_mul
 from sympy.core.logic import fuzzy_or
 from sympy.core.numbers import I, pi, Rational, Integer
@@ -2927,8 +2931,26 @@ class owens_t(DefinedFunction):
         return super()._eval_aseries(n, args0, x, logx)
 
     def _eval_evalf(self, prec):
-        from sympy.integrals.integrals import Integral
-        return self.rewrite(Integral).evalf(n=prec_to_dps(prec))
+        h, a = self.args
+        if not (h.is_number and a.is_number):
+            return None
+        try:
+            hm = h._to_mpmath(prec)
+            am = a._to_mpmath(prec)
+        except (ValueError, TypeError):
+            return None
+        # Evaluate the defining integral by mpmath quadrature at the
+        # requested precision (with guard bits): the working precision
+        # matters, because ``Add`` retries at higher precision to recover
+        # cancellation between T(h, a) and error function terms. An
+        # mpmath integrand is much cheaper than evaluating the symbolic
+        # integrand at every node through ``evalf``.
+        with workprec(prec + 10):
+            def integrand(t):
+                s = 1 + t**2
+                return mpmath.exp(-hm**2*s/2)/s
+            result = mpmath.quad(integrand, [0, am])/(2*mpmath.pi)
+        return Expr._from_mpmath(result, prec)
 
 
 ###############################################################################

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2,9 +2,6 @@
     of incomplete gamma functions. It should probably be renamed. """
 from __future__ import annotations
 
-import mpmath
-from mpmath import workprec
-
 from sympy.core import EulerGamma # Must be imported from core, not core.numbers
 from sympy.core.add import Add
 from sympy.core.cache import cacheit
@@ -25,7 +22,7 @@ from sympy.functions.elementary.exponential import exp, log, exp_polar
 from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.trigonometric import cos, sin, sinc, atan
 from sympy.functions.special.hyper import hyper, meijerg
-from sympy.external.mpmath import prec_to_dps
+from sympy.external.mpmath import prec_to_dps, local_workprec
 
 # TODO series expansions
 # TODO see the "Note:" in Ei
@@ -2934,22 +2931,24 @@ class owens_t(DefinedFunction):
         h, a = self.args
         if not (h.is_number and a.is_number):
             return None
-        try:
-            hm = h._to_mpmath(prec)
-            am = a._to_mpmath(prec)
-        except (ValueError, TypeError):
-            return None
         # Evaluate the defining integral by mpmath quadrature at the
         # requested precision (with guard bits): the working precision
         # matters, because ``Add`` retries at higher precision to recover
         # cancellation between T(h, a) and error function terms. An
         # mpmath integrand is much cheaper than evaluating the symbolic
         # integrand at every node through ``evalf``.
-        with workprec(prec + 10):
+        with local_workprec(prec + 10) as ctx:
+            try:
+                hm = ctx.convert(h._to_mpmath(prec + 10))
+                am = ctx.convert(a._to_mpmath(prec + 10))
+            except (ValueError, TypeError):
+                return None
+
             def integrand(t):
                 s = 1 + t**2
-                return mpmath.exp(-hm**2*s/2)/s
-            result = mpmath.quad(integrand, [0, am])/(2*mpmath.pi)
+                return ctx.exp(-hm**2*s/2)/s
+
+            result = ctx.quad(integrand, [0, am])/(2*ctx.pi)
         return Expr._from_mpmath(result, prec)
 
 

--- a/sympy/functions/special/error_functions.py
+++ b/sympy/functions/special/error_functions.py
@@ -2931,12 +2931,6 @@ class owens_t(DefinedFunction):
         h, a = self.args
         if not (h.is_number and a.is_number):
             return None
-        # Evaluate the defining integral by mpmath quadrature at the
-        # requested precision (with guard bits): the working precision
-        # matters, because ``Add`` retries at higher precision to recover
-        # cancellation between T(h, a) and error function terms. An
-        # mpmath integrand is much cheaper than evaluating the symbolic
-        # integrand at every node through ``evalf``.
         with local_workprec(prec + 10) as ctx:
             try:
                 hm = ctx.convert(h._to_mpmath(prec + 10))


### PR DESCRIPTION
A timeout issue I've noticed in other PRs. 

`owens_t` was introduced recently during GSoC 2026, so this is probably something we want to fix before the next SymPy release.

#### References to other Issues or PRs

Follow-up of #30347 (`bde8a69ccd`, "Fix precision loss in owens_t evalf"), whose `test_owent_evalf_cancellation` times out on CI.

#### Brief description of what is fixed or changed

`test_owent_evalf_cancellation` has been failing on master with `Failed: Timeout (>10.0s)` (e.g. run 33671000501). The expression `erf(-3*sqrt(2))/2 + 1/2 - 2*owens_t(-6, 2)` cancels down to `7.1e-43`, so `Add` retries the evaluation at increasing precision (eight times, from 67 to 207 bits). Each retry re-evaluated `owens_t` by rewriting it as an `Integral` and running the quadrature through the generic `evalf` machinery, which evaluates the symbolic integrand at every node: 2.3 s locally, and over the 10 s limit on a loaded runner.

`owens_t._eval_evalf` now evaluates the defining integral

$$T(h, a) = \frac{1}{2\pi}\int_0^a \frac{e^{-h^2(1+t^2)/2}}{1+t^2}\,dt$$

directly with `mpmath.quad` at the requested precision (plus guard bits), returning `None` for symbolic arguments as before. The cancellation test takes 0.07 s, and the whole `owens_t` test group 0.8 s. Values agree with the previous `Integral` path at 30 digits for real, negative, large, tiny and complex arguments.

#### Other comments

`test_kane.py::test_implicit_kinematics` shows the same timeout pattern on master and is unrelated to this change.

#### AI Generation Disclosure

Claude Code (Claude Fable 5.1), working under the direction of the author, who reviewed the changes.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XigkSxBiMvAFEY8S2yYyP4
