### PR TITLE
[WIP] calculus: use global convexity and concavity to find extrema on closed interval in `maximum` and `minimum`

### DIFF
--- a/sympy/calculus/tests/test_util.py
+++ b/sympy/calculus/tests/test_util.py
@@ -350,10 +350,12 @@ def test_maximum():
         ) is S.One
     assert maximum(cos(x)-sin(x), x, S.Reals) == sqrt(2)
     assert maximum(y, x, S.Reals) == y
+    assert maximum(log(y), x, Interval(0, 1)) == log(y)
     assert maximum(abs(a**3 + a), a, Interval(0, 2)) == 10
     assert maximum(abs(60*a**3 + 24*a), a, Interval(0, 2)) == 528
     assert maximum(abs(12*a*(5*a**2 + 2)), a, Interval(0, 2)) == 528
     assert maximum(x/sqrt(x**2+1), x, S.Reals) == 1
+    assert maximum(x**2 + exp(x), x, Interval(0, 1)) == 1 + E
 
     raises(ValueError, lambda : maximum(sin(x), x, S.EmptySet))
     raises(ValueError, lambda : maximum(log(cos(x)), x, S.EmptySet))
@@ -380,7 +382,9 @@ def test_minimum():
         ) is S.NegativeOne
     assert minimum(cos(x)-sin(x), x, S.Reals) == -sqrt(2)
     assert minimum(y, x, S.Reals) == y
+    assert minimum(log(y), x, Interval(0, 1)) == log(y)
     assert minimum(x/sqrt(x**2+1), x, S.Reals) == -1
+    assert minimum(-x**2 - exp(x), x, Interval(0, 1)) == -1 - E
 
     raises(ValueError, lambda : minimum(sin(x), x, S.EmptySet))
     raises(ValueError, lambda : minimum(log(cos(x)), x, S.EmptySet))

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -12,6 +12,7 @@ from sympy.core.sympify import _sympify
 from sympy.functions.elementary.complexes import Abs, im, re
 from sympy.functions.elementary.exponential import exp, log
 from sympy.functions.elementary.integers import frac
+from sympy.functions.elementary.miscellaneous import Max, Min
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (
     TrigonometricFunction, sin, cos, tan, cot, csc, sec,
@@ -806,6 +807,28 @@ def stationary_points(f, symbol, domain=S.Reals):
     return set
 
 
+def _is_continuous_on_closed_interval_and_globally_convex(f, symbol, domain):
+    if not (isinstance(domain, Interval) and domain.is_closed and
+            domain.inf.is_finite and domain.sup.is_finite):
+        return False
+    if symbol not in f.free_symbols:
+        return False
+    x = Dummy('x', real=True)
+    f_x = f.subs(symbol, x)
+    if f_x.has(Piecewise):
+        return False
+    if f_x.is_real is not True:
+        return False
+    if f_x.diff(x, 2).is_nonnegative is not True:
+        return False
+    if f_x.diff(x) == S.Zero:
+        return False
+    if periodicity(f, symbol) == S.Zero:
+        # the expression is constant wrt symbol
+        return False
+    return continuous_domain(f, symbol, domain) == domain
+
+
 def maximum(f, symbol, domain=S.Reals):
     """
     Returns the maximum value of a function in the given domain.
@@ -847,6 +870,11 @@ def maximum(f, symbol, domain=S.Reals):
     if isinstance(symbol, Symbol):
         if domain is S.EmptySet:
             raise ValueError("Maximum value not defined for empty domain.")
+
+        if _is_continuous_on_closed_interval_and_globally_convex(
+                f, symbol, domain):
+            return Max(f.subs(symbol, domain.inf),
+                       f.subs(symbol, domain.sup))
 
         return function_range(f, symbol, domain).sup
     else:
@@ -894,6 +922,11 @@ def minimum(f, symbol, domain=S.Reals):
     if isinstance(symbol, Symbol):
         if domain is S.EmptySet:
             raise ValueError("Minimum value not defined for empty domain.")
+
+        if _is_continuous_on_closed_interval_and_globally_convex(
+                -f, symbol, domain):
+            return Min(f.subs(symbol, domain.inf),
+                       f.subs(symbol, domain.sup))
 
         return function_range(f, symbol, domain).inf
     else:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
None.

#### Brief description of what is fixed or changed

Before the fix:

```python
In [1]: maximum(x**2 + exp(x), x, Interval(0, 1))
---------------------------------------------------------------------------
NotImplementedError: Unable to find critical points for x**2 + exp(x)
```

After the fix:

```python
In [1]: maximum(x**2 + exp(x), x, Interval(0, 1))
Out[2]: 1 + ℯ
```

#### Other comments
I used

```math
[a,b]\subset\mathbb R,\quad f\ \text{is continuous on } [a,b],\quad \frac{\mathrm{d}^2 f}{\mathrm{d}x^2}(x)\ge 0\ (x\in \mathbb R)
\ \Longrightarrow\ 
\max_{x\in [a,b]} f(x)=\max\{f(a),f(b)\}.                      (1)
```

Though

```math
[a,b]\subset\mathbb R,\quad f\ \text{is continuous on } [a,b],\quad \frac{\mathrm{d}^2 f}{\mathrm{d}x^2}(x)\ge 0\ (x\in [a, b])
\ \Longrightarrow\ 
\max_{x\in [a,b]} f(x)=\max\{f(a),f(b)\}.                (2)
```
is also mathematically correct, I think it is quite tricky to implement (2) in SymPy.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, leave this area blank. Read our
Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html. -->

I discussed the code's performance with DeepSeek.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->
<!-- BEGIN RELEASE NOTES -->
* calculus
  * Use global convexity and concavity to find extrema on closed interval in `maximum` and `minimum`.
<!-- END RELEASE NOTES -->