### PR TITLE
Polarify Meijer G argument before hyperexpand

### DIFF
--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -2170,7 +2170,7 @@ class _besseli(DefinedFunction):
         return exp(-z)*besseli(nu, z)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        x0 = self.args[0].limit(x, 0)
+        x0 = self.args[1].limit(x, 0)
         if x0.is_zero:
             f = self._eval_rewrite_as_intractable(*self.args)
             return f._eval_nseries(x, n, logx)
@@ -2201,7 +2201,7 @@ class _besselk(DefinedFunction):
         return exp(z)*besselk(nu, z)
 
     def _eval_nseries(self, x, n, logx, cdir=0):
-        x0 = self.args[0].limit(x, 0)
+        x0 = self.args[1].limit(x, 0)
         if x0.is_zero:
             f = self._eval_rewrite_as_intractable(*self.args)
             return f._eval_nseries(x, n, logx)

--- a/sympy/functions/special/hyper.py
+++ b/sympy/functions/special/hyper.py
@@ -503,7 +503,7 @@ class meijerg(TupleParametersBase):
     >>> expand_func(meijerg([[],[]], [[0],[]], -x))
     exp(x)
     >>> hyperexpand(meijerg([[],[]], [[S(1)/2],[0]], (x/2)**2))
-    sin(x)/sqrt(pi)
+    sin(sqrt(x**2))/sqrt(pi)
 
     See Also
     ========

--- a/sympy/holonomic/holonomic.py
+++ b/sympy/holonomic/holonomic.py
@@ -2038,7 +2038,7 @@ class HolonomicFunction:
         >>> from sympy import sin, cos, hyperexpand, log, symbols
         >>> x = symbols('x')
         >>> hyperexpand(expr_to_holonomic(cos(x) + sin(x)).to_meijerg())
-        sin(x) + cos(x)
+        x*sin(sqrt(x**2))/sqrt(x**2) + cos(sqrt(x**2))
         >>> hyperexpand(expr_to_holonomic(log(x)).to_meijerg()).simplify()
         log(x)
 
@@ -2138,7 +2138,7 @@ def from_meijerg(func, x0=0, evalf=False, initcond=True, domain=QQ):
     >>> from sympy import symbols, meijerg, S
     >>> x = symbols('x')
     >>> from_meijerg(meijerg(([], []), ([S(1)/2], [0]), x**2/4))
-    HolonomicFunction((1) + (1)*Dx**2, x, 0, [0, 1/sqrt(pi)])
+    HolonomicFunction((1) + (1)*Dx**2, x, 1, [sin(1)/sqrt(pi), cos(1)/sqrt(pi)])
     """
 
     a = func.ap

--- a/sympy/holonomic/tests/test_holonomic.py
+++ b/sympy/holonomic/tests/test_holonomic.py
@@ -736,12 +736,22 @@ def test_extended_domain_in_expr_to_holonomic():
 
 def test_to_meijerg():
     x = symbols('x')
-    assert hyperexpand(expr_to_holonomic(sin(x)).to_meijerg()) == sin(x)
-    assert hyperexpand(expr_to_holonomic(cos(x)).to_meijerg()) == cos(x)
+    sine = hyperexpand(expr_to_holonomic(sin(x)).to_meijerg())
+    cosine = hyperexpand(expr_to_holonomic(cos(x)).to_meijerg())
+    assert sine == x*sin(sqrt(x**2))/sqrt(x**2)
+    assert cosine == cos(sqrt(x**2))
     assert hyperexpand(expr_to_holonomic(exp(x)).to_meijerg()) == exp(x)
     assert hyperexpand(expr_to_holonomic(log(x)).to_meijerg()).simplify() == log(x)
     assert expr_to_holonomic(4*x**2/3 + 7).to_meijerg() == 4*x**2/3 + 7
-    assert hyperexpand(expr_to_holonomic(besselj(2, x), lenics=3).to_meijerg()) == besselj(2, x)
+    bessel = hyperexpand(expr_to_holonomic(besselj(2, x), lenics=3).to_meijerg())
+    assert bessel == besselj(2, sqrt(x**2))
+    # These forms agree with the original functions by parity, without
+    # assuming sqrt(x**2) = x. Check both signs on the real and imaginary axes.
+    for result, expected in ((sine, sin(x)), (cosine, cos(x)),
+                             (bessel, besselj(2, x))):
+        for value in (-1, 1, -I, I):
+            assert (result - expected).subs(x, value).simplify() == 0
+    assert sine.limit(x, 0) == 0
     p = hyper((Rational(-1, 2), -3), (), x)
     assert from_hyper(p).to_meijerg() == hyperexpand(p)
     p = hyper((S.One, S(3)), (S(2), ), x)

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -2015,6 +2015,13 @@ def _meijerint_definite_3(f, x):
 
 
 def _my_unpolarify(f):
+    # Whole integer-power coefficients are lifted only to keep polar
+    # denesting from exposing their bases. Once that simplification is over,
+    # project the lift while retaining the grouped ordinary power.
+    if not isinstance(f, bool):
+        lifts = {p: p.args[0] for p in f.atoms(polar_lift)
+                 if p.args[0].is_Pow and p.args[0].exp.is_Integer}
+        f = f.xreplace(lifts)
     return _eval_cond(unpolarify(f))
 
 

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1506,8 +1506,13 @@ def _rewrite_single(f, x, recursive=True):
             if subs:
                 subs_ = {}
                 for fro, to in subs.items():
-                    subs_[fro] = unpolarify(polarify(to, lift=True),
-                                            exponents_only=True)
+                    if to.is_Pow and to.exp.is_Integer and not to.is_polar:
+                        # A matched coefficient is an ordinary value: lifting
+                        # y**2 as polar_lift(y)**2 adds a turn when y is negative.
+                        subs_[fro] = polar_lift(to)
+                    else:
+                        subs_[fro] = unpolarify(polarify(to, lift=True),
+                                                exponents_only=True)
                 subs = subs_
                 if not isinstance(hint, bool):
                     hint = hint.subs(subs)
@@ -1737,7 +1742,14 @@ def _meijerint_indefinite_1(f, x):
 
         # now substitute back
         # Note: we really do want the powers of x to combine.
-        res += powdenest(fac_*r, polar=True)
+        expr = fac_*r
+        # Denesting must not reinterpret the inside of a principal lift as
+        # polar: that would undo the whole-coefficient lifting in the lookup.
+        lifts = {p: Dummy('lift', polar=True) for p in expr.atoms(polar_lift)
+                 if not p.has(x) and p.args[0].is_Pow
+                 and p.args[0].exp.is_Integer}
+        res += powdenest(expr.xreplace(lifts), polar=True).xreplace(
+            {v: k for k, v in lifts.items()})
 
     def _clean(res):
         """This multiplies out superfluous powers of x we created, and chops off

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -139,6 +139,11 @@ def _create_lookup_table(table):
         # existing callers changes many established conditional answers.
         if not (constant.is_number and coefficient.is_number):
             return True
