### PR TITLE
ArrayPrinter: print scalar assignments as scalar code

### DIFF
--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -8,7 +8,8 @@ from collections import defaultdict
 from itertools import chain
 from sympy.core import S
 from sympy.core.mod import Mod
-from .precedence import precedence
+from sympy.core.symbol import Dummy
+from .precedence import precedence, PRECEDENCE
 from .codeprinter import CodePrinter
 
 _kw = {
@@ -423,6 +424,43 @@ class AbstractPythonCodePrinter(CodePrinter):
         return "{}**{}".format(base_str, exp_str)
 
 
+def _is_atomic_code(code):
+    # Whether ``code`` is an identifier or a single call, i.e. needs no
+    # parentheses when an operator is applied to it.
+    if code.isidentifier():
+        return True
+    head, sep, rest = code.partition("(")
+    if not sep or not head.replace(".", "").isidentifier() or not rest.endswith(")"):
+        return False
+    depth = 1
+    for i, c in enumerate(rest):
+        depth += (c == "(") - (c == ")")
+        if depth == 0:
+            return i == len(rest) - 1
+    return False
+
+
+class _ElementwiseOperand(Dummy):
+    """Placeholder for the operand of an ``ArrayElementwiseApplyFunc``.
+
+    Its name is the printed code of the operand, which ``ArrayPrinter``
+    prints as it is: nothing is substituted in the printed function body,
+    so the operand cannot be confused with other symbols. Its precedence
+    is the one of the printed operand, so that it is parenthesized when
+    needed.
+    """
+    __slots__ = ('precedence',)
+
+    def __new__(cls, code, precedence):
+        obj = Dummy.__new__(cls, code)
+        obj.precedence = precedence
+        return obj
+
+    def sort_key(self, order=None):
+        # Before symbols, so that the operand leads printed sums and products.
+        return (2, 0, ''), (0, ()), S.One.sort_key(), S.One
+
+
 class ArrayPrinter:
 
     def _arrayify(self, indexed):
@@ -542,39 +580,29 @@ class ArrayPrinter:
         return self._expand_fold_binary_op(self._module + "." + self._add, expr.args)
 
     def _print_ArrayElementwiseApplyFunc(self, expr):
+        return self._print(self._elementwise_body(expr))
+
+    def _elementwise_body(self, expr):
+        # The function of ``expr`` applied to a placeholder printing as the
+        # printed operand. Scalar functions and arithmetic are elementwise
+        # in the array libraries, while applying the function to the
+        # operand symbolically would turn e.g. d**2 into a matrix power
+        # for a matrix operand.
         from sympy.core.function import Lambda
-        from sympy.core.symbol import Symbol
-        # Print the function applied to a scalar placeholder, then splice
-        # the printed operand in its place. Scalar functions and
-        # arithmetic are elementwise in the array libraries, while applying
-        # the function to the operand symbolically would turn e.g. d**2
-        # into a matrix power for a matrix operand.
-        placeholder = Symbol("_elementwise_operand")
+        from sympy.tensor.array.expressions.array_expressions import ArrayElementwiseApplyFunc
+        operand = expr.expr
+        if isinstance(operand, ArrayElementwiseApplyFunc):
+            operand = self._elementwise_body(operand)
+        code = self._print(operand)
+        prec = PRECEDENCE["Atom"] if _is_atomic_code(code) else precedence(operand)
+        placeholder = _ElementwiseOperand(code, prec)
         function = expr.function
         if isinstance(function, Lambda):
-            body = function.expr.xreplace({function.variables[0]: placeholder})
-        else:
-            body = function(placeholder)
-        operand = self._print(expr.expr)
-        if not self._is_atomic_code(operand):
-            operand = "(%s)" % operand
-        return self._print(body).replace(self._print(placeholder), operand)
+            return function.expr.xreplace({function.variables[0]: placeholder})
+        return function(placeholder)
 
-    @staticmethod
-    def _is_atomic_code(code):
-        # Whether ``code`` is an identifier or a single call, i.e. needs no
-        # parentheses when an operator is applied to it.
-        if code.isidentifier():
-            return True
-        head, sep, rest = code.partition("(")
-        if not sep or not head.replace(".", "").isidentifier() or not rest.endswith(")"):
-            return False
-        depth = 1
-        for i, c in enumerate(rest):
-            depth += (c == "(") - (c == ")")
-            if depth == 0:
-                return i == len(rest) - 1
-        return False
+    def _print__ElementwiseOperand(self, expr):
+        return expr.name
 
     def _print_OneArray(self, expr):
         return "%s((%s,))" % (

--- a/sympy/printing/pycode.py
+++ b/sympy/printing/pycode.py
@@ -541,6 +541,41 @@ class ArrayPrinter:
     def _print_ArrayAdd(self, expr):
         return self._expand_fold_binary_op(self._module + "." + self._add, expr.args)
 
+    def _print_ArrayElementwiseApplyFunc(self, expr):
+        from sympy.core.function import Lambda
+        from sympy.core.symbol import Symbol
+        # Print the function applied to a scalar placeholder, then splice
+        # the printed operand in its place. Scalar functions and
+        # arithmetic are elementwise in the array libraries, while applying
+        # the function to the operand symbolically would turn e.g. d**2
+        # into a matrix power for a matrix operand.
+        placeholder = Symbol("_elementwise_operand")
+        function = expr.function
+        if isinstance(function, Lambda):
+            body = function.expr.xreplace({function.variables[0]: placeholder})
+        else:
+            body = function(placeholder)
+        operand = self._print(expr.expr)
+        if not self._is_atomic_code(operand):
+            operand = "(%s)" % operand
+        return self._print(body).replace(self._print(placeholder), operand)
+
+    @staticmethod
+    def _is_atomic_code(code):
+        # Whether ``code`` is an identifier or a single call, i.e. needs no
+        # parentheses when an operator is applied to it.
+        if code.isidentifier():
+            return True
+        head, sep, rest = code.partition("(")
+        if not sep or not head.replace(".", "").isidentifier() or not rest.endswith(")"):
+            return False
+        depth = 1
+        for i, c in enumerate(rest):
+            depth += (c == "(") - (c == ")")
+            if depth == 0:
+                return i == len(rest) - 1
+        return False
+
     def _print_OneArray(self, expr):
         return "%s((%s,))" % (
             self._module_format(self._module+ "." + self._ones),

--- a/sympy/printing/tests/test_numpy.py
+++ b/sympy/printing/tests/test_numpy.py
@@ -392,3 +392,36 @@ def test_numpy_contains_integers():
     result = f(arr)
     expected = np.array([True, False, True])
     assert np.array_equal(result, expected)
+
+
+def test_issue_30395_scalar_assignment():
+    # Assignments of purely scalar expressions must print as scalar code:
+    # they used to be converted to array operators, which printed a sum as
+    # nested add(...) calls and failed on functions.
+    from sympy.core.symbol import symbols
+    from sympy.functions.elementary.trigonometric import sin
+    from sympy.printing.numpy import JaxPrinter
+    x, y, z = symbols('x y z')
+    np_p = NumPyPrinter()
+    jp = JaxPrinter()
+    assert np_p.doprint(x + y + z, 'out') == 'out = x + y + z'
+    assert jp.doprint(x + y + z, 'out') == 'out = x + y + z'
+    expr = x**2 + sqrt(y) - sin(x*z)
+    assert np_p.doprint(expr, 'out') == 'out = x**2 + numpy.sqrt(y) - numpy.sin(x*z)'
+    assert jp.doprint(expr, 'out') == 'out = x**2 + jax.numpy.sqrt(y) - jax.numpy.sin(x*z)'
+    assert np_p.doprint(x*z, 'out') == 'out = x*z'
+
+    # Array expressions still go through the array operators:
+    from sympy.tensor.array.expressions.array_expressions import (
+        ArrayElementwiseApplyFunc, ArraySymbol)
+    A = ArraySymbol('A', (3, 3))
+    assert np_p.doprint(A + A, 'out') == 'out = numpy.einsum(",ab", 2, A)'
+    assert jp.doprint(ArrayElementwiseApplyFunc(sin, A)) == 'jax.numpy.sin(A)'
+    # Elementwise, also for matrix operands (not a matrix power):
+    from sympy.core.function import Lambda
+    from sympy.core.symbol import Dummy
+    d = Dummy('d')
+    M = MatrixSymbol('M', 3, 3)
+    assert np_p.doprint(ArrayElementwiseApplyFunc(Lambda(d, d**2), M)) == 'M**2'
+    N = MatrixSymbol('N', 3, 3)
+    assert np_p.doprint(ArrayElementwiseApplyFunc(Lambda(d, 2*d + 1), M + N)) == '2*(M + N) + 1'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -472,7 +472,7 @@ def test_array_printer():
     # Elementwise function application prints as the (elementwise) NumPy
     # function or arithmetic applied to the printed operand:
     from sympy.core.function import Lambda
-    from sympy.core.symbol import Dummy
+    from sympy.core.symbol import Dummy, Symbol
     from sympy.functions.elementary.trigonometric import sin
     from sympy.tensor.array.expressions.array_expressions import ArrayElementwiseApplyFunc, ArrayTensorProduct
     B = ArraySymbol('B', (3, 3))
@@ -481,6 +481,15 @@ def test_array_printer():
     assert prntr.doprint(ArrayElementwiseApplyFunc(Lambda(d, d**2), B)) == 'B**2'
     assert prntr.doprint(ArrayElementwiseApplyFunc(Lambda(d, 1/d), ArrayContraction(ArrayTensorProduct(B, B), (1, 2)))) == \
         'numpy.einsum("ab,bc->ac", B,B)**(-1.0)'
+    # Symbols in the function body are never confused with the operand:
+    s = Symbol('_elementwise_operand')
+    assert prntr.doprint(ArrayElementwiseApplyFunc(Lambda(d, d + s), B)) == 'B + _elementwise_operand'
+    s = Symbol('prefix_elementwise_operand_suffix')
+    assert prntr.doprint(ArrayElementwiseApplyFunc(Lambda(d, d + s), B)) == 'B + prefix_elementwise_operand_suffix'
+    nested = ArrayElementwiseApplyFunc(Lambda(d, d + 1), ArrayElementwiseApplyFunc(Lambda(d, d**2), B))
+    assert prntr.doprint(nested) == 'B**2 + 1'
+    assert prntr.doprint(ArrayElementwiseApplyFunc(Lambda(d, d**3), ArrayElementwiseApplyFunc(Lambda(d, d**2), B))) == '(B**2)**3'
+    assert prntr.doprint(ArrayElementwiseApplyFunc(sin, ArrayElementwiseApplyFunc(Lambda(d, d + 1), B))) == 'numpy.sin(B + 1)'
 
     prntr = TensorflowPrinter()
     assert prntr.doprint(ZeroArray(5)) == 'tensorflow.zeros((5,))'

--- a/sympy/printing/tests/test_pycode.py
+++ b/sympy/printing/tests/test_pycode.py
@@ -469,6 +469,19 @@ def test_array_printer():
     assert prntr.doprint(ArrayContraction(A, [2], [3])) == 'numpy.einsum("abcde->abe", A)'
     assert prntr.doprint(Assignment(I[i,j,k], I[i,j,k])) == 'I = I'
 
+    # Elementwise function application prints as the (elementwise) NumPy
+    # function or arithmetic applied to the printed operand:
+    from sympy.core.function import Lambda
+    from sympy.core.symbol import Dummy
+    from sympy.functions.elementary.trigonometric import sin
+    from sympy.tensor.array.expressions.array_expressions import ArrayElementwiseApplyFunc, ArrayTensorProduct
+    B = ArraySymbol('B', (3, 3))
+    d = Dummy('d')
+    assert prntr.doprint(ArrayElementwiseApplyFunc(sin, B)) == 'numpy.sin(B)'
+    assert prntr.doprint(ArrayElementwiseApplyFunc(Lambda(d, d**2), B)) == 'B**2'
+    assert prntr.doprint(ArrayElementwiseApplyFunc(Lambda(d, 1/d), ArrayContraction(ArrayTensorProduct(B, B), (1, 2)))) == \
+        'numpy.einsum("ab,bc->ac", B,B)**(-1.0)'
+
     prntr = TensorflowPrinter()
     assert prntr.doprint(ZeroArray(5)) == 'tensorflow.zeros((5,))'
     assert prntr.doprint(OneArray(5)) == 'tensorflow.ones((5,))'

--- a/sympy/printing/tests/test_tensorflow.py
+++ b/sympy/printing/tests/test_tensorflow.py
@@ -492,3 +492,13 @@ def test_tensorflow_isnan_isinf():
     for _input, _expected in [(float('inf'), 0.0), (float('-inf'), 0.0), (float('nan'), 1.0), (1.0, 1.0)]:
         _output = lambdify((x), expression, modules="tensorflow")(x=tf.constant([_input]))
         assert (_output == _expected).numpy().all()
+
+
+def test_tensorflow_elementwise_apply_func():
+    from sympy.core.function import Lambda
+    from sympy.core.symbol import Dummy
+    from sympy.functions.elementary.trigonometric import sin
+    from sympy.tensor.array.expressions.array_expressions import ArrayElementwiseApplyFunc
+    d = Dummy('d')
+    assert tensorflow_code(ArrayElementwiseApplyFunc(sin, M)) == 'tensorflow.math.sin(M)'
+    assert tensorflow_code(ArrayElementwiseApplyFunc(Lambda(d, d**2), M)) == 'tensorflow.math.pow(M, 2)'

--- a/sympy/tensor/array/expressions/from_indexed_to_array.py
+++ b/sympy/tensor/array/expressions/from_indexed_to_array.py
@@ -16,7 +16,7 @@ from sympy.tensor.array.expressions import ArrayElementwiseApplyFunc
 from sympy.tensor.indexed import (Indexed, IndexedBase)
 from sympy.combinatorics import Permutation
 from sympy.matrices.expressions.matexpr import MatrixElement
-from sympy.tensor.array.expressions.array_expressions import ArrayDiagonal, \
+from sympy.tensor.array.expressions.array_expressions import ArrayDiagonal, _ArrayExpr, _CodegenArrayAbstract, \
     get_shape, ArrayElement, _array_tensor_product, _array_diagonal, _array_contraction, _array_add, \
     _permute_dims, OneArray, ArrayAdd
 from sympy.tensor.array.expressions.utils import _get_argindex, _get_diagonal_indices
@@ -106,6 +106,13 @@ def convert_indexed_to_array(expr, first_indices=None):
         return _array_add(*[_permute_dims(arg, permutation) for arg in result.args])
     else:
         return _permute_dims(result, permutation)
+
+
+def _is_array_expression(expr):
+    # Whether a converted (sub)expression is an array expression, as opposed
+    # to a plain scalar. Rank-0 array expressions (e.g. a full contraction)
+    # have no indices but still have to be combined with array operators.
+    return isinstance(expr, (_ArrayExpr, _CodegenArrayAbstract))
 
 
 def _convert_indexed_to_array(expr):
@@ -258,6 +265,9 @@ def _convert_indexed_to_array(expr):
     if isinstance(expr, Add):
         args, indices = zip(*[_convert_indexed_to_array(arg) for arg in expr.args])
         args = list(args)
+        if not any(indices) and not any(_is_array_expression(arg) for arg in args):
+            # A sum of scalars stays a scalar:
+            return expr, ()
         # Check if all indices are compatible. Otherwise expand the dimensions:
         index0 = []
         shape0 = []
@@ -279,13 +289,17 @@ def _convert_indexed_to_array(expr):
         return _array_add(*args), tuple(index0)
     if isinstance(expr, Pow):
         subexpr, subindices = _convert_indexed_to_array(expr.base)
-        if not subindices:
+        if not subindices and not _is_array_expression(subexpr):
             # Scalar base, no array axes involved:
             return expr, ()
         exp = expr.exp
         if isinstance(exp, (int, Integer)) and exp >= 1:
             if exp == 1:
                 return subexpr, subindices
+            if not subindices:
+                # Power of a rank-0 array expression (e.g. of a full
+                # contraction): a rank-0 tensor product.
+                return _array_tensor_product(*[subexpr for i in range(exp)]), ()
             diags = zip(*[(2*i, 2*i + 1) for i in range(exp)])
             arr = _array_diagonal(_array_tensor_product(*[subexpr for i in range(exp)]), *diags)
             return arr, subindices
@@ -307,5 +321,8 @@ def _convert_indexed_to_array(expr):
             raise NotImplementedError(
                 "cannot convert multi-argument function to array expression: %s" % expr)
         subexpr, subindices = _convert_indexed_to_array(expr.args[0])
+        if not subindices and not _is_array_expression(subexpr):
+            # A function of a scalar stays a scalar:
+            return expr, ()
         return ArrayElementwiseApplyFunc(type(expr), subexpr), subindices
     return expr, ()

--- a/sympy/tensor/array/expressions/tests/test_convert_indexed_to_array.py
+++ b/sympy/tensor/array/expressions/tests/test_convert_indexed_to_array.py
@@ -283,3 +283,30 @@ def test_convert_indexed_to_array_multiarg_function():
     # arguments after the first one:
     f = Function("f")
     raises(NotImplementedError, lambda: convert_indexed_to_array(f(M[i, j], N[i, j])))
+
+
+def test_convert_indexed_to_array_scalars_stay_scalars():
+    # An expression without array axes is a scalar and stays as it is
+    # (issue #30395: converting it to ArrayAdd/ArrayElementwiseApplyFunc
+    # made the array printers print scalar assignments as array code):
+    from sympy import sin, sqrt
+    x, y, z = symbols("x y z")
+    for expr in [x + y + z, x*z, x**2, sin(x), x**2 + sqrt(y) - sin(x*z),
+                 sin(x)*x**2 + 1/z]:
+        assert convert_indexed_to_array(expr) == expr
+
+    # Rank-0 array expressions (here the trace) are still converted, also
+    # as base of a power or argument of a function:
+    tr = Sum(M[i, i], (i, 0, k - 1))
+    trace = ArrayContraction(M, (0, 1))
+    assert convert_indexed_to_array(tr) == trace
+    assert convert_indexed_to_array(tr + x) == ArrayAdd(x, trace)
+    assert convert_indexed_to_array(tr**2) == \
+        ArrayContraction(ArrayTensorProduct(M, M), (0, 1), (2, 3))
+    d = Dummy("d")
+    assert convert_indexed_to_array(1/tr).dummy_eq(
+        ArrayElementwiseApplyFunc(Lambda(d, 1/d), trace))
+    assert convert_indexed_to_array(sqrt(tr)).dummy_eq(
+        ArrayElementwiseApplyFunc(Lambda(d, sqrt(d)), trace))
+    assert convert_indexed_to_array(sin(tr)).dummy_eq(
+        ArrayElementwiseApplyFunc(Lambda(d, sin(d)), trace))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30395. Regression from #30132.

#### Brief description of what is fixed or changed

`convert_indexed_to_array` leaves scalar expressions unchanged, so the array printers print scalar assignments as scalar code again; `ArrayElementwiseApplyFunc` is now printable. Details in the code comments of the review.

#### Other comments

#### AI Generation Disclosure

Claude Code (Claude Fable 5.1), working under the direction of the author, who reviewed the changes.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* printing
  * Fixed a regression in the NumPy, JAX, TensorFlow and PyTorch printers where assignments of purely scalar expressions were printed with array operators or failed to print when they contained functions. `ArrayElementwiseApplyFunc` is now printable by these printers.
<!-- END RELEASE NOTES -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XigkSxBiMvAFEY8S2yYyP4
