### PR TITLE
manualintegrate: add rule to target integrals with square-root denominators whose radicands have perfect-square factors

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -73,7 +73,8 @@ from .integrals import Integral
 from .rationaltools import ratint
 from sympy.logic.boolalg import And, Boolean
 from sympy.ntheory.factor_ import primefactors
-from sympy.polys.polytools import degree, factor_list, lcm_list, gcd_list, Poly
+from sympy.polys.polytools import degree, factor_list, lcm_list, gcd_list, Poly, sqf_list
+from sympy.polys.rationaltools import together
 from sympy.simplify.simplify import simplify
 from sympy.simplify.fu import sincos_to_sum
 from sympy.simplify.powsimp import powsimp
@@ -3176,6 +3177,55 @@ def trig_product_to_sum_rule(integral: IntegralInfo):
     return RewriteRule(integrand, symbol, rewritten, substep)
 
 
+def perfect_square_radicand_rule(integral: IntegralInfo):
+    r"""
+    Rewrite an integral containing a square-root denominator by extracting
+    perfect-square factors from its radicand. Useful for integrals in the
+    complex domain of the form
+
+    integral H(z)/sqrt(c*G(z)) dz = (F(z)*sqrt(c*R(z)))/sqrt(c*G(z)) * integral H(z)/(F(z)*sqrt(c*R(z))) dz
+    """
+    integrand, symbol = integral
+    if symbol.is_real:
+        return
+    if not isinstance(integrand, Mul) and not isinstance(integrand, Pow):
+        return
+
+    H_ = Wild('H', exclude=[0])
+    G_ = Wild('G')
+    pattern = H_/sqrt(G_)
+    match = integrand.match(pattern)
+    if not match:
+        return
+    H, G = match[H_], match[G_]
+
+    if not G.has(symbol):
+        return
+
+    _, denom = together(G).as_numer_denom()
+    if denom.has(symbol):
+        return
+
+    # Do not use `symbol` to be able to target functions e.g. G = sin(x)**2.
+    # Use `frac=True` to be able to target fractional constants e.g. G = x**4/z
+    # + x**2, without comprimising on functions targeting
+    coeff, numer_factors, denom_factors = sqf_list(G, frac=True)
+    c = coeff / Mul(*[f**e for f, e in denom_factors])
+    reducible = {r[0]**(Integer(r[1])/2) for r in numer_factors if r[1] % 2 == 0}
+    irreducible = {r[0]**r[1] for r in numer_factors if r[1] % 2 != 0}
+
+    if not reducible:
+        return
+
+    F = Mul(*reducible)
+    R = Mul(*irreducible)
+    factor = (F*sqrt(c*R))/sqrt(G)
+    rewritten = H/(F*sqrt(c*R))
+
+    substep = yield IntegralInfo(rewritten, symbol)
+    return ConstantTimesRule(integrand, symbol, factor, rewritten, substep)
+
+
 def hyperbolic_rule(integral: tuple[Expr, Symbol]):
     integrand, symbol = integral
     if isinstance(integrand, HyperbolicFunction) and integrand.args[0] == symbol:
@@ -3988,6 +4038,7 @@ class IntegrationSolver:
                     branch=self.branch
                 )),
                 null_safe(condition(_integral_is_subclass(Mul, Pow), w(nested_pow_rule))),
+                null_safe(w(perfect_square_radicand_rule)),
             ),
             w(fallback_rule))
 

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2127,8 +2127,8 @@ def test_issue_19639():
 
 
 def test_issue_23942():
