### PR TITLE
cad: lifting phase and cylindrical_algebraic_decomposition

### DIFF
--- a/sympy/polys/cad/__init__.py
+++ b/sympy/polys/cad/__init__.py
@@ -1,0 +1,11 @@
+"""Cylindrical algebraic decomposition (CAD).
+
+The projection phase is in :mod:`sympy.polys.cad.projection`.
+"""
+from __future__ import annotations
+
+from .projection import (projection_sets, mccallum_projection,
+    hong_projection, squarefree_basis)
+
+__all__ = ['projection_sets', 'mccallum_projection', 'hong_projection',
+    'squarefree_basis']

--- a/sympy/polys/cad/__init__.py
+++ b/sympy/polys/cad/__init__.py
@@ -1,14 +1,19 @@
 """Cylindrical algebraic decomposition (CAD).
 
-The projection phase is in :mod:`sympy.polys.cad.projection` and the exact
-real algebraic sample points used by the lifting phase are in
-:mod:`sympy.polys.cad.samplepoints`.
+The projection phase is in :mod:`sympy.polys.cad.projection`, the exact real
+algebraic sample points in :mod:`sympy.polys.cad.samplepoints` and the
+lifting phase, with the main entry point
+:func:`cylindrical_algebraic_decomposition`, in
+:mod:`sympy.polys.cad.lifting`.
 """
 from __future__ import annotations
 
 from .projection import (projection_sets, mccallum_projection,
     hong_projection, squarefree_basis)
 from .samplepoints import SamplePoint
+from .lifting import (cylindrical_algebraic_decomposition, CAD, CADCell,
+    NotWellOriented)
 
 __all__ = ['projection_sets', 'mccallum_projection', 'hong_projection',
-    'squarefree_basis', 'SamplePoint']
+    'squarefree_basis', 'SamplePoint', 'cylindrical_algebraic_decomposition',
+    'CAD', 'CADCell', 'NotWellOriented']

--- a/sympy/polys/cad/__init__.py
+++ b/sympy/polys/cad/__init__.py
@@ -1,11 +1,14 @@
 """Cylindrical algebraic decomposition (CAD).
 
-The projection phase is in :mod:`sympy.polys.cad.projection`.
+The projection phase is in :mod:`sympy.polys.cad.projection` and the exact
+real algebraic sample points used by the lifting phase are in
+:mod:`sympy.polys.cad.samplepoints`.
 """
 from __future__ import annotations
 
 from .projection import (projection_sets, mccallum_projection,
     hong_projection, squarefree_basis)
+from .samplepoints import SamplePoint
 
 __all__ = ['projection_sets', 'mccallum_projection', 'hong_projection',
-    'squarefree_basis']
+    'squarefree_basis', 'SamplePoint']

--- a/sympy/polys/cad/lifting.py
+++ b/sympy/polys/cad/lifting.py
@@ -1,0 +1,323 @@
+"""Lifting phase of cylindrical algebraic decomposition.
+
+Given the projection factor sets `P_1, \\ldots, P_n` of a set of
+polynomials (see :func:`~.projection_sets`), the lifting phase builds the
+decomposition level by level. The real line is split at the real roots of
+`P_1` into *sections* (the roots) and *sectors* (the open intervals between
+them). Over every cell `c` of `\\mathbb{R}^{k-1}` the polynomials of `P_k`
+are evaluated at the sample point of `c`; their real roots split the
+cylinder `c \\times \\mathbb{R}` into sections and sectors again, each with
+its own sample point. The polynomials are sign-invariant on every cell, so
+the sign of every input polynomial on a cell is read off its sample point.
+"""
+from __future__ import annotations
+
+from sympy.core.numbers import Rational
+from sympy.polys.polyerrors import PolynomialError
+from sympy.polys.polytools import Poly
+
+from .projection import projection_sets, _to_polys
+from .samplepoints import (SamplePoint, compare_real, rational_between,
+    rational_below, rational_above)
+
+
+class NotWellOriented(PolynomialError):
+    """Raised when a projection factor vanishes identically on a cell of
+    positive dimension, so that McCallum's projection is not guaranteed to
+    give a sign-invariant decomposition."""
+
+
+class CADCell:
+    """A cell of a cylindrical algebraic decomposition.
+
+    Attributes
+    ==========
+
+    index : tuple of int
+        The position of the cell in the decomposition, one integer per
+        level: the `k`-th entry is odd for a sector and even for a section
+        of the cylinder over the parent cell, counted from 1 upwards.
+    point : tuple of Expr
+        The coordinates of an exact sample point of the cell: rational
+        numbers for the sectors and :class:`~.ComplexRootOf` roots (possibly
+        times a rational number) for the sections.
+    sample : SamplePoint
+        The same sample point with its coordinates in a common algebraic
+        field, for exact sign evaluations.
+    parent : CADCell or None
+        The cell of the previous level over which this cell lies.
+    """
+
+    __slots__ = ('index', 'point', 'sample', 'parent', '_signs', 'signs')
+
+    def __init__(self, index, point, sample, parent, signs):
+        self.index = index
+        self.point = point
+        self.sample = sample
+        self.parent = parent
+        # signs of the projection factors of this level at the sample point
+        self._signs = signs
+        # signs of the input polynomials, filled by CAD for the top level
+        self.signs = None
+
+    @property
+    def level(self):
+        return len(self.index)
+
+    @property
+    def dimension(self):
+        """The dimension of the cell: the number of sectors in its index."""
+        return sum(i % 2 for i in self.index)
+
+    @property
+    def is_section(self):
+        """Whether the cell is a section (a root) over its parent."""
+        return self.index[-1] % 2 == 0
+
+    def __repr__(self):
+        return "CADCell(%s, %s)" % (self.index, self.point)
+
+    def _factor_sign(self, level, i):
+        """Sign of the ``i``-th projection factor of level ``level`` at the
+        sample point of this cell."""
+        cell = self
+        while cell.level > level:
+            cell = cell.parent
+        return cell._signs[i]
+
+
+class CAD:
+    """A cylindrical algebraic decomposition of `\\mathbb{R}^n`, sign-invariant
+    for a set of polynomials.
+
+    Instances are built by :func:`cylindrical_algebraic_decomposition`.
+
+    Attributes
+    ==========
+
+    gens : tuple of Symbol
+        The variables, in the order of the levels.
+    polys : list of Poly
+        The input polynomials.
+    projection : list of list of Poly
+        The projection factor sets ``P_1, ..., P_n``.
+    method : str
+        The projection operator used, ``'mccallum'`` or ``'hong'``.
+    cells : list of CADCell
+        The cells of `\\mathbb{R}^n`, in lexicographic order of their indices.
+        The ``signs`` attribute of each cell is the tuple of signs of the
+        input polynomials on the cell.
+    """
+
+    def __init__(self, gens, polys, projection, method, levels):
+        self.gens = tuple(gens)
+        self.polys = polys
+        self.projection = projection
+        self.method = method
+        self._levels = levels
+        self.cells = levels[-1]
+
+    def __len__(self):
+        return len(self.cells)
+
+    def __iter__(self):
+        return iter(self.cells)
+
+    def __repr__(self):
+        return "CAD(%d cells, %s)" % (len(self.cells), ", ".join(map(str, self.gens)))
+
+    def cells_at(self, level):
+        """The cells of `\\mathbb{R}^k` for ``level = k``, ``1 <= k <= n``."""
+        if not 1 <= level <= len(self.gens):
+            raise ValueError("level must be between 1 and %d" % len(self.gens))
+        return self._levels[level - 1]
+
+    def children(self, cell):
+        """The cells of the next level lying over ``cell``."""
+        if cell.level >= len(self.gens):
+            return []
+        return [c for c in self._levels[cell.level] if c.parent is cell]
+
+
+def _merge_roots(roots, new):
+    """Merge the sorted lists of distinct real roots ``roots`` and ``new``."""
+    result = []
+    i = j = 0
+    while i < len(roots) and j < len(new):
+        c = compare_real(roots[i], new[j])
+        if c < 0:
+            result.append(roots[i])
+            i += 1
+        elif c > 0:
+            result.append(new[j])
+            j += 1
+        else:
+            result.append(roots[i])
+            i += 1
+            j += 1
+    result.extend(roots[i:])
+    result.extend(new[j:])
+    return result
+
+
+def _lift(projection, gens, method):
+    """Build the cells of all levels from the projection factor sets."""
+    root = CADCell((), (), SamplePoint(), None, ())
+    levels = []
+    current = [root]
+    for k, polys in enumerate(projection, start=1):
+        level_gens = gens[:k]
+        cells = []
+        for parent in current:
+            roots = []
+            nullified = set()
+            for i, f in enumerate(polys):
+                r = parent.sample.real_roots(f, level_gens)
+                if r is None:
+                    if method == 'mccallum' and parent.dimension > 0:
+                        raise NotWellOriented(
+                            "%s vanishes identically on a cell of dimension %d"
+                            % (f.as_expr(), parent.dimension))
+                    nullified.add(i)
+                else:
+                    roots = _merge_roots(roots, r)
+            values = []
+            if not roots:
+                values.append((Rational(0), None))
+            else:
+                values.append((rational_below(roots[0]), None))
+                for j, r in enumerate(roots):
+                    values.append((r, r))
+                    if j + 1 < len(roots):
+                        values.append((rational_between(r, roots[j + 1]), None))
+                values.append((rational_above(roots[-1]), None))
+            for j, (value, section_root) in enumerate(values, start=1):
+                sample = parent.sample.extend(value)
+                signs = []
+                for i, f in enumerate(polys):
+                    if i in nullified:
+                        signs.append(0)
+                    else:
+                        signs.append(sample.sign(f, level_gens))
+                cells.append(CADCell(parent.index + (j,), parent.point + (value,),
+                                     sample, parent, tuple(signs)))
+        levels.append(cells)
+        current = cells
+    return levels
+
+
+def _level_of(f, gens):
+    for k in range(len(gens), 0, -1):
+        if f.degree(gens[k - 1]) > 0:
+            return k
+    return 0
+
+
+def _factor_signs(polys, projection, gens):
+    """For every input polynomial, the sign of its constant factor and the
+    positions ``(level, index, exponent)`` of its irreducible factors in
+    the projection sets."""
+    positions = {}
+    for k, level in enumerate(projection, start=1):
+        for i, g in enumerate(level):
+            positions[Poly(g.as_expr(), *gens)] = (k, i)
+    result = []
+    for f in polys:
+        coeff, factors = f.factor_list()
+        c = 0 if f.is_zero else (1 if coeff > 0 else -1)
+        items = []
+        for g, e in factors:
+            if g.LC() < 0:
+                g = -g
+                if e % 2:
+                    c = -c
+            items.append(positions[g] + (e,))
+        result.append((c, items))
+    return result
+
+
+def cylindrical_algebraic_decomposition(polys, gens, method=None):
+    """Cylindrical algebraic decomposition sign-invariant for ``polys``.
+
+    Parameters
+    ==========
+
+    polys : list of Expr or Poly
+        Polynomials with rational coefficients in ``gens``.
+    gens : list of Symbol
+        The variables. The decomposition is cylindrical with respect to this
+        order: the cells of `\\mathbb{R}^n` project onto cells of
+        `\\mathbb{R}^{n-1}` in the first ``n - 1`` variables, and so on.
+    method : ``'mccallum'``, ``'hong'`` or None
+        The projection operator, see :mod:`sympy.polys.cad.projection`. By
+        default McCallum's projection is tried first and Hong's is used if
+        the polynomials are not well-oriented for it. With
+        ``method='mccallum'`` :class:`NotWellOriented` is raised instead.
+
+    Returns
+    =======
+
+    A :class:`CAD` whose ``cells`` are sign-invariant for every polynomial:
+    each cell is a connected set on which every input polynomial is
+    constantly positive, negative or zero, and every point of
+    `\\mathbb{R}^n` belongs to exactly one cell.
+
+    Examples
+    ========
+
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad import cylindrical_algebraic_decomposition
+    >>> cad = cylindrical_algebraic_decomposition([x**2 + y**2 - 1], [x, y])
+    >>> cad
+    CAD(13 cells, x, y)
+    >>> for cell in cad:
+    ...     print(cell.index, cell.point, cell.signs)
+    (1, 1) (-2, 0) (1,)
+    (2, 1) (-1, -1) (1,)
+    (2, 2) (-1, 0) (0,)
+    (2, 3) (-1, 1) (1,)
+    (3, 1) (0, -2) (1,)
+    (3, 2) (0, -1) (0,)
+    (3, 3) (0, 0) (-1,)
+    (3, 4) (0, 1) (0,)
+    (3, 5) (0, 2) (1,)
+    (4, 1) (1, -1) (1,)
+    (4, 2) (1, 0) (0,)
+    (4, 3) (1, 1) (1,)
+    (5, 1) (2, 0) (1,)
+
+    The cells of index ``(2, 2)``, ``(3, 2)``, ``(3, 4)`` and ``(4, 2)``
+    are the two points and the two arcs of the circle, ``(3, 3)`` is the
+    open disc and the others cover its complement.
+    """
+    gens = list(gens)
+    if not gens:
+        raise ValueError("at least one generator is needed")
+    polys = _to_polys(polys, gens)
+    if method is None:
+        methods = ['mccallum', 'hong']
+    elif method in ('mccallum', 'hong'):
+        methods = [method]
+    else:
+        raise ValueError("unknown projection method %r" % (method,))
+
+    for m in methods:
+        projection = projection_sets(polys, gens, method=m)
+        try:
+            levels = _lift(projection, gens, m)
+        except NotWellOriented:
+            if m == methods[-1]:
+                raise
+            continue
+        break
+
+    factor_signs = _factor_signs(polys, projection, gens)
+    for cell in levels[-1]:
+        signs = []
+        for c, items in factor_signs:
+            s = c
+            for level, i, e in items:
+                s *= cell._factor_sign(level, i)**e
+            signs.append(s)
+        cell.signs = tuple(signs)
+    return CAD(gens, polys, projection, m, levels)

