### PR TITLE
polys: principal subresultant coefficients and CAD projection operators

### DIFF
--- a/sympy/polys/cad/__init__.py
+++ b/sympy/polys/cad/__init__.py
@@ -1,0 +1,11 @@
+"""Cylindrical algebraic decomposition (CAD).
+
+The projection phase is in :mod:`sympy.polys.cad.projection`.
+"""
+from __future__ import annotations
+
+from .projection import (projection_sets, mccallum_projection,
+    hong_projection, squarefree_basis)
+
+__all__ = ['projection_sets', 'mccallum_projection', 'hong_projection',
+    'squarefree_basis']

--- a/sympy/polys/cad/projection.py
+++ b/sympy/polys/cad/projection.py
@@ -1,0 +1,299 @@
+"""Projection operators for cylindrical algebraic decomposition.
+
+The projection phase of CAD takes a set of polynomials in
+`x_1, \\ldots, x_k` and produces a set of polynomials in
+`x_1, \\ldots, x_{k-1}` such that, over every cell of a decomposition of
+`\\mathbb{R}^{k-1}` which is sign-invariant for the projected set, the real
+roots of the original polynomials in `x_k` are delineable: they are given by
+finitely many continuous functions, which do not cross, and the polynomials
+have constant signs between them.
+
+Two operators are implemented:
+
+* :func:`mccallum_projection` is the projection of McCallum [1]_ applied to a
+  squarefree basis: coefficients, discriminants and pairwise resultants. It
+  gives small projection sets but it is only guaranteed to work if no
+  polynomial of the projection factor sets vanishes identically on a cell of
+  positive dimension (the set is *well-oriented*). The lifting phase checks
+  this and falls back to the second operator if the check fails.
+
+* :func:`hong_projection` is the projection of Hong [2]_, an improvement of
+  the original operator of Collins, based on the reducta of the polynomials
+  and on their principal subresultant coefficients. It is always correct but
+  produces many more polynomials.
+
+References
+==========
+
+.. [1] S. McCallum, An improved projection operation for cylindrical
+       algebraic decomposition, in: Quantifier Elimination and Cylindrical
+       Algebraic Decomposition, Springer, 1998, pp. 242-268.
+.. [2] H. Hong, An improvement of the projection operator in cylindrical
+       algebraic decomposition, ISSAC 1990, pp. 261-264.
+"""
+from __future__ import annotations
+
+from itertools import combinations
+
+from sympy.polys.densebasic import dmp_strip, dmp_zero_p
+from sympy.polys.domains import ZZ
+from sympy.polys.euclidtools import dmp_psc
+from sympy.polys.polyclasses import DMP
+from sympy.polys.polyerrors import PolynomialError
+from sympy.polys.polytools import Poly
+
+
+def _to_polys(polys, gens):
+    """Convert ``polys`` to primitive polynomials over ZZ in ``gens``."""
+    result = []
+    for p in polys:
+        if isinstance(p, Poly):
+            p = p.as_expr()
+        p = Poly(p, *gens)
+        if not p.domain.is_ZZ:
+            if not (p.domain.is_QQ or p.domain.is_ZZ):
+                raise PolynomialError(
+                    "polynomial with rational coefficients expected, got %s" % p)
+            _, p = p.clear_denoms()
+            p = p.set_domain(ZZ)
+        result.append(p)
+    return result
+
+
+def _level(f, gens):
+    """Index of the last generator of ``gens`` that ``f`` depends on."""
+    for k in range(len(gens), 0, -1):
+        if gens[k - 1] in f.gens and f.degree(gens[k - 1]) > 0:
+            return k
+    return 0
+
+
+def _factors(f):
+    """Irreducible non-constant factors of ``f`` with positive leading
+    coefficient."""
+    factors = []
+    for g, _ in f.factor_list()[1]:
+        if g.is_ground:
+            continue
+        if g.LC() < 0:
+            g = -g
+        factors.append(g)
+    return factors
+
+
+def squarefree_basis(polys, gens):
+    """Finest squarefree basis of ``polys``, split by level.
+
+    Returns a list ``[B_1, ..., B_n]`` where ``n = len(gens)`` and ``B_k``
+    contains the irreducible factors (over ZZ, with positive leading
+    coefficient) of the polynomials that depend on ``gens[k-1]`` but not on
+    any later generator. Constants are dropped.
+
+    Examples
+    ========
+
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad import squarefree_basis
+    >>> squarefree_basis([(x**2 - 1)*(x + y)**2, 6], [x, y])
+    [[Poly(x - 1, x, y, domain='ZZ'), Poly(x + 1, x, y, domain='ZZ')], [Poly(x + y, x, y, domain='ZZ')]]
+
+    The polynomials in ``B_k`` are pairwise coprime and squarefree, so that
+    the sign of each input polynomial is determined by the signs of the basis
+    elements.
+    """
+    levels = [[] for _ in gens]
+    for f in _to_polys(polys, gens):
+        for g in _factors(f):
+            k = _level(g, gens)
+            if k and g not in levels[k - 1]:
+                levels[k - 1].append(g)
+    return levels
+
+
+def _main_first(f, x):
+    """Reorder the generators of ``f`` so that ``x`` comes first."""
+    gens = [x] + [g for g in f.gens if g != x]
+    return f.reorder(*gens)
+
+
+def _from_dense(rep, f):
+    """Polynomial in the generators of ``f`` after the first one from the
+    dense representation ``rep``. Univariate ``f`` give domain elements."""
+    rest = f.gens[1:]
+    if not rest:
+        return rep
+    return Poly.new(DMP(rep, f.domain, len(rest) - 1), *rest)
+
+
+def _coefficients(f):
+    """Coefficients of ``f`` with respect to its first generator, from the
+    leading one down, as polynomials in the other generators."""
+    return [_from_dense(c, f) for c in f.rep.to_list()]
+
+
+def _psc(f, g):
+    """Principal subresultant coefficients of ``f`` and ``g`` with respect
+    to their first generator."""
+    lev = len(f.gens) - 1
+    psc = dmp_psc(f.rep.to_list(), g.rep.to_list(), lev, f.domain)
+    return [_from_dense(c, f) for c in psc]
+
+
+def _reducta(f):
+    """The nonzero reducta of ``f`` with respect to its first generator:
+    ``f``, ``f`` minus its leading term, and so on."""
+    rep = f.rep.to_list()
+    lev = len(f.gens) - 1
+    reducta = []
+    while not dmp_zero_p(rep, lev):
+        reducta.append(Poly.new(DMP(rep, f.domain, lev), *f.gens))
+        rep = dmp_strip(rep[1:], lev)
+    return reducta
+
+
+def _is_constant(c):
+    return not isinstance(c, Poly) or c.is_ground
+
+
+def _is_zero(c):
+    return c.is_zero if isinstance(c, Poly) else not c
+
+
+def _collect(items):
+    """Irreducible factors of the non-constant polynomials in ``items``."""
+    result = []
+    for c in items:
+        if _is_constant(c):
+            continue
+        for g in _factors(c):
+            if g not in result:
+                result.append(g)
+    return result
+
+
+def mccallum_projection(polys, x):
+    """McCallum's projection of ``polys`` with respect to ``x``.
+
+    ``polys`` must be a squarefree basis (pairwise coprime squarefree
+    polynomials) of positive degree in ``x``, see :func:`squarefree_basis`.
+    The projection consists of the irreducible factors of the coefficients
+    with respect to ``x``, of the discriminants and of the pairwise
+    resultants.
+
+    Only the coefficients from the leading one down to the first nonzero
+    constant coefficient are used: they are all that is needed for the
+    degree to be invariant on each cell, and if some coefficient is a nonzero
+    constant the polynomial cannot vanish identically anywhere.
+
+    Examples
+    ========
+
+    >>> from sympy import Poly
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad import mccallum_projection
+    >>> mccallum_projection([Poly(x**2 + y**2 - 1, x, y)], y)
+    [Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ')]
+    >>> mccallum_projection([Poly(x*y - 1, x, y), Poly(y - x, x, y)], y)
+    [Poly(x, x, domain='ZZ'), Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ')]
+    """
+    polys = [_main_first(f, x) for f in polys]
+    items = []
+    for f in polys:
+        for c in _coefficients(f):
+            if not _is_constant(c):
+                items.append(c)
+            elif not _is_zero(c):
+                break
+        if f.degree() >= 2:
+            items.append(f.discriminant())
+    for f, g in combinations(polys, 2):
+        items.append(f.resultant(g))
+    return _collect(items)
+
+
+def hong_projection(polys, x):
+    """Hong's projection of ``polys`` with respect to ``x``.
+
+    ``polys`` must be a squarefree basis of positive degree in ``x``. For
+    every reductum `r` of every polynomial the projection contains the
+    leading coefficient of `r` and the principal subresultant coefficients of
+    `r` and its derivative; for every pair `f, g` it contains the principal
+    subresultant coefficients of every reductum of `f` with `g`.
+
+    Examples
+    ========
+
+    >>> from sympy import Poly
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad import hong_projection
+    >>> hong_projection([Poly(x**2 + y**2 - 1, x, y)], y)
+    [Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ')]
+    >>> hong_projection([Poly(x*y - 1, x, y), Poly(y - x, x, y)], y)
+    [Poly(x, x, domain='ZZ'), Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ')]
+    """
+    polys = [_main_first(f, x) for f in polys]
+    items = []
+    for f in polys:
+        for r in _reducta(f):
+            items.append(_coefficients(r)[0])
+            if r.degree() >= 2:
+                items.extend(_psc(r, r.diff(r.gens[0])))
+    for f, g in combinations(polys, 2):
+        for r in _reducta(f):
+            if r.degree() == 0:
+                items.append(_coefficients(r)[0])
+            else:
+                items.extend(_psc(r, g))
+    return _collect(items)
+
+
+_PROJECTIONS = {
+    'mccallum': mccallum_projection,
+    'hong': hong_projection,
+}
+
+
+def projection_sets(polys, gens, method='mccallum'):
+    """Projection factor sets of ``polys`` for the variables ``gens``.
+
+    The last generator is projected first. Returns a list
+    ``[P_1, ..., P_n]`` where ``P_k`` is a squarefree basis of polynomials in
+    ``gens[:k]`` of positive degree in ``gens[k-1]``: ``P_n`` is the basis of
+    the input and each ``P_k`` for ``k < n`` contains the projection of
+    ``P_{k+1}`` together with the factors of the input (and of the
+    projections of higher levels) that only depend on ``gens[:k]``.
+
+    ``method`` is ``'mccallum'`` (default) or ``'hong'``.
+
+    Examples
+    ========
+
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad import projection_sets
+    >>> projection_sets([x**2 + y**2 - 1, x - y], [x, y])
+    [[Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ'), Poly(2*x**2 - 1, x, domain='ZZ')], [Poly(x**2 + y**2 - 1, x, y, domain='ZZ'), Poly(x - y, x, y, domain='ZZ')]]
+    """
+    try:
+        project = _PROJECTIONS[method]
+    except KeyError:
+        raise ValueError("unknown projection method %r" % (method,))
+
+    gens = list(gens)
+    if not gens:
+        raise ValueError("at least one generator is needed")
+
+    levels = squarefree_basis(polys, gens)
+    n = len(gens)
+
+    result = [None]*n
+    for k in range(n, 0, -1):
+        current = [Poly(f.as_expr(), *gens[:k]) for f in levels[k - 1]]
+        result[k - 1] = current
+        if k == 1:
+            break
+        for g in project(current, gens[k - 1]):
+            g = Poly(g.as_expr(), *gens)
+            j = _level(g, gens)
+            if j and g not in levels[j - 1]:
+                levels[j - 1].append(g)
+    return result