-    I1 = Integral(1/sqrt(a*(1 + x)**3 + (1 + x)**2), (x, 0, z))
-    assert I1.series(a, 1, n=1) == Integral(1/sqrt(x**3 + 4*x**2 + 5*x + 2), (x, 0, z)) + O(a - 1, (a, 1))
+    I1 = Integral(1/sqrt(a*(1 + x)**3 + (2 + x)**2), (x, 0, z))
+    assert I1.series(a, 1, n=1) == Integral(1/sqrt(x**3 + 4*x**2 + 7*x + 5), (x, 0, z)) + O(a - 1, (a, 1))
     I2 = Integral(1/sqrt(a*(4 - x)**4 + (5 + x)**2), (x, 0, z))
     assert I2.series(a, 2, n=1) == Integral(1/sqrt(2*x**4 - 32*x**3 + 193*x**2 - 502*x + 537), (x, 0, z)) + O(a - 2, (a, 2))
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -19,7 +19,8 @@ from sympy.functions.special.zeta_functions import polylog
 from sympy.integrals.integrals import (Integral, integrate)
 from sympy.logic.boolalg import And
 from sympy.integrals.manualintegrate import (manualintegrate, find_substitutions,
-    _parts_rule, bioche_substitution, integral_steps, manual_subs, IntegrationSolver)
+    _parts_rule, bioche_substitution, integral_steps, manual_subs,
+    IntegralInfo, IntegrationSolver, perfect_square_radicand_rule)
 from sympy.testing.pytest import raises, slow
 from typing import TYPE_CHECKING
 
@@ -1457,6 +1458,46 @@ def test_manualintegrate_solver_cache_with_max_depth():
     unbounded_solver = IntegrationSolver(max_depth=None)
     unbounded_solver.solve(exp(x)*sin(x), x)
     assert len(unbounded_solver._solved) == len(solver._solved)
+
+
+def test_manualintegrate_perfect_square_radicand_rule():
+    f = 1/sqrt(-z*sin(x)**2)
+    F = -log(cot(x) + csc(x))*sin(x)/sqrt(-z*sin(x)**2)
+    assert_is_integral_of(f, F)
+
+    f = 1/sqrt(z*x**4)
+    F = -x/sqrt(z*x**4)
+    assert_is_integral_of(f, F)
+
+    f = x**3/sqrt(z*x**4)
+    F = sqrt(z*x**4)/(2*z)
+    assert_is_integral_of(f, F)
+
+    f = 1/sqrt(-z*x**2)
+    F = x*log(x)/sqrt(-z*x**2)
+    assert_is_integral_of(f, F)
+
+    f = 1/sqrt(z*exp(2*x))
+    F = -1/sqrt(z*exp(2*x))
+    assert_is_integral_of(f, F)
+
+    f = 1/sqrt(z*log(x)**2)
+    F = log(x)*li(x)/sqrt(z*log(x)**2)
+    assert_is_integral_of(f, F)
+
+    f = x/sqrt(z*exp(2*x))
+    F = (-x*exp(-x) - exp(-x))*exp(x)/sqrt(z*exp(2*x))
+    assert_is_integral_of(f, F)
+
+
+def test_manualintegrate_perfect_square_radicand_rule_real_symbol():
+    t = symbols('t', real=True)
+    integral = IntegralInfo(1/sqrt(z*t**4), t)
+    assert IntegrationSolver().run(perfect_square_radicand_rule, integral) is None
+
+    f = 1/sqrt(z*t**4)
+    F = -1/(t*sqrt(z))
+    assert manualintegrate(f, t) == F
 
 
 def test_mul_pow_derivative():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->
Fixes #30163.
Reimplements #30258.

#### Brief description of what is fixed or changed
Now it handles all the previously failing cases (or at least does not return an error on them).

Before:
```python
>>> manualintegrate(1/sqrt(x + 1/x), x)
PolynomialError: a polynomial expected, got x + 1/x
>>> manualintegrate(1/((x + 1)*sqrt((x - 1)**2)), x)
PolynomialError: a polynomial expected, got 4 - 4/_u + _u**(-2)
```

After:
```python
In [3]: manualintegrate(1/sqrt(x + 1/x), x)
Out[3]:
⌠
⎮      1
⎮ ─────────── dx
⎮     _______
⎮    ╱     1
⎮   ╱  x + ─
⎮ ╲╱       x
⌡

In [4]: manualintegrate(1/((x + 1)*sqrt((x - 1)**2)), x)
   ...:
Out[4]:
        ⎛log(x - 1)   log(x + 1)⎞
(x - 1)⋅⎜────────── - ──────────⎟
        ⎝    2            2     ⎠
─────────────────────────────────
             __________
            ╱        2
          ╲╱  (x - 1)
```