--- a/sympy/polys/cad/projection.py
+++ b/sympy/polys/cad/projection.py
@@ -1,0 +1,299 @@
+"""Projection operators for cylindrical algebraic decomposition.
+
+The projection phase of CAD takes a set of polynomials in
+`x_1, \\ldots, x_k` and produces a set of polynomials in
+`x_1, \\ldots, x_{k-1}` such that, over every cell of a decomposition of
+`\\mathbb{R}^{k-1}` which is sign-invariant for the projected set, the real
+roots of the original polynomials in `x_k` are delineable: they are given by
+finitely many continuous functions, which do not cross, and the polynomials
+have constant signs between them.
+
+Two operators are implemented:
+
+* :func:`mccallum_projection` is the projection of McCallum [1]_ applied to a
+  squarefree basis: coefficients, discriminants and pairwise resultants. It
+  gives small projection sets but it is only guaranteed to work if no
+  polynomial of the projection factor sets vanishes identically on a cell of
+  positive dimension (the set is *well-oriented*). The lifting phase checks
+  this and falls back to the second operator if the check fails.
+
+* :func:`hong_projection` is the projection of Hong [2]_, an improvement of
+  the original operator of Collins, based on the reducta of the polynomials
+  and on their principal subresultant coefficients. It is always correct but
+  produces many more polynomials.
+
+References
+==========
+
+.. [1] S. McCallum, An improved projection operation for cylindrical
+       algebraic decomposition, in: Quantifier Elimination and Cylindrical
+       Algebraic Decomposition, Springer, 1998, pp. 242-268.
+.. [2] H. Hong, An improvement of the projection operator in cylindrical
+       algebraic decomposition, ISSAC 1990, pp. 261-264.
+"""
+from __future__ import annotations
+
+from itertools import combinations
+
+from sympy.polys.densebasic import dmp_strip, dmp_zero_p
+from sympy.polys.domains import ZZ
+from sympy.polys.euclidtools import dmp_psc
+from sympy.polys.polyclasses import DMP
+from sympy.polys.polyerrors import PolynomialError
+from sympy.polys.polytools import Poly
+
+
+def _to_polys(polys, gens):
+    """Convert ``polys`` to primitive polynomials over ZZ in ``gens``."""
+    result = []
+    for p in polys:
+        if isinstance(p, Poly):
+            p = p.as_expr()
+        p = Poly(p, *gens)
+        if not p.domain.is_ZZ:
+            if not (p.domain.is_QQ or p.domain.is_ZZ):
+                raise PolynomialError(
+                    "polynomial with rational coefficients expected, got %s" % p)
+            _, p = p.clear_denoms()
+            p = p.set_domain(ZZ)
+        result.append(p)
+    return result
+
+
+def _level(f, gens):
+    """Index of the last generator of ``gens`` that ``f`` depends on."""
+    for k in range(len(gens), 0, -1):
+        if gens[k - 1] in f.gens and f.degree(gens[k - 1]) > 0:
+            return k
+    return 0
+
+
+def _factors(f):
+    """Irreducible non-constant factors of ``f`` with positive leading
+    coefficient."""
+    factors = []
+    for g, _ in f.factor_list()[1]:
+        if g.is_ground:
+            continue
+        if g.LC() < 0:
+            g = -g
+        factors.append(g)
+    return factors
+
+
+def squarefree_basis(polys, gens):
+    """Finest squarefree basis of ``polys``, split by level.
+
+    Returns a list ``[B_1, ..., B_n]`` where ``n = len(gens)`` and ``B_k``
+    contains the irreducible factors (over ZZ, with positive leading
+    coefficient) of the polynomials that depend on ``gens[k-1]`` but not on
+    any later generator. Constants are dropped.
+
+    Examples
+    ========
+
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad import squarefree_basis
+    >>> squarefree_basis([(x**2 - 1)*(x + y)**2, 6], [x, y])
+    [[Poly(x - 1, x, y, domain='ZZ'), Poly(x + 1, x, y, domain='ZZ')], [Poly(x + y, x, y, domain='ZZ')]]
+
+    The polynomials in ``B_k`` are pairwise coprime and squarefree, so that
+    the sign of each input polynomial is determined by the signs of the basis
+    elements.
+    """
+    levels = [[] for _ in gens]
+    for f in _to_polys(polys, gens):
+        for g in _factors(f):
+            k = _level(g, gens)
+            if k and g not in levels[k - 1]:
+                levels[k - 1].append(g)
+    return levels
+
+
+def _main_first(f, x):
+    """Reorder the generators of ``f`` so that ``x`` comes first."""
+    gens = [x] + [g for g in f.gens if g != x]
+    return f.reorder(*gens)
+
+
+def _from_dense(rep, f):
+    """Polynomial in the generators of ``f`` after the first one from the
+    dense representation ``rep``. Univariate ``f`` give domain elements."""
+    rest = f.gens[1:]
+    if not rest:
+        return rep
+    return Poly.new(DMP(rep, f.domain, len(rest) - 1), *rest)
+
+
+def _coefficients(f):
+    """Coefficients of ``f`` with respect to its first generator, from the
+    leading one down, as polynomials in the other generators."""
+    return [_from_dense(c, f) for c in f.rep.to_list()]
+
+
+def _psc(f, g):
+    """Principal subresultant coefficients of ``f`` and ``g`` with respect
+    to their first generator."""
+    lev = len(f.gens) - 1
+    psc = dmp_psc(f.rep.to_list(), g.rep.to_list(), lev, f.domain)
+    return [_from_dense(c, f) for c in psc]
+
+
+def _reducta(f):
+    """The nonzero reducta of ``f`` with respect to its first generator:
+    ``f``, ``f`` minus its leading term, and so on."""
+    rep = f.rep.to_list()
+    lev = len(f.gens) - 1
+    reducta = []
+    while not dmp_zero_p(rep, lev):
+        reducta.append(Poly.new(DMP(rep, f.domain, lev), *f.gens))
+        rep = dmp_strip(rep[1:], lev)
+    return reducta
+
+
+def _is_constant(c):
+    return not isinstance(c, Poly) or c.is_ground
+
+
+def _is_zero(c):
+    return c.is_zero if isinstance(c, Poly) else not c
+
+
+def _collect(items):
+    """Irreducible factors of the non-constant polynomials in ``items``."""
+    result = []
+    for c in items:
+        if _is_constant(c):
+            continue
+        for g in _factors(c):
+            if g not in result:
+                result.append(g)
+    return result
+
+
+def mccallum_projection(polys, x):
+    """McCallum's projection of ``polys`` with respect to ``x``.
+
+    ``polys`` must be a squarefree basis (pairwise coprime squarefree
+    polynomials) of positive degree in ``x``, see :func:`squarefree_basis`.
+    The projection consists of the irreducible factors of the coefficients
+    with respect to ``x``, of the discriminants and of the pairwise
+    resultants.
+
+    Only the coefficients from the leading one down to the first nonzero
+    constant coefficient are used: they are all that is needed for the
+    degree to be invariant on each cell, and if some coefficient is a nonzero
+    constant the polynomial cannot vanish identically anywhere.
+
+    Examples
+    ========
+
+    >>> from sympy import Poly
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad import mccallum_projection
+    >>> mccallum_projection([Poly(x**2 + y**2 - 1, x, y)], y)
+    [Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ')]
+    >>> mccallum_projection([Poly(x*y - 1, x, y), Poly(y - x, x, y)], y)
+    [Poly(x, x, domain='ZZ'), Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ')]
+    """
+    polys = [_main_first(f, x) for f in polys]
+    items = []
+    for f in polys:
+        for c in _coefficients(f):
+            if not _is_constant(c):
+                items.append(c)
+            elif not _is_zero(c):
+                break
+        if f.degree() >= 2:
+            items.append(f.discriminant())
+    for f, g in combinations(polys, 2):
+        items.append(f.resultant(g))
+    return _collect(items)
+
+
+def hong_projection(polys, x):
+    """Hong's projection of ``polys`` with respect to ``x``.
+
+    ``polys`` must be a squarefree basis of positive degree in ``x``. For
+    every reductum `r` of every polynomial the projection contains the
+    leading coefficient of `r` and the principal subresultant coefficients of
+    `r` and its derivative; for every pair `f, g` it contains the principal
+    subresultant coefficients of every reductum of `f` with `g`.
+
+    Examples
+    ========
+
+    >>> from sympy import Poly
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad import hong_projection
+    >>> hong_projection([Poly(x**2 + y**2 - 1, x, y)], y)
+    [Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ')]
+    >>> hong_projection([Poly(x*y - 1, x, y), Poly(y - x, x, y)], y)
+    [Poly(x, x, domain='ZZ'), Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ')]
+    """
+    polys = [_main_first(f, x) for f in polys]
+    items = []
+    for f in polys:
+        for r in _reducta(f):
+            items.append(_coefficients(r)[0])
+            if r.degree() >= 2:
+                items.extend(_psc(r, r.diff(r.gens[0])))
+    for f, g in combinations(polys, 2):
+        for r in _reducta(f):
+            if r.degree() == 0:
+                items.append(_coefficients(r)[0])
+            else:
+                items.extend(_psc(r, g))
+    return _collect(items)
+
+
+_PROJECTIONS = {
+    'mccallum': mccallum_projection,
+    'hong': hong_projection,
+}
+
+
+def projection_sets(polys, gens, method='mccallum'):
+    """Projection factor sets of ``polys`` for the variables ``gens``.
+
+    The last generator is projected first. Returns a list
+    ``[P_1, ..., P_n]`` where ``P_k`` is a squarefree basis of polynomials in
+    ``gens[:k]`` of positive degree in ``gens[k-1]``: ``P_n`` is the basis of
+    the input and each ``P_k`` for ``k < n`` contains the projection of
+    ``P_{k+1}`` together with the factors of the input (and of the
+    projections of higher levels) that only depend on ``gens[:k]``.
+
+    ``method`` is ``'mccallum'`` (default) or ``'hong'``.
+
+    Examples
+    ========
+
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad import projection_sets
+    >>> projection_sets([x**2 + y**2 - 1, x - y], [x, y])
+    [[Poly(x - 1, x, domain='ZZ'), Poly(x + 1, x, domain='ZZ'), Poly(2*x**2 - 1, x, domain='ZZ')], [Poly(x**2 + y**2 - 1, x, y, domain='ZZ'), Poly(x - y, x, y, domain='ZZ')]]
+    """
+    try:
+        project = _PROJECTIONS[method]
+    except KeyError:
+        raise ValueError("unknown projection method %r" % (method,))
+
+    gens = list(gens)
+    if not gens:
+        raise ValueError("at least one generator is needed")
+
+    levels = squarefree_basis(polys, gens)
+    n = len(gens)
+
+    result = [None]*n
+    for k in range(n, 0, -1):
+        current = [Poly(f.as_expr(), *gens[:k]) for f in levels[k - 1]]
+        result[k - 1] = current
+        if k == 1:
+            break
+        for g in project(current, gens[k - 1]):
+            g = Poly(g.as_expr(), *gens)
+            j = _level(g, gens)
+            if j and g not in levels[j - 1]:
+                levels[j - 1].append(g)
+    return result

