### PR TITLE
Fix zero results for whole-period trigonometric integrals

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1845,6 +1845,7 @@ foice <foice.news@gmail.com>
 generatingfunctions <573848+generatingfunctions@users.noreply.github.com>
 goddus <39923708+goddus@users.noreply.github.com>
 gregmedlock <gmedlo@gmail.com>
+greyf <258340642+jonathanwxh-cell@users.noreply.github.com>
 helo9 <helo9@users.noreply.github.com>
 hm <hacman0@gmail.com>
 immerrr <immerrr@gmail.com>

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -555,6 +555,14 @@ class Integral(AddWithLimits):
             if (function.has(Piecewise) and
                 not isinstance(function, Piecewise)):
                     function = piecewise_fold(function)
+            if (len(xab) == 3 and not function.is_Poly
+                    and not any((manual, meijerg, risch, heurisch))):
+                ret = trigintegrate_definite(function, *xab, conds=conds)
+                if ret is not None:
+                    if conds == 'separate' and len(self.limits) != 1:
+                        raise ValueError('conds=separate not supported in multiple integrals')
+                    function = ret
+                    continue
             if isinstance(function, Piecewise):
                 if len(xab) == 1:
                     antideriv = function._eval_integral(xab[0],
@@ -1644,4 +1652,4 @@ def _(expr):
 # Delayed imports
 from .deltafunctions import deltaintegrate
 from .meijerint import meijerint_definite, meijerint_indefinite, _debug
-from .trigonometry import trigintegrate
+from .trigonometry import trigintegrate, trigintegrate_definite

--- a/sympy/integrals/tests/test_failing_integrals.py
+++ b/sympy/integrals/tests/test_failing_integrals.py
@@ -238,12 +238,6 @@ def test_issue_4311_slow():
     assert not integrate(x*abs(9-x**2), x).has(Integral)
 
 @XFAIL
-def test_issue_20370():
-    a = symbols('a', positive=True)
-    assert integrate((1 + a * cos(x))**-1, (x, 0, 2 * pi)) == (2 * pi / sqrt(1 - a**2))
-
-
-@XFAIL
 def test_polylog():
     # log(1/x)*log(x+1)-polylog(2, -x)
     assert not integrate(log(1/x)/(x + 1), x).has(Integral)

--- a/sympy/integrals/tests/test_trigonometry_definite.py
+++ b/sympy/integrals/tests/test_trigonometry_definite.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from sympy import (And, Eq, I, Integral, Ne, Piecewise, Rational, S, cos,
+                   exp, integrate, oo, pi, sign, sin, sqrt, symbols)
+from sympy.integrals.trigonometry import trigintegrate_definite
+from sympy.testing.pytest import raises
+
+
+x = symbols('x')
+
+
+def test_issue_20370():
+    a = symbols('a', positive=True)
+    result = integrate(1/(1 + a*cos(x)), (x, 0, 2*pi))
+    assert result == Piecewise(
+        (2*pi/sqrt(1 - a**2), a**2 < 1),
+        (oo, Eq(a**2, 1)), (S.NaN, True))
+    assert result.subs(a, Rational(1, 2)) == 4*sqrt(3)*pi/3
+    assert result.subs(a, 1) is oo
+    assert result.subs(a, 2) is S.NaN
+
+
+def test_real_parameter_and_specialization():
+    a = symbols('a', real=True)
+    result = integrate(1/(1 + a*cos(x)), (x, 0, 2*pi))
+    for value in [-2, -1, -S.Half, 0, S.Half, 1, 2]:
+        assert result.subs(a, value) == integrate(
+            1/(1 + value*cos(x)), (x, 0, 2*pi))
+
+
+def test_affine_sine_cosine_denominator():
+    a, b, c = symbols('a b c', real=True)
+    delta = a**2 - b**2 - c**2
+    result = integrate(1/(a + b*cos(x) + c*sin(x)), (x, 0, 2*pi))
+    assert result == Piecewise(
+        (2*pi*sign(a)/sqrt(delta), delta > 0),
+        (oo*sign(a), And(Eq(delta, 0), Ne(a, 0))), (S.NaN, True))
+    assert result.subs({a: 6, b: 3, c: 4}) == 2*pi/sqrt(11)
+    assert result.subs({a: -6, b: 3, c: 4}) == -2*pi/sqrt(11)
+    assert result.subs({a: 5, b: 3, c: 4}) is oo
+    assert result.subs({a: -5, b: 3, c: 4}) is -oo
+    assert result.subs({a: 4, b: 3, c: 4}) is S.NaN
+    assert result.subs({a: 2, b: 0, c: 0}) == pi
+
+
+def test_period_orientation_and_phase():
+    phase, start = symbols('phase start', real=True)
+    k = symbols('k', positive=True)
+    n = symbols('n', positive=True, integer=True)
+    f = 1/(6 + 3*cos(k*x + phase) + 4*sin(k*x + phase))
+    end = start + 2*pi*n/k
+    assert integrate(f, (x, start, end)) == 2*pi*n/(k*sqrt(11))
+    assert integrate(f, (x, end, start)) == -2*pi*n/(k*sqrt(11))
+    assert integrate(f.subs(k, -k), (x, start, end)) == 2*pi*n/(k*sqrt(11))
+    assert integrate(1/(2 + cos(x)), (x, -pi, pi)) == 2*pi/sqrt(3)
+
+
+def test_improper_integrals_and_scalar_numerator():
+    d = symbols('d', real=True)
+    result = integrate(d/(1 + cos(x)), (x, 0, 2*pi))
+    assert result.subs(d, 0) == 0
+    assert result.subs(d, 2) is oo
+    assert result.subs(d, -2) is -oo
+    assert integrate(1/(1 + cos(x)), (x, 2*pi, 0)) is -oo
+    assert integrate(1/(-1 + sin(x)), (x, 0, 2*pi)) is -oo
+    assert integrate(1/cos(x), (x, 0, 2*pi)) is S.NaN
+    assert integrate(1/(1 + 2*sin(x)), (x, 0, 2*pi)) is S.NaN
+    assert integrate(7/(6 + 3*cos(x) + 4*sin(x)), (x, 0, 2*pi)) == 14*pi/sqrt(11)
+
+
+def test_convergence_hints():
+    a = symbols('a', positive=True)
+    f = 1/(1 + a*cos(x))
+    assert integrate(f, (x, 0, 2*pi), conds='separate') == (
+        2*pi/sqrt(1 - a**2), 1 - a**2 > 0)
+    assert integrate(f, (x, 0, 2*pi), conds='none') == 2*pi/sqrt(1 - a**2)
+    assert integrate(1/(2 + cos(x)), (x, 0, 2*pi), conds='separate') == (
+        2*pi/sqrt(3), S.true)
+    y = symbols('y')
+    raises(ValueError, lambda: integrate(f, (x, 0, 2*pi), (y, 0, 1), conds='separate'))
+
+
+def test_nested_integral():
+    a = symbols('a', positive=True)
+    assert integrate(1/(1 + a*cos(x)), (x, 0, 2*pi), (a, 0, S.Half)) == pi**2/3
+
+
+def test_definite_rule_scope():
+    a = symbols('a')
+    r = symbols('r', real=True)
+    # Unsupported inputs must reach the other integration methods.
+    for f, lo, hi in [
+        (exp(x), 0, 2*pi),
+        (cos(x), 0, 2*pi),
+        (x/(2 + cos(x)), 0, 2*pi),
+        (1/(2 + cos(x)**2), 0, 2*pi),
+        (1/(2 + cos(x) + sin(2*x)), 0, 2*pi),
+        (1/(2 + cos(x**2)), 0, 2*pi),
+        (1/(2 + cos(a*x)), 0, 2*pi),
+        (1/(2 + cos(r*x)), 0, 2*pi),
+        (1/(a + cos(x)), 0, 2*pi),
+        (1/(2 + cos(x + I)), 0, 2*pi),
+        (1/(2 + cos(x)), 0, pi),
+        (1/(2 + cos(x)), 0, oo),
+        (1/(2 + cos(x)), 0, 2*pi*I),
+        (1/(2 + cos(x)), 0, 0),
+    ]:
+        assert trigintegrate_definite(f, x, S(lo), S(hi)) is None
+    assert integrate(1/(2 + cos(x)), (x, 0, pi)) == pi/sqrt(3)
+    f = 1/(2 + cos(x))
+    assert isinstance(integrate(f, x, meijerg=True), Integral)

--- a/sympy/integrals/trigonometry.py
+++ b/sympy/integrals/trigonometry.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
-from sympy.core import cacheit, Dummy, Ne, Integer, Rational, S, Wild
-from sympy.functions import binomial, sin, cos, Piecewise, Abs
+from sympy.core import cacheit, Dummy, Eq, Ne, Integer, Rational, S, Wild
+from sympy.core.numbers import pi
+from sympy.functions import binomial, sin, cos, Piecewise, Abs, sign, sqrt
+from sympy.logic.boolalg import And
 from .integrals import integrate
 
 # TODO sin(a*x)*cos(b*x) -> sin((a+b)x) + sin((a-b)x) ?
@@ -25,6 +27,69 @@ def _pat_sincos(x):
     return pat, a, n, m
 
 _u = Dummy('u')
+
+
+def trigintegrate_definite(f, x, a, b, conds='piecewise'):
+    """Integrate a reciprocal affine sine/cosine over whole periods.
+
+    Recognize ``d/(A + B*cos(k*x + p) + C*sin(k*x + p))`` with real
+    coefficients, nonzero real ``k``, and finite real limits spanning a
+    nonzero integer number of periods. Return None for other integrands.
+
+    Writing ``B*cos(t) + C*sin(t)`` as a shifted cosine shows that the
+    denominator has constant sign precisely when ``A**2 > B**2 + C**2``.
+    In that case the tangent half-angle substitution on each half-period
+    gives the mean ``sign(A)/sqrt(A**2 - B**2 - C**2)``. Evaluating a
+    logarithmic antiderivative only at the endpoints can lose its branch
+    jump, incorrectly giving zero (issue #20370).
+
+    At equality, with nonzero ``A``, the denominator has a double zero
+    and the integral has a signed infinite limit. Inside that boundary there are simple poles:
+    the ordinary improper integral is undefined, even when its Cauchy
+    principal value exists. ``conds`` follows integrate's convention:
+    'separate' returns the finite value and its convergence condition;
+    'none' omits that condition.
+    """
+    if not f.has(sin, cos) or not all(v.is_real for v in (a, b)):
+        return None
+    numerator, denominator = f.as_numer_denom()
+    if numerator.has(x) or numerator.is_real is not True:
+        return None
+    trig = [t for t in denominator.atoms(sin, cos) if t.has(x)]
+    if not trig:
+        return None
+    argument = trig[0].args[0]
+    if any(t.args[0] != argument for t in trig):
+        return None
+    k = argument.diff(x)
+    phase = argument - k*x
+    if (k.has(x) or phase.has(x) or k.is_real is not True
+            or k.is_zero is not False or phase.is_real is not True):
+        return None
+    periods = (k*(b - a)/(2*pi)).cancel()
+    if periods.is_integer is not True or periods.is_zero is not False:
+        return None
+
+    c, s = Dummy('c'), Dummy('s')
+    polynomial = denominator.xreplace({cos(argument): c, sin(argument): s}).as_poly(c, s)
+    if polynomial is None or polynomial.total_degree() != 1:
+        return None
+    A, B, C = [polynomial.coeff_monomial(m) for m in (1, c, s)]
+    if any(v.has(x) or v.is_real is not True for v in (A, B, C)):
+        return None
+
+    discriminant = A**2 - B**2 - C**2
+    condition = discriminant > 0
+    value = numerator*(b - a)*sign(A)/sqrt(discriminant)
+    if conds == 'separate':
+        return value, condition
+    if conds == 'none':
+        return value
+    return Piecewise(
+        (S.Zero, Eq(numerator, 0)),
+        (value, condition),
+        (S.Infinity*sign(numerator*A*(b - a)), And(Eq(discriminant, 0), Ne(A, 0))),
+        (S.NaN, True))
 
 
 def trigintegrate(f, x, conds='piecewise'):


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes #20370

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed

SymPy was returning zero for an integral that should be positive. The fix was to calculate over whole periods, accounting for whether the integral converges or diverges. Codex wrote the implementation and tests—all 457 integration tests and 63 numerical checks passed.


#### Other comments

```text
pytest sympy/integrals/tests -n 4 -q --timeout=180
445 passed, 24 xfailed, 1 xpassed

pytest sympy/integrals/tests/test_integrals.py sympy/integrals/tests/test_trigonometry.py sympy/integrals/tests/test_trigonometry_definite.py -m 'slow and not tooslow' -n 4 -q --timeout=300
12 passed
```


#### AI Generation Disclosure

Codex wrote the implementation and tests.

```text
sympy/integrals/trigonometry.py:2-5,32-94
sympy/integrals/integrals.py:558-565,1655
sympy/integrals/tests/test_trigonometry_definite.py:1-111
sympy/integrals/tests/test_failing_integrals.py:240-245 (removed, base revision)
.mailmap:1848
```

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* integrals
  * SymPy was returning zero for an integral that should be positive. The fix was to calculate over whole periods, accounting for whether the integral converges or diverges.

<!-- END RELEASE NOTES -->
