### PR TITLE
Fix _solve_trig2 to include poles of tan and add related tests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -650,6 +650,7 @@ Fabio Luporini <fabio@devitocodes.com>
 Faisal Anees <faisal.iiit@gmail.com>
 Faisal Riyaz <faisalriyaz011@gmail.com>
 Fawaz Alazemi <Mba7eth@gmail.com>
+Fazeel Usmani <fazeelusmani18@gmail.com>
 Felix Kaiser <felix.kaiser@fxkr.net> <felix.kaiser@fxkr.net>
 Felix Kaiser <felix.kaiser@fxkr.net> <kaiser.fx@gmail.com>
 Felix Kaiser <felix.kaiser@fxkr.net> <whatfxkr@gmail.com>

--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -66,6 +66,9 @@ def test_function_range():
         log(x), x, S.Integers))
     raises(NotImplementedError, lambda : function_range(
         sin(x)/2, x, S.Naturals))
+    # issue 30386: the critical point at pi was dropped
+    assert function_range(cos(x)*cos(4*x), x, S.Reals).inf == -1
+    assert function_range(cos(x)*cos(6*x), x, S.Reals).inf == -1
 
 
 @slow

--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1006,15 +1006,17 @@ def _solve_trig2(f, symbol, domain):
         return ConditionSet(symbol, Eq(f_original, 0), domain)
     solns = solveset(g, y, S.Reals) - solveset(h, y, S.Reals)
 
-    if isinstance(solns, FiniteSet):
+    if isinstance(solns, FiniteSet) or solns is S.EmptySet:
         result = Union(*[invert_real(tan(symbol/mu), s, symbol)[1]
                        for s in solns])
-        dsol = invert_real(tan(symbol/mu), oo, symbol)[1]
-        if degree(h) > degree(g):                   # If degree(denom)>degree(num) then there
-            result = Union(result, dsol)            # would be another sol at Lim(denom-->oo)
+        # tan(symbol/mu) blows up at mu*(pi/2 + n*pi) so those never show up
+        # in solns. Lim(denom-->oo) == 0 isn't enough to add them though,
+        # (1 + cos(x))/sin(x) is nan at pi rather than 0.
+        if degree(h) > degree(g) and f_original.subs(symbol, mu*pi/2).is_zero:
+            n = Dummy('n')
+            dsol = imageset(Lambda(n, mu*(pi/2 + n*pi)), S.Integers)
+            result = Union(result, dsol)
         return Intersection(result, domain)
-    elif solns is S.EmptySet:
-        return S.EmptySet
     else:
         return ConditionSet(symbol, Eq(f_original, 0), S.Reals)
 

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -1022,6 +1022,29 @@ def test_solve_trig():
         ImageSet(Lambda(n, 360*n + 30), S.Integers)))
 
 
+def test_solve_trig2_tan_poles():
+    # _solve_trig2 works in y = tan(x/mu), so roots at the poles of that
+    # tan were being dropped. See issue #30386.
+    from sympy.solvers.solveset import _solve_trig2
+
+    assert dumeq(_solve_trig2(cos(x) + 1, x, S.Reals),
+        ImageSet(Lambda(n, 2*n*pi + pi), S.Integers))
+    assert dumeq(_solve_trig2(cos(x)**3 + 1, x, S.Reals),
+        ImageSet(Lambda(n, 2*n*pi + pi), S.Integers))
+    # sin(x) vanishes at every multiple of pi, not just the even ones
+    assert dumeq(_solve_trig2(sin(x), x, S.Reals),
+        Union(ImageSet(Lambda(n, 2*n*pi), S.Integers),
+              ImageSet(Lambda(n, 2*n*pi + pi), S.Integers)))
+
+    # pi is a critical point of cos(x)*cos(4*x) that used to be missed
+    assert pi in solveset(diff(cos(x)*cos(4*x), x), x, Interval(0, 2*pi))
+
+    # removable singularities at pi, not roots, so pi must not be added
+    assert not _solve_trig2((1 + cos(x))/sin(x), x, S.Reals).contains(pi)
+    assert not _solve_trig2(sin(x)/(1 + cos(x)), x, S.Reals).contains(pi)
+    assert not _solve_trig2((1 - cos(x))/sin(x), x, S.Reals).contains(pi)
+
+
 def test_solve_trig_hyp_by_inversion():
     n = Dummy('n')
     assert solveset_real(sin(2*x + 3) - S(1)/2, x).dummy_eq(Union(


### PR DESCRIPTION
**References to other Issues or PRs:**
Fixes #30386

**Brief description of what is fixed or changed:**

_solve_trig2 solves trig equations by substituting y = tan(symbol/mu) and turning things into a rational equation g(y)/h(y) = 0. Problem is, tan has its own poles at symbol = mu*(pi/2 + n*pi), and no finite y maps back to those points — so if the original equation happened to have a genuine root sitting right on one of those poles, it just never showed up in solveset(g, y).

There was already an attempt to patch this in the degree(h) > degree(g) case, but it only ran inside the isinstance(solns, FiniteSet) branch. When solveset(g, y) - solveset(h, y) came back as S.EmptySet instead (e.g. for cos(x) + 1, where g reduces to the constant 2 and never has a root), the function returned S.EmptySet straight away and never got a chance to check for a pole. So cos(x) + 1 was losing its root at x = pi. That's what was causing the reported bug — function_range finds critical points by running solveset on the derivative, and cos(x)*cos(4*x)'s derivative has exactly this kind of dropped root at pi, so the reported minimum came out wrong.

**Two changes:**

1. Folded the EmptySet case into the same branch as FiniteSet, so the pole check actually runs either way.
2. Added a check — f_original.subs(symbol, mu*pi/2).is_zero — before actually treating a pole as a root. degree(h) > degree(g) on its own isn't enough to tell a real root at the pole apart from a removable singularity, e.g. (1 + cos(x))/sin(x) at x = pi is 0/0, not 0, even though it satisfies the same degree condition. Without this check the old-style fix would've reintroduced a false positive there.

Also swapped invert_real(tan(symbol/mu), oo, symbol) for building the pole set directly with imageset, mostly just to make it obvious what's being constructed.

**Other comments:**

Tested this against a bunch of things beyond what's in the new test file — fractional mu, sec/csc, restricted domains, a parameterized coefficient, and a handful of other removable-singularity shapes (zoo as well as nan) — didn't find a case where it adds a wrong root or misses a real one. Ran the full test_solveset.py and test_util.py suites, no regressions.

**Release Notes:**

<!-- BEGIN RELEASE NOTES -->
- solvers
  - Fixed _solve_trig2 dropping real roots that land exactly on a pole of tan, which was causing wrong results from solveset/function_range for things like cos(x)*cos(4*x).
<!-- END RELEASE NOTES -->