--- a/sympy/polys/cad/samplepoints.py
+++ b/sympy/polys/cad/samplepoints.py
@@ -1,0 +1,452 @@
+"""Exact real algebraic sample points for cylindrical algebraic decomposition.
+
+The lifting phase of CAD needs to evaluate polynomials at points whose
+coordinates are real algebraic numbers, to find the real roots of the
+resulting univariate polynomials and to compare them exactly. Here a sample
+point is represented by a single real algebraic number `\\theta`, given as a
+:class:`~.ComplexRootOf` with its isolating interval, together with the
+coordinates as elements of the field `\\mathbb{Q}(\\theta)`. Signs and
+comparisons are decided by interval arithmetic, refining the isolating
+interval of `\\theta` as needed, and the field is extended by a primitive
+element whenever a new algebraic coordinate is added.
+"""
+from __future__ import annotations
+
+from itertools import count
+
+from sympy.core.expr import Expr
+from sympy.core.numbers import Rational
+from sympy.core.symbol import Dummy
+from sympy.polys.densetools import dup_eval
+from sympy.polys.domains import QQ
+from sympy.polys.polyerrors import PolynomialError
+from sympy.polys.polytools import Poly
+from sympy.polys.rootoftools import ComplexRootOf
+
+
+def _split(r):
+    """Split a real algebraic number into a rational factor and a
+    :class:`~.ComplexRootOf` (or ``None`` for a rational number).
+
+    Real roots are represented by :class:`~.Rational` numbers, by real
+    :class:`~.ComplexRootOf` roots or by products of a rational number and
+    such a root, which is the form :func:`~.real_roots` may return.
+    """
+    if isinstance(r, ComplexRootOf):
+        return QQ.one, r
+    if isinstance(r, Expr) and r.is_Mul and len(r.args) == 2 and \
+            r.args[0].is_Rational and isinstance(r.args[1], ComplexRootOf):
+        return QQ.convert(r.args[0]), r.args[1]
+    return QQ.convert(r), None
+
+
+def _bounds(r):
+    """Rational lower and upper bounds of the real algebraic number ``r``."""
+    c, root = _split(r)
+    if root is None:
+        return c, c
+    interval = root._get_interval()
+    a, b = c*QQ.convert(interval.a), c*QQ.convert(interval.b)
+    return (a, b) if a <= b else (b, a)
+
+
+def _refine(r):
+    """Refine the isolating interval of the real algebraic number ``r``."""
+    _, root = _split(r)
+    if root is not None:
+        root._set_interval(root._get_interval().refine())
+
+
+def _minpoly(r):
+    """Minimal polynomial over ZZ of the real algebraic number ``r``, which
+    must not be rational."""
+    c, root = _split(r)
+    p = root.poly
+    if c != 1:
+        x = p.gen
+        d = p.degree()
+        p = Poly(p.as_expr().subs(x, x/c.numerator*c.denominator)*c.numerator**d, x)
+        p = p.primitive()[1]
+    return p
+
+
+def compare_real(a, b):
+    """Compare two real algebraic numbers exactly.
+
+    ``a`` and ``b`` must be :class:`~.Rational` numbers, real
+    :class:`~.ComplexRootOf` roots or products of the two. Returns ``-1``,
+    ``0`` or ``1``.
+
+    Examples
+    ========
+
+    >>> from sympy import CRootOf, Rational
+    >>> from sympy.abc import x
+    >>> from sympy.polys.cad.samplepoints import compare_real
+    >>> compare_real(CRootOf(x**2 - 2, 1), Rational(3, 2))
+    -1
+    >>> compare_real(CRootOf(x**2 - 2, 1), CRootOf(x**3 - 2, 0))
+    1
+    """
+    if a == b:
+        return 0
+    while True:
+        alo, ahi = _bounds(a)
+        blo, bhi = _bounds(b)
+        if ahi < blo:
+            return -1
+        if bhi < alo:
+            return 1
+        _refine(a)
+        _refine(b)
+
+
+def _floor(q):
+    return q.numerator // q.denominator
+
+
+def _floor_scaled(a, k):
+    """Exact value of `\\lfloor 2^k a \\rfloor` for a real algebraic ``a``."""
+    scale = QQ(2)**k
+    while True:
+        lo, hi = _bounds(a)
+        flo, fhi = _floor(lo*scale), _floor(hi*scale)
+        if flo == fhi:
+            return flo
+        _refine(a)
+
+
+def simplest_between(lo, hi, lo_open=True, hi_open=True):
+    """The rational number with the smallest denominator in the interval
+    with rational endpoints ``lo`` and ``hi``. The endpoints are excluded
+    unless ``lo_open`` or ``hi_open`` is ``False``; ``hi`` may be ``None``
+    for `+\\infty`.
+
+    Examples
+    ========
+
+    >>> from sympy import QQ
+    >>> from sympy.polys.cad.samplepoints import simplest_between
+    >>> simplest_between(QQ(1, 3), QQ(1, 2))
+    2/5
+    >>> simplest_between(QQ(1, 3), QQ(1, 2), hi_open=False)
+    1/2
+    >>> simplest_between(QQ(5, 2), QQ(3))
+    8/3
+    """
+    if hi is None:
+        if lo < 0 or (lo == 0 and not lo_open):
+            return QQ.zero
+        n = _floor(lo)
+        return QQ(n if n == lo and not lo_open else n + 1)
+    if lo > hi or (lo == hi and (lo_open or hi_open)):
+        raise ValueError("empty interval")
+    if (lo < 0 or (lo == 0 and not lo_open)) and (hi > 0 or (hi == 0 and not hi_open)):
+        return QQ.zero
+    if hi < 0 or (hi == 0 and hi_open):
+        return -simplest_between(-hi, -lo, hi_open, lo_open)
+    # now 0 <= lo < hi, with lo excluded if it is 0
+    n = _floor(lo)
+    c = n if (n == lo and not lo_open) else n + 1
+    if c < hi or (c == hi and not hi_open):
+        return QQ(c)
+    # no integer is admissible: both bounds lie in [n, n + 1] and the
+    # result is n + 1/q with q in the reciprocal interval
+    inner_hi = 1/(lo - n) if lo > n else None
+    inner = simplest_between(1/(hi - n), inner_hi, hi_open, lo_open)
+    return n + 1/inner
+
+
+def _dyadic_bounds(r, k):
+    """Rational bounds of the real algebraic number ``r`` at the scale
+    `2^{-k}`, and whether they are attained.
+
+    For a rational number both bounds are the number itself and are
+    excluded; for an irrational one they are the dyadic numbers just below
+    and above it, and are included.
+    """
+    c, root = _split(r)
+    if root is None:
+        return c, c, True, True
+    scale = QQ(2)**k
+    lo = QQ(_floor_scaled(r, k))/scale
+    return lo, lo + 1/scale, False, False
+
+
+def rational_between(a, b):
+    """A simple rational number strictly between the real algebraic
+    numbers ``a < b``.
+
+    The result only depends on ``a`` and ``b``: it is the rational number
+    with the smallest denominator between the dyadic approximations of the
+    irrational endpoints, at the coarsest scale that separates them.
+
+    Examples
+    ========
+
+    >>> from sympy import CRootOf
+    >>> from sympy.abc import x
+    >>> from sympy.polys.cad.samplepoints import rational_between
+    >>> rational_between(CRootOf(x**2 - 2, 0), CRootOf(x**2 - 2, 1))
+    0
+    >>> rational_between(1, CRootOf(x**2 - 2, 1))
+    5/4
+    >>> rational_between(-1, 1)
+    0
+    """
+    if compare_real(a, b) >= 0:
+        raise ValueError("%s is not smaller than %s" % (a, b))
+    for k in count(0):
+        _, hi, _, hi_open = _dyadic_bounds(a, k)
+        lo, _, lo_open, _ = _dyadic_bounds(b, k)
+        if hi < lo or (hi == lo and not (hi_open or lo_open)):
+            return Rational(simplest_between(hi, lo, hi_open, lo_open))
+
+
+def rational_below(a):
+    """A simple rational number smaller than the real algebraic number ``a``.
+
+    >>> from sympy import CRootOf
+    >>> from sympy.abc import x
+    >>> from sympy.polys.cad.samplepoints import rational_below
+    >>> rational_below(CRootOf(x**2 - 2, 1))
+    0
+    >>> rational_below(-3)
+    -4
+    """
+    if compare_real(a, Rational(0)) > 0:
+        return Rational(0)
+    fl = _floor_scaled(a, 0)
+    if fl == a:
+        fl -= 1
+    return Rational(fl)
+
+
+def rational_above(a):
+    """A simple rational number greater than the real algebraic number ``a``.
+
+    >>> from sympy import CRootOf
+    >>> from sympy.abc import x
+    >>> from sympy.polys.cad.samplepoints import rational_above
+    >>> rational_above(CRootOf(x**2 - 2, 1))
+    2
+    """
+    if compare_real(a, Rational(0)) < 0:
+        return Rational(0)
+    return Rational(_floor_scaled(a, 0) + 1)
+
+
+def _sign_in_field(theta, a):
+    """Sign of the element ``a`` of `\\mathbb{Q}(\\theta)`, with
+    ``theta`` a real :class:`~.ComplexRootOf`."""
+    if not a:
+        return 0
+    coeffs = a.to_list()
+    while True:
+        lo, hi = _bounds(theta)
+        vlo = vhi = QQ.zero
+        for c in coeffs:
+            products = [vlo*lo, vlo*hi, vhi*lo, vhi*hi]
+            vlo, vhi = min(products) + c, max(products) + c
+        if vlo > 0:
+            return 1
+        if vhi < 0:
+            return -1
+        _refine(theta)
+
+
+def _horner(coeffs, a, K):
+    """Evaluate the polynomial with rational ``coeffs`` at the element
+    ``a`` of the field ``K``."""
+    result = K.zero
+    for c in coeffs:
+        result = result*a + K.convert(c, QQ)
+    return result
+
+
+def _join(theta, beta):
+    """Primitive element of `\\mathbb{Q}(\\theta, \\beta)`.
+
+    Returns ``(gamma, K, theta_K, beta_K)`` where ``gamma`` is a real
+    :class:`~.ComplexRootOf` generating the field, ``K`` is the algebraic
+    field ``QQ<gamma>`` and ``theta_K``, ``beta_K`` are ``theta`` and
+    ``beta`` as elements of ``K``.
+    """
+    z, t = Dummy('z'), Dummy('t')
+    m1, m2 = _minpoly(theta), _minpoly(beta)
+    for k in count(1):
+        # the roots of N are the sums of a conjugate of theta and k times a
+        # conjugate of beta: if they are all distinct then gamma is
+        # primitive
+        m1z = Poly(m1.as_expr().subs(m1.gen, z - k*t), t, z)
+        m2t = Poly(m2.as_expr().subs(m2.gen, t), t, z)
+        N = m2t.resultant(m1z)
+        if N.is_sqf:
+            break
+    candidates = []
+    for factor, _ in N.factor_list()[1]:
+        candidates.extend(factor.real_roots(radicals=False))
+    while True:
+        tlo, thi = _bounds(theta)
+        blo, bhi = _bounds(beta)
+        lo, hi = tlo + k*blo, thi + k*bhi
+        alive = []
+        for r in candidates:
+            rlo, rhi = _bounds(r)
+            if not (rhi < lo or hi < rlo):
+                alive.append(r)
+        if len(alive) == 1:
+            break
+        # the candidates come from different factors, so their isolating
+        # intervals may overlap: refine them as well
+        _refine(theta)
+        _refine(beta)
+        for r in alive:
+            _refine(r)
+    gamma = alive[0]
+    if _split(gamma)[1] is None:
+        raise PolynomialError("unexpected rational primitive element")
+    K = QQ.algebraic_field(gamma)
+    # beta is the only common root of m2(t) and m1(gamma - k*t)
+    u = Poly.from_list([K.convert(-k), K.unit], t, domain=K)
+    f = Poly(0, t, domain=K)
+    for c in m1.all_coeffs():
+        f = f*u + c
+    g = Poly(m2.as_expr().subs(m2.gen, t), t, domain=K).gcd(f)
+    if g.degree() != 1:
+        raise PolynomialError("failed to compute a primitive element")
+    g1, g0 = g.rep.to_list()
+    beta_K = -g0/g1
+    theta_K = K.unit - k*beta_K
+    return gamma, K, theta_K, beta_K
+
+
+class SamplePoint:
+    """A point with real algebraic coordinates.
+
+    The coordinates are elements of the field ``QQ<theta>`` (or ``QQ``) where
+    ``theta`` is a real :class:`~.ComplexRootOf`. Points are built by
+    extending the origin one coordinate at a time with :meth:`extend`.
+
+    Examples
+    ========
+
+    >>> from sympy import CRootOf, Rational
+    >>> from sympy.abc import x, y
+    >>> from sympy.polys.cad.samplepoints import SamplePoint
+    >>> q = SamplePoint().extend(CRootOf(x**2 - 2, 1))
+    >>> q.real_roots(x**2 + y**2 - 1, [x, y])
+    []
+    >>> q.real_roots(x**2 - y**2 - 1, [x, y])
+    [-1, 1]
+    >>> p = q.extend(Rational(1, 2))
+    >>> p
+    SamplePoint(CRootOf(x**2 - 2, 1), 1/2)
+    >>> p.sign(x**2 + y**2 - 2, [x, y])
+    1
+    >>> p.sign(2*y - 1, [x, y])
+    0
+    """
+
+    __slots__ = ('field', 'theta', 'coords')
+
+    def __init__(self, field=QQ, theta=None, coords=()):
+        self.field = field
+        self.theta = theta
+        self.coords = tuple(coords)
+
+    def __len__(self):
+        return len(self.coords)
+
+    def __repr__(self):
+        return "SamplePoint(%s)" % ", ".join(str(c) for c in self.as_exprs())
+
+    def as_exprs(self):
+        """The coordinates as SymPy expressions."""
+        return tuple(self.field.to_sympy(c) for c in self.coords)
+
+    @property
+    def degree(self):
+        """Degree of the field of the coordinates over the rationals."""
+        if self.theta is None:
+            return 1
+        return _minpoly(self.theta).degree()
+
+    def extend(self, root):
+        """The point with the coordinate ``root`` appended.
+
+        ``root`` is a :class:`~.Rational`, a real :class:`~.ComplexRootOf`
+        or a product of the two.
+        """
+        if _split(root)[1] is not None:
+            if root == self.theta:
+                return SamplePoint(self.field, self.theta,
+                                   self.coords + (self.field.unit,))
+            if self.theta is None:
+                K = QQ.algebraic_field(root)
+                coords = [K.convert(c, QQ) for c in self.coords]
+                return SamplePoint(K, root, coords + [K.unit])
+            gamma, K, theta_K, beta_K = _join(self.theta, root)
+            coords = [_horner(c.to_list(), theta_K, K) for c in self.coords]
+            return SamplePoint(K, gamma, coords + [beta_K])
+        value = self.field.convert(QQ.from_sympy(Rational(root)), QQ)
+        return SamplePoint(self.field, self.theta, self.coords + (value,))
+
+    def _evaluate(self, poly, gens):
+        """``poly`` in the generators ``gens`` with the leading ones
+        replaced by the coordinates: a polynomial in the remaining generators
+        over the field, or an element of the field if none remains."""
+        gens = tuple(gens)
+        n = len(self.coords)
+        if len(gens) < n:
+            raise ValueError("the point has more coordinates than generators")
+        if not gens:
+            return QQ.convert(poly.as_expr() if isinstance(poly, Poly) else poly)
+        if not isinstance(poly, Poly) or poly.gens != gens:
+            poly = Poly(poly, *gens)
+        f = poly.set_domain(self.field)
+        for gen, value in zip(gens[:n - 1], self.coords):
+            f = f.eval(gen, value)
+        if n:
+            last = self.coords[n - 1]
+            if len(gens) == n:
+                return dup_eval(f.rep.to_list(), last, self.field)
+            f = f.eval(gens[n - 1], last)
+        return f
+
+    def sign(self, poly, gens):
+        """Exact sign of the polynomial ``poly`` in the generators ``gens``
+        at the point. There must be as many generators as coordinates."""
+        if len(gens) != len(self.coords):
+            raise ValueError("expected %d generators" % len(self.coords))
+        value = self._evaluate(poly, gens)
+        if self.theta is None:
+            return (value > 0) - (value < 0)
+        return _sign_in_field(self.theta, value)
+
+    def real_roots(self, poly, gens):
+        """Sorted distinct real roots of ``poly`` in the last generator of
+        ``gens``, after substituting the point for the other generators.
+
+        Returns ``None`` if the polynomial vanishes identically at the
+        point.
+        """
+        if len(gens) != len(self.coords) + 1:
+            raise ValueError("expected %d generators" % (len(self.coords) + 1))
+        f = self._evaluate(poly, gens)
+        if f.is_zero:
+            return None
+        if f.degree() <= 0:
+            return []
+        roots = [r for r, _ in f.real_roots(multiple=False, radicals=False)]
+        return sorted(roots, key=_SortKey)
+
+
+class _SortKey:
+    __slots__ = ('root',)
+
+    def __init__(self, root):
+        self.root = root
+
+    def __lt__(self, other):
+        return compare_real(self.root, other.root) < 0

