### PR TITLE
Invalidate the postprocessor cache when _constructor_postprocessor_mapping changes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -379,6 +379,7 @@ Arnab Nandi <arnabnandi2002@gmail.com>
 Arnav Mummineni <45217840+RCoder01@users.noreply.github.com>
 Arpan Chattopadhyay <f20180319@pilani.bits-pilani.ac.in> Arpan612 <f20180319@pilani.bits-pilani.ac.in>
 Arpit Goyal <agmps18@gmail.com>
+Arsh Goyal <business.arshgoyal@gmail.com> businessarshgoyal <business.arshgoyal@gmail.com>
 Arshdeep Singh <singh.arshdeep1999@gmail.com>
 Arthur Milchior <arthur@milchior.fr>
 Arthur Ryman <arthur.ryman@gmail.com>

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -8,7 +8,7 @@ from functools import cmp_to_key
 from typing import TYPE_CHECKING, overload
 
 from .assumptions import _prepare_class_assumptions
-from .cache import cacheit
+from .cache import cacheit, clear_cache
 from .sympify import _sympify, sympify, SympifyError, _external_converter
 from .sorting import ordered
 from .kind import Kind, UndefinedKind
@@ -159,6 +159,46 @@ def _get_postprocessors_for_type(arg_type):
         for cls in arg_type.mro()
         if cls in Basic._constructor_postprocessor_mapping
     )
+
+
+class _PostprocessorMapping(dict):
+    """Mapping of classes to constructor postprocessors.
+
+    The lookups above are cached by type only, so any change to this mapping
+    has to invalidate the cache or registrations made after an expression
+    involving the class has been built would never be seen.
+    """
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        clear_cache()
+
+    def __delitem__(self, key):
+        super().__delitem__(key)
+        clear_cache()
+
+    def update(self, *args, **kwargs):
+        super().update(*args, **kwargs)
+        clear_cache()
+
+    def setdefault(self, key, default=None):
+        value = super().setdefault(key, default)
+        clear_cache()
+        return value
+
+    def pop(self, *args):
+        value = super().pop(*args)
+        clear_cache()
+        return value
+
+    def popitem(self):
+        item = super().popitem()
+        clear_cache()
+        return item
+
+    def clear(self):
+        super().clear()
+        clear_cache()
 
 
 class Basic(Printable):
@@ -2192,7 +2232,7 @@ class Basic(Printable):
     def _eval_rewrite(self, rule, args, **hints):
         return None
 
-    _constructor_postprocessor_mapping = {}  # type: ignore
+    _constructor_postprocessor_mapping = _PostprocessorMapping()  # type: ignore
 
     @classmethod
     def _exec_constructor_postprocessors(cls, obj):

--- a/sympy/core/tests/test_constructor_postprocessor.py
+++ b/sympy/core/tests/test_constructor_postprocessor.py
@@ -86,3 +86,26 @@ def test_subexpression_postprocessors():
     w = SubclassSymbolRemovesOtherSymbols("w")
     assert 3*a*w**2 == 3*w**2
     assert 3*a*x**3*w**2 == 3*w**2
+
+
+def test_postprocessor_registered_after_use():
+    # Registering a postprocessor after expressions with the class have
+    # already been built must take effect right away.
+    class LateSymbol(Symbol):
+        pass
+
+    x = LateSymbol("x")
+    y = LateSymbol("y")
+    assert (3*x).args == (3, x)
+
+    Basic._constructor_postprocessor_mapping[LateSymbol] = {
+        "Mul": [lambda expr: expr.func(*[a for a in expr.args
+                                         if not a.is_Number])],
+    }
+    try:
+        assert 3*y == y
+        assert 3*x == x
+    finally:
+        del Basic._constructor_postprocessor_mapping[LateSymbol]
+
+    assert (3*y).args == (3, y)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #30420

#### Brief description of what is fixed or changed

`_get_postprocessors` and `_get_postprocessors_for_type` are memoized with `cacheit` and keyed only on the type, but what they return depends on the current contents of `Basic._constructor_postprocessor_mapping`. So registering a postprocessor for a class after an `Add`/`Mul`/`Pow` involving that class had already been constructed was ignored until something else happened to call `clear_cache()`.

`_constructor_postprocessor_mapping` is now a small `dict` subclass that calls `clear_cache()` whenever it is mutated, the same thing `_global_parameters` in `core/parameters.py` does. The registration API (plain item assignment on the mapping) is unchanged.

Added a test that registers a postprocessor after the class has already been used in a `Mul`.

#### Other comments

I used Devin (Claude) to help write this. I reviewed and ran the changes myself.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Postprocessors added to `Basic._constructor_postprocessor_mapping` after expressions involving the class have already been built are no longer ignored because of a stale cache.
<!-- END RELEASE NOTES -->