Before:

```python
>>> manualintegrate(1/sqrt(x + sin(x)/z), x)
PolynomialError: sin(x) contains an element of the set of generators.
>>> manualintegrate(1/sqrt(x + log(x)/z), x)      # same
>>> manualintegrate(1/sqrt(x**x/z + 1), x)        # same
>>> manualintegrate(1/sqrt(x**2*exp(x)/z), x)     # same
```

After:

```python
In [6]: manualintegrate(1/sqrt(x + sin(x)/z), x)
   ...:
Out[6]:
⌠
⎮        1
⎮ ──────────────── dx
⎮     ____________
⎮    ╱     sin(x)
⎮   ╱  x + ──────
⎮ ╲╱         z
⌡

In [7]: manualintegrate(1/sqrt(x + log(x)/z), x)
   ...:
Out[7]:
⌠
⎮        1
⎮ ──────────────── dx
⎮     ____________
⎮    ╱     log(x)
⎮   ╱  x + ──────
⎮ ╲╱         z
⌡

In [8]: manualintegrate(1/sqrt(x**x/z + 1), x)
   ...:
Out[8]:
⌠
⎮       1
⎮ ───────────── dx
⎮      ________
⎮     ╱  x
⎮    ╱  x
⎮   ╱   ── + 1
⎮ ╲╱    z
⌡

In [9]: manualintegrate(1/sqrt(x**2*exp(x)/z), x)
   ...:
Out[9]:
       ____
      ╱  x  ⌠
     ╱  ℯ   ⎮      1
x⋅  ╱   ── ⋅⎮ ─────────── dx
  ╲╱    z   ⎮        ____
            ⎮       ╱  x
            ⎮      ╱  ℯ
            ⎮ x⋅  ╱   ──
            ⎮   ╲╱    z
            ⌡
────────────────────────────
             _______
            ╱  2  x
           ╱  x ⋅ℯ
          ╱   ─────
        ╲╱      z
```

By before, I am referencing to the previous PR, not master. These integrals are fully unevaluated on master.

#### Other comments
One of the found issues is that now it tries to add nonsensical degenerate for the extra constant when its reciprocal. 

```python
In [3]: manualintegrate(1/sqrt(x**4/z+x**2), x)
Out[3]:
                ⎛⎧                                                                              1    ⎞
                ⎜⎪                                  nan                                     for ─ = 0⎟
       ________ ⎜⎪                                                                              z    ⎟
      ╱  2      ⎜⎪                                                                                   ⎟
     ╱  x  + z  ⎜⎪   ⎛                 1            ⎞      ⎛                1            ⎞           ⎟
x⋅  ╱   ────── ⋅⎜⎨log⎜-1 + ─────────────────────────⎟ - log⎜1 + ─────────────────────────⎟  otherwise⎟
  ╲╱      z     ⎜⎪   ⎜                      ________⎟      ⎜                     ________⎟           ⎟
                ⎜⎪   ⎜           ___       ╱  2     ⎟      ⎜          ___       ╱  2     ⎟           ⎟
                ⎜⎪   ⎜          ╱ 1       ╱  x      ⎟      ⎜         ╱ 1       ╱  x      ⎟           ⎟
                ⎜⎪   ⎜     x⋅  ╱  ─  +   ╱   ── + 1 ⎟      ⎜    x⋅  ╱  ─  +   ╱   ── + 1 ⎟           ⎟
                ⎝⎩   ⎝       ╲╱   z    ╲╱    z      ⎠      ⎝      ╲╱   z    ╲╱    z      ⎠           ⎠
──────────────────────────────────────────────────────────────────────────────────────────────────────
                                                 _________
                                                ╱  4
                                               ╱  x     2
                                              ╱   ── + x
                                            ╲╱    z
```

I have no clue how to fix that.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->
Claude Code (Sonnet 5) suggest the use of `sqf_list(G, frac=True)`.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added a new rule for integrals involving the reciprocal of a perfect-square radicands for integration variables in the complex domain.
<!-- END RELEASE NOTES -->