--- a/sympy/polys/cad/tests/test_lifting.py
+++ b/sympy/polys/cad/tests/test_lifting.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from sympy.core.numbers import Rational
+from sympy.polys.polytools import Poly
+from sympy.polys.rootoftools import CRootOf
+from sympy.polys.cad.lifting import (cylindrical_algebraic_decomposition, CAD,
+    CADCell, NotWellOriented, _merge_roots)
+from sympy.polys.cad.samplepoints import SamplePoint, compare_real
+from sympy.testing.pytest import raises
+from sympy.abc import x, y, z, w
+
+
+def _check_signs(cad):
+    """The signs of the input polynomials on each cell, which are derived
+    from the signs of the projection factors, must agree with a direct
+    exact evaluation at the sample point."""
+    for cell in cad:
+        direct = tuple(cell.sample.sign(f, cad.gens) for f in cad.polys)
+        assert direct == cell.signs, (cell, direct)
+        assert cell.sample.as_exprs() != () or cell.point == ()
+        for value, coord in zip(cell.point, cell.sample.as_exprs()):
+            assert abs(value.evalf(30) - coord.evalf(30)) < 1e-25
+
+
+def _check_structure(cad):
+    """Indices are lexicographic, parents are consistent and the sample
+    points of the children lie over the parent's sample point."""
+    n = len(cad.gens)
+    for k in range(1, n + 1):
+        cells = cad.cells_at(k)
+        assert [c.index for c in cells] == sorted(c.index for c in cells)
+        assert all(c.level == k for c in cells)
+        if k > 1:
+            parents = cad.cells_at(k - 1)
+            for c in cells:
+                assert c.parent in parents
+                assert c.index[:-1] == c.parent.index
+                assert c.point[:-1] == c.parent.point
+            for p in parents:
+                children = cad.children(p)
+                assert children and [c.index[-1] for c in children] == list(range(1, len(children) + 1))
+                # sections alternate with sectors
+                assert len(children) % 2 == 1
+                for c in children:
+                    assert c.is_section == (c.index[-1] % 2 == 0)
+                # sections are ordered
+                sections = [c.point[-1] for c in children if c.is_section]
+                for a, b in zip(sections, sections[1:]):
+                    assert compare_real(a, b) < 0
+        for c in cells:
+            assert c.dimension == sum(i % 2 for i in c.index)
+    assert cad.cells is cad.cells_at(n)
+
+
+def test_merge_roots():
+    r = CRootOf(x**2 - 2, 1)
+    assert _merge_roots([], []) == []
+    assert _merge_roots([1], []) == [1]
+    assert _merge_roots([Rational(-1), r], [Rational(1), r, 2]) == [-1, 1, r, 2]
+    assert _merge_roots([0, 3], [1, 2]) == [0, 1, 2, 3]
+
+
+def test_univariate():
+    cad = cylindrical_algebraic_decomposition([x**2 - 2, x - 1], [x])
+    assert len(cad) == 7
+    assert cad.gens == (x,)
+    r0, r1 = CRootOf(x**2 - 2, 0), CRootOf(x**2 - 2, 1)
+    assert [c.point for c in cad] == [(-2,), (r0,), (0,), (1,), (Rational(5, 4),), (r1,), (2,)]
+    assert [c.signs for c in cad] == [(1, -1), (0, -1), (-1, -1), (-1, 0),
+                                       (-1, 1), (0, 1), (1, 1)]
+    assert [c.index for c in cad] == [(1,), (2,), (3,), (4,), (5,), (6,), (7,)]
+    assert [c.dimension for c in cad] == [1, 0, 1, 0, 1, 0, 1]
+    assert cad.projection == [[Poly(x**2 - 2, x), Poly(x - 1, x)]]
+    assert cad.method == 'mccallum'
+    _check_signs(cad)
+    _check_structure(cad)
+
+    cad = cylindrical_algebraic_decomposition([x**2 + 1], [x])
+    assert len(cad) == 1 and cad.cells[0].point == (0,) and cad.cells[0].signs == (1,)
+    cad = cylindrical_algebraic_decomposition([], [x])
+    assert len(cad) == 1 and cad.cells[0].point == (0,) and cad.cells[0].signs == ()
+    cad = cylindrical_algebraic_decomposition([3, -x**2], [x])
+    assert [c.signs for c in cad] == [(1, -1), (1, 0), (1, -1)]
+    cad = cylindrical_algebraic_decomposition([0], [x])
+    assert [c.signs for c in cad] == [(0,)]
+    cad = cylindrical_algebraic_decomposition([(x - 1)**2*(x + 1)], [x])
+    assert [c.point for c in cad] == [(-2,), (-1,), (0,), (1,), (2,)]
+    assert [c.signs for c in cad] == [(-1,), (0,), (1,), (0,), (1,)]
+    cad = cylindrical_algebraic_decomposition([x/2 - Rational(1, 3)], [x])
+    assert [c.point for c in cad] == [(0,), (Rational(2, 3),), (1,)]
+    assert [c.signs for c in cad] == [(-1,), (0,), (1,)]
+
+
+def test_circle():
+    cad = cylindrical_algebraic_decomposition([x**2 + y**2 - 1], [x, y])
+    assert repr(cad) == "CAD(13 cells, x, y)"
+    assert len(cad) == 13
+    assert [c.index for c in cad] == [
+        (1, 1), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2), (3, 3), (3, 4), (3, 5),
+        (4, 1), (4, 2), (4, 3), (5, 1)]
+    assert [c.point for c in cad] == [
+        (-2, 0), (-1, -1), (-1, 0), (-1, 1), (0, -2), (0, -1), (0, 0), (0, 1),
+        (0, 2), (1, -1), (1, 0), (1, 1), (2, 0)]
+    assert [c.signs[0] for c in cad] == [1, 1, 0, 1, 1, 0, -1, 0, 1, 1, 0, 1, 1]
+    assert [c.dimension for c in cad] == [2, 1, 0, 1, 2, 1, 2, 1, 2, 1, 0, 1, 2]
+    assert len(cad.cells_at(1)) == 5
+    assert [c.point for c in cad.cells_at(1)] == [(-2,), (-1,), (0,), (1,), (2,)]
+    assert cad.children(cad.cells_at(1)[2]) == cad.cells[4:9]
+    assert cad.children(cad.cells[0]) == []
+    raises(ValueError, lambda: cad.cells_at(0))
+    raises(ValueError, lambda: cad.cells_at(3))
+    assert repr(cad.cells[6]) == "CADCell((3, 3), (0, 0))"
+    assert isinstance(cad.cells[6].sample, SamplePoint)
+    assert isinstance(cad.cells[6], CADCell)
+    assert isinstance(cad, CAD)
+    assert list(cad) == cad.cells
+    _check_signs(cad)
+    _check_structure(cad)
+
+
+def test_circle_and_line():
+    circle, line = x**2 + y**2 - 1, x - y
+    cad = cylindrical_algebraic_decomposition([circle, line], [x, y])
+    assert len(cad) == 47
+    assert [len(cad.children(c)) for c in cad.cells_at(1)] == [3, 5, 7, 5, 7, 5, 7, 5, 3]
+    assert {c.signs for c in cad} == {
+        (1, -1), (1, 1), (1, 0), (0, -1), (0, 1), (0, 0), (-1, -1), (-1, 1), (-1, 0)}
+    # the two intersection points
+    both = [c for c in cad if c.signs == (0, 0)]
+    r0, r1 = CRootOf(2*x**2 - 1, 0), CRootOf(2*x**2 - 1, 1)
+    assert [c.point for c in both] == [(r0, r0), (r1, r1)]
+    assert [c.dimension for c in both] == [0, 0]
+    # the open regions
+    regions = [c for c in cad if c.dimension == 2]
+    assert len(regions) == 16
+    assert {c.signs for c in regions} == {(1, -1), (1, 1), (-1, -1), (-1, 1)}
+    _check_signs(cad)
+    _check_structure(cad)
+    # the order of the polynomials does not change the cells
+    cad2 = cylindrical_algebraic_decomposition([line, circle], [x, y])
+    assert [c.point for c in cad2] == [c.point for c in cad]
+    assert [c.signs for c in cad2] == [c.signs[::-1] for c in cad]
+    # the other variable order gives the symmetric decomposition
+    cad3 = cylindrical_algebraic_decomposition([circle, line], [y, x])
+    assert [c.point for c in cad3] == [c.point for c in cad]
+    assert [c.signs for c in cad3] == [(s, -t) for s, t in [c.signs for c in cad]]
+
+
+def test_parabola_and_circle():
+    cad = cylindrical_algebraic_decomposition([y - x**2, x**2 + y**2 - 1], [x, y])
+    assert len(cad) == 47
+    assert [c.point[0] for c in cad.cells_at(1)] == [
+        -2, -1, Rational(-7, 8), CRootOf(x**4 + x**2 - 1, 0), 0,
+        CRootOf(x**4 + x**2 - 1, 1), Rational(7, 8), 1, 2]
+    both = [c for c in cad if c.signs == (0, 0)]
+    assert [c.index for c in both] == [(4, 4), (6, 4)]
+    assert [c.point[1] for c in both] == [CRootOf(x**2 + x - 1, 1)]*2
+    # the sample point of the intersection lies in a field of degree 4
+    assert both[0].sample.degree == 4
+    assert both[0].sample.sign(y - x**2, [x, y]) == 0
+    _check_signs(cad)
+    _check_structure(cad)
+
+
+def test_polynomials_in_fewer_variables():
+    cad = cylindrical_algebraic_decomposition([x - 1], [x, y])
+    assert [c.point for c in cad] == [(0, 0), (1, 0), (2, 0)]
+    assert [c.signs for c in cad] == [(-1,), (0,), (1,)]
+    cad = cylindrical_algebraic_decomposition([y - 1], [x, y])
+    assert [c.point for c in cad] == [(0, 0), (0, 1), (0, 2)]
+    assert [c.signs for c in cad] == [(-1,), (0,), (1,)]
+    cad = cylindrical_algebraic_decomposition([x*y], [x, y])
+    assert [c.point for c in cad] == [(a, b) for a in (-1, 0, 1) for b in (-1, 0, 1)]
+    assert [c.signs for c in cad] == [(a*b,) for a in (-1, 0, 1) for b in (-1, 0, 1)]
+    cad = cylindrical_algebraic_decomposition([x*y - 1], [x, y])
+    assert [c.point for c in cad] == [
+        (-1, -2), (-1, -1), (-1, 0), (0, 0), (1, 0), (1, 1), (1, 2)]
+    assert [c.signs for c in cad] == [(1,), (0,), (-1,), (-1,), (-1,), (0,), (1,)]
+    _check_signs(cad)
+    _check_structure(cad)
+    cad = cylindrical_algebraic_decomposition([], [x, y, z])
+    assert [c.point for c in cad] == [(0, 0, 0)]
+    assert cad.cells[0].index == (1, 1, 1)
+
+
+def test_three_variables():
+    sphere, saddle = x**2 + y**2 + z**2 - 1, z - x*y
+    cad = cylindrical_algebraic_decomposition([sphere, saddle], [x, y, z])
+    assert len(cad) == 137
+    assert cad.method == 'mccallum'
+    assert {c.signs for c in cad} == {(s, t) for s in (-1, 0, 1) for t in (-1, 0, 1)}
+    _check_signs(cad)
+    _check_structure(cad)
+    # Whitney umbrella
+    cad = cylindrical_algebraic_decomposition([x**2 - y**2*z], [x, y, z])
+    assert len(cad) == 21
+    _check_signs(cad)
+    _check_structure(cad)
+
+
+def test_not_well_oriented():
+    # x*w + y vanishes identically on the line x = y = 0 in (x, y, z)
+    raises(NotWellOriented, lambda: cylindrical_algebraic_decomposition(
+        [x*w + y], [x, y, z, w], method='mccallum'))
+    cad = cylindrical_algebraic_decomposition([x*w + y], [x, y, z, w])
+    assert cad.method == 'hong'
+    assert len(cad) == 21
+    assert {c.signs for c in cad} == {(-1,), (0,), (1,)}
+    zero = [c for c in cad if c.signs == (0,)]
+    assert [c.point for c in zero] == [
+        (-1, -1, 0, -1), (-1, 0, 0, 0), (-1, 1, 0, 1), (0, 0, 0, 0),
+        (1, -1, 0, 1), (1, 0, 0, 0), (1, 1, 0, -1)]
+    assert [c.dimension for c in zero] == [3, 2, 3, 2, 3, 2, 3]
+    _check_signs(cad)
+    _check_structure(cad)
+    cad2 = cylindrical_algebraic_decomposition([x*w + y], [x, y, z, w], method='hong')
+    assert [c.point for c in cad2] == [c.point for c in cad]
+    # the same polynomial in three variables is well-oriented
+    cad = cylindrical_algebraic_decomposition([x*z + y], [x, y, z], method='mccallum')
+    assert cad.method == 'mccallum' and len(cad) == 21
+    _check_signs(cad)
+
+
+def test_hong_method():
+    circle, line = x**2 + y**2 - 1, x - y
+    cad = cylindrical_algebraic_decomposition([circle, line], [x, y], method='hong')
+    assert cad.method == 'hong'
+    # Hong's projection adds the factor x, so there are more cells
+    assert len(cad) == 61
+    assert {c.signs for c in cad if c.dimension == 2} == {
+        (1, -1), (1, 1), (-1, -1), (-1, 1)}
+    _check_signs(cad)
+    _check_structure(cad)
+
+
+def test_errors():
+    raises(ValueError, lambda: cylindrical_algebraic_decomposition([x], []))
+    raises(ValueError, lambda: cylindrical_algebraic_decomposition([x], [x], method='collins'))
+    raises(Exception, lambda: cylindrical_algebraic_decomposition([x + z], [x, y]))
+    raises(Exception, lambda: cylindrical_algebraic_decomposition([x**Rational(1, 2)], [x]))

