### PR TITLE
manualintegrate: support u = LambertW(x) substitutions

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -52,7 +52,7 @@ from sympy.core.symbol import Dummy, Symbol, Wild
 from sympy.core.exprtools import factor_terms
 from sympy.core.function import WildFunction, count_ops
 from sympy.functions.elementary.complexes import Abs
-from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.elementary.exponential import exp, log, LambertW
 from sympy.functions.elementary.hyperbolic import (HyperbolicFunction, csch,
     cosh, coth, sech, sinh, tanh, asinh)
 from sympy.functions.elementary.integers import ceiling, floor
@@ -1222,6 +1222,10 @@ def manual_subs(expr, *args):
             expr = expr.replace(lambda x: x.is_Pow and x.base == x0,
                 lambda x: exp(x.exp*new))
             new_subs.append((x0, exp(new)))
+        elif isinstance(old, LambertW):
+            # LambertW(x) = y => x = y*exp(y)
+            x0 = old.args[0]
+            new_subs.append((x0, new*exp(new)))
 
     return expr.subs(list(sequence) + new_subs)
 
@@ -1286,7 +1290,7 @@ def find_substitutions(integrand, symbol, u_var):
     def possible_subterms(term):
         if isinstance(term, (TrigonometricFunction, HyperbolicFunction,
                              *inverse_trig_functions,
-                             exp, log, Heaviside)):
+                             exp, log, LambertW, Heaviside)):
             return [term.args[0]]
         elif isinstance(term, (chebyshevt, chebyshevu,
                         legendre, hermite, laguerre)):
@@ -1308,7 +1312,7 @@ def find_substitutions(integrand, symbol, u_var):
                     if 1 < d < abs(term.args[1])])
                 if term.base.is_Add:
                     r.extend([t for t in possible_subterms(term.base)
-                        if t.is_Pow])
+                        if t.is_Pow or isinstance(t, LambertW)])
             return r
         elif isinstance(term, Add):
             r = []

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1223,9 +1223,13 @@ def manual_subs(expr, *args):
                 lambda x: exp(x.exp*new))
             new_subs.append((x0, exp(new)))
         elif isinstance(old, LambertW):
-            # LambertW(x) = y => x = y*exp(y)
-            x0 = old.args[0]
-            new_subs.append((x0, new*exp(new)))
+            z = old.args[0]
+            z_symbol = z.free_symbols.pop()
+            if z.is_polynomial(z_symbol) and degree(z, z_symbol) == 1:
+                a = z.coeff(z_symbol)
+                b = z.subs(z_symbol, 0)
+                if a != 0:
+                    new_subs.append((z_symbol, (new*exp(new) - b)/a))
 
     return expr.subs(list(sequence) + new_subs)
 

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1290,8 +1290,10 @@ def find_substitutions(integrand, symbol, u_var):
     def possible_subterms(term):
         if isinstance(term, (TrigonometricFunction, HyperbolicFunction,
                              *inverse_trig_functions,
-                             exp, log, LambertW, Heaviside)):
+                             exp, log, Heaviside)):
             return [term.args[0]]
+        elif isinstance(term, LambertW):
+            return [term, term.args[0]]
         elif isinstance(term, (chebyshevt, chebyshevu,
                         legendre, hermite, laguerre)):
             return [term.args[1]]

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -5,7 +5,7 @@ from sympy.core.relational import Ne, Eq
 from sympy.core.singleton import S
 from sympy.core.symbol import (Dummy, Symbol, symbols)
 from sympy.core.mul import Mul
-from sympy.functions.elementary.exponential import (exp, log)
+from sympy.functions.elementary.exponential import (exp, log, LambertW)
 from sympy.functions.elementary.hyperbolic import (asinh, csch, cosh, coth, sech, sinh, tanh)
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
@@ -42,6 +42,12 @@ def test_find_substitutions():
                               x, u) == [(sec(x) + tan(x), 1, 1/u)]
     assert (-x**2, Rational(-1, 2), exp(u)) in find_substitutions(x * exp(-x**2), x, u)
     assert not find_substitutions(Derivative(f(x), x)**2, x, u)
+
+
+def test_manualintegrate_lambertw():
+    assert manualintegrate(1/(1 + LambertW(x)), x) == exp(LambertW(x))
+    assert manualintegrate(1/(x*(1 + LambertW(x))), x) == log(LambertW(x))
+    assert manualintegrate(LambertW(x)/(x*(LambertW(x) + 1)), x) == LambertW(x)
 
 
 def test_manualintegrate_polynomials():

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -48,6 +48,9 @@ def test_manualintegrate_lambertw():
     assert manualintegrate(1/(1 + LambertW(x)), x) == exp(LambertW(x))
     assert manualintegrate(1/(x*(1 + LambertW(x))), x) == log(LambertW(x))
     assert manualintegrate(LambertW(x)/(x*(LambertW(x) + 1)), x) == LambertW(x)
+    f = LambertW(3*x+1)
+    F = exp(LambertW(3*x + 1))*LambertW(3*x + 1)**2/3 - exp(LambertW(3*x + 1))*LambertW(3*x + 1)/3 + exp(LambertW(3*x + 1))/3
+    assert manualintegrate(f, x) == F
 
 
 def test_manualintegrate_polynomials():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #30412. 

#### Brief description of what is fixed or changed
Update `manual_subs` in `substitution_rule` to be able to recognize Lambert W function as a viable substitution.

Now the following classes of integrals are evaluated:

$$
\int p(x)W(x) dx,
$$

$$
\int \frac{p(x)}{W(x)^n} dx,
$$

$$
\int \frac{p(x)}{W(x)+y} dx;
$$

where `p(x)` is a polynomial and `n` is an integer.

#### Other comments
Currently the simplification system in SymPy cannot reduce

$$
W(x)\exp(W(x)) = x
$$

hence some tests are not simplified and some results do not match that of what's already evaluated through `heurisch`. This does not, however, change the result of `integrate` because `heurisch` precedes `manualintegrate` in the `integrate` module. 

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Claude Code (Sonnet 5) was used to help generate the code.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Extend support for integrals involving Lambert W function.
<!-- END RELEASE NOTES -->