--- a/sympy/polys/cad/tests/test_projection.py
+++ b/sympy/polys/cad/tests/test_projection.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+from sympy.core.numbers import Rational
+from sympy.polys.polytools import Poly
+from sympy.polys.polyerrors import PolynomialError
+from sympy.polys.cad.projection import (squarefree_basis, mccallum_projection,
+    hong_projection, projection_sets, _reducta, _psc, _coefficients)
+from sympy.testing.pytest import raises
+from sympy.abc import x, y, z, w
+
+
+def _exprs(polys):
+    return {p.as_expr() for p in polys}
+
+
+def test_squarefree_basis():
+    assert squarefree_basis([], [x, y]) == [[], []]
+    assert squarefree_basis([3, -7], [x, y]) == [[], []]
+    assert squarefree_basis([(x**2 - 1)*(x + y)**2, 6], [x, y]) == [
+        [Poly(x - 1, x, y), Poly(x + 1, x, y)], [Poly(x + y, x, y)]]
+    # sign normalization and deduplication
+    assert squarefree_basis([-x + 1, 2*x - 2, x - 1], [x]) == [[Poly(x - 1, x)]]
+    # rational coefficients are cleared
+    assert squarefree_basis([x**2/4 + y**2/9 - 1], [x, y]) == [
+        [], [Poly(9*x**2 + 4*y**2 - 36, x, y)]]
+    # levels are determined by the last generator present
+    assert squarefree_basis([y**2 - 2, x*z - 1, w], [x, y, z, w]) == [
+        [], [Poly(y**2 - 2, x, y, z, w)], [Poly(x*z - 1, x, y, z, w)],
+        [Poly(w, x, y, z, w)]]
+    assert squarefree_basis([Poly(x**2 - y, x, y)], [x, y]) == [
+        [], [Poly(x**2 - y, x, y)]]
+    raises(PolynomialError, lambda: squarefree_basis([x + z], [x, y]))
+
+
+def test_coefficients_and_reducta():
+    f = Poly(x*y**2 + (x - 1)*y + 3, y, x)
+    assert _coefficients(f) == [Poly(x, x), Poly(x - 1, x), Poly(3, x)]
+    assert _reducta(f) == [f, Poly((x - 1)*y + 3, y, x), Poly(3, y, x)]
+    g = Poly(x*y**2 + 3, y, x)
+    assert _reducta(g) == [g, Poly(3, y, x)]
+    h = Poly(x**3 - 2*x, x)
+    assert _coefficients(h) == [1, 0, -2, 0]
+    assert _reducta(h) == [h, Poly(-2*x, x)]
+
+
+def test_psc():
+    f = Poly(x**2 + y**2 - 1, y, x)
+    assert _psc(f, f.diff(y)) == [Poly(4*x**2 - 4, x), Poly(2, x)]
+    g = Poly(y - x, y, x)
+    assert _psc(f, g) == [Poly(2*x**2 - 1, x), Poly(1, x)]
+    u = Poly(x**2 + 1, x)
+    assert _psc(u, Poly(x**2 - 1, x)) == [4, 0, 1]
+
+
+def test_mccallum_projection():
+    circle = Poly(x**2 + y**2 - 1, x, y)
+    assert mccallum_projection([circle], y) == [Poly(x - 1, x), Poly(x + 1, x)]
+    assert mccallum_projection([circle], x) == [Poly(y - 1, y), Poly(y + 1, y)]
+    line = Poly(x - y, x, y)
+    assert _exprs(mccallum_projection([circle, line], y)) == {x - 1, x + 1, 2*x**2 - 1}
+    assert mccallum_projection([line], y) == []
+    # coefficients are taken down to the first nonzero constant one
+    f = Poly((x**2 - 1)*y**2 + x*y + 5, x, y)
+    assert _exprs(mccallum_projection([f], y)) == {x - 1, x + 1, x, 19*x**2 - 20}
+    g = Poly(x*y**3 + (x - 2)*y + x**2, x, y)
+    proj = _exprs(mccallum_projection([g], y))
+    assert x in proj and x - 2 in proj
+    assert g.reorder(y, x).discriminant().as_expr() in proj or any(
+        p != x and p != x - 2 for p in proj)
+    # a vanishing coefficient does not stop the search
+    h = Poly(x*y**2 + 3, x, y)
+    assert _exprs(mccallum_projection([h], y)) == {x}
+    # three variables
+    sphere = Poly(x**2 + y**2 + z**2 - 1, x, y, z)
+    saddle = Poly(z - x*y, x, y, z)
+    assert _exprs(mccallum_projection([sphere, saddle], z)) == {
+        x**2 + y**2 - 1, x**2*y**2 + x**2 + y**2 - 1}
+
+
+def test_hong_projection():
+    circle = Poly(x**2 + y**2 - 1, x, y)
+    assert hong_projection([circle], y) == [Poly(x - 1, x), Poly(x + 1, x)]
+    # the constant term of a linear polynomial is a reductum, so it is added
+    line = Poly(x - y, x, y)
+    assert _exprs(hong_projection([circle, line], y)) == {x - 1, x + 1, x, 2*x**2 - 1}
+    # Hong's projection contains McCallum's
+    sphere = Poly(x**2 + y**2 + z**2 - 1, x, y, z)
+    saddle = Poly(z - x*y, x, y, z)
+    cubic = Poly(x*z**3 + y*z + 1, x, y, z)
+    for polys in [[sphere, saddle], [sphere, cubic], [saddle, cubic],
+                  [sphere, saddle, cubic]]:
+        assert _exprs(mccallum_projection(polys, z)) <= _exprs(hong_projection(polys, z))
+    assert _exprs(hong_projection([cubic], z)) == {x, y, 27*x + 4*y**3}
+    assert _exprs(mccallum_projection([cubic], z)) == {x, y, 27*x + 4*y**3}
+    f = Poly((x**2 - 1)*y**2 + x*y + 5, x, y)
+    assert _exprs(hong_projection([f], y)) == {x - 1, x + 1, x, 19*x**2 - 20}
+
+
+def test_projection_sets():
+    circle, line = x**2 + y**2 - 1, x - y
+    P1, P2 = projection_sets([circle, line], [x, y])
+    assert _exprs(P1) == {x - 1, x + 1, 2*x**2 - 1}
+    assert P1[0].gens == (x,)
+    assert _exprs(P2) == {circle, line}
+    assert P2[0].gens == (x, y)
+    H1, H2 = projection_sets([circle, line], [x, y], method='hong')
+    assert _exprs(H1) == {x - 1, x + 1, x, 2*x**2 - 1} and H2 == P2
+    raises(ValueError, lambda: projection_sets([circle], [x, y], method='collins'))
+    raises(ValueError, lambda: projection_sets([circle], []))
+
+    assert projection_sets([3], [x, y]) == [[], []]
+    assert projection_sets([x**2 - 2, y], [x, y]) == [
+        [Poly(x**2 - 2, x)], [Poly(y, x, y)]]
+    # polynomials in fewer variables are placed at their own level
+    assert projection_sets([x*y*z + 1], [x, y, z]) == [
+        [Poly(x, x)], [Poly(y, x, y)], [Poly(x*y*z + 1, x, y, z)]]
+    P1, P2, P3, P4 = projection_sets([x*w + y], [x, y, z, w])
+    assert (P1, P2, P3) == ([Poly(x, x)], [Poly(y, x, y)], [])
+    assert P4 == [Poly(x*w + y, x, y, z, w)]
+
+    sphere, saddle = x**2 + y**2 + z**2 - 1, z - x*y
+    P1, P2, P3 = projection_sets([sphere, saddle], [x, y, z])
+    assert _exprs(P3) == {sphere, x*y - z}
+    assert _exprs(P2) == {x**2 + y**2 - 1, x**2*y**2 + x**2 + y**2 - 1}
+    assert _exprs(P1) == {x - 1, x + 1, x**2 + 1, x}
+    H1, H2, H3 = projection_sets([sphere, saddle], [x, y, z], method='hong')
+    assert _exprs(P1) <= _exprs(H1) and _exprs(P2) <= _exprs(H2) and H3 == P3
+    assert len(H1) == len(set(H1)) and len(H2) == len(set(H2))
+
+    # rational coefficients
+    assert projection_sets([x**2/4 + y**2/9 - 1], [x, y]) == [
+        [Poly(x - 2, x), Poly(x + 2, x)], [Poly(9*x**2 + 4*y**2 - 36, x, y)]]
+    assert projection_sets([Rational(1, 2)*x - y], [x, y]) == [
+        [], [Poly(x - 2*y, x, y)]]