--- a/sympy/polys/cad/tests/test_projection.py
+++ b/sympy/polys/cad/tests/test_projection.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+from sympy.core.numbers import Rational
+from sympy.polys.polytools import Poly
+from sympy.polys.polyerrors import PolynomialError
+from sympy.polys.cad.projection import (squarefree_basis, mccallum_projection,
+    hong_projection, projection_sets, _reducta, _psc, _coefficients)
+from sympy.testing.pytest import raises
+from sympy.abc import x, y, z, w
+
+
+def _exprs(polys):
+    return {p.as_expr() for p in polys}
+
+
+def test_squarefree_basis():
+    assert squarefree_basis([], [x, y]) == [[], []]
+    assert squarefree_basis([3, -7], [x, y]) == [[], []]
+    assert squarefree_basis([(x**2 - 1)*(x + y)**2, 6], [x, y]) == [
+        [Poly(x - 1, x, y), Poly(x + 1, x, y)], [Poly(x + y, x, y)]]
+    # sign normalization and deduplication
+    assert squarefree_basis([-x + 1, 2*x - 2, x - 1], [x]) == [[Poly(x - 1, x)]]
+    # rational coefficients are cleared
+    assert squarefree_basis([x**2/4 + y**2/9 - 1], [x, y]) == [
+        [], [Poly(9*x**2 + 4*y**2 - 36, x, y)]]
+    # levels are determined by the last generator present
+    assert squarefree_basis([y**2 - 2, x*z - 1, w], [x, y, z, w]) == [
+        [], [Poly(y**2 - 2, x, y, z, w)], [Poly(x*z - 1, x, y, z, w)],
+        [Poly(w, x, y, z, w)]]
+    assert squarefree_basis([Poly(x**2 - y, x, y)], [x, y]) == [
+        [], [Poly(x**2 - y, x, y)]]
+    raises(PolynomialError, lambda: squarefree_basis([x + z], [x, y]))
+
+
+def test_coefficients_and_reducta():
+    f = Poly(x*y**2 + (x - 1)*y + 3, y, x)
+    assert _coefficients(f) == [Poly(x, x), Poly(x - 1, x), Poly(3, x)]
+    assert _reducta(f) == [f, Poly((x - 1)*y + 3, y, x), Poly(3, y, x)]
+    g = Poly(x*y**2 + 3, y, x)
+    assert _reducta(g) == [g, Poly(3, y, x)]
+    h = Poly(x**3 - 2*x, x)
+    assert _coefficients(h) == [1, 0, -2, 0]
+    assert _reducta(h) == [h, Poly(-2*x, x)]
+
+
+def test_psc():
+    f = Poly(x**2 + y**2 - 1, y, x)
+    assert _psc(f, f.diff(y)) == [Poly(4*x**2 - 4, x), Poly(2, x)]
+    g = Poly(y - x, y, x)
+    assert _psc(f, g) == [Poly(2*x**2 - 1, x), Poly(1, x)]
+    u = Poly(x**2 + 1, x)
+    assert _psc(u, Poly(x**2 - 1, x)) == [4, 0, 1]
+
+
+def test_mccallum_projection():
+    circle = Poly(x**2 + y**2 - 1, x, y)
+    assert mccallum_projection([circle], y) == [Poly(x - 1, x), Poly(x + 1, x)]
+    assert mccallum_projection([circle], x) == [Poly(y - 1, y), Poly(y + 1, y)]
+    line = Poly(x - y, x, y)
+    assert _exprs(mccallum_projection([circle, line], y)) == {x - 1, x + 1, 2*x**2 - 1}
+    assert mccallum_projection([line], y) == []
+    # coefficients are taken down to the first nonzero constant one
+    f = Poly((x**2 - 1)*y**2 + x*y + 5, x, y)
+    assert _exprs(mccallum_projection([f], y)) == {x - 1, x + 1, x, 19*x**2 - 20}
+    g = Poly(x*y**3 + (x - 2)*y + x**2, x, y)
+    proj = _exprs(mccallum_projection([g], y))
+    assert x in proj and x - 2 in proj
+    assert g.reorder(y, x).discriminant().as_expr() in proj or any(
+        p != x and p != x - 2 for p in proj)
+    # a vanishing coefficient does not stop the search
+    h = Poly(x*y**2 + 3, x, y)
+    assert _exprs(mccallum_projection([h], y)) == {x}
+    # three variables
+    sphere = Poly(x**2 + y**2 + z**2 - 1, x, y, z)
+    saddle = Poly(z - x*y, x, y, z)
+    assert _exprs(mccallum_projection([sphere, saddle], z)) == {
+        x**2 + y**2 - 1, x**2*y**2 + x**2 + y**2 - 1}
+
+
+def test_hong_projection():
+    circle = Poly(x**2 + y**2 - 1, x, y)
+    assert hong_projection([circle], y) == [Poly(x - 1, x), Poly(x + 1, x)]
+    # the constant term of a linear polynomial is a reductum, so it is added
+    line = Poly(x - y, x, y)
+    assert _exprs(hong_projection([circle, line], y)) == {x - 1, x + 1, x, 2*x**2 - 1}
+    # Hong's projection contains McCallum's
+    sphere = Poly(x**2 + y**2 + z**2 - 1, x, y, z)
+    saddle = Poly(z - x*y, x, y, z)
+    cubic = Poly(x*z**3 + y*z + 1, x, y, z)
+    for polys in [[sphere, saddle], [sphere, cubic], [saddle, cubic],
+                  [sphere, saddle, cubic]]:
+        assert _exprs(mccallum_projection(polys, z)) <= _exprs(hong_projection(polys, z))
+    assert _exprs(hong_projection([cubic], z)) == {x, y, 27*x + 4*y**3}
+    assert _exprs(mccallum_projection([cubic], z)) == {x, y, 27*x + 4*y**3}
+    f = Poly((x**2 - 1)*y**2 + x*y + 5, x, y)
+    assert _exprs(hong_projection([f], y)) == {x - 1, x + 1, x, 19*x**2 - 20}
+
+
+def test_projection_sets():
+    circle, line = x**2 + y**2 - 1, x - y
+    P1, P2 = projection_sets([circle, line], [x, y])
+    assert _exprs(P1) == {x - 1, x + 1, 2*x**2 - 1}
+    assert P1[0].gens == (x,)
+    assert _exprs(P2) == {circle, line}
+    assert P2[0].gens == (x, y)
+    H1, H2 = projection_sets([circle, line], [x, y], method='hong')
+    assert _exprs(H1) == {x - 1, x + 1, x, 2*x**2 - 1} and H2 == P2
+    raises(ValueError, lambda: projection_sets([circle], [x, y], method='collins'))
+    raises(ValueError, lambda: projection_sets([circle], []))
+
+    assert projection_sets([3], [x, y]) == [[], []]
+    assert projection_sets([x**2 - 2, y], [x, y]) == [
+        [Poly(x**2 - 2, x)], [Poly(y, x, y)]]
+    # polynomials in fewer variables are placed at their own level
+    assert projection_sets([x*y*z + 1], [x, y, z]) == [
+        [Poly(x, x)], [Poly(y, x, y)], [Poly(x*y*z + 1, x, y, z)]]
+    P1, P2, P3, P4 = projection_sets([x*w + y], [x, y, z, w])
+    assert (P1, P2, P3) == ([Poly(x, x)], [Poly(y, x, y)], [])
+    assert P4 == [Poly(x*w + y, x, y, z, w)]
+
+    sphere, saddle = x**2 + y**2 + z**2 - 1, z - x*y
+    P1, P2, P3 = projection_sets([sphere, saddle], [x, y, z])
+    assert _exprs(P3) == {sphere, x*y - z}
+    assert _exprs(P2) == {x**2 + y**2 - 1, x**2*y**2 + x**2 + y**2 - 1}
+    assert _exprs(P1) == {x - 1, x + 1, x**2 + 1, x}
+    H1, H2, H3 = projection_sets([sphere, saddle], [x, y, z], method='hong')
+    assert _exprs(P1) <= _exprs(H1) and _exprs(P2) <= _exprs(H2) and H3 == P3
+    assert len(H1) == len(set(H1)) and len(H2) == len(set(H2))
+
+    # rational coefficients
+    assert projection_sets([x**2/4 + y**2/9 - 1], [x, y]) == [
+        [Poly(x - 2, x), Poly(x + 2, x)], [Poly(9*x**2 + 4*y**2 - 36, x, y)]]
+    assert projection_sets([Rational(1, 2)*x - y], [x, y]) == [
+        [], [Poly(x - 2*y, x, y)]]

