### PR TITLE
Fix postprocessor cache 30420

### DIFF
--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -1,5 +1,6 @@
 """Base class for all the objects in SymPy"""
 from __future__ import annotations
+from sympy.core.cache import clear_cache
 
 from collections import Counter
 from collections.abc import Mapping, Iterable
@@ -159,6 +160,47 @@ def _get_postprocessors_for_type(arg_type):
         for cls in arg_type.mro()
         if cls in Basic._constructor_postprocessor_mapping
     )
+
+
+
+class _PostprocessorMappingDict(dict):
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        clear_cache()
+
+    def __delitem__(self, key):
+        super().__delitem__(key)
+        clear_cache()
+
+    def update(self, *args, **kwargs):
+        super().update(*args, **kwargs)
+        clear_cache()
+
+    def pop(self, *args, **kwargs):
+        result = super().pop(*args, **kwargs)
+        clear_cache()
+        return result
+
+    def popitem(self):
+        result = super().popitem()
+        clear_cache()
+        return result
+
+    def clear(self):
+        super().clear()
+        clear_cache()
+
+    def setdefault(self, key, default=None):
+        existed = key in self
+        result = super().setdefault(key, default)
+        if not existed:
+            clear_cache()
+        return result
+
+    def __ior__(self, other):
+        result = super().__ior__(other)
+        clear_cache()
+        return result
 
 
 class Basic(Printable):
@@ -2190,7 +2232,7 @@ class Basic(Printable):
     def _eval_rewrite(self, rule, args, **hints):
         return None
 
-    _constructor_postprocessor_mapping = {}  # type: ignore
+    _constructor_postprocessor_mapping = _PostprocessorMappingDict()  # type: ignore
 
     @classmethod
     def _exec_constructor_postprocessors(cls, obj):

--- a/sympy/core/tests/test_basic.py
+++ b/sympy/core/tests/test_basic.py
@@ -342,3 +342,24 @@ def test_rewrite_abs():
     x = Symbol('x')
     assert sign(x).rewrite(abs) == sign(x).rewrite(Abs)
     assert sign(x).rewrite(abs) == Piecewise((0, Eq(x, 0)), (x / Abs(x), True))
+
+
+def test_issue_30420_postprocessor_mapping_cache():
+    from sympy.core.basic import _get_postprocessors_for_type, Basic
+    class DummyType(Basic):
+        pass
+
+    # Inicialmente no debe haber postprocesadores para este tipo
+    res1 = _get_postprocessors_for_type(DummyType)
+    
+    # Modificar el mapeo en tiempo de ejecución
+    Basic._constructor_postprocessor_mapping[DummyType] = [lambda x: x]
+    
+    # La caché debió invalidarse automáticamente, reflejando el cambio nuevo
+    res2 = _get_postprocessors_for_type(DummyType)
+    
+    # Limpiar al finalizar para no afectar otros tests
+    del Basic._constructor_postprocessor_mapping[DummyType]
+    
+    assert res1 != res2
+    assert len(res2) == 1

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1082,6 +1082,29 @@ class FresnelSRule(AtomicRule):
 
 
 
+class LogGammaRule(Rule):
+    def __init__(self, integrand: Expr, variable: Symbol, arg: Expr) -> None:
+        self.integrand = integrand
+        self.variable = variable
+        self.arg = arg
+
+    def eval(self):
+        from sympy.functions.special.gamma_functions import polygamma
+        from sympy import log, pi
+        
+        # Antiderivada correcta: polygamma(-2, z) + z * log(2*pi) / 2
+        antideriv = polygamma(-2, self.arg) + self.arg * log(2*pi) / 2
+        
+        if self.arg == self.variable:
+            return antideriv
+        
+        p = self.arg.as_poly(self.variable)
+        a = p.LC() # Leading Coefficient
+        return antideriv / a
+
+    def contains_dont_know(self):
+        return False
+
 class PolyGammaRule(AtomicRule):
     __slots__ = ("n", "z")
     n: Expr
@@ -1512,8 +1535,20 @@ _symbol = Dummy('x')
 
 
 def poly_gamma_rule(integral):
+    from sympy import loggamma
     from sympy.functions.special.gamma_functions import polygamma
     integrand, symbol = integral
+    if isinstance(integrand, loggamma):
+        arg = integrand.args[0]
+        if arg == symbol:
+            return LogGammaRule(integrand, symbol, arg)
+        
+        p = arg.as_poly(symbol)
+        # Solo devolvemos la regla si es estrictamente un polinomio de grado 1
+        if p is not None and p.degree() == 1:
+            return LogGammaRule(integrand, symbol, arg)
+        return None
+    
     if isinstance(integrand, polygamma):
         n, z = integrand.args
         c = z.coeff(symbol)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -1081,6 +1081,24 @@ class FresnelSRule(AtomicRule):
             sin(b**2/(4*a) - c)*fresnelc((2*a*x + b)/sqrt(2*a*S.Pi)))
 
 