--- a/sympy/polys/compatibility.py
+++ b/sympy/polys/compatibility.py
@@ -145,6 +145,8 @@ from sympy.polys.euclidtools import dup_prs_resultant
 from sympy.polys.euclidtools import dup_resultant
 from sympy.polys.euclidtools import dmp_inner_subresultants
 from sympy.polys.euclidtools import dmp_subresultants
+from sympy.polys.euclidtools import dup_psc
+from sympy.polys.euclidtools import dmp_psc
 from sympy.polys.euclidtools import dmp_prs_resultant
 from sympy.polys.euclidtools import dmp_zz_modular_resultant
 from sympy.polys.euclidtools import dmp_zz_collins_resultant
@@ -968,6 +970,13 @@ class IPolys(Generic[Er]):
             self.to_dense(f), self.to_dense(g), self.domain
         )
         return (list(map(self.from_dense, prs)), sres)
+
+    def dup_psc(self, f, g):
+        return dup_psc(self.to_dense(f), self.to_dense(g), self.domain)
+
+    def dmp_psc(self, f, g):
+        psc = dmp_psc(self.to_dense(f), self.to_dense(g), self.ngens - 1, self.domain)
+        return list(map(self[1:].from_dense, psc))
 
     def dmp_inner_subresultants(self, f, g):
         prs, sres = dmp_inner_subresultants(

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -562,6 +562,80 @@ def dmp_subresultants(f, g, u, K):
     return dmp_inner_subresultants(f, g, u, K)[0]
 
 
+def dup_psc(f, g, K):
+    r"""
+    Principal subresultant coefficients of two polynomials in `K[x]`.
+
+    Returns the list ``[psc_0, psc_1, ..., psc_m]`` where ``m`` is the
+    smaller of the degrees of ``f`` and ``g``. ``psc_j`` is the leading
+    coefficient of the `j`-th subresultant of ``f`` and ``g``, i.e. the
+    coefficient of `x^j` in `S_j`; it is zero if `S_j` is defective. In
+    particular ``psc_0`` is the resultant and ``psc_j`` vanishes for
+    `j < \deg\gcd(f, g)`.
+
+    If `\deg f < \deg g` the coefficients of `(g, f)` are computed. The
+    list is empty if one of the polynomials is zero.
+
+    Examples
+    ========
+
+    >>> from sympy.polys import ring, ZZ
+    >>> R, x = ring("x", ZZ)
+
+    >>> R.dup_psc(x**2 + 1, x**2 - 1)
+    [4, 0, 1]
+    >>> R.dup_psc(x**3 - x, x**2 - 1)
+    [0, 0, 1]
+
+    """
+    R, S = dup_inner_subresultants(f, g, K)
+
+    if not R:
+        return []
+
+    m = min(dup_degree(f), dup_degree(g))
+    psc = [K.zero]*(m + 1)
+
+    for r, s in zip(R[1:], S[1:]):
+        psc[dup_degree(r)] = s
+
+    return psc
+
+
+def dmp_psc(f, g, u, K):
+    """
+    Principal subresultant coefficients of two polynomials in `K[X]`.
+
+    The coefficients are taken with respect to the main variable, see
+    :func:`dup_psc`.
+
+    Examples
+    ========
+
+    >>> from sympy.polys import ring, ZZ
+    >>> R, x,y = ring("x,y", ZZ)
+
+    >>> R.dmp_psc(x**2*y + x, x + y)
+    [y**3 - y, 1]
+
+    """
+    if not u:
+        return dup_psc(f, g, K)
+
+    R, S = dmp_inner_subresultants(f, g, u, K)
+
+    if not R:
+        return []
+
+    m = min(dmp_degree(f, u), dmp_degree(g, u))
+    psc = [dmp_zero(u - 1, K)]*(m + 1)
+
+    for r, s in zip(R[1:], S[1:]):
+        psc[dmp_degree(r, u)] = s
+
+    return psc
+
+
 def dmp_prs_resultant(f, g, u, K):
     """
     Resultant algorithm in `K[X]` using subresultant PRS.

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -243,6 +243,82 @@ def test_dup_discriminant():
     assert R.dup_discriminant(12*x**7 + 15*x**4 + 30*x**3 + x**2 + 1) == -220289699947514112
 
 
+def test_dup_psc():
+    R, x = ring("x", ZZ)
+
+    assert R.dup_psc(0, 0) == []
+    assert R.dup_psc(x**2 + 1, 0) == []
+    assert R.dup_psc(0, x**2 + 1) == []
+    assert R.dup_psc(3, 5) == [1]
+    assert R.dup_psc(x**2 + 1, x**2 - 1) == [4, 0, 1]
+    assert R.dup_psc(x**2 - 1, x**2 + 1) == [4, 0, 1]
+    assert R.dup_psc(x**3 - x, x**2 - 1) == [0, 0, 1]
+    assert R.dup_psc(x**2 - 1, x**3 - x) == [0, 0, 1]
+    assert R.dup_psc(x**3 - 3*x**2 + 2*x, x**3 - x) == [0, 0, 3, 1]
+    assert R.dup_psc(x**5 + x**3 - 1, 2*x**3) == [32, 0, 0, 4]
+    assert R.dup_psc(x**4 + x + 1, 3*x**2 - 2) == [115, -27, 9]
+
+    f = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    g = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+
+    assert R.dup_psc(f, g)[0] == R.dup_resultant(f, g)
+    assert R.dup_psc(f, g)[-1] == 9
+
+    # principal subresultant coefficients as determinants of the Sylvester
+    # submatrices, checked on a few cases with degree jumps and common roots
+    from sympy.matrices import Matrix
+
+    def psc_det(f, g):
+        n, m = len(f) - 1, len(g) - 1
+        out = []
+        for j in range(m + 1):
+            rows = []
+            width = n + m - j
+            for i in range(m - j):
+                rows.append([0]*i + f + [0]*(width - n - 1 - i))
+            for i in range(n - j):
+                rows.append([0]*i + g + [0]*(width - m - 1 - i))
+            M = Matrix(rows)
+            out.append(M[:, :n + m - 2*j].det() if M.rows else 1)
+        return [ZZ(c) for c in out]
+
+    cases = [
+        ([1, 0, 1, 0, -1], [2, 0, 0, 0]),
+        ([1, -1, 0, 2, 3], [1, 0, 0, -1]),
+        ([2, -3, 1, 0, 0, -1, 5], [1, 0, 0, 0, 0, 2]),
+        ([1, -2, 1], [1, -1, 0]),
+        ([1, 0, -2, 0, 1], [1, 0, -1]),
+        ([3, 1, -4, 1, 2, -1], [1, 2, 0, 0, -3]),
+    ]
+    for f, g in cases:
+        assert R.dup_psc(R.from_list(f), R.from_list(g)) == psc_det(f, g)
+
+
+def test_dmp_psc():
+    R, x, y = ring("x,y", ZZ)
+
+    assert R.dmp_psc(0, 0) == []
+    assert R.dmp_psc(x*y + 1, 0) == []
+    assert R.dmp_psc(x**2*y + x, x + y) == [(y**3 - y).drop(x), 1]
+    assert R.dmp_psc(x**2*y + x, 3) == [9]
+    assert R.dmp_psc(x**2 - y, x**2*y - 1) == [(y**4 - 2*y**2 + 1).drop(x), 0, 1]
+
+    f = x**2 + y**2 - 1
+    assert R.dmp_psc(f, f.diff(x)) == [(4*y**2 - 4).drop(x), 2]
+    assert R.dmp_psc(f, x - y) == [(2*y**2 - 1).drop(x), 1]
+    assert R.dmp_psc(f, x - y)[0] == R.dmp_resultant(f, x - y)
+
+    g = (x - y)*(x**2 + 1)
+    h = (x - y)*(x + 3)
+    assert R.dmp_psc(g, h) == [0, 10, 1]
+
+    R, x, y, z = ring("x,y,z", ZZ)
+    f = x**2 + y**2 + z**2 - 1
+    psc = R.dmp_psc(f, x*y - z)
+    assert psc == [R.dmp_resultant(f, x*y - z), y.drop(x)]
+    assert psc[0] == (y**4 + y**2*z**2 - y**2 + z**2).drop(x)
+
+
 def test_dmp_discriminant():
     R, x = ring("x", ZZ)
 


### PR DESCRIPTION
First of four PRs implementing cylindrical algebraic decomposition (CAD), written from scratch. Related: #26177, #26785, #27088.

This one adds:

- `dup_psc`/`dmp_psc` in `euclidtools`: principal subresultant coefficients, read off the subresultant PRS that is already there. The tests check them against the determinant definition.
- `sympy.polys.cad.projection`: squarefree basis by level, McCallum's and Hong's projection operators, and `projection_sets` computing the projection factor sets of all levels.

Sample points, lifting and quantifier elimination come in the next PRs, each on top of the previous one.

A note on how this was written: I have a temporary boost of Claude tokens that expires soon, so I used Claude Fable 5.1 to do something useful for SymPy before they expire and finally get CAD done. The code is not copied from anywhere; the results were checked against answers from QEPCAD, Redlog and the Sage docs in the last PR.

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added `dup_psc` and `dmp_psc` (principal subresultant coefficients) and the projection phase of cylindrical algebraic decomposition in `sympy.polys.cad`.
<!-- END RELEASE NOTES -->