--- a/sympy/polys/cad/tests/test_samplepoints.py
+++ b/sympy/polys/cad/tests/test_samplepoints.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from sympy.core.numbers import Rational
+from sympy.functions.elementary.integers import floor
+from sympy.functions.elementary.miscellaneous import sqrt
+from sympy.polys.domains import QQ
+from sympy.polys.polytools import Poly
+from sympy.polys.rootoftools import CRootOf
+from sympy.polys.cad.samplepoints import (SamplePoint, compare_real,
+    simplest_between, rational_between, rational_below, rational_above,
+    _floor_scaled, _join, _sign_in_field, _minpoly)
+from sympy.testing.pytest import raises
+from sympy.abc import x, y, z, w
+
+
+def _roots(f):
+    return Poly(f, x).real_roots(radicals=False)
+
+
+def test_simplest_between():
+    assert simplest_between(QQ(1, 3), QQ(1, 2)) == QQ(2, 5)
+    assert simplest_between(QQ(5, 2), QQ(3)) == QQ(8, 3)
+    assert simplest_between(QQ(-1), QQ(1)) == 0
+    assert simplest_between(QQ(2), QQ(5)) == 3
+    assert simplest_between(QQ(0), QQ(1)) == QQ(1, 2)
+    assert simplest_between(QQ(1), QQ(2)) == QQ(3, 2)
+    assert simplest_between(QQ(-3, 2), QQ(-1)) == QQ(-4, 3)
+    assert simplest_between(QQ(7, 3), None) == 3
+    assert simplest_between(QQ(-7, 3), None) == 0
+    assert simplest_between(QQ(3), None) == 4
+    assert simplest_between(QQ(99, 100), QQ(101, 100)) == 1
+    assert simplest_between(QQ(1, 3), QQ(1, 2), hi_open=False) == QQ(1, 2)
+    assert simplest_between(QQ(1, 3), QQ(1, 2), lo_open=False) == QQ(1, 3)
+    assert simplest_between(QQ(0), QQ(1), lo_open=False) == 0
+    assert simplest_between(QQ(-2), QQ(-1), hi_open=False) == -1
+    assert simplest_between(QQ(-2), QQ(-1), lo_open=False) == -2
+    assert simplest_between(QQ(3), None, lo_open=False) == 3
+    assert simplest_between(QQ(1, 2), QQ(1, 2), False, False) == QQ(1, 2)
+    assert simplest_between(QQ(7, 5), QQ(3, 2), hi_open=False) == QQ(3, 2)
+    raises(ValueError, lambda: simplest_between(QQ(1), QQ(1), lo_open=False))
+    assert simplest_between(QQ(100, 101), QQ(101, 102)) == QQ(2011, 2030) or \
+        simplest_between(QQ(100, 101), QQ(101, 102)).denominator <= 2030
+    raises(ValueError, lambda: simplest_between(QQ(1), QQ(1)))
+    raises(ValueError, lambda: simplest_between(QQ(2), QQ(1)))
+
+    # the result has the smallest denominator among all rationals in the
+    # interval, checked by brute force
+    for lo, hi in [(QQ(1, 3), QQ(1, 2)), (QQ(5, 2), QQ(3)), (QQ(-3, 2), QQ(-1)),
+                   (QQ(7, 10), QQ(8, 10)), (QQ(-5, 7), QQ(-2, 3))]:
+        q = simplest_between(lo, hi)
+        assert lo < q < hi
+        for d in range(1, q.denominator):
+            for n in range(int(lo*d) - 1, int(hi*d) + 2):
+                assert not (lo < QQ(n, d) < hi)
+
+
+def test_compare_real():
+    s2, ms2 = CRootOf(x**2 - 2, 1), CRootOf(x**2 - 2, 0)
+    c2 = CRootOf(x**3 - 2, 0)
+    assert compare_real(s2, Rational(3, 2)) == -1
+    assert compare_real(Rational(3, 2), s2) == 1
+    assert compare_real(s2, c2) == 1
+    assert compare_real(c2, s2) == -1
+    assert compare_real(s2, s2) == 0
+    assert compare_real(ms2, s2) == -1
+    assert compare_real(Rational(1), Rational(2)) == -1
+    assert compare_real(Rational(2), Rational(2)) == 0
+    assert compare_real(Rational(1), s2) == -1
+    assert compare_real(Rational(2), s2) == 1
+    # close roots of different polynomials
+    a = CRootOf(x**2 - 2, 1)
+    b = CRootOf(x**4 - 4, 1)  # this is sqrt(2) too but CRootOf canonicalizes
+    assert a == b
+    c = CRootOf(1000000*x**2 - 2000001, 1)
+    assert compare_real(a, c) == -1
+    assert compare_real(c, a) == 1
+    # roots with a rational factor
+    r0, r1 = Poly(2*x**2 - 9, x).real_roots(radicals=False)
+    assert r1 == 3*CRootOf(2*x**2 - 1, 1)
+    assert compare_real(r0, r1) == -1
+    assert compare_real(r1, 2) == 1
+    assert compare_real(r1, Rational(3, 2)) == 1
+    assert compare_real(r1, CRootOf(x**2 - 5, 1)) == -1
+    assert compare_real(r0, -2) == -1
+    assert _minpoly(r0).all_coeffs() == _minpoly(r1).all_coeffs() == [2, 0, -9]
+    assert _minpoly(r0).gens == r0.args[1].poly.gens
+    assert _minpoly(CRootOf(x**3 - 2, 0)).all_coeffs() == [1, 0, 0, -2]
+    assert rational_between(r0, r1) == 0
+    assert rational_between(2, r1) == Rational(33, 16)
+    assert rational_below(r0) == -3
+    assert rational_above(r1) == 3
+
+
+def test_floor_scaled():
+    s2 = CRootOf(x**2 - 2, 1)
+    for k in range(6):
+        assert _floor_scaled(s2, k) == floor(2**k*sqrt(2))
+    ms2 = CRootOf(x**2 - 2, 0)
+    for k in range(6):
+        assert _floor_scaled(ms2, k) == floor(-2**k*sqrt(2))
+    assert _floor_scaled(Rational(7, 2), 0) == 3
+    assert _floor_scaled(Rational(7, 2), 1) == 7
+    assert _floor_scaled(Rational(-7, 2), 0) == -4
+
+
+def test_rational_between():
+    s2, ms2 = CRootOf(x**2 - 2, 1), CRootOf(x**2 - 2, 0)
+    assert rational_between(ms2, s2) == 0
+    assert rational_between(1, s2) == Rational(5, 4)
+    assert rational_between(Rational(1, 3), Rational(1, 2)) == Rational(2, 5)
+    assert rational_between(-2, ms2) == Rational(-3, 2)
+    assert rational_between(ms2, -1) == Rational(-5, 4)
+    assert rational_between(-1, 1) == 0
+    assert rational_between(Rational(9, 10), s2) == 1
+    assert rational_between(ms2, 1) == 0
+    assert rational_between(Rational(-1, 2), Rational(1, 3)) == 0
+    assert rational_between(Rational(1, 3), Rational(1, 2)) == Rational(2, 5)
+    assert rational_between(3, 4) == Rational(7, 2)
+    raises(ValueError, lambda: rational_between(s2, 1))
+    raises(ValueError, lambda: rational_between(s2, s2))
+
+    # the result does not depend on the state of the isolating intervals
+    s2.evalf(60)
+    assert rational_between(1, s2) == Rational(5, 4)
+    assert rational_between(ms2, s2) == 0
+
+    roots = sorted(_roots((x**2 - 2)*(x**3 - 2)*(x**2 - 3)*(4*x**2 - 5)*(x - 1)),
+                   key=lambda r: r.evalf())
+    for a, b in zip(roots, roots[1:]):
+        q = rational_between(a, b)
+        assert q.is_Rational
+        assert compare_real(a, q) == -1 and compare_real(q, b) == -1
+        assert q.q <= 16
+
+
+def test_rational_below_above():
+    s2, ms2 = CRootOf(x**2 - 2, 1), CRootOf(x**2 - 2, 0)
+    assert rational_below(s2) == 0
+    assert rational_above(s2) == 2
+    assert rational_below(ms2) == -2
+    assert rational_above(ms2) == 0
+    assert rational_below(2) == 0
+    assert rational_above(2) == 3
+    assert rational_below(-3) == -4
+    assert rational_above(-3) == 0
+    assert rational_below(Rational(-7, 2)) == -4
+    assert rational_above(Rational(7, 2)) == 4
+    assert rational_below(Rational(1, 2)) == 0
+    assert rational_above(Rational(-1, 2)) == 0
+    assert rational_below(0) == -1
+    assert rational_above(0) == 1
+    r = CRootOf(x**3 - 100, 0)
+    assert rational_below(r) == 0
+    assert rational_above(r) == 5
+    r = CRootOf(x**3 + 100, 0)
+    assert rational_below(r) == -5
+    assert rational_above(r) == 0
+
+
+def test_sign_in_field():
+    s2 = CRootOf(x**2 - 2, 1)
+    K = QQ.algebraic_field(s2)
+    assert _sign_in_field(s2, K.zero) == 0
+    assert _sign_in_field(s2, K.unit) == 1
+    assert _sign_in_field(s2, -K.unit) == -1
+    # sqrt(2) - 1.4142 is positive although small
+    a = K.unit - K.convert(QQ(14142, 10000))
+    assert _sign_in_field(s2, a) == 1
+    a = K.unit - K.convert(QQ(141421356237, 10**11))
+    assert _sign_in_field(s2, a) == 1
+    a = K.unit - K.convert(QQ(141421356238, 10**11))
+    assert _sign_in_field(s2, a) == -1
+    # elements whose leading representation coefficient has the wrong sign
+    a = K.unit - K.convert(QQ(2))
+    assert _sign_in_field(s2, a) == -1
+    a = -K.unit + K.convert(QQ(2))
+    assert _sign_in_field(s2, a) == 1
+
+
+def test_join():
+    s2, ms2 = CRootOf(x**2 - 2, 1), CRootOf(x**2 - 2, 0)
+    s3 = CRootOf(x**2 - 3, 1)
+    g, K, tK, bK = _join(s2, s3)
+    assert g.poly.degree() == 4
+    assert abs(K.to_sympy(tK).evalf(20) - sqrt(2).evalf(20)) < 1e-15
+    assert abs(K.to_sympy(bK).evalf(20) - sqrt(3).evalf(20)) < 1e-15
+    assert abs(g.evalf(20) - sqrt(2).evalf(20) - sqrt(3).evalf(20)) < 1e-15
+    assert _sign_in_field(g, tK**2 - K.convert(QQ(2))) == 0
+    assert _sign_in_field(g, bK**2 - K.convert(QQ(3))) == 0
+    # conjugates and elements of the same field give no bigger field
+    g, K, tK, bK = _join(s2, ms2)
+    assert g.poly.degree() == 2
+    assert K.to_sympy(tK) == -ms2 and K.to_sympy(bK) == ms2
+    assert _sign_in_field(g, tK + bK) == 0
+    g, K, tK, bK = _join(s2, CRootOf(x**2 - 8, 1))
+    assert g.poly.degree() == 2
+    assert K.to_sympy(tK)*2 == K.to_sympy(bK)
+    c2 = CRootOf(x**3 - 2, 0)
+    g, K, tK, bK = _join(c2, s2)
+    assert g.poly.degree() == 6
+    assert abs(K.to_sympy(tK).evalf(20) - c2.evalf(20)) < 1e-15
+    assert abs(K.to_sympy(bK).evalf(20) - s2.evalf(20)) < 1e-15
+
+
+def test_sample_point():
+    origin = SamplePoint()
+    assert len(origin) == 0 and origin.degree == 1
+    assert origin.sign(3, []) == 1
+    assert origin.sign(Rational(-1, 2), []) == -1
+    assert origin.sign(0, []) == 0
+    assert origin.real_roots(x**3 - x, [x]) == [-1, 0, 1]
+    assert origin.real_roots(x**2 + 1, [x]) == []
+    assert origin.real_roots(Poly(x**2 - 2, x), [x]) == [
+        CRootOf(x**2 - 2, 0), CRootOf(x**2 - 2, 1)]
+    assert origin.real_roots(Poly(0, x), [x]) is None
+    assert origin.real_roots(7, [x]) == []
+    raises(ValueError, lambda: origin.sign(x, [x]))
+    raises(ValueError, lambda: origin.real_roots(x, [x, y]))
+
+    p = origin.extend(Rational(1, 2))
+    assert p.field == QQ and p.theta is None and len(p) == 1
+    assert p.as_exprs() == (Rational(1, 2),)
+    assert p.sign(2*x - 1, [x]) == 0
+    assert p.sign(x - 1, [x]) == -1
+    assert p.sign(Poly(x**2, x), [x]) == 1
+    assert p.real_roots(y**2 - x, [x, y]) == [-sqrt(2)/2, sqrt(2)/2] or \
+        p.real_roots(y**2 - x, [x, y]) == [CRootOf(2*x**2 - 1, 0), CRootOf(2*x**2 - 1, 1)]
+    assert p.real_roots(x*y - y, [x, y]) == [0]
+    assert p.real_roots((2*x - 1)*y, [x, y]) is None
+
+    s2 = CRootOf(x**2 - 2, 1)
+    q = origin.extend(s2)
+    assert q.degree == 2 and q.theta == s2
+    assert q.as_exprs() == (s2,)
+    assert repr(q) == "SamplePoint(CRootOf(x**2 - 2, 1))"
+    assert q.sign(x**2 - 2, [x]) == 0
+    assert q.sign(x - 1, [x]) == 1
+    assert q.sign(x - 2, [x]) == -1
+    assert q.real_roots(x**2 + y**2 - 1, [x, y]) == []
+    assert q.real_roots(x**2 - y**2 - 1, [x, y]) == [-1, 1]
+    assert q.real_roots(x**2 - 2, [x, y]) is None
+    assert q.real_roots(x**2 - 1, [x, y]) == []
+    r = q.real_roots(y**2 - x, [x, y])
+    assert r == [CRootOf(x**4 - 2, 0), CRootOf(x**4 - 2, 1)]
+
+    # the same algebraic number again does not extend the field
+    qq = q.extend(s2)
+    assert qq.degree == 2 and qq.as_exprs() == (s2, s2)
+    assert qq.sign(x - y, [x, y]) == 0
+    # a rational coordinate neither
+    p2 = q.extend(Rational(1, 2))
+    assert p2.degree == 2
+    assert repr(p2) == "SamplePoint(CRootOf(x**2 - 2, 1), 1/2)"
+    assert p2.sign(x**2 + y**2 - 2, [x, y]) == 1
+    assert p2.sign(2*y - 1, [x, y]) == 0
+    assert p2.sign(x*y - 1, [x, y]) == -1
+
+    # extension by a root over an algebraic point
+    q2 = q.extend(r[1])
+    assert q2.degree == 4
+    e1, e2 = q2.as_exprs()
+    assert abs(e1.evalf(20) - sqrt(2).evalf(20)) < 1e-15
+    assert abs(e2.evalf(20) - 2**Rational(1, 4)) < 1e-15
+    assert q2.sign(y**2 - x, [x, y]) == 0
+    assert q2.sign(y - x, [x, y]) == -1
+    assert q2.sign(y**4 - 2, [x, y]) == 0
+    r3 = q2.real_roots(z**2 - x - y, [x, y, z])
+    assert len(r3) == 2 and compare_real(r3[0], r3[1]) == -1
+    q3 = q2.extend(r3[1])
+    assert q3.degree == 8
+    assert q3.sign(z**2 - x - y, [x, y, z]) == 0
+    assert q3.sign(z - 1, [x, y, z]) == 1
+    assert q3.sign(z - 2, [x, y, z]) == -1
+    assert q3.real_roots(0*w, [x, y, z, w]) is None
+    assert q3.real_roots(w**2 + 1, [x, y, z, w]) == []
+    assert q3.real_roots(w**2 - z**2, [x, y, z, w]) == [-r3[1], r3[1]] or \
+        len(q3.real_roots(w**2 - z**2, [x, y, z, w])) == 2
+    raises(ValueError, lambda: q3.sign(x, [x]))
+    raises(ValueError, lambda: q3.real_roots(w, [x, y]))
+
+    # distinct roots are sorted and duplicates removed
+    roots = q2.real_roots((z**2 - x)*(z - y)*(z**2 - 3), [x, y, z])
+    assert roots == [CRootOf(x**2 - 3, 0), CRootOf(x**4 - 2, 0),
+                     CRootOf(x**4 - 2, 1), CRootOf(x**2 - 3, 1)]
+
+    # coordinates given as a rational multiple of a root
+    r0, r1 = Poly(2*x**2 - 9, x).real_roots(radicals=False)
+    p = origin.extend(r1)
+    assert p.degree == 2 and p.theta == r1
+    assert p.sign(2*x**2 - 9, [x]) == 0
+    assert p.sign(x - 2, [x]) == 1
+    assert p.sign(x - 3, [x]) == -1
+    q = p.extend(CRootOf(x**3 - 2, 0))
+    assert q.degree == 6
+    assert q.sign(y**3 - 2, [x, y]) == 0 and q.sign(2*x**2 - 9, [x, y]) == 0
+    assert q.sign(x*y - 3, [x, y]) == -1
+    q = origin.extend(CRootOf(x**3 - 2, 0)).extend(r0)
+    assert q.degree == 6
+    assert q.sign(2*y**2 - 9, [x, y]) == 0 and q.sign(y, [x, y]) == -1
+
+    # several quadratic extensions
+    pp = origin.extend(CRootOf(x**2 - 2, 1)).extend(CRootOf(x**2 - 3, 1))
+    pp = pp.extend(CRootOf(x**2 - 5, 1))
+    assert pp.degree == 8
+    assert pp.sign(x**2*y**2*z**2 - 30, [x, y, z]) == 0
+    assert pp.sign(x**2*y**2*z**2 - 29, [x, y, z]) == 1
+    assert pp.sign(x*y*z - 6, [x, y, z]) == -1
+    assert pp.sign(x*y*z - 5, [x, y, z]) == 1
+    vals = [e.evalf(20) for e in pp.as_exprs()]
+    assert all(abs(v - sqrt(n).evalf(20)) < 1e-15 for v, n in zip(vals, [2, 3, 5]))

