### PR TITLE
Fix doctest exception format in xreplace docstring example

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1165,6 +1165,7 @@ Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
 MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@users.noreply.github.com>
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
+Muhammad Usaid <shkusaid910@gmail.com> shkusaid <shkusaid910@gmail.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Musab Kasbati <musab16000@gmail.com> Musab Kasbati <43878981+Musab1Blaser@users.noreply.github.com>
 Musab Kasbati <musab16000@gmail.com> Musab1Blaser <musab16000@gmail.com>

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1353,7 +1353,9 @@ class Basic(Printable):
 
         Trying to replace x with an expression raises an error:
 
-        >>> Integral(x, (x, 1, 2*x)).xreplace({x: 2*y}) # doctest: +SKIP
+        >>> Integral(x, (x, 1, 2*x)).xreplace({x: 2*y})
+        Traceback (most recent call last):
+        ...
         ValueError: Invalid limits given: ((2*y, 1, 4*y),)
 
         See Also


### PR DESCRIPTION
The ValueError example in Basic.xreplace's docstring was marked with doctest: +SKIP because it only showed the bare error message without the Traceback header that doctest needs to recognize an example as an intentional exception. Added the Traceback (most recent call last): line and ... so doctest can validate it properly, and removed the SKIP since it now passes.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

#6572 

#### Brief description of what is fixed or changed

After opening the issue #30385. I continued my search of finding SKIP comments from issue #6572 I found an example of xreplace docstring (Basic.xreplace) which was marked with 'doctest: +SKIP'. This example was about calling xreplace with substitution that create invalid Integral limit which raises a ValueError. but it didn't contain any "Traceback (most recent call last):" that was needed by Python's doctest module to recognize an example as an intentional exception.

I added the "Traceback (most recent call last):" and ellipsis before the error that is standard format for exception examples. I also removed the SKIP as the example passes now.

#### Other comments

I ran and confirmed the test cases through both 
python bin/doctest sympy/core/basic.py
python bin/test sympy/core/tests/test_basic.py

#### AI Generation Disclosure

AI helped me to give the terminal commands and also in the tracking of issue


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