+        # A zero term makes this a monomial or a constant, so there are not
+        # two rays whose relative phases need to be checked. Also, arg(0) is
+        # NaN and cannot be used in the comparison below.
+        if constant.is_zero or coefficient.is_zero:
+            return True
         # Positive multiples of b and p stay within one sector of width < pi.
         # Otherwise the sum can cross its principal cut while the G-function
         # continues on the sheet selected near zero.

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -124,8 +124,28 @@ def _create_lookup_table(table):
         gamma(a)*b**(a - 1), And(b > 0))
     add(Heaviside((b/p)**(1/q) - z)*(b - t)**(a - 1), [], [a], [0], [], t/b,
         gamma(a)*b**(a - 1), And(b > 0))
+
+    def binomial_condition(subs, positive_ray):
+        exponent, constant, coefficient = (subs[v] for v in (a, b, p))
+        # This condition concerns principal ordinary powers on x > 0.
+        # Inversion has a different contour and retains its existing checks;
+        # explicit polar inputs likewise specify their own continuation.
+        if not positive_ray or constant.is_polar or coefficient.is_polar:
+            return True
+        if exponent.is_integer:
+            return True
+        # Keep symbolic lookup behavior unchanged for now. Although the
+        # condition is sufficient symbolically, propagating it through all
+        # existing callers changes many established conditional answers.
+        if not (constant.is_number and coefficient.is_number):
+            return True
+        # Positive multiples of b and p stay within one sector of width < pi.
+        # Otherwise the sum can cross its principal cut while the G-function
+        # continues on the sheet selected near zero.
+        return Abs(arg(coefficient) - arg(constant)) <= pi
+
     add((b + t)**(-a), [1 - a], [], [0], [], t/b, b**(-a)/gamma(a),
-        hint=Not(IsNonPositiveInteger(a)))
+        cond=binomial_condition, hint=Not(IsNonPositiveInteger(a)))
     add(Abs(b - t)**(-a), [1 - a], [(1 - a)/2], [0], [(1 - a)/2], t/b,
         2*sin(pi*a/2)*gamma(1 - a)*Abs(b)**(-a), re(a) < 1)
     add((t**a - b**a)/(t - b), [0, a], [], [0, a], [], t/b,
@@ -1467,7 +1487,7 @@ _lookup_table = None
 
 @cacheit
 @timeit
-def _rewrite_single(f, x, recursive=True):
+def _rewrite_single(f, x, recursive=True, positive_ray=True):
     """
     Try to rewrite f as a sum of single G functions of the form
     C*x**s*G(a*x**b), where b is a rational number and C is independent of x.
@@ -1475,6 +1495,9 @@ def _rewrite_single(f, x, recursive=True):
     or (a, ()).
     Returns a list of tuples (C, s, G) and a condition cond.
     Returns None on failure.
+    With ``positive_ray=True``, ordinary binomial rewrites include a
+    sufficient branch condition for x > 0. Inversion sets this to False:
+    a positive-ray condition does not establish validity on its contour.
     """
     from .transforms import (mellin_transform, inverse_mellin_transform,
         IntegralTransformError, MellinTransformStripError)
@@ -1504,6 +1527,10 @@ def _rewrite_single(f, x, recursive=True):
         for formula, terms, cond, hint in l:
             subs = f.match(formula, old=True)
             if subs:
+                # Branch conditions must see the original ordinary values,
+                # before coefficient lifting changes their representation.
+                if callable(cond):
+                    cond = cond(subs, positive_ray)
                 subs_ = {}
                 for fro, to in subs.items():
                     if to.is_Pow and to.exp.is_Integer and not to.is_polar:
@@ -1612,7 +1639,7 @@ def _rewrite_single(f, x, recursive=True):
     return res, True
 
 
-def _rewrite1(f, x, recursive=True):
+def _rewrite1(f, x, recursive=True, positive_ray=True):
     """
     Try to rewrite ``f`` using a (sum of) single G functions with argument a*x**b.
     Return fac, po, g such that f = fac*po*g, fac is independent of ``x``.
@@ -1621,7 +1648,7 @@ def _rewrite1(f, x, recursive=True):
     Return None on failure.
     """
     fac, po, g = _split_mul(f, x)
-    g = _rewrite_single(g, x, recursive)
+    g = _rewrite_single(g, x, recursive, positive_ray=positive_ray)
     if g:
         return fac, po, g[0], g[1]
 
@@ -1635,7 +1662,8 @@ def _rewrite2(f, x):
     Returns None on failure.
     """
     fac, po, g = _split_mul(f, x)
-    if any(_rewrite_single(expr, x, False) is None for expr in _mul_args(g)):
+    if any(_rewrite_single(expr, x, False, positive_ray=False) is None
+           for expr in _mul_args(g)):
         return None
     l = _mul_as_two_parts(g)
     if not l:
@@ -1647,8 +1675,8 @@ def _rewrite2(f, x):
                       len(_find_splitting_points(p[1], x)))]))
 
     for recursive, (fac1, fac2) in itertools.product((False, True), l):
-        g1 = _rewrite_single(fac1, x, recursive)
-        g2 = _rewrite_single(fac2, x, recursive)
+        g1 = _rewrite_single(fac1, x, recursive, positive_ray=False)
+        g2 = _rewrite_single(fac2, x, recursive, positive_ray=False)
         if g1 and g2:
             cond = And(g1[1], g2[1])
             if cond != False:
@@ -1674,7 +1702,13 @@ def meijerint_indefinite(f, x):
         res = _meijerint_indefinite_1(f.subs(x, x + a), x)
         if not res:
             continue
-        res = res.subs(x, x - a)
+        try:
+            res = res.subs(x, x - a)
+        except TypeError:
+            # A conditional positive-ray rewrite can become an invalid
+            # comparison after undoing a nonreal trial shift. Try another
+            # shift or integration method instead.
+            continue
         if _has(res, hyper, meijerg):
             results.append(res)
         else:
@@ -2044,7 +2078,7 @@ def _meijerint_definite_4(f, x, only_double=False):
     _debug('Integrating', f)
     # Try single G function.
     if not only_double:
-        gs = _rewrite1(f, x, recursive=False)
+        gs = _rewrite1(f, x, recursive=False, positive_ray=False)
         if gs is not None:
             fac, po, g, cond = gs
             _debug('Could rewrite as single G function:', fac, po, g)
@@ -2182,7 +2216,7 @@ def meijerint_inversion(f, x, t):
         # cond is True or Eq
         return Piecewise((res.subs(t, t_), cond))
 
-    gs = _rewrite1(f, x)
+    gs = _rewrite1(f, x, positive_ray=False)
     if gs is not None:
         fac, po, g, cond = gs
         _debug('Could rewrite as single G function:', fac, po, g)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -11,7 +11,7 @@ from sympy.core.relational import (Eq, Ne)
 from sympy.core.singleton import S
 from sympy.core.symbol import (Symbol, symbols)
 from sympy.core.sympify import sympify
-from sympy.functions.elementary.complexes import (Abs, im, polar_lift, re, sign)
+from sympy.functions.elementary.complexes import (Abs, im, polar_lift, re, sign, unpolarify)
 from sympy.functions.elementary.exponential import (LambertW, exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import (acosh, asinh, cosh, coth, csch, sinh, tanh, sech)
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
@@ -2150,7 +2150,9 @@ def test_old_issues():
     assert I1 == sin(log(x**2))/2
     # https://github.com/sympy/sympy/issues/5462
     I2 = integrate(1/(x**2+y**2)**(Rational(3,2)),x)
-    assert I2 == x/(y**3*sqrt(x**2/y**2 + 1))
+    for value in [-1, 1]:
+        error = I2.diff(x).subs(y, value) - (x**2 + 1)**(-Rational(3, 2))
+        assert simplify(unpolarify(error)) == 0
     # https://github.com/sympy/sympy/issues/6278
     I3 = integrate(1/(cos(x)+2),(x,0,2*pi))
     assert I3 == 2*sqrt(3)*pi/3

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1408,9 +1408,9 @@ def test_issue_8368i():
             (
                 Integral(exp(-s*x)*cosh(x), (x, 0, oo)),
                 True))
-    assert integrate(exp(-s*x)*sinh(x), (x, 0, oo)) == \
+    assert integrate(exp(-s*x)*sinh(x), (x, 0, oo)).cancel() == \
         Piecewise(
-            (   -1/(s + 1)/2 - 1/(-s + 1)/2,
+            (   1/(s**2 - 1),
                 And(
                     Abs(s) > 1,
                     Abs(arg(s)) < pi/2,

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -70,6 +70,39 @@ def test_rewrite1():
         (5, x**3, [(1, 0, meijerg([a], [b], [c], [d], x**2*(y + 1)))], True)
 
 
+def test_issue_5462_coefficient_lifting():
+    from sympy.core.symbol import Symbol
+
+    f = (x**2 + y**2)**(-Rational(3, 2))
+    terms, cond = _rewrite_single(f, x, recursive=False)
+    assert cond is True
+    rewritten = sum(C*x**s*g for C, s, g in terms)
+    # Specialize before expanding to test the lookup independently of
+    # hyperexpand and the final antiderivative simplification.
+    assert unpolarify(hyperexpand(rewritten.subs({x: 0, y: -1}))) == 1
+
+    for assumptions in ({}, {'real': True}, {'negative': True},
+                        {'positive': True}):
+        parameter = Symbol('y', **assumptions)
+        integrand = f.subs(y, parameter)
+        for primitive in (meijerint_indefinite(integrand, x),
+                          integrate(integrand, x, meijerg=True)):
+            values = ([1] if parameter.is_positive else
+                      [-1] if parameter.is_negative else [-1, 1])
+            for value in values:
+                for point in [0, 1, 2]:
+                    error = (primitive.diff(x) - integrand).subs(
+                        {x: point, parameter: value})
+                    assert simplify(unpolarify(error)) == 0
+
+    # A coefficient already on the logarithmic surface must retain its turn.
+    coefficient = exp_polar(2*pi*I)
+    terms, _ = _rewrite_single((x**2 + coefficient)**(-Rational(3, 2)),
+                               x, recursive=False)
+    rewritten = sum(C*x**s*g for C, s, g in terms)
+    assert unpolarify(hyperexpand(rewritten.subs(x, 0))) == -1
+
+
 def test_meijerint_indefinite_numerically():
     def t(fac, arg):
         g = meijerg([a], [b], [c], [d], arg)*fac
@@ -723,8 +756,34 @@ def test_issue_8368():
 
 def test_issue_10211():
     from sympy.abc import h, w
-    assert integrate((1/sqrt((y-x)**2 + h**2)**3), (x,0,w), (y,0,w)) == \
-        2*sqrt(1 + w**2/h**2)/h - 2/h
+    result = integrate(1/sqrt((y-x)**2 + h**2)**3,
+                       (x, 0, w), (y, 0, w))
+    expected = 2*(sqrt(h**2 + w**2) - sqrt(h**2))/h**2
+    for height in [-1, 1]:
+        assert simplify(unpolarify(
+            (result - expected).subs({h: height, w: 1}))) == 0
+
+
+def test_issue_2537():
+    integrand = (a/sqrt(x**2 + a**2))**3
+    scaled_integrand = a/sqrt(x**2 + a**2)**3
+
+    for force_meijerg in [False, True]:
+        kwargs = {'meijerg': True} if force_meijerg else {}
+        result = integrate(integrand, x, **kwargs)
+        scaled_result = integrate(scaled_integrand, x, **kwargs)
+        symmetric_result = integrate(integrand, (x, -b, b), **kwargs)
+        for parameter in [-2, 2]:
+            substitutions = {a: parameter, x: 1}
+            assert simplify(unpolarify(
+                (result.diff(x) - integrand).subs(
+                    substitutions))) == 0
+            assert simplify(unpolarify(
+                (scaled_result.diff(x) - scaled_integrand).subs(
+                    substitutions))) == 0
+            assert simplify(unpolarify(
+                (symmetric_result - 2*a*b/sqrt(a**2 + b**2)).subs(
+                    {a: parameter, b: 1}))) == 0
 
 
 def test_issue_11806():
@@ -734,8 +793,10 @@ def test_issue_11806():
         2*L/(y**2*sqrt(L**2 + y**2))
 
 def test_issue_10681():
+    from sympy.core.symbol import Symbol
     from sympy.polys.domains.realfield import RR
-    from sympy.abc import R, r
+    from sympy.abc import r
+    R = Symbol('R', positive=True)
     f = integrate(r**2*(R**2-r**2)**0.5, r, meijerg=True)
     g = (1.0/3)*R**1.0*r**3*hyper((-0.5, Rational(3, 2)), (Rational(5, 2),),
                                   r**2*exp_polar(2*I*pi)/R**2)

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -74,15 +74,16 @@ def test_binomial_lookup_branch_condition():
     from sympy.core.symbol import symbols
 
     x = symbols('x', positive=True)
-    for b, p in [(-2 + I, -2*I), (-2 - I, 2*I)]:
-        f = (b + p*x)**(-Rational(3, 2))
+    for constant, coefficient in [(-2 + I, -2*I), (-2 - I, 2*I)]:
+        f = (constant + coefficient*x)**(-Rational(3, 2))
         assert _rewrite_single(f, x, recursive=False) is None
 
     # Safe coefficient rays and branch-independent integer powers retain
     # their rewrites. Check values on both sides of the counterexample's cut.
-    for b, p, a in [(1, 1, S(3)/2), (1 + I, -I, S(3)/2),
-                    (-2 + I, -2*I, S(2))]:
-        f = (b + p*x)**(-a)
+    for constant, coefficient, exponent in [
+            (1, 1, S(3)/2), (1 + I, -I, S(3)/2),
+            (-2 + I, -2*I, S(2))]:
+        f = (constant + coefficient*x)**(-exponent)
         terms, cond = _rewrite_single(f, x, recursive=False)
         assert cond == True
         rewritten = sum(C*x**s*g for C, s, g in terms)
@@ -90,12 +91,13 @@ def test_binomial_lookup_branch_condition():
             assert abs((rewritten.subs(x, value).evalf(20)
                         - f.subs(x, value).evalf(20))) < 1e-15
 
+
 def test_binomial_branch_rejection_fallback():
     from sympy.core.symbol import symbols
 
     x = symbols('x', positive=True)
-    for b, p in [(-2 + I, -2*I), (-2 - I, 2*I)]:
-        f = (b + p*x)**(-Rational(3, 2))
+    for constant, coefficient in [(-2 + I, -2*I), (-2 - I, 2*I)]:
+        f = (constant + coefficient*x)**(-Rational(3, 2))
         assert integrate(f, x, meijerg=True) == Integral(f, x)
         primitive = integrate(f, x)
         for value in [S(1)/4, S(3)/4]:

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -3,7 +3,7 @@ from sympy.core.function import expand_func
 from sympy.core.numbers import (I, Rational, oo, pi)
 from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
-from sympy.functions.elementary.complexes import Abs, arg, re, unpolarify
+from sympy.functions.elementary.complexes import Abs, arg, polar_lift, re, unpolarify
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import cosh, acosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -170,7 +170,10 @@ def test_meijerint():
     assert meijerint_definite(exp(x), x, -oo, 2) == (exp(2), True)
     # Note: causes a NaN in _check_antecedents
     assert expand(meijerint_definite(exp(x), x, 0, I)[0]) == exp(I) - 1
-    assert expand(meijerint_definite(exp(-x), x, 0, x)[0]) == \
+    result = meijerint_definite(exp(-x), x, 0, x)[0]
+    # The principal lift leaves the argument unchanged, but arg does not
+    # automatically remove polar_lift from this symbolic expression.
+    assert expand(result.xreplace({arg(polar_lift(x)): arg(x)})) == \
         1 - exp(-exp(I*arg(x))*abs(x))
 
     # Test -oo to oo
@@ -762,6 +765,35 @@ def test_pr_23583():
     # This result is wrong. Check whether new result is correct when this test fail.
     assert integrate(1/sqrt((x - I)**2-1), meijerg=True) == \
            Piecewise((acosh(x - I), Abs((x - I)**2) > 1), (-I*asin(x - I), True))
+
+
+def test_meijerg_polar_argument_negative_interval():
+    # Explicit polar factors must remain visible to hyperexpand when it
+    # chooses the analytic continuation of the antiderivative.
+    result = integrate(1/sqrt(x**2 - 1), (x, -2, -1), meijerg=True)
+    assert abs((result - acosh(2)).evalf()) < 1e-12
+
+
+def test_issue_30319_acsc():
+    from sympy.functions.elementary.trigonometric import acsc
+
+    f = x**2*cos(acsc(x))
+    for kwargs in ({}, {'meijerg': True}):
+        derivative = integrate(f, x, **kwargs).diff(x)
+        # Check both real intervals outside the branch points at -1 and 1.
+        for value in (-3, -2, 2, 3):
+            assert simplify((derivative - f).subs(x, value)) == 0
+
+
+def test_issue_28485():
+    from sympy.core.symbol import symbols
+
+    a = symbols('a', negative=True)
+    # Complete the square: a*(x**2 + 2*x) = a*(x + 1)**2 - a.
+    expected = sqrt(pi)*exp(-a)/sqrt(-a)
+    for kwargs in ({}, {'meijerg': True}):
+        result = integrate(exp(a*(x**2 + 2*x)), (x, -oo, oo), **kwargs)
+        assert simplify(result - expected) == 0
 
 
 # 25786

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -70,6 +70,47 @@ def test_rewrite1():
         (5, x**3, [(1, 0, meijerg([a], [b], [c], [d], x**2*(y + 1)))], True)
 
 
+def test_binomial_lookup_branch_condition():
+    from sympy.core.symbol import symbols
+
+    x = symbols('x', positive=True)
+    for b, p in [(-2 + I, -2*I), (-2 - I, 2*I)]:
+        f = (b + p*x)**(-Rational(3, 2))
+        assert _rewrite_single(f, x, recursive=False) is None
+
+    # Safe coefficient rays and branch-independent integer powers retain
+    # their rewrites. Check values on both sides of the counterexample's cut.
+    for b, p, a in [(1, 1, S(3)/2), (1 + I, -I, S(3)/2),
+                    (-2 + I, -2*I, S(2))]:
+        f = (b + p*x)**(-a)
+        terms, cond = _rewrite_single(f, x, recursive=False)
+        assert cond == True
+        rewritten = sum(C*x**s*g for C, s, g in terms)
+        for value in [S(1)/4, S(3)/4]:
+            assert abs((rewritten.subs(x, value).evalf(20)
+                        - f.subs(x, value).evalf(20))) < 1e-15
+
+def test_binomial_branch_rejection_fallback():
+    from sympy.core.symbol import symbols
+
+    x = symbols('x', positive=True)
+    for b, p in [(-2 + I, -2*I), (-2 - I, 2*I)]:
+        f = (b + p*x)**(-Rational(3, 2))
+        assert integrate(f, x, meijerg=True) == Integral(f, x)
+        primitive = integrate(f, x)
+        for value in [S(1)/4, S(3)/4]:
+            assert simplify((primitive.diff(x) - f).subs(x, value)) == 0
+
+
+def test_binomial_branch_condition_definite():
+    from sympy.core.symbol import symbols
+
+    x = symbols('x', positive=True)
+    assert integrate((1 + x)**(-S(3)/2), (x, 0, oo), meijerg=True) == 2
+    f = (-2 + I - 2*I*x)**(-S(3)/2)
+    assert integrate(f, (x, 0, oo), meijerg=True) == Integral(f, (x, 0, oo))
+
+
 def test_issue_5462_coefficient_lifting():
     from sympy.core.symbol import Symbol
 

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -579,8 +579,10 @@ def test_cosine_transform():
     assert inverse_cosine_transform(sqrt(2)*meijerg(((S.Half, 0), ()), (
         (S.Half, 0, 0), (S.Half,)), a**2*w**2/4)/(2*pi), w, t) == 1/(a + t)
 
-    assert cosine_transform(1/sqrt(a**2 + t**2), t, w) == sqrt(2)*meijerg(
-        ((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2/4)/(2*sqrt(pi))
+    res = cosine_transform(1/sqrt(a**2 + t**2), t, w)
+    assert res == sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2*exp_polar(0)/4)/(2*sqrt(pi))
+    assert res.replace(exp_polar, exp) == sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2/4)/(2*sqrt(pi))
+
     assert inverse_cosine_transform(sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2/4)/(2*sqrt(pi)), w, t) == 1/(t*sqrt(a**2/t**2 + 1))
 
 

--- a/sympy/integrals/tests/test_transforms.py
+++ b/sympy/integrals/tests/test_transforms.py
@@ -360,8 +360,12 @@ def test_inverse_mellin_transform():
     expr = IMT(d**c*d**(s - 1)*sin(pi*c)
                          *gamma(s)*gamma(s + c)*gamma(1 - s)*gamma(1 - s - c)/pi,
                          s, x, (Max(-re(c), 0), Min(1 - re(c), 1)))
-    assert powsimp(expand_mul(expr, deep=False)).replace(exp_polar, exp).simplify() \
-        == (-d**c + x**c)/(-d + x)
+    expr = powsimp(expand_mul(expr, deep=False)).replace(exp_polar, exp)
+    # Inverse Mellin transforms assume x > 0. This allows the powers of
+    # d/x to combine without imposing assumptions on d or c.
+    positive_x = symbols('x', positive=True)
+    expected = (-d**c + x**c)/(-d + x)
+    assert simplify((expr - expected).subs(x, positive_x)) == 0
 
     assert simplify(IMT(1/sqrt(pi)*(-c/2)*gamma(s)*gamma((1 - c)/2 - s)
                         *gamma(-c/2 - s)/gamma(1 - c - s),
@@ -446,7 +450,7 @@ def test_inverse_mellin_transform():
 
     # for coverage
 
-    assert IMT(pi/cos(pi*s), s, x, (0, S.Half)) == sqrt(x)/(x + 1)
+    assert simplify(IMT(pi/cos(pi*s), s, x, (0, S.Half))) == sqrt(x)/(x + 1)
 
 
 def test_fourier_transform():
@@ -580,8 +584,7 @@ def test_cosine_transform():
         (S.Half, 0, 0), (S.Half,)), a**2*w**2/4)/(2*pi), w, t) == 1/(a + t)
 
     res = cosine_transform(1/sqrt(a**2 + t**2), t, w)
-    assert res == sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2*exp_polar(0)/4)/(2*sqrt(pi))
-    assert res.replace(exp_polar, exp) == sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2/4)/(2*sqrt(pi))
+    assert res == sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2/4)/(2*sqrt(pi))
 
     assert inverse_cosine_transform(sqrt(2)*meijerg(((S.Half,), ()), ((0, 0), (S.Half,)), a**2*w**2/4)/(2*sqrt(pi)), w, t) == 1/(t*sqrt(a**2/t**2 + 1))
 

--- a/sympy/integrals/transforms.py
+++ b/sympy/integrals/transforms.py
@@ -912,11 +912,11 @@ def inverse_mellin_transform(F, s, x, strip, **hints):
 
     >>> f = 1/(s**2 - 1)
     >>> inverse_mellin_transform(f, s, x, (-oo, -1))
-    x*(1 - 1/x**2)*Heaviside(x - 1)/2
+    x*(1/2 - 1/(2*x**2))*Heaviside(x - 1)
     >>> inverse_mellin_transform(f, s, x, (-1, 1))
     -x*Heaviside(1 - x)/2 - Heaviside(x - 1)/(2*x)
     >>> inverse_mellin_transform(f, s, x, (1, oo))
-    (1/2 - x**2/2)*Heaviside(1 - x)/x
+    (1 - x**2)*Heaviside(1 - x)/(2*x)
 
     See Also
     ========

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2488,8 +2488,17 @@ def hyperexpand(f, allow_hyper=False, rewrite='default', place=None):
             return r
 
     def do_meijer(ap, bq, z):
-        r = _meijergexpand(G_Function(ap[0], ap[1], bq[0], bq[1]), z,
-                   allow_hyper, rewrite=rewrite, place=place)
+        c = 1
+        if z.extract_multiplicatively(-I):
+            c *= -1
+        zp = 1
+        for zf in z.as_ordered_factors():
+            if zf.is_number:
+                zp *= polarify(zf, lift=True)
+            else:
+                zp *= zf
+        r = c*_meijergexpand(G_Function(ap[0], ap[1], bq[0], bq[1]), zp,
+                             allow_hyper, rewrite=rewrite, place=place)
         if not r.has(nan, zoo, oo, -oo):
             return r
     return f.replace(hyper, do_replace).replace(meijerg, do_meijer)

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2503,14 +2503,9 @@ def hyperexpand(f, allow_hyper=False, rewrite='default', place=None):
             return r
 
     def do_meijer(ap, bq, z):
-        numeric, symbolic = [], []
-        for factor in Mul.make_args(z):
-            (numeric if factor.is_number else symbolic).append(factor)
-        # Lift the complete numeric coefficient: lifting -1 and I separately
-        # would give -I an extra turn around the origin.
-        zp = Mul(*symbolic)
-        if numeric:
-            zp *= polarify(Mul(*numeric), lift=True)
+        # A fully numeric argument has a known principal phase.  Do not split
+        # an ordinary symbolic product: its phase can change on substitution.
+        zp = polarify(z, lift=True) if z.is_number else z
         r = _meijergexpand(G_Function(ap[0], ap[1], bq[0], bq[1]), zp,
                           allow_hyper, rewrite=rewrite, place=place)
         if not r.has(nan, zoo, oo, -oo):

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2208,6 +2208,21 @@ def _meijergexpand(func, z0, allow_hyper=False, rewrite='default',
     If expansions exist both at zero and at infinity, ``place``
     can be set to ``0`` or ``zoo`` for the preferred choice.
     """
+    polar_factors, ordinary_factors = [], []
+    for factor in Mul.make_args(z0):
+        (polar_factors if factor.is_polar else ordinary_factors).append(factor)
+    ordinary = Mul(*ordinary_factors)
+    if not (ordinary.is_number or ordinary.is_Symbol):
+        # Keep an ordinary composite argument intact while the expansion
+        # simplifies powers on the logarithmic surface. Substituting it
+        # before polar denesting can, for example, turn sqrt(z**2) into z.
+        # Explicit polar factors must remain visible when choosing analytic
+        # continuations; only the ordinary part is replaced by the dummy.
+        argument = Dummy('argument')
+        result = _meijergexpand(func, argument*Mul(*polar_factors), allow_hyper,
+                               rewrite=rewrite, place=place)
+        return unpolarify(result.subs(argument, ordinary))
+
     global _meijercollection
     if _meijercollection is None:
         _meijercollection = MeijerFormulaCollection()

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2503,17 +2503,16 @@ def hyperexpand(f, allow_hyper=False, rewrite='default', place=None):
             return r
 
     def do_meijer(ap, bq, z):
-        c = 1
-        if z.extract_multiplicatively(-I):
-            c *= -1
-        zp = 1
-        for zf in z.as_ordered_factors():
-            if zf.is_number:
-                zp *= polarify(zf, lift=True)
-            else:
-                zp *= zf
-        r = c*_meijergexpand(G_Function(ap[0], ap[1], bq[0], bq[1]), zp,
-                             allow_hyper, rewrite=rewrite, place=place)
+        numeric, symbolic = [], []
+        for factor in Mul.make_args(z):
+            (numeric if factor.is_number else symbolic).append(factor)
+        # Lift the complete numeric coefficient: lifting -1 and I separately
+        # would give -I an extra turn around the origin.
+        zp = Mul(*symbolic)
+        if numeric:
+            zp *= polarify(Mul(*numeric), lift=True)
+        r = _meijergexpand(G_Function(ap[0], ap[1], bq[0], bq[1]), zp,
+                          allow_hyper, rewrite=rewrite, place=place)
         if not r.has(nan, zoo, oo, -oo):
             return r
     return f.replace(hyper, do_replace).replace(meijerg, do_meijer)

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -13,7 +13,7 @@ from sympy.simplify.hyperexpand import (ShiftA, ShiftB, UnShiftA, UnShiftB,
 from sympy.concrete.summations import Sum
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
-from sympy.core.numbers import I
+from sympy.core.numbers import I, Rational, pi
 from sympy.core.singleton import S
 from sympy.core.symbol import symbols
 from sympy.functions.combinatorial.factorials import binomial
@@ -22,8 +22,6 @@ from sympy.functions.special.hyper import (hyper, meijerg)
 from sympy.abc import z, a, b, c
 from sympy.testing.pytest import XFAIL, raises, slow, tooslow
 from sympy.core.random import verify_numerically as tn
-
-from sympy.core.numbers import (Rational, pi)
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import atanh
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -31,6 +29,9 @@ from sympy.functions.elementary.trigonometric import (asin, cos, sin)
 from sympy.functions.special.bessel import besseli
 from sympy.functions.special.error_functions import erf
 from sympy.functions.special.gamma_functions import (gamma, lowergamma)
+from sympy.polys.domains.realfield import RR
+from sympy.polys.domains.complexfield import CC
+from sympy.polys.polytools import factor_terms
 
 
 def test_branch_bug():
@@ -573,7 +574,6 @@ def test_meijerg_confluence():
 
 def test_meijerg_with_Floats():
     # see issue #10681
-    from sympy.polys.domains.realfield import RR
     f = meijerg(((3.0, 1), ()), ((Rational(3, 2),), (0,)), z)
     a = -2.3632718012073
     g = a*z**Rational(3, 2)*hyper((-0.5, Rational(3, 2)), (Rational(5, 2),), z*exp_polar(I*pi))
@@ -1062,3 +1062,45 @@ def test_omgissue_203():
     assert hyperexpand(h) == Rational(1, 30)
     h = hyper((-6, -7, -5), (-6, -6), 1)
     assert hyperexpand(h) == Rational(-1, 6)
+
+
+@slow
+def test_issue_26525_polarify_z():
+    x = symbols("x")
+
+    g = meijerg(((1, x + 2), ()), ((x + S(1)/2,), (0,)), -I*z)
+    h = hyperexpand(g)
+    assert h.replace(exp_polar, exp) == \
+           2*sqrt(pi)*z**(x + S.Half)*exp(3*I*pi*(x + S.Half)/2)*gamma(x + S.Half)*hyper(
+               (-S.Half, x + S.Half), (x + S(3)/2,), I*z)/gamma(x + S(3)/2)
+    for i in [g, h]:
+        assert CC.almosteq(i.subs({x: 0, z: 1}).evalf(),
+                           -4.32257296433943 + 5.92192068901469*I, 1e-12)
+
+    g = meijerg(((1, 2), ()), ((S(1)/2,), (0,)), -I)
+    h = hyperexpand(g)
+    for i in [g, h]:
+        assert CC.almosteq(i.evalf(),
+                           -4.32257296433943 + 5.92192068901469*I, 1e-12)
+
+    g = meijerg(((1, 2), ()), ((S(1)/2,), (0,)), -1)
+    h = hyperexpand(g)
+    assert h == -I*pi**(S(3)/2)
+
+    g = meijerg(((1, 2), ()), ((S(1)/2,), (0,)), 1)
+    assert hyperexpand(g) == sqrt(pi)*(-2*sqrt(2) - 2*log(1 + sqrt(2)))
+
+    g = meijerg(((0,), ()), ((S(1)/2,), (1,)), -1)
+    assert hyperexpand(g) == 3*exp(1)*I/2
+
+    g = meijerg(((0,), ()), ((S.Half,), (1,)), I)
+    assert hyperexpand(g) == (S.Half - I)*exp(-I)*exp(I*pi/4)
+
+    g = meijerg(((0,), ()), ((S.Half,), (1,)), -I)
+    assert factor_terms(hyperexpand(g)) == factor_terms((-S.Half - I)*exp(I)*exp(3*I*pi/4))
+
+    g = meijerg(((1,), ()), ((1,), ()), 0)
+    assert hyperexpand(g) == 0
+
+    g = meijerg(((S.Half,), ()), ((1,), ()), 0)
+    assert hyperexpand(g) == 0

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1104,3 +1104,12 @@ def test_issue_26525_polarify_z():
 
     g = meijerg(((S.Half,), ()), ((1,), ()), 0)
     assert hyperexpand(g) == 0
+
+
+def test_issue_26525_gamma_sign():
+    a = symbols("a")
+    g = I*meijerg(((1, a + 2), ()), ((a + S.Half,), (0,)), -1)/(2*sqrt(pi))
+    h = hyperexpand(g)
+    assert h == I*sqrt(pi)*exp(I*pi*(a + S(3)/2))*gamma(a + S.Half)/(2*gamma(a + 2))
+    assert h.subs(a, 0) == pi/2
+    assert h.subs(a, 1) == -pi/8

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1072,11 +1072,20 @@ def test_issue_26525_polarify_z():
     g = meijerg(((1, x + 2), ()), ((x + S(1)/2,), (0,)), -I*z)
     h = hyperexpand(g)
     assert h.replace(exp_polar, exp) == \
-           2*sqrt(pi)*z**(x + S.Half)*exp(3*I*pi*(x + S.Half)/2)*gamma(x + S.Half)*hyper(
+           -2*sqrt(pi)*z**(x + S.Half)*exp(-I*pi*(x + S.Half)/2)*gamma(x + S.Half)*hyper(
                (-S.Half, x + S.Half), (x + S(3)/2,), I*z)/gamma(x + S(3)/2)
     for i in [g, h]:
         assert CC.almosteq(i.subs({x: 0, z: 1}).evalf(),
                            -4.32257296433943 + 5.92192068901469*I, 1e-12)
+
+    # Integer parameters conceal an incorrect full turn in the argument.
+    for value in (S.One/3, S.Half):
+        point = {x: value, z: 1}
+        assert abs(h.subs(point).evalf() - g.subs(point).evalf()) < 1e-12
+
+    # Outside the unit circle, the wrong winding changes the continuation.
+    g = meijerg(((1, 2), ()), ((S.Half,), (0,)), -2*I)
+    assert abs(hyperexpand(g).evalf() - g.evalf()) < 1e-12
 
     g = meijerg(((1, 2), ()), ((S(1)/2,), (0,)), -I)
     h = hyperexpand(g)
@@ -1098,7 +1107,7 @@ def test_issue_26525_polarify_z():
     assert hyperexpand(g) == (S.Half - I)*exp(-I)*exp(I*pi/4)
 
     g = meijerg(((0,), ()), ((S.Half,), (1,)), -I)
-    assert factor_terms(hyperexpand(g)) == factor_terms((-S.Half - I)*exp(I)*exp(3*I*pi/4))
+    assert factor_terms(hyperexpand(g)) == factor_terms((S.Half + I)*exp(I)*exp(-I*pi/4))
 
     g = meijerg(((1,), ()), ((1,), ()), 0)
     assert hyperexpand(g) == 0

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -22,6 +22,7 @@ from sympy.functions.special.hyper import (hyper, meijerg)
 from sympy.abc import z, a, b, c
 from sympy.testing.pytest import XFAIL, raises, slow, tooslow
 from sympy.core.random import verify_numerically as tn
+from sympy.functions.elementary.complexes import Abs
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
 from sympy.functions.elementary.hyperbolic import atanh
 from sympy.functions.elementary.miscellaneous import sqrt
@@ -372,9 +373,9 @@ def test_meijerg_expand():
     assert hyperexpand(meijerg([[1, 1], []], [[1], [1]], z)) == \
         z/(z + 1)
     assert hyperexpand(meijerg([[], []], [[S.Half], [0]], (z/2)**2)) \
-        == sin(z)/sqrt(pi)
+        == sin(sqrt(z**2))/sqrt(pi)
     assert hyperexpand(meijerg([[], []], [[0], [S.Half]], (z/2)**2)) \
-        == cos(z)/sqrt(pi)
+        == cos(sqrt(z**2))/sqrt(pi)
     assert can_do_meijer([], [a], [a - 1, a - S.Half], [])
     assert can_do_meijer([], [], [a/2], [-a/2], False)  # branches...
     assert can_do_meijer([a], [b], [a], [b, a - 1])
@@ -424,7 +425,7 @@ def test_meijerg_expand():
     # Test place option
     f = meijerg(((0, 1), ()), ((S.Half,), (0,)), z**2)
     assert hyperexpand(f) == sqrt(pi)/sqrt(1 + z**(-2))
-    assert hyperexpand(f, place=0) == sqrt(pi)*z/sqrt(z**2 + 1)
+    assert hyperexpand(f, place=0) == sqrt(pi)*sqrt(z**2)/sqrt(z**2 + 1)
 
 
 def test_meijerg_lookup():
@@ -1113,3 +1114,44 @@ def test_issue_26525_gamma_sign():
     assert h == I*sqrt(pi)*exp(I*pi*(a + S(3)/2))*gamma(a + S.Half)/(2*gamma(a + 2))
     assert h.subs(a, 0) == pi/2
     assert h.subs(a, 1) == -pi/8
+
+
+def test_issue_24374():
+    x = symbols("x", real=True)
+    g = meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
+    assert hyperexpand(g) == sin(Abs(x))/sqrt(pi)
+
+    x = symbols("x", positive=True)
+    g = meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
+    assert hyperexpand(g) == sin(x)/sqrt(pi)
+
+
+def test_meijerg_composite_argument_branches():
+    from sympy.simplify.simplify import simplify
+
+    x, y = symbols('x y', real=True)
+    g = meijerg([], [], [S.Half], [0], x*y)
+    assert hyperexpand(g) == sin(2*sqrt(x*y))/sqrt(pi)
+
+    # The protection must apply to other parameter tuples too.
+    g = meijerg([], [], [3*S.Half], [0], x**2/4)
+    h = hyperexpand(g)
+    assert simplify(h.subs(x, -1) - (sin(1) - cos(1))/(2*sqrt(pi))) == 0
+
+    # An explicitly specified turn around the origin must be retained.
+    g = meijerg([], [], [S.Half], [0], x**2*exp_polar(2*pi*I)/4)
+    assert hyperexpand(g) == -sin(Abs(x))/sqrt(pi)
+
+
+def test_issue_25123():
+    from sympy.simplify.simplify import simplify
+
+    for x in (symbols('x'), symbols('x', real=True)):
+        g = meijerg([-S.Half], [0, 0, S.Half, 1],
+                    [-S.Half, 0, 0], [], x**-2)
+        h = hyperexpand(g)
+        # The input depends on x**2, so its expansion must be even.
+        assert h.subs(x, -x) == h
+        for value in (-2, -1, 1, 2):
+            expected = (2*abs(value) - sin(2*abs(value)))/sqrt(pi)
+            assert simplify(h.subs(x, value) - expected) == 0

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1071,9 +1071,10 @@ def test_issue_26525_polarify_z():
 
     g = meijerg(((1, x + 2), ()), ((x + S(1)/2,), (0,)), -I*z)
     h = hyperexpand(g)
-    assert h.replace(exp_polar, exp) == \
-           -2*sqrt(pi)*z**(x + S.Half)*exp(-I*pi*(x + S.Half)/2)*gamma(x + S.Half)*hyper(
-               (-S.Half, x + S.Half), (x + S(3)/2,), I*z)/gamma(x + S(3)/2)
+    assert h == \
+           -2*sqrt(pi)*(-I*z)**(x + S.Half)*gamma(x + S.Half)*hyper(
+               (-S.Half, x + S.Half), (x + S(3)/2,),
+               -I*z*exp_polar(I*pi))/gamma(x + S(3)/2)
     for i in [g, h]:
         assert CC.almosteq(i.subs({x: 0, z: 1}).evalf(),
                            -4.32257296433943 + 5.92192068901469*I, 1e-12)
@@ -1133,6 +1134,16 @@ def test_issue_24374():
     x = symbols("x", positive=True)
     g = meijerg(((), ()), ((S.Half,), (0,)), x**2/4)
     assert hyperexpand(g) == sin(x)/sqrt(pi)
+
+
+def test_hyperexpand_negated_unrestricted_symbol():
+    x = symbols("x")
+    g = meijerg(((-S.Half,), (0, 0, S.Half, 1)),
+                ((-S.Half, 0, 0), ()), -x)
+    h = hyperexpand(g)
+
+    for value in (-2, 2):
+        assert abs(h.subs(x, value).evalf() - g.subs(x, value).evalf()) < 1e-12
 
 
 def test_meijerg_composite_argument_branches():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #25123
Fixes #28485

Partial fix for #26525
Partial fix for #30319
Partial fix for #5462
Partial fix for #2537

See #10211
See #24374

Replaces #26551
See also #30430


<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed



#### Other comments

@ehren sorry I never got back to gh-26551. I partly forgot about it but remembered now when going back through all of the issues with meijerint. I've kept your commit here although based on current master now and I just added another test.

#### AI Generation Disclosure

I used codex to search through all old issues for other examples of meijerint integrals fixed by this but did not find anything although codex suggested adding another test.

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* simplify
    * polarify meijerg z param prior to hyperexpand to fix some flipped signs / incorrect results from hyperexpand for particular z
<!-- END RELEASE NOTES -->