--- a/sympy/polys/compatibility.py
+++ b/sympy/polys/compatibility.py
@@ -145,6 +145,8 @@ from sympy.polys.euclidtools import dup_prs_resultant
 from sympy.polys.euclidtools import dup_resultant
 from sympy.polys.euclidtools import dmp_inner_subresultants
 from sympy.polys.euclidtools import dmp_subresultants
+from sympy.polys.euclidtools import dup_psc
+from sympy.polys.euclidtools import dmp_psc
 from sympy.polys.euclidtools import dmp_prs_resultant
 from sympy.polys.euclidtools import dmp_zz_modular_resultant
 from sympy.polys.euclidtools import dmp_zz_collins_resultant
@@ -968,6 +970,13 @@ class IPolys(Generic[Er]):
             self.to_dense(f), self.to_dense(g), self.domain
         )
         return (list(map(self.from_dense, prs)), sres)
+
+    def dup_psc(self, f, g):
+        return dup_psc(self.to_dense(f), self.to_dense(g), self.domain)
+
+    def dmp_psc(self, f, g):
+        psc = dmp_psc(self.to_dense(f), self.to_dense(g), self.ngens - 1, self.domain)
+        return list(map(self[1:].from_dense, psc))
 
     def dmp_inner_subresultants(self, f, g):
         prs, sres = dmp_inner_subresultants(

--- a/sympy/polys/euclidtools.py
+++ b/sympy/polys/euclidtools.py
@@ -562,6 +562,80 @@ def dmp_subresultants(f, g, u, K):
     return dmp_inner_subresultants(f, g, u, K)[0]
 
 
+def dup_psc(f, g, K):
+    r"""
+    Principal subresultant coefficients of two polynomials in `K[x]`.
+
+    Returns the list ``[psc_0, psc_1, ..., psc_m]`` where ``m`` is the
+    smaller of the degrees of ``f`` and ``g``. ``psc_j`` is the leading
+    coefficient of the `j`-th subresultant of ``f`` and ``g``, i.e. the
+    coefficient of `x^j` in `S_j`; it is zero if `S_j` is defective. In
+    particular ``psc_0`` is the resultant and ``psc_j`` vanishes for
+    `j < \deg\gcd(f, g)`.
+
+    If `\deg f < \deg g` the coefficients of `(g, f)` are computed. The
+    list is empty if one of the polynomials is zero.
+
+    Examples
+    ========
+
+    >>> from sympy.polys import ring, ZZ
+    >>> R, x = ring("x", ZZ)
+
+    >>> R.dup_psc(x**2 + 1, x**2 - 1)
+    [4, 0, 1]
+    >>> R.dup_psc(x**3 - x, x**2 - 1)
+    [0, 0, 1]
+
+    """
+    R, S = dup_inner_subresultants(f, g, K)
+
+    if not R:
+        return []
+
+    m = min(dup_degree(f), dup_degree(g))
+    psc = [K.zero]*(m + 1)
+
+    for r, s in zip(R[1:], S[1:]):
+        psc[dup_degree(r)] = s
+
+    return psc
+
+
+def dmp_psc(f, g, u, K):
+    """
+    Principal subresultant coefficients of two polynomials in `K[X]`.
+
+    The coefficients are taken with respect to the main variable, see
+    :func:`dup_psc`.
+
+    Examples
+    ========
+
+    >>> from sympy.polys import ring, ZZ
+    >>> R, x,y = ring("x,y", ZZ)
+
+    >>> R.dmp_psc(x**2*y + x, x + y)
+    [y**3 - y, 1]
+
+    """
+    if not u:
+        return dup_psc(f, g, K)
+
+    R, S = dmp_inner_subresultants(f, g, u, K)
+
+    if not R:
+        return []
+
+    m = min(dmp_degree(f, u), dmp_degree(g, u))
+    psc = [dmp_zero(u - 1, K)]*(m + 1)
+
+    for r, s in zip(R[1:], S[1:]):
+        psc[dmp_degree(r, u)] = s
+
+    return psc
+
+
 def dmp_prs_resultant(f, g, u, K):
     """
     Resultant algorithm in `K[X]` using subresultant PRS.

--- a/sympy/polys/tests/test_euclidtools.py
+++ b/sympy/polys/tests/test_euclidtools.py
@@ -243,6 +243,82 @@ def test_dup_discriminant():
     assert R.dup_discriminant(12*x**7 + 15*x**4 + 30*x**3 + x**2 + 1) == -220289699947514112
 
 
+def test_dup_psc():
+    R, x = ring("x", ZZ)
+
+    assert R.dup_psc(0, 0) == []
+    assert R.dup_psc(x**2 + 1, 0) == []
+    assert R.dup_psc(0, x**2 + 1) == []
+    assert R.dup_psc(3, 5) == [1]
+    assert R.dup_psc(x**2 + 1, x**2 - 1) == [4, 0, 1]
+    assert R.dup_psc(x**2 - 1, x**2 + 1) == [4, 0, 1]
+    assert R.dup_psc(x**3 - x, x**2 - 1) == [0, 0, 1]
+    assert R.dup_psc(x**2 - 1, x**3 - x) == [0, 0, 1]
+    assert R.dup_psc(x**3 - 3*x**2 + 2*x, x**3 - x) == [0, 0, 3, 1]
+    assert R.dup_psc(x**5 + x**3 - 1, 2*x**3) == [32, 0, 0, 4]
+    assert R.dup_psc(x**4 + x + 1, 3*x**2 - 2) == [115, -27, 9]
+
+    f = x**8 + x**6 - 3*x**4 - 3*x**3 + 8*x**2 + 2*x - 5
+    g = 3*x**6 + 5*x**4 - 4*x**2 - 9*x + 21
+
+    assert R.dup_psc(f, g)[0] == R.dup_resultant(f, g)
+    assert R.dup_psc(f, g)[-1] == 9
+
+    # principal subresultant coefficients as determinants of the Sylvester
+    # submatrices, checked on a few cases with degree jumps and common roots
+    from sympy.matrices import Matrix
+
+    def psc_det(f, g):
+        n, m = len(f) - 1, len(g) - 1
+        out = []
+        for j in range(m + 1):
+            rows = []
+            width = n + m - j
+            for i in range(m - j):
+                rows.append([0]*i + f + [0]*(width - n - 1 - i))
+            for i in range(n - j):
+                rows.append([0]*i + g + [0]*(width - m - 1 - i))
+            M = Matrix(rows)
+            out.append(M[:, :n + m - 2*j].det() if M.rows else 1)
+        return [ZZ(c) for c in out]
+
+    cases = [
+        ([1, 0, 1, 0, -1], [2, 0, 0, 0]),
+        ([1, -1, 0, 2, 3], [1, 0, 0, -1]),
+        ([2, -3, 1, 0, 0, -1, 5], [1, 0, 0, 0, 0, 2]),
+        ([1, -2, 1], [1, -1, 0]),
+        ([1, 0, -2, 0, 1], [1, 0, -1]),
+        ([3, 1, -4, 1, 2, -1], [1, 2, 0, 0, -3]),
+    ]
+    for f, g in cases:
+        assert R.dup_psc(R.from_list(f), R.from_list(g)) == psc_det(f, g)
+
+
+def test_dmp_psc():
+    R, x, y = ring("x,y", ZZ)
+
+    assert R.dmp_psc(0, 0) == []
+    assert R.dmp_psc(x*y + 1, 0) == []
+    assert R.dmp_psc(x**2*y + x, x + y) == [(y**3 - y).drop(x), 1]
+    assert R.dmp_psc(x**2*y + x, 3) == [9]
+    assert R.dmp_psc(x**2 - y, x**2*y - 1) == [(y**4 - 2*y**2 + 1).drop(x), 0, 1]
+
+    f = x**2 + y**2 - 1
+    assert R.dmp_psc(f, f.diff(x)) == [(4*y**2 - 4).drop(x), 2]
+    assert R.dmp_psc(f, x - y) == [(2*y**2 - 1).drop(x), 1]
+    assert R.dmp_psc(f, x - y)[0] == R.dmp_resultant(f, x - y)
+
+    g = (x - y)*(x**2 + 1)
+    h = (x - y)*(x + 3)
+    assert R.dmp_psc(g, h) == [0, 10, 1]
+
+    R, x, y, z = ring("x,y,z", ZZ)
+    f = x**2 + y**2 + z**2 - 1
+    psc = R.dmp_psc(f, x*y - z)
+    assert psc == [R.dmp_resultant(f, x*y - z), y.drop(x)]
+    assert psc[0] == (y**4 + y**2*z**2 - y**2 + z**2).drop(x)
+
+
 def test_dmp_discriminant():
     R, x = ring("x", ZZ)
 


### PR DESCRIPTION
Third CAD PR, on top of #30422 and #30423.

Adds `sympy.polys.cad.lifting` with `cylindrical_algebraic_decomposition(polys, gens)`. It builds the cells level by level from the projection factor sets: the real roots of the factors at the sample point of a cell split the cylinder over it into sections and sectors, each with an exact sample point. The signs of the input polynomials on a cell are derived from the signs of their irreducible factors, which are known from the lifting, so nothing is recomputed afterwards.

McCallum's projection is used first; if a projection factor vanishes identically on a cell of positive dimension (not well-oriented) the decomposition is redone with Hong's projection. `method='mccallum'` raises `NotWellOriented` instead.

```
>>> cad = cylindrical_algebraic_decomposition([x**2 + y**2 - 1], [x, y])
>>> cad
CAD(13 cells, x, y)
>>> [c.point for c in cad if c.signs == (0,)]
[(-1, 0), (0, -1), (0, 1), (1, 0)]
```

The tests check every cell of every example by evaluating the polynomials exactly at the sample point, and check the cylindrical structure (indices, parents, ordering of sections).

Same note as in #30422: written with Claude Fable 5.1 on a token boost that expires soon, from scratch.

<!-- BEGIN RELEASE NOTES -->
* polys
  * Added `cylindrical_algebraic_decomposition` in `sympy.polys.cad`.
<!-- END RELEASE NOTES -->
