### PR TITLE
manualintegrate: document the rules with their transformations

### DIFF
--- a/doc/ext/manualintegrate_rules.py
+++ b/doc/ext/manualintegrate_rules.py
@@ -1,0 +1,143 @@
+"""
+Table of the rules of :mod:`sympy.integrals.manualintegrate`.
+
+The ``manualintegrate-rules`` directive collects the concrete subclasses of
+``Rule`` and builds a table from their docstrings. The ``Explanation`` section
+of a rule docstring holds a ``.. math::`` block with the integral before and
+after the rule, separated by ``\\longrightarrow``, followed by the conditions
+under which the rule applies; the ``.. math::`` blocks of the ``Examples``
+section are the examples. The full docstrings are rendered after the table.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+from typing import Any, TYPE_CHECKING
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import StringList
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+MODULE = "sympy.integrals.manualintegrate"
+ARROW = r"\longrightarrow"
+
+
+def _rule_classes():
+    module = importlib.import_module(MODULE)
+    classes = [obj for obj in vars(module).values()
+               if inspect.isclass(obj) and issubclass(obj, module.Rule)
+               and obj.__module__ == MODULE and not inspect.isabstract(obj)]
+    classes.sort(key=lambda cls: inspect.getsourcelines(cls)[1])
+    return classes
+
+
+def _sections(docstring):
+    """Split a docstring into its sections: {name: lines}, summary under ''."""
+    lines = inspect.cleandoc(docstring or "").splitlines()
+    sections: dict[str, list[str]] = {"": []}
+    name = ""
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        underline = lines[i + 1].strip() if i + 1 < len(lines) else ""
+        if (line.strip() and underline and set(underline) <= {"=", "-"}
+                and len(underline) >= len(line.strip())):
+            name = line.strip()
+            sections[name] = []
+            i += 2
+            continue
+        sections[name].append(line)
+        i += 1
+    return sections
+
+
+def _math_blocks(lines):
+    """Return the ``.. math::`` blocks (each joined into one line) and the
+    remaining lines."""
+    blocks, other = [], []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.lstrip().startswith(".. math::"):
+            indent = len(line) - len(line.lstrip())
+            content = [line.split(".. math::", 1)[1].strip()]
+            i += 1
+            while i < len(lines) and (not lines[i].strip() or
+                                      len(lines[i]) - len(lines[i].lstrip()) > indent):
+                content.append(lines[i].strip())
+                i += 1
+            blocks.append(" ".join(c for c in content if c))
+        else:
+            other.append(line)
+            i += 1
+    return blocks, other
+
+
+def _row(cls):
+    sections = _sections(cls.__doc__)
+    blocks, prose = _math_blocks(sections.get("Explanation", []))
+    before = after = ""
+    if blocks and ARROW in blocks[0]:
+        before, after = (s.strip() for s in blocks[0].split(ARROW, 1))
+    conditions = " ".join(l.strip() for l in prose if l.strip())
+    examples, _ = _math_blocks(sections.get("Examples", []))
+    summary = " ".join(l.strip() for l in sections[""] if l.strip())
+    return summary, before, after, conditions, examples
+
+
+class ManualintegrateRules(Directive):
+
+    has_content = False
+
+    def run(self):
+        lines = [
+            ".. list-table::",
+            "   :header-rows: 1",
+            "   :widths: 14 28 30 28",
+            "",
+            "   * - Rule",
+            "     - Integral",
+            "     - Result",
+            "     - Examples",
+        ]
+        classes = _rule_classes()
+        for cls in classes:
+            summary, before, after, conditions, examples = _row(cls)
+            lines.append("   * - :class:`~%s.%s`" % (MODULE, cls.__name__))
+            if before:
+                lines.append("     - .. math:: %s" % before)
+                lines.append("     - .. math:: %s" % after)
+                if conditions:
+                    lines.append("")
+                    lines.append("       %s" % conditions)
+            else:
+                lines.append("     - %s" % summary)
+                lines.append("     -")
+            if examples:
+                for k, example in enumerate(examples):
+                    lines.append("     - .. math:: %s" % example if k == 0
+                                 else "       .. math:: %s" % example)
+                    lines.append("")
+            else:
+                lines.append("     -")
+        lines.append("")
+        lines.append(".. autoclass:: %s.Rule" % MODULE)
+        for cls in classes:
+            lines.append(".. autoclass:: %s.%s" % (MODULE, cls.__name__))
+        node = nodes.section()
+        node.document = self.state.document
+        self.state.nested_parse(StringList(lines, source=__file__),
+                                self.content_offset, node)
+        return node.children
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    app.add_directive("manualintegrate-rules", ManualintegrateRules)
+    return {
+        'version': 'builtin',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -37,7 +37,8 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.linkcode',
               'sphinx_reredirects', 'sphinx_copybutton',
               'sphinx.ext.graphviz', 'sphinxcontrib.jquery',
               'matplotlib.sphinxext.plot_directive', 'myst_parser',
-              'convert-svg-to-pdf', 'sphinx.ext.intersphinx', ]
+              'convert-svg-to-pdf', 'sphinx.ext.intersphinx',
+              'manualintegrate_rules', ]
 
 # Add redirects here. This should be done whenever a page that is in the
 # existing release docs is moved somewhere else so that the URLs don't break.

--- a/doc/src/modules/integrals/index.rst
+++ b/doc/src/modules/integrals/index.rst
@@ -15,3 +15,4 @@ Contents
 
    g-functions.rst
    integrals.rst
+   manualintegrate.rst

--- a/doc/src/modules/integrals/manualintegrate.rst
+++ b/doc/src/modules/integrals/manualintegrate.rst
@@ -1,0 +1,13 @@
+.. _manualintegrate-rules:
+
+=========================
+Rules of manualintegrate
+=========================
+
+:func:`~sympy.integrals.manualintegrate.integral_steps` returns a tree of
+rules. Each rule rewrites an integral into a result, or into simpler
+integrals that are solved by its substeps; ``eval()`` evaluates the tree into
+the antiderivative. The table is generated from the docstrings of the rule
+classes, which are listed below it.
+
+.. manualintegrate-rules::

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -182,7 +182,26 @@ class AtomicRule(Rule, ABC):
 
 
 class ConstantRule(AtomicRule):
-    """integrate(a, x)  ->  a*x"""
+    r"""integrate(a, x)  ->  a*x
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int a\,dx
+        \longrightarrow
+        a x
+
+    where $a$ does not depend on $x$.
+
+    Examples
+    ========
+
+    .. math:: \int 3\,dx = 3x
+
+    .. math:: \int y\,dx = x y
+    """
 
     __slots__ = ()
 
@@ -191,13 +210,26 @@ class ConstantRule(AtomicRule):
 
 
 class ConstantTimesRule(Rule):
-    """integrate(a*f(x), x)  ->  a*integrate(f(x), x)
+    r"""integrate(a*f(x), x)  ->  a*integrate(f(x), x)
 
     ``eval()`` returns ``constant * substep.eval()``, where ``substep``
     integrates ``other``.
 
+    Explanation
+    ===========
+
+    .. math::
+
+        \int a\,f(x)\,dx
+        \longrightarrow
+        a \int f(x)\,dx
+
+    where $a$ does not depend on $x$.
+
     Examples
     ========
+
+    .. math:: \int 3\sin x\,dx = 3\int \sin x\,dx = -3\cos x
 
     Extraction of the perfect-square factor of a radicand; ``constant`` is
     the ratio between the original and the rewritten integrand:
@@ -244,7 +276,26 @@ class ConstantTimesRule(Rule):
 
 
 class PowerRule(AtomicRule):
-    """integrate(x**a, x)"""
+    r"""integrate(x**a, x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int x^a\,dx
+        \longrightarrow
+        \frac{x^{a+1}}{a+1}
+
+    for $a \neq -1$, and $\log x$ for $a = -1$.
+
+    Examples
+    ========
+
+    .. math:: \int x^3\,dx = \frac{x^4}{4}
+
+    .. math:: \int x^{-1/2}\,dx = 2\sqrt{x}
+    """
 
     __slots__ = ("base", "exp")
 
@@ -266,7 +317,24 @@ class PowerRule(AtomicRule):
 
 
 class NestedPowRule(AtomicRule):
-    """integrate((x**a)**b, x)"""
+    r"""integrate((x**a)**b, x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \bigl((x - h)^a\bigr)^b\,dx
+        \longrightarrow
+        \frac{(x - h)\bigl((x - h)^a\bigr)^b}{a b + 1}
+
+    for $a b \neq -1$, and $(x - h)\bigl((x - h)^a\bigr)^b \log(x - h)$ for $a b = -1$. The nested power is not collapsed to $(x - h)^{a b}$, which is not valid for all complex $x$.
+
+    Examples
+    ========
+
+    .. math:: \int (x^a)^b\,dx = \frac{x\,(x^a)^b}{a b + 1}
+    """
 
     __slots__ = ("base", "exp")
 
@@ -287,7 +355,22 @@ class NestedPowRule(AtomicRule):
 
 
 class AddRule(Rule):
-    """integrate(f(x) + g(x), x) -> integrate(f(x), x) + integrate(g(x), x)"""
+    r"""integrate(f(x) + g(x), x) -> integrate(f(x), x) + integrate(g(x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \bigl(f(x) + g(x)\bigr)\,dx
+        \longrightarrow
+        \int f(x)\,dx + \int g(x)\,dx
+
+    Examples
+    ========
+
+    .. math:: \int (x + e^x)\,dx = \frac{x^2}{2} + e^x
+    """
 
     __slots__ = ("substeps",)
 
@@ -305,16 +388,29 @@ class AddRule(Rule):
 
 
 class URule(Rule):
-    """integrate(f(g(x))*g'(x), x) -> integrate(f(u), u), u = g(x)
+    r"""integrate(f(g(x))*g'(x), x) -> integrate(f(u), u), u = g(x)
 
     ``eval()`` evaluates ``substep``, the integral in ``u_var``, and
     substitutes ``u_var -> u_func`` back.
 
+    Explanation
+    ===========
+
+    .. math::
+
+        \int f(g(x))\,g'(x)\,dx
+        \longrightarrow
+        \int f(u)\,du
+
+    with $u = g(x)$, substituted back into the result.
+
     Examples
     ========
 
+    .. math:: \int 2x\cos(x^2)\,dx = \int \cos u\,du = \sin(x^2)
+
     The universal tangent half-angle (Weierstrass) substitution
-    u = tan(x/2), the fallback of :func:`bioche_substitution`:
+    u = tan(x/2), the fallback of ``bioche_substitution``:
 
     >>> from sympy import Symbol, Dummy, Rational, S, sin, sqrt, tan
     >>> from sympy.integrals.manualintegrate import (URule, ArctanRule,
@@ -333,7 +429,7 @@ class URule(Rule):
     2*sqrt(3)*atan(2*sqrt(3)*(tan(x/2) + 1/2)/3)/3
 
     A Chebyshev substitution for the binomial integrand
-    x**m*(a + b*x**n)**p, from :func:`chebyshev_substitution_rule`:
+    x**m*(a + b*x**n)**p, from ``chebyshev_substitution_rule``:
 
     >>> # the rule tree that IntegrationSolver().run(
     >>> #     chebyshev_substitution_rule,
@@ -351,11 +447,11 @@ class URule(Rule):
     (x**2 + 1)**(7/2)/7 - 2*(x**2 + 1)**(5/2)/5 + (x**2 + 1)**(3/2)/3
 
     The Bioche chart substitutions (u = cos(2*x), sin(x), cos(x) or
-    tan(x)) of :func:`bioche_substitution`, the Euler substitution
+    tan(x)) of ``bioche_substitution``, the Euler substitution
     u = sqrt(a + b*x + c*x**2) + sqrt(c)*x of
-    :func:`euler_substitution_rule` and the substitution
+    ``euler_substitution_rule`` and the substitution
     u = ((a*x + b)/(c*x + d))**(1/n) of
-    :func:`sqrt_fractional_linear_rule` produce URule trees of the same
+    ``sqrt_fractional_linear_rule`` produce URule trees of the same
     shape.
     """
 
@@ -392,7 +488,24 @@ class URule(Rule):
 
 
 class ReparameterizationRule(Rule):
-    """Restore auxiliary parameters after evaluating a substep."""
+    r"""Restore auxiliary parameters after evaluating a substep.
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int f(x; e_1, \ldots, e_n)\,dx
+        \longrightarrow
+        \Bigl[\int f(x; p_1, \ldots, p_n)\,dx\Bigr]_{p_i = e_i}
+
+    the substep integrates with auxiliary parameters $p_i$ in place of the expressions $e_i$, which are substituted back into its result. Used by the Bioche substitution for the phases of trigonometric arguments.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{dx}{2 + \sin(x + \varphi)} = \Bigl[\int \frac{dx}{2 + \sin(x + p)}\Bigr]_{p = \varphi}
+    """
 
     __slots__ = ("replacements", "substep")
 
@@ -415,7 +528,22 @@ class ReparameterizationRule(Rule):
 
 
 class PartsRule(Rule):
-    """integrate(u(x)*v'(x), x) -> u(x)*v(x) - integrate(u'(x)*v(x), x)"""
+    r"""integrate(u(x)*v'(x), x) -> u(x)*v(x) - integrate(u'(x)*v(x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int u(x)\,v'(x)\,dx
+        \longrightarrow
+        u(x)\,v(x) - \int u'(x)\,v(x)\,dx
+
+    Examples
+    ========
+
+    .. math:: \int x e^x\,dx = x e^x - \int e^x\,dx = x e^x - e^x
+    """
 
     __slots__ = ("u", "dv", "v_step", "second_step")
 
@@ -450,7 +578,24 @@ class PartsRule(Rule):
 
 
 class CyclicPartsRule(Rule):
-    """Apply PartsRule multiple times to integrate exp(x)*sin(x)"""
+    r"""Apply PartsRule multiple times to integrate exp(x)*sin(x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        I = \int f(x)\,dx
+        \longrightarrow
+        \frac{\sum_k (-1)^k\,u_k(x)\,v_k(x)}{1 - c}
+
+    when repeated integration by parts reproduces the original integral, $I = \sum_k (-1)^k u_k v_k + c\,I$ with a constant $c \neq 1$.
+
+    Examples
+    ========
+
+    .. math:: \int e^x \sin x\,dx = \frac{e^x \sin x - e^x \cos x}{2}
+    """
 
     __slots__ = ("parts_rules", "coefficient")
 
@@ -485,7 +630,22 @@ class TrigRule(AtomicRule, ABC):
 
 
 class SinRule(TrigRule):
-    """integrate(sin(x), x) -> -cos(x)"""
+    r"""integrate(sin(x), x) -> -cos(x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \sin x\,dx
+        \longrightarrow
+        -\cos x
+
+    Examples
+    ========
+
+    .. math:: \int \sin x\,dx = -\cos x
+    """
 
     __slots__ = ()
 
@@ -494,7 +654,22 @@ class SinRule(TrigRule):
 
 
 class CosRule(TrigRule):
-    """integrate(cos(x), x) -> sin(x)"""
+    r"""integrate(cos(x), x) -> sin(x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \cos x\,dx
+        \longrightarrow
+        \sin x
+
+    Examples
+    ========
+
+    .. math:: \int \cos x\,dx = \sin x
+    """
 
     __slots__ = ()
 
@@ -507,7 +682,22 @@ class HyperbolicRule(AtomicRule, ABC):
 
 
 class SinhRule(HyperbolicRule):
-    """integrate(sinh(x), x) -> cosh(x)"""
+    r"""integrate(sinh(x), x) -> cosh(x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \sinh x\,dx
+        \longrightarrow
+        \cosh x
+
+    Examples
+    ========
+
+    .. math:: \int \sinh x\,dx = \cosh x
+    """
 
     __slots__ = ()
 
@@ -516,7 +706,22 @@ class SinhRule(HyperbolicRule):
 
 
 class CoshRule(HyperbolicRule):
-    """integrate(cosh(x), x) -> sinh(x)"""
+    r"""integrate(cosh(x), x) -> sinh(x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \cosh x\,dx
+        \longrightarrow
+        \sinh x
+
+    Examples
+    ========
+
+    .. math:: \int \cosh x\,dx = \sinh x
+    """
 
     __slots__ = ()
 
@@ -525,7 +730,26 @@ class CoshRule(HyperbolicRule):
 
 
 class ExpRule(AtomicRule):
-    """integrate(a**x, x) -> a**x/ln(a)"""
+    r"""integrate(a**x, x) -> a**x/ln(a)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int a^x\,dx
+        \longrightarrow
+        \frac{a^x}{\log a}
+
+    for a constant $a$ with $\log a \neq 0$.
+
+    Examples
+    ========
+
+    .. math:: \int e^x\,dx = e^x
+
+    .. math:: \int 2^x\,dx = \frac{2^x}{\log 2}
+    """
 
     __slots__ = ("base", "exp")
 
@@ -544,7 +768,26 @@ class ExpRule(AtomicRule):
 
 
 class ReciprocalRule(AtomicRule):
-    """integrate(1/x, x) -> ln(x)"""
+    r"""integrate(1/x, x) -> ln(x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{dx}{x + c}
+        \longrightarrow
+        \log(x + c)
+
+    where $c$ does not depend on $x$.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{dx}{x} = \log x
+
+    .. math:: \int \frac{dx}{x + 2} = \log(x + 2)
+    """
 
     __slots__ = ("base",)
 
@@ -559,7 +802,24 @@ class ReciprocalRule(AtomicRule):
 
 
 class ArcsinRule(AtomicRule):
-    """integrate(1/sqrt(1-x**2), x) -> asin(x)"""
+    r"""integrate(1/sqrt(1-x**2), x) -> asin(x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{dx}{\sqrt{1 - x^2}}
+        \longrightarrow
+        \arcsin x
+
+    Examples
+    ========
+
+    .. math:: \int \frac{dx}{\sqrt{1 - x^2}} = \arcsin x
+
+    .. math:: \int \frac{dx}{\sqrt{4 - x^2}} = \arcsin\frac{x}{2}
+    """
 
     __slots__ = ()
 
@@ -568,7 +828,24 @@ class ArcsinRule(AtomicRule):
 
 
 class ArcsinhRule(AtomicRule):
-    """integrate(1/sqrt(1+x**2), x) -> asin(x)"""
+    r"""integrate(1/sqrt(1+x**2), x) -> asinh(x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{dx}{\sqrt{1 + x^2}}
+        \longrightarrow
+        \operatorname{arcsinh} x
+
+    Examples
+    ========
+
+    .. math:: \int \frac{dx}{\sqrt{1 + x^2}} = \operatorname{arcsinh} x
+
+    .. math:: \int \frac{dx}{\sqrt{x^2 + 2x + 3}} = \operatorname{arcsinh}\frac{\sqrt{2}\,(x + 1)}{2}
+    """
 
     __slots__ = ()
 
@@ -577,7 +854,24 @@ class ArcsinhRule(AtomicRule):
 
 
 class ReciprocalSqrtQuadraticRule(AtomicRule):
-    """integrate(1/sqrt(a+b*x+c*x**2), x) -> log(2*sqrt(c)*sqrt(a+b*x+c*x**2)+b+2*c*x)/sqrt(c)"""
+    r"""integrate(1/sqrt(a+b*x+c*x**2), x) -> log(2*sqrt(c)*sqrt(a+b*x+c*x**2)+b+2*c*x)/sqrt(c)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{dx}{\sqrt{a + b x + c x^2}}
+        \longrightarrow
+        \frac{\log\bigl(2\sqrt{c}\,\sqrt{a + b x + c x^2} + b + 2 c x\bigr)}{\sqrt{c}}
+
+    for $c \neq 0$.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{dx}{\sqrt{a + x^2}} = \log\bigl(2\sqrt{a + x^2} + 2x\bigr)
+    """
 
     __slots__ = ("a", "b", "c")
 
@@ -621,7 +915,24 @@ def _sqrt_quadratic_denom_reduce(
 
 
 class SqrtQuadraticDenomRule(AtomicRule):
-    """integrate(poly(x)/sqrt(a+b*x+c*x**2), x)"""
+    r"""integrate(poly(x)/sqrt(a+b*x+c*x**2), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{p(x)}{\sqrt{a + b x + c x^2}}\,dx
+        \longrightarrow
+        q(x)\sqrt{a + b x + c x^2} + k\int \frac{dx}{\sqrt{a + b x + c x^2}}
+
+    where $q$ is a polynomial of degree $\deg p - 1$ and $k$ a constant, both obtained by reducing the coefficients of $p$; the remaining integral is solved by a substep.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{x^2}{\sqrt{x^2 + 1}}\,dx = \frac{x\sqrt{x^2 + 1}}{2} - \frac{1}{2}\int \frac{dx}{\sqrt{x^2 + 1}} = \frac{x\sqrt{x^2 + 1}}{2} - \frac{\operatorname{arcsinh} x}{2}
+    """
 
     __slots__ = ("a", "b", "c", "coeffs", "i0_step")
 
@@ -662,7 +973,26 @@ class SqrtQuadraticDenomRule(AtomicRule):
 
 
 class SqrtQuadraticRule(Rule):
-    """integrate(sqrt(a+b*x+c*x**2), x)"""
+    r"""integrate(sqrt(a+b*x+c*x**2), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \sqrt{a + b x + c x^2}\,dx
+        \longrightarrow
+        \int \frac{a + b x + c x^2}{\sqrt{a + b x + c x^2}}\,dx
+
+    which is then integrated by :class:`~sympy.integrals.manualintegrate.SqrtQuadraticDenomRule`.
+
+    Examples
+    ========
+
+    .. math:: \int \sqrt{x^2 + 1}\,dx = \frac{x\sqrt{x^2 + 1}}{2} + \frac{\operatorname{arcsinh} x}{2}
+
+    .. math:: \int \sqrt{1 - x^2}\,dx = \frac{x\sqrt{1 - x^2}}{2} + \frac{\arcsin x}{2}
+    """
 
     __slots__ = ("a", "b", "c", "substep")
 
@@ -697,7 +1027,24 @@ class SqrtQuadraticRule(Rule):
 
 
 class RatintRule(AtomicRule):
-    """Integrate a rational function using ``ratint`` as a fallback."""
+    r"""Integrate a rational function using ``ratint`` as a fallback.
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{p(x)}{q(x)}\,dx
+        \longrightarrow
+        R(x) + \sum_i c_i \log v_i(x)
+
+    for polynomials $p$ and $q$, with a rational function $R$ and polynomials $v_i$ computed by :func:`~sympy.integrals.rationaltools.ratint`.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{dx}{x^2 - 1} = \frac{\log(x - 1)}{2} - \frac{\log(x + 1)}{2}
+    """
 
     __slots__ = ()
 
@@ -706,7 +1053,24 @@ class RatintRule(AtomicRule):
 
 
 class AlternativeRule(Rule):
-    """Multiple ways to do integration."""
+    r"""Multiple ways to do integration.
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int f(x)\,dx
+        \longrightarrow
+        R_1\Bigl(\int f(x)\,dx\Bigr)
+
+    where $R_1, R_2, \ldots$ are alternative rule trees for the same integral; ``eval()`` uses the first one. Only produced with ``branch=True``.
+
+    Examples
+    ========
+
+    .. math:: \int x e^{x^2}\,dx = \frac{e^{x^2}}{2} \quad \text{with } u = x^2 \text{ or with } u = e^{x^2}
+    """
 
     __slots__ = ("alternatives",)
 
@@ -726,7 +1090,24 @@ class AlternativeRule(Rule):
 
 
 class DontKnowRule(Rule):
-    """Leave the integral as is."""
+    r"""Leave the integral as is.
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int f(x)\,dx
+        \longrightarrow
+        \int f(x)\,dx
+
+    left unevaluated, as no rule applies.
+
+    Examples
+    ========
+
+    .. math:: \int e^{x^3}\,dx = \int e^{x^3}\,dx
+    """
 
     __slots__ = ()
 
@@ -738,7 +1119,24 @@ class DontKnowRule(Rule):
 
 
 class DerivativeRule(AtomicRule):
-    """integrate(f'(x), x) -> f(x)"""
+    r"""integrate(f'(x), x) -> f(x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{d}{dx} f(x)\,dx
+        \longrightarrow
+        f(x)
+
+    for a higher derivative $\partial^n f / \partial x^n$ one order of differentiation in $x$ is removed.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{d}{dx}\bigl(y \sin x\bigr)\,dx = y \sin x
+    """
 
     __slots__ = ()
 
@@ -753,15 +1151,28 @@ class DerivativeRule(AtomicRule):
 
 
 class RewriteRule(Rule):
-    """Rewrite integrand to another form that is easier to handle.
+    r"""Rewrite integrand to another form that is easier to handle.
 
     ``eval()`` evaluates ``substep``, the integral of ``rewritten``.
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int f(x)\,dx
+        \longrightarrow
+        \int g(x)\,dx
+
+    with $g(x) = f(x)$ written in a form that another rule handles.
 
     Examples
     ========
 
+    .. math:: \int \tan x\,dx = \int \frac{\sin x}{\cos x}\,dx = -\log\cos x
+
     A partial-fraction decomposition applied by
-    :func:`partial_fractions_rule`:
+    ``partial_fractions_rule``:
 
     >>> from sympy import Symbol, Dummy, Rational, sin, cos
     >>> from sympy.integrals.manualintegrate import (RewriteRule, AddRule,
@@ -784,7 +1195,7 @@ class RewriteRule(Rule):
     5*log(x - 2) - 4*log(x - 1)
 
     A product-to-sum identity applied by
-    :func:`trig_product_to_sum_rule`:
+    ``trig_product_to_sum_rule``:
 
     >>> # the rule tree that IntegrationSolver().run(
     >>> #     trig_product_to_sum_rule,
@@ -801,9 +1212,9 @@ class RewriteRule(Rule):
     >>> rule.rewritten
     sin(x**2 - x)/2 + sin(x**2 + x)/2
 
-    The complex-exponential rewriting of :func:`trig_cmplx_exp_rule` and
-    the reciprocal identities of :func:`trig_sincos_rule`,
-    :func:`trig_tansec_rule` and :func:`trig_cotcsc_rule` produce
+    The complex-exponential rewriting of ``trig_cmplx_exp_rule`` and
+    the reciprocal identities of ``trig_sincos_rule``,
+    ``trig_tansec_rule`` and ``trig_cotcsc_rule`` produce
     RewriteRule trees of the same shape.
     """
 
@@ -827,10 +1238,21 @@ class RewriteRule(Rule):
 
 
 class CompleteSquareRule(RewriteRule):
-    """Rewrite a+b*x+c*x**2 to a-b**2/(4*c) + c*(x+b/(2*c))**2
+    r"""Rewrite a+b*x+c*x**2 to a-b**2/(4*c) + c*(x+b/(2*c))**2
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int f(a + b x + c x^2)\,dx
+        \longrightarrow
+        \int f\Bigl(a - \frac{b^2}{4c} + c\Bigl(x + \frac{b}{2c}\Bigr)^2\Bigr)\,dx
 
     Examples
     ========
+
+    .. math:: \int \frac{dx}{\sqrt{-x^2 + 2x + 3}} = \int \frac{dx}{\sqrt{4 - (x - 1)^2}} = \arcsin\frac{x - 1}{2}
 
     >>> from sympy import Symbol, Dummy, Rational, sqrt
     >>> from sympy.integrals.manualintegrate import (CompleteSquareRule,
@@ -845,13 +1267,31 @@ class CompleteSquareRule(RewriteRule):
     >>> rule.eval()
     asin(x/2 - 1/2)
 
-    :func:`trig_poly_mul_rule` produces a CompleteSquareRule when it
+    ``trig_poly_mul_rule`` produces a CompleteSquareRule when it
     completes the square in the argument of a trigonometric factor.
     """
     __slots__ = ()
 
 
 class PiecewiseRule(Rule):
+    r"""Combine the results of substeps valid under different conditions.
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int f(x)\,dx
+        \longrightarrow
+        \begin{cases} F_1(x) & \text{if } c_1 \\ F_2(x) & \text{if } c_2 \\ \ldots \end{cases}
+
+    where each $F_i$ is the result of a substep valid under the condition $c_i$ on the parameters of the integrand.
+
+    Examples
+    ========
+
+    .. math:: \int x^a\,dx = \begin{cases} \dfrac{x^{a+1}}{a+1} & \text{if } a \neq -1 \\ \log x & \text{otherwise} \end{cases}
+    """
 
     __slots__ = ("subfunctions",)
 
@@ -876,6 +1316,24 @@ class PiecewiseRule(Rule):
 
 
 class HeavisideRule(Rule):
+    r"""integrate(Heaviside(m*x + b)*g(x), x) -> Heaviside(m*x + b)*(G(x) - G(-b/m))
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \theta(m x + b)\,g(x)\,dx
+        \longrightarrow
+        \theta(m x + b)\bigl(G(x) - G(-b/m)\bigr)
+
+    where $G$ is an antiderivative of $g$ found by the substep, so that the result vanishes at the jump $x = -b/m$.
+
+    Examples
+    ========
+
+    .. math:: \int \theta(x - 1)\,x\,dx = \theta(x - 1)\Bigl(\frac{x^2}{2} - \frac{1}{2}\Bigr)
+    """
 
     __slots__ = ("harg", "ibnd", "substep")
 
@@ -909,6 +1367,26 @@ class HeavisideRule(Rule):
 
 
 class DiracDeltaRule(AtomicRule):
+    r"""integrate(DiracDelta(a + b*x, n), x) -> DiracDelta(a + b*x, n - 1)/b
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \delta^{(n)}(a + b x)\,dx
+        \longrightarrow
+        \frac{\delta^{(n-1)}(a + b x)}{b}
+
+    for $n \geq 1$, and $\theta(a + b x)/b$ for $n = 0$.
+
+    Examples
+    ========
+
+    .. math:: \int \delta(2x - 1)\,dx = \frac{\theta(2x - 1)}{2}
+
+    .. math:: \int \delta'(2x - 1)\,dx = \frac{\delta(2x - 1)}{2}
+    """
 
     __slots__ = ("n", "a", "b")
 
@@ -932,7 +1410,26 @@ class DiracDeltaRule(AtomicRule):
 
 
 class ArctanRule(AtomicRule):
-    """integrate(a/(b*x**2+c), x) -> a/b / sqrt(c/b) * atan(x/sqrt(c/b))"""
+    r"""integrate(a/(b*x**2+c), x) -> a/b / sqrt(c/b) * atan(x/sqrt(c/b))
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{a}{b x^2 + c}\,dx
+        \longrightarrow
+        \frac{a}{b\sqrt{c/b}}\arctan\frac{x}{\sqrt{c/b}}
+
+    for $c/b > 0$; for $c/b < 0$ the integrand is rewritten with partial fractions instead.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{dx}{x^2 + 1} = \arctan x
+
+    .. math:: \int \frac{3}{4x^2 + 9}\,dx = \frac{1}{2}\arctan\frac{2x}{3}
+    """
 
     __slots__ = ("a", "b", "c")
 
@@ -965,6 +1462,24 @@ class OrthogonalPolyRule(AtomicRule, ABC):
 
 
 class JacobiRule(OrthogonalPolyRule):
+    r"""integrate(jacobi(n, a, b, x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int P^{(\alpha,\beta)}_n(x)\,dx
+        \longrightarrow
+        \frac{2\,P^{(\alpha-1,\beta-1)}_{n+1}(x)}{n + \alpha + \beta}
+
+    for $n + \alpha + \beta \neq 0$; otherwise $x$ for $n = 0$ and $(\alpha + \beta + 2)x^2/4 + (\alpha - \beta)x/2$ for $n = 1$.
+
+    Examples
+    ========
+
+    .. math:: \int P^{(\alpha,\beta)}_2(x)\,dx = \frac{2\,P^{(\alpha-1,\beta-1)}_3(x)}{\alpha + \beta + 2}
+    """
 
     __slots__ = ("a", "b")
 
@@ -987,6 +1502,24 @@ class JacobiRule(OrthogonalPolyRule):
 
 
 class GegenbauerRule(OrthogonalPolyRule):
+    r"""integrate(gegenbauer(n, a, x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int C^{(\alpha)}_n(x)\,dx
+        \longrightarrow
+        \frac{C^{(\alpha-1)}_{n+1}(x)}{2(\alpha - 1)}
+
+    for $\alpha \neq 1$, and $T_{n+1}(x)/(n+1)$ for $\alpha = 1$.
+
+    Examples
+    ========
+
+    .. math:: \int C^{(2)}_n(x)\,dx = \frac{C^{(1)}_{n+1}(x)}{2}
+    """
 
     __slots__ = ("a",)
 
@@ -1005,6 +1538,24 @@ class GegenbauerRule(OrthogonalPolyRule):
 
 
 class ChebyshevTRule(OrthogonalPolyRule):
+    r"""integrate(chebyshevt(n, x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int T_n(x)\,dx
+        \longrightarrow
+        \frac{1}{2}\Bigl(\frac{T_{n+1}(x)}{n+1} - \frac{T_{n-1}(x)}{n-1}\Bigr)
+
+    for $n \neq \pm 1$, and $x^2/2$ otherwise.
+
+    Examples
+    ========
+
+    .. math:: \int T_2(x)\,dx = \frac{T_3(x)}{6} - \frac{T_1(x)}{2}
+    """
 
     __slots__ = ()
 
@@ -1017,6 +1568,24 @@ class ChebyshevTRule(OrthogonalPolyRule):
 
 
 class ChebyshevURule(OrthogonalPolyRule):
+    r"""integrate(chebyshevu(n, x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int U_n(x)\,dx
+        \longrightarrow
+        \frac{T_{n+1}(x)}{n+1}
+
+    for $n \neq -1$.
+
+    Examples
+    ========
+
+    .. math:: \int U_2(x)\,dx = \frac{T_3(x)}{3}
+    """
 
     __slots__ = ()
 
@@ -1028,6 +1597,22 @@ class ChebyshevURule(OrthogonalPolyRule):
 
 
 class LegendreRule(OrthogonalPolyRule):
+    r"""integrate(legendre(n, x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int P_n(x)\,dx
+        \longrightarrow
+        \frac{P_{n+1}(x) - P_{n-1}(x)}{2n + 1}
+
+    Examples
+    ========
+
+    .. math:: \int P_2(x)\,dx = \frac{P_3(x) - P_1(x)}{5}
+    """
 
     __slots__ = ()
 
@@ -1037,6 +1622,22 @@ class LegendreRule(OrthogonalPolyRule):
 
 
 class HermiteRule(OrthogonalPolyRule):
+    r"""integrate(hermite(n, x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int H_n(x)\,dx
+        \longrightarrow
+        \frac{H_{n+1}(x)}{2(n + 1)}
+
+    Examples
+    ========
+
+    .. math:: \int H_2(x)\,dx = \frac{H_3(x)}{6}
+    """
 
     __slots__ = ()
 
@@ -1046,6 +1647,22 @@ class HermiteRule(OrthogonalPolyRule):
 
 
 class LaguerreRule(OrthogonalPolyRule):
+    r"""integrate(laguerre(n, x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int L_n(x)\,dx
+        \longrightarrow
+        L_n(x) - L_{n+1}(x)
+
+    Examples
+    ========
+
+    .. math:: \int L_2(x)\,dx = L_2(x) - L_3(x)
+    """
 
     __slots__ = ()
 
@@ -1055,6 +1672,22 @@ class LaguerreRule(OrthogonalPolyRule):
 
 
 class AssocLaguerreRule(OrthogonalPolyRule):
+    r"""integrate(assoc_laguerre(n, a, x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int L^{(\alpha)}_n(x)\,dx
+        \longrightarrow
+        -L^{(\alpha-1)}_{n+1}(x)
+
+    Examples
+    ========
+
+    .. math:: \int L^{(2)}_1(x)\,dx = -L^{(1)}_2(x)
+    """
 
     __slots__ = ("a",)
 
@@ -1082,6 +1715,24 @@ class IRule(AtomicRule, ABC):
 
 
 class CiRule(IRule):
+    r"""integrate(cos(a*x + b)/x, x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{\cos(a x + b)}{x}\,dx
+        \longrightarrow
+        \cos b\,\operatorname{Ci}(a x) - \sin b\,\operatorname{Si}(a x)
+
+    for $a \neq 0$, with $a$ and $b$ independent of $x$.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{\cos(2x + 1)}{x}\,dx = \cos 1\,\operatorname{Ci}(2x) - \sin 1\,\operatorname{Si}(2x)
+    """
 
     __slots__ = ()
 
@@ -1091,6 +1742,24 @@ class CiRule(IRule):
 
 
 class ChiRule(IRule):
+    r"""integrate(cosh(a*x + b)/x, x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{\cosh(a x + b)}{x}\,dx
+        \longrightarrow
+        \cosh b\,\operatorname{Chi}(a x) + \sinh b\,\operatorname{Shi}(a x)
+
+    for $a \neq 0$, with $a$ and $b$ independent of $x$.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{\cosh x}{x}\,dx = \operatorname{Chi}(x)
+    """
 
     __slots__ = ()
 
@@ -1100,6 +1769,24 @@ class ChiRule(IRule):
 
 
 class EiRule(IRule):
+    r"""integrate(exp(a*x + b)/x, x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{e^{a x + b}}{x}\,dx
+        \longrightarrow
+        e^b\,\operatorname{Ei}(a x)
+
+    for $a \neq 0$, with $a$ and $b$ independent of $x$.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{e^{2x + 1}}{x}\,dx = e\,\operatorname{Ei}(2x)
+    """
 
     __slots__ = ()
 
@@ -1109,6 +1796,24 @@ class EiRule(IRule):
 
 
 class SiRule(IRule):
+    r"""integrate(sin(a*x + b)/x, x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{\sin(a x + b)}{x}\,dx
+        \longrightarrow
+        \sin b\,\operatorname{Ci}(a x) + \cos b\,\operatorname{Si}(a x)
+
+    for $a \neq 0$, with $a$ and $b$ independent of $x$.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{\sin 3x}{x}\,dx = \operatorname{Si}(3x)
+    """
 
     __slots__ = ()
 
@@ -1118,6 +1823,24 @@ class SiRule(IRule):
 
 
 class ShiRule(IRule):
+    r"""integrate(sinh(a*x + b)/x, x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{\sinh(a x + b)}{x}\,dx
+        \longrightarrow
+        \sinh b\,\operatorname{Chi}(a x) + \cosh b\,\operatorname{Shi}(a x)
+
+    for $a \neq 0$, with $a$ and $b$ independent of $x$.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{\sinh 2x}{x}\,dx = \operatorname{Shi}(2x)
+    """
 
     __slots__ = ()
 
@@ -1127,6 +1850,24 @@ class ShiRule(IRule):
 
 
 class LiRule(IRule):
+    r"""integrate(1/log(a*x + b), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{dx}{\log(a x + b)}
+        \longrightarrow
+        \frac{\operatorname{li}(a x + b)}{a}
+
+    for $a \neq 0$, with $a$ and $b$ independent of $x$.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{dx}{\log(2x + 1)} = \frac{\operatorname{li}(2x + 1)}{2}
+    """
 
     __slots__ = ()
 
@@ -1136,6 +1877,26 @@ class LiRule(IRule):
 
 
 class ErfRule(AtomicRule):
+    r"""integrate(exp(a*x**2 + b*x + c), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int e^{a x^2 + b x + c}\,dx
+        \longrightarrow
+        \frac{\sqrt{\pi}}{2\sqrt{a}}\,e^{c - b^2/(4a)}\,\operatorname{erfi}\Bigl(\frac{2 a x + b}{2\sqrt{a}}\Bigr)
+
+    for $a \neq 0$; for real negative $a$ the result is written as $\frac{\sqrt{\pi}}{2\sqrt{-a}}\,e^{c - b^2/(4a)}\,\operatorname{erf}\bigl(\frac{-2 a x - b}{2\sqrt{-a}}\bigr)$.
+
+    Examples
+    ========
+
+    .. math:: \int e^{-x^2}\,dx = \frac{\sqrt{\pi}}{2}\operatorname{erf} x
+
+    .. math:: \int e^{x^2 + 2x}\,dx = \frac{\sqrt{\pi}}{2e}\operatorname{erfi}(x + 1)
+    """
 
     __slots__ = ("a", "b", "c")
 
@@ -1164,6 +1925,24 @@ class ErfRule(AtomicRule):
 
 
 class OwensTRule(AtomicRule):
+    r"""integrate(exp(-(a*x + b)**2)*erf(y*(a*x + b)), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int e^{-(a x + b)^2}\,\operatorname{erf}\bigl(y(a x + b)\bigr)\,dx
+        \longrightarrow
+        -\frac{2\sqrt{\pi}}{a}\,T\bigl(\sqrt{2}\,(a x + b),\, y\bigr)
+
+    for $a \neq 0$ and $y \neq \pm 1$, where $T$ is Owen's T function.
+
+    Examples
+    ========
+
+    .. math:: \int e^{-x^2}\operatorname{erf}(y x)\,dx = -2\sqrt{\pi}\,T(\sqrt{2}\,x, y)
+    """
 
     __slots__ = ("a", "b", "y")
 
@@ -1184,6 +1963,24 @@ class OwensTRule(AtomicRule):
         return - 2*sqrt(S.Pi)/a * owens_t(sqrt(2)*(a*x+b), y)
 
 class FresnelCRule(AtomicRule):
+    r"""integrate(cos(a*x**2 + b*x + c), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \cos(a x^2 + b x + c)\,dx
+        \longrightarrow
+        \sqrt{\frac{\pi}{2a}}\Bigl[\cos\Bigl(\frac{b^2}{4a} - c\Bigr) C\Bigl(\frac{2 a x + b}{\sqrt{2\pi a}}\Bigr) + \sin\Bigl(\frac{b^2}{4a} - c\Bigr) S\Bigl(\frac{2 a x + b}{\sqrt{2\pi a}}\Bigr)\Bigr]
+
+    for $a \neq 0$, where $C$ and $S$ are the Fresnel integrals.
+
+    Examples
+    ========
+
+    .. math:: \int \cos(x^2)\,dx = \sqrt{\frac{\pi}{2}}\,C\Bigl(\sqrt{\frac{2}{\pi}}\,x\Bigr)
+    """
 
     __slots__ = ("a", "b", "c")
 
@@ -1207,6 +2004,24 @@ class FresnelCRule(AtomicRule):
 
 
 class FresnelSRule(AtomicRule):
+    r"""integrate(sin(a*x**2 + b*x + c), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \sin(a x^2 + b x + c)\,dx
+        \longrightarrow
+        \sqrt{\frac{\pi}{2a}}\Bigl[\cos\Bigl(\frac{b^2}{4a} - c\Bigr) S\Bigl(\frac{2 a x + b}{\sqrt{2\pi a}}\Bigr) - \sin\Bigl(\frac{b^2}{4a} - c\Bigr) C\Bigl(\frac{2 a x + b}{\sqrt{2\pi a}}\Bigr)\Bigr]
+
+    for $a \neq 0$, where $C$ and $S$ are the Fresnel integrals.
+
+    Examples
+    ========
+
+    .. math:: \int \sin(x^2)\,dx = \sqrt{\frac{\pi}{2}}\,S\Bigl(\sqrt{\frac{2}{\pi}}\,x\Bigr)
+    """
 
     __slots__ = ("a", "b", "c")
 
@@ -1230,6 +2045,24 @@ class FresnelSRule(AtomicRule):
 
 
 class PolylogRule(AtomicRule):
+    r"""integrate(polylog(b, a*x)/x, x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{\operatorname{Li}_b(a x)}{x}\,dx
+        \longrightarrow
+        \operatorname{Li}_{b+1}(a x)
+
+    for $a \neq 0$.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{\operatorname{Li}_2(3x)}{x}\,dx = \operatorname{Li}_3(3x)
+    """
 
     __slots__ = ("a", "b")
 
@@ -1246,6 +2079,24 @@ class PolylogRule(AtomicRule):
 
 
 class UpperGammaRule(AtomicRule):
+    r"""integrate(x**e*exp(a*x), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int x^e\,e^{a x}\,dx
+        \longrightarrow
+        \frac{x^e\,(-a x)^{-e}\,\Gamma(e + 1, -a x)}{a}
+
+    for $a \neq 0$ and an exponent $e$ that is not a non-negative integer (those are integrated by parts).
+
+    Examples
+    ========
+
+    .. math:: \int x^{1/3} e^{2x}\,dx = \frac{x^{1/3}\,(-2x)^{-1/3}\,\Gamma(4/3, -2x)}{2}
+    """
 
     __slots__ = ("a", "e")
 
@@ -1263,6 +2114,24 @@ class UpperGammaRule(AtomicRule):
 
 
 class EllipticFRule(AtomicRule):
+    r"""integrate(1/sqrt(a - d*sin(x)**2), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \frac{dx}{\sqrt{a - d\sin^2 x}}
+        \longrightarrow
+        \frac{F(x \mid d/a)}{\sqrt{a}}
+
+    for $a, d \neq 0$ and $a \neq d$, where $F(\phi \mid m)$ is the incomplete elliptic integral of the first kind.
+
+    Examples
+    ========
+
+    .. math:: \int \frac{dx}{\sqrt{2 - \sin^2 x}} = \frac{F(x \mid 1/2)}{\sqrt{2}}
+    """
 
     __slots__ = ("a", "d")
 
@@ -1279,6 +2148,24 @@ class EllipticFRule(AtomicRule):
 
 
 class EllipticERule(AtomicRule):
+    r"""integrate(sqrt(a - d*sin(x)**2), x)
+
+    Explanation
+    ===========
+
+    .. math::
+
+        \int \sqrt{a - d\sin^2 x}\,dx
+        \longrightarrow
+        \sqrt{a}\,E(x \mid d/a)
+
+    for $a, d \neq 0$ and $a \neq d$, where $E(\phi \mid m)$ is the incomplete elliptic integral of the second kind.
+
+    Examples
+    ========
+
+    .. math:: \int \sqrt{4 - \sin^2 x}\,dx = 2\,E(x \mid 1/4)
+    """
 
     __slots__ = ("a", "d")
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -191,7 +191,31 @@ class ConstantRule(AtomicRule):
 
 
 class ConstantTimesRule(Rule):
-    """integrate(a*f(x), x)  ->  a*integrate(f(x), x)"""
+    """integrate(a*f(x), x)  ->  a*integrate(f(x), x)
+
+    ``eval()`` returns ``constant * substep.eval()``, where ``substep``
+    integrates ``other``.
+
+    Examples
+    ========
+
+    Extraction of the perfect-square factor of a radicand; ``constant`` is
+    the ratio between the original and the rewritten integrand:
+
+    >>> from sympy import Symbol, sqrt
+    >>> from sympy.integrals.manualintegrate import (ConstantTimesRule,
+    ...     PowerRule)
+    >>> x, z = Symbol('x'), Symbol('z')
+    >>> # a rule tree for integrate(1/sqrt(z*x**4), x):
+    >>> rule = ConstantTimesRule(1/sqrt(x**4*z), x,
+    ...     x**2*sqrt(z)/sqrt(x**4*z), 1/(x**2*sqrt(z)),
+    ...     ConstantTimesRule(1/(x**2*sqrt(z)), x, 1/sqrt(z), x**(-2),
+    ...         PowerRule(x**(-2), x, x, -2)))
+    >>> rule.constant
+    x**2*sqrt(z)/sqrt(x**4*z)
+    >>> rule.eval()
+    -x/sqrt(x**4*z)
+    """
 
     __slots__ = ('constant', 'other', 'substep')
 
@@ -281,7 +305,59 @@ class AddRule(Rule):
 
 
 class URule(Rule):
-    """integrate(f(g(x))*g'(x), x) -> integrate(f(u), u), u = g(x)"""
+    """integrate(f(g(x))*g'(x), x) -> integrate(f(u), u), u = g(x)
+
+    ``eval()`` evaluates ``substep``, the integral in ``u_var``, and
+    substitutes ``u_var -> u_func`` back.
+
+    Examples
+    ========
+
+    The universal tangent half-angle (Weierstrass) substitution
+    u = tan(x/2), the fallback of :func:`bioche_substitution`:
+
+    >>> from sympy import Symbol, Dummy, Rational, S, sin, sqrt, tan
+    >>> from sympy.integrals.manualintegrate import (URule, ArctanRule,
+    ...     RewriteRule, AddRule, ConstantTimesRule, PowerRule)
+    >>> x = Symbol('x')
+    >>> t, u = Dummy('t'), Dummy('u')
+    >>> # the rule tree that IntegrationSolver().run(bioche_substitution,
+    >>> #     IntegralInfo(1/(2 + sin(x)), x)) finds:
+    >>> rule = URule(1/(sin(x) + 2), x, t, tan(x/2),
+    ...     URule(1/(t**2 + t + 1), t, u, t + Rational(1, 2),
+    ...         ArctanRule(1/(u**2 + Rational(3, 4)), u,
+    ...                    S.One, S.One, Rational(3, 4))))
+    >>> rule.u_func
+    tan(x/2)
+    >>> rule.eval()
+    2*sqrt(3)*atan(2*sqrt(3)*(tan(x/2) + 1/2)/3)/3
+
+    A Chebyshev substitution for the binomial integrand
+    x**m*(a + b*x**n)**p, from :func:`chebyshev_substitution_rule`:
+
+    >>> # the rule tree that IntegrationSolver().run(
+    >>> #     chebyshev_substitution_rule,
+    >>> #     IntegralInfo(x**5*sqrt(1 + x**2), x)) finds:
+    >>> rule = URule(x**5*sqrt(x**2 + 1), x, u, sqrt(x**2 + 1),
+    ...     RewriteRule(u**2*(u**2 - 1)**2, u, u**6 - 2*u**4 + u**2,
+    ...         AddRule(u**6 - 2*u**4 + u**2, u, [
+    ...             PowerRule(u**6, u, u, 6),
+    ...             ConstantTimesRule(-2*u**4, u, -2, u**4,
+    ...                 PowerRule(u**4, u, u, 4)),
+    ...             PowerRule(u**2, u, u, 2)])))
+    >>> rule.u_func
+    sqrt(x**2 + 1)
+    >>> rule.eval()
+    (x**2 + 1)**(7/2)/7 - 2*(x**2 + 1)**(5/2)/5 + (x**2 + 1)**(3/2)/3
+
+    The Bioche chart substitutions (u = cos(2*x), sin(x), cos(x) or
+    tan(x)) of :func:`bioche_substitution`, the Euler substitution
+    u = sqrt(a + b*x + c*x**2) + sqrt(c)*x of
+    :func:`euler_substitution_rule` and the substitution
+    u = ((a*x + b)/(c*x + d))**(1/n) of
+    :func:`sqrt_fractional_linear_rule` produce URule trees of the same
+    shape.
+    """
 
     __slots__ = ("u_var", "u_func", "substep")
 
@@ -677,7 +753,59 @@ class DerivativeRule(AtomicRule):
 
 
 class RewriteRule(Rule):
-    """Rewrite integrand to another form that is easier to handle."""
+    """Rewrite integrand to another form that is easier to handle.
+
+    ``eval()`` evaluates ``substep``, the integral of ``rewritten``.
+
+    Examples
+    ========
+
+    A partial-fraction decomposition applied by
+    :func:`partial_fractions_rule`:
+
+    >>> from sympy import Symbol, Dummy, Rational, sin, cos
+    >>> from sympy.integrals.manualintegrate import (RewriteRule, AddRule,
+    ...     ConstantTimesRule, URule, ReciprocalRule, FresnelSRule)
+    >>> x, u = Symbol('x'), Dummy('u')
+    >>> # the rule tree that IntegrationSolver().run(partial_fractions_rule,
+    >>> #     IntegralInfo((x + 3)/(x**2 - 3*x + 2), x)) finds:
+    >>> rule = RewriteRule((x + 3)/(x**2 - 3*x + 2), x,
+    ...     -4/(x - 1) + 5/(x - 2),
+    ...     AddRule(-4/(x - 1) + 5/(x - 2), x, [
+    ...         ConstantTimesRule(-4/(x - 1), x, -4, 1/(x - 1),
+    ...             URule(1/(x - 1), x, u, x - 1,
+    ...                 ReciprocalRule(1/u, u, u))),
+    ...         ConstantTimesRule(5/(x - 2), x, 5, 1/(x - 2),
+    ...             URule(1/(x - 2), x, u, x - 2,
+    ...                 ReciprocalRule(1/u, u, u)))]))
+    >>> rule.rewritten
+    -4/(x - 1) + 5/(x - 2)
+    >>> rule.eval()
+    5*log(x - 2) - 4*log(x - 1)
+
+    A product-to-sum identity applied by
+    :func:`trig_product_to_sum_rule`:
+
+    >>> # the rule tree that IntegrationSolver().run(
+    >>> #     trig_product_to_sum_rule,
+    >>> #     IntegralInfo(sin(x**2)*cos(x), x)) finds:
+    >>> rule = RewriteRule(sin(x**2)*cos(x), x,
+    ...     sin(x**2 - x)/2 + sin(x**2 + x)/2,
+    ...     AddRule(sin(x**2 - x)/2 + sin(x**2 + x)/2, x, [
+    ...         ConstantTimesRule(sin(x**2 - x)/2, x,
+    ...             Rational(1, 2), sin(x**2 - x),
+    ...             FresnelSRule(sin(x**2 - x), x, 1, -1, 0)),
+    ...         ConstantTimesRule(sin(x**2 + x)/2, x,
+    ...             Rational(1, 2), sin(x**2 + x),
+    ...             FresnelSRule(sin(x**2 + x), x, 1, 1, 0))]))
+    >>> rule.rewritten
+    sin(x**2 - x)/2 + sin(x**2 + x)/2
+
+    The complex-exponential rewriting of :func:`trig_cmplx_exp_rule` and
+    the reciprocal identities of :func:`trig_sincos_rule`,
+    :func:`trig_tansec_rule` and :func:`trig_cotcsc_rule` produce
+    RewriteRule trees of the same shape.
+    """
 
     __slots__ = ("rewritten", "substep")
 
@@ -699,7 +827,27 @@ class RewriteRule(Rule):
 
 
 class CompleteSquareRule(RewriteRule):
-    """Rewrite a+b*x+c*x**2 to a-b**2/(4*c) + c*(x+b/(2*c))**2"""
+    """Rewrite a+b*x+c*x**2 to a-b**2/(4*c) + c*(x+b/(2*c))**2
+
+    Examples
+    ========
+
+    >>> from sympy import Symbol, Dummy, Rational, sqrt
+    >>> from sympy.integrals.manualintegrate import (CompleteSquareRule,
+    ...     URule, ArcsinRule)
+    >>> x, u = Symbol('x'), Dummy('u')
+    >>> # the rule tree that IntegrationSolver().run(inverse_trig_rule,
+    >>> #     IntegralInfo(1/sqrt(-x**2 + 2*x + 3), x)) finds:
+    >>> rule = CompleteSquareRule(1/sqrt(-x**2 + 2*x + 3), x,
+    ...     1/sqrt(4 - (x - 1)**2),
+    ...     URule(1/sqrt(4 - (x - 1)**2), x, u, x/2 - Rational(1, 2),
+    ...         ArcsinRule(1/sqrt(1 - u**2), u)))
+    >>> rule.eval()
+    asin(x/2 - 1/2)
+
+    :func:`trig_poly_mul_rule` produces a CompleteSquareRule when it
+    completes the square in the argument of a trigonometric factor.
+    """
     __slots__ = ()
 
 


### PR DESCRIPTION
#### References to other Issues or PRs

Builds on #30408.

#### Brief description of what is fixed or changed

Documents every `manualintegrate` rule with the integral before and after the rule, its conditions and LaTeX examples, and adds a docs page that builds a table of the rules from these docstrings.

#### Other comments

#### AI Generation Disclosure

Claude Code (Claude Fable 5.1), under the direction of the author.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XigkSxBiMvAFEY8S2yYyP4
