### PR TITLE
Fix missing pole solutions in solveset trig solver

### DIFF
--- a/sympy/solvers/solveset.py
+++ b/sympy/solvers/solveset.py
@@ -1004,14 +1004,19 @@ def _solve_trig2(f, symbol, domain):
 
     if g.has(x) or h.has(x):
         return ConditionSet(symbol, Eq(f_original, 0), domain)
+
     solns = solveset(g, y, S.Reals) - solveset(h, y, S.Reals)
 
     if isinstance(solns, FiniteSet):
         result = Union(*[invert_real(tan(symbol/mu), s, symbol)[1]
                        for s in solns])
-        dsol = invert_real(tan(symbol/mu), oo, symbol)[1]
-        if degree(h) > degree(g):                   # If degree(denom)>degree(num) then there
-            result = Union(result, dsol)            # would be another sol at Lim(denom-->oo)
+        if degree(h) > degree(g):
+            _n = Dummy('n', integer=True)
+            dsol = ImageSet(
+                Lambda(_n, (2*_n + 1)*pi*mu/2),
+                S.Integers
+            )
+            result = Union(result, dsol)
         return Intersection(result, domain)
     elif solns is S.EmptySet:
         return S.EmptySet


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30401

#### Brief description of what is fixed or changed

Fix missing pole solutions in `_solve_trig2`.

The previous implementation used `invert_real(..., oo, ...)`
to determine additional solutions at tangent poles. This could
miss valid solutions.

This change explicitly adds the missing pole solutions when the
denominator degree is greater than the numerator degree.

For example, this fixes missing solutions for:

`sin(4*x) + sin(3*x)`

#### Other comments

The modified solveset test suite passes:

181 passed, 2 skipped, 5 deselected, 13 xfailed.

Additional checks confirm that `pi`, `3*pi`, and `5*pi` are
recognized as solutions of `sin(4*x) + sin(3*x)`.

#### AI Generation Disclosure

AI assistance was used during development to help diagnose the
issue and review/debug the implementation. The final code was
tested locally and verified by the author.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* solvers
  * Fixed missing pole solutions in `_solve_trig2`.

<!-- END RELEASE NOTES -->