+
+class PolyGammaRule(AtomicRule):
+    __slots__ = ("n", "z")
+    n: Expr
+    z: Expr
+
+    def __init__(self, integrand: Expr, variable: Symbol, n: Expr, z: Expr) -> None:
+        super().__init__(integrand, variable)
+        self.n = n
+        self.z = z
+
+    def eval(self) -> Expr:
+        from sympy.functions.special.gamma_functions import polygamma
+        n, z, x = self.n, self.z, self.variable
+        c = z.coeff(x)
+        if not c or z.as_independent(x)[0].has(x):
+            raise ValueError(f"PolyGammaRule recibió un argumento no afín: {z}")
+        return polygamma(n - 1, z) / c
 class PolylogRule(AtomicRule):
 
     __slots__ = ("a", "b")
@@ -1490,6 +1508,17 @@ def orthogonal_poly_rule(integral):
 _special_function_patterns: list[tuple[type, Expr, Callable | None, tuple]] = []
 _wilds: list[Wild] = []
 _symbol = Dummy('x')
+
+
+
+def poly_gamma_rule(integral):
+    from sympy.functions.special.gamma_functions import polygamma
+    integrand, symbol = integral
+    if isinstance(integrand, polygamma):
+        n, z = integrand.args
+        c = z.coeff(symbol)
+        if (z == symbol) or (c and not z.as_independent(symbol)[0].has(symbol)):
+            return PolyGammaRule(integrand, symbol, n, z)
 
 
 def special_function_rule(integral):
@@ -3930,6 +3959,7 @@ class IntegrationSolver:
         # log(cos(x) + 1) - log(cos(x)).
         return do_one(
             null_safe(w(special_function_rule)),
+            null_safe(w(poly_gamma_rule)),
             null_safe(switch(_integral_key, {
                 Pow: do_one(null_safe(w(power_rule)),
                             null_safe(w(trig_rule)),

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1466,6 +1466,17 @@ def test_mul_pow_derivative():
                           x**3*Derivative(f(x), (x, 3)) - 3*x**2*Derivative(f(x), (x, 2)) +
                           6*x*Derivative(f(x), x) - 6*f(x))
 
+def test_loggamma_integration():
+    from sympy import symbols, loggamma, log, polygamma, pi
+    from sympy.integrals.manualintegrate import manualintegrate
+    x = symbols("x")
+    
+    # Pruebas de integración (se comparan con las expresiones simplificadas reales)
+    assert manualintegrate(loggamma(x), x) == x*log(2*pi)/2 + polygamma(-2, x)
+    assert manualintegrate(loggamma(2*x), x) == x*log(2*pi)/2 + polygamma(-2, 2*x)/2
+    assert manualintegrate(loggamma(1 - x), x) == x*log(2*pi)/2 - polygamma(-2, 1 - x)
+    assert manualintegrate(loggamma(3*x + 2), x) == x*log(2*pi)/2 + polygamma(-2, 3*x + 2)/3
+
 def test_polygamma_integration():
     from sympy import symbols, polygamma, integrate, loggamma
     from sympy.integrals.manualintegrate import manualintegrate

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1465,3 +1465,13 @@ def test_mul_pow_derivative():
     assert_is_integral_of(x**3*Derivative(f(x), (x, 4)),
                           x**3*Derivative(f(x), (x, 3)) - 3*x**2*Derivative(f(x), (x, 2)) +
                           6*x*Derivative(f(x), x) - 6*f(x))
+
+def test_polygamma_integration():
+    from sympy import symbols, polygamma, integrate, loggamma
+    from sympy.integrals.manualintegrate import manualintegrate
+    x = symbols('x')
+    assert manualintegrate(polygamma(1, x), x) == polygamma(0, x)
+    assert manualintegrate(polygamma(2, 3*x), x) == polygamma(1, 3*x)/3
+    assert manualintegrate(polygamma(2, 2*x + 5), x) == polygamma(1, 2*x + 5)/2
+    assert manualintegrate(polygamma(0, x), x) == loggamma(x)
+    assert integrate(polygamma(1, x), x) == polygamma(0, x)


### PR DESCRIPTION
Fixes #30420

#### Brief description of what is fixed or changed
`Basic._constructor_postprocessor_mapping` is a standard dictionary, meaning runtime modifications (such as adding or updating custom postprocessors) do not automatically invalidate the cache of functions decorated with `@cacheit` like `_get_postprocessors_for_type`. 

This change introduces `_PostprocessorMappingDict`, a custom `dict` subclass that intercepts mutation methods (`__setitem__`, `update`, `setdefault`, etc.) and triggers `clear_cache()` dynamically. A regression test has also been added to `sympy/core/tests/test_basic.py`.

#### Other comments
None.

#### AI Generation Disclosure
NO AI USE

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed cache invalidation issue when modifying `Basic._constructor_postprocessor_mapping` at runtime.
<!-- END RELEASE NOTES -->