### PR TITLE
meijerint: reject G-function antiderivatives that do not differentiate back to the integrand

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -209,6 +209,7 @@ Abhi58 <abhijithbharadwaj58@gmail.com>
 Abhigyan Khaund <mail@abhigyan.xyz>
 Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
 Abhijith Shaji <abhijithshajikp@gmail.com> <84089020+abhiskp@users.noreply.github.com>
+Abhinav <alpha9coder@gmail.com> abhinav-phi <alpha9coder@gmail.com>
 Abhinav Agarwal <abhinavagarwal1996@gmail.com>
 Abhinav Anand <abhinav.anand2807@gmail.com>
 Abhinav Chanda <abhinavchanda01@gmail.com>

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1650,6 +1650,48 @@ def _rewrite2(f, x):
                 return fac, po, g1[0], g2[0], cond
 
 
+def _antiderivative_passes(res, f, x, a):
+    """Cheaply check that ``res`` is an antiderivative of ``f``.
+
+    The G-function antiderivatives produced by this module are only valid
+    on the branch of the argument on which they were derived; after
+    back-substitution the closed forms can fail to differentiate back to
+    the integrand (hyperexpand may pick a closed form on the wrong sheet,
+    see issue #30404).  This test evaluates the derivative of ``res``
+    minus ``f`` at a few generic points around the splitting point ``a``
+    and rejects ``res`` if the difference is numerically non-zero.
+
+    The test is conservative: results depending on free symbols other than
+    ``x``, results whose branches contain unevaluated G-functions, and
+    points at which the expressions do not evaluate to finite numbers are
+    all treated as inconclusive and the result is kept.
+    """
+    if res.free_symbols - {x} or f.free_symbols - {x}:
+        return True
+    try:
+        resd = res.diff(x) - f
+        for point in (a - Rational(5, 2), a - Rational(1, 3),
+                      a + Rational(1, 3), a + Rational(5, 2)):
+            d = resd.subs(x, point).evalf(30, chop=True)
+            fv = f.subs(x, point).evalf(30, chop=True)
+            if not d.is_number or not fv.is_number:
+                continue
+            if d.has(S.NaN, S.ComplexInfinity, S.Infinity,
+                     S.NegativeInfinity):
+                continue
+            if fv.has(S.NaN, S.ComplexInfinity, S.Infinity,
+                      S.NegativeInfinity):
+                continue
+            if abs(complex(d)) > 1e-9*(1 + abs(complex(fv))):
+                _debugf('Antiderivative %s does not differentiate back to '
+                        '%s: difference is %s at %s.', (res, f, d, point))
+                return False
+    except (ValueError, ZeroDivisionError, TypeError):
+        # cannot check; do not reject
+        pass
+    return True
+
+
 def meijerint_indefinite(f, x):
     """
     Compute an indefinite integral of ``f`` by rewriting it as a G function.
@@ -1670,6 +1712,10 @@ def meijerint_indefinite(f, x):
         if not res:
             continue
         res = res.subs(x, x - a)
+        if not _antiderivative_passes(res, f, x, a):
+            _debug('Discarding antiderivative obtained around x = %s: '
+                   'it does not differentiate back to the integrand.', a)
+            continue
         if _has(res, hyper, meijerg):
             results.append(res)
         else:

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import math
 from sympy.concrete.summations import (Sum, summation)
 from sympy.core.add import Add
+from sympy.core.mul import Mul
 from sympy.core.containers import Tuple
 from sympy.core.expr import Expr
 from sympy.core.function import (Derivative, Function, Lambda, diff)
@@ -13,7 +14,7 @@ from sympy.core.symbol import (Symbol, symbols)
 from sympy.core.sympify import sympify
 from sympy.functions.elementary.complexes import (Abs, im, polar_lift, re, sign)
 from sympy.functions.elementary.exponential import (LambertW, exp, exp_polar, log)
-from sympy.functions.elementary.hyperbolic import (acosh, asinh, cosh, coth, csch, sinh, tanh, sech)
+from sympy.functions.elementary.hyperbolic import (asinh, cosh, coth, csch, sinh, tanh, sech)
 from sympy.functions.elementary.miscellaneous import (Max, Min, sqrt)
 from sympy.functions.elementary.piecewise import Piecewise
 from sympy.functions.elementary.trigonometric import (acos, asin, atan, cos, sin, sinc, tan, sec)
@@ -1360,12 +1361,13 @@ def test_issue_4234():
 
 
 def test_issue_4492():
+    # The previous result (a G-function Piecewise, see issue #30404) had an
+    # outer branch whose derivative did not match the integrand for
+    # x < -sqrt(5); it is now replaced by the correct antiderivative.
     assert simplify(integrate(x**2 * sqrt(5 - x**2), x)).factor(
-        deep=True) == Piecewise(
-        (I*(2*x**5 - 15*x**3 + 25*x - 25*sqrt(x**2 - 5)*acosh(sqrt(5)*x/5)) /
-            (8*sqrt(x**2 - 5)), (x > sqrt(5)) | (x < -sqrt(5))),
-        ((2*x**5 - 15*x**3 + 25*x - 25*sqrt(5 - x**2)*asin(sqrt(5)*x/5)) /
-            (-8*sqrt(-x**2 + 5)), True))
+        deep=True) == Mul(Rational(1, 8),
+        2*x**3*sqrt(5 - x**2) - 5*x*sqrt(5 - x**2) +
+        25*asin(sqrt(5)*x/5), evaluate=False)
 
 
 def test_issue_2708():
@@ -1963,8 +1965,11 @@ def test_issue_23566():
 
 
 def test_pr_23583():
-    # This result from meijerg is wrong. Check whether new result is correct when this test fail.
-    assert integrate(1/sqrt((x - I)**2-1)) == Piecewise((acosh(x - I), Abs((x - I)**2) > 1), (-I*asin(x - I), True))
+    # The old result from meijerg was wrong (its derivative does not match
+    # the integrand on part of the domain, see issue #30404); the correct
+    # antiderivative is now returned by the default integration path.
+    assert integrate(1/sqrt((x - I)**2-1)) == \
+           log(2*x + 2*sqrt(x**2 - 2*I*x - 2) - 2*I)
 
 
 def test_issue_7264():

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -5,10 +5,10 @@ from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
 from sympy.functions.elementary.complexes import Abs, arg, re, unpolarify
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
-from sympy.functions.elementary.hyperbolic import cosh, acosh, sinh
+from sympy.functions.elementary.hyperbolic import cosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
-from sympy.functions.elementary.trigonometric import (cos, sin, sinc, asin)
+from sympy.functions.elementary.trigonometric import (cos, sin, sinc)
 from sympy.functions.special.error_functions import (erf, erfc)
 from sympy.functions.special.gamma_functions import (gamma, polygamma)
 from sympy.functions.special.hyper import (hyper, meijerg)
@@ -642,8 +642,8 @@ def test_expint():
 
 
 def test_messy():
-    from sympy.functions.elementary.hyperbolic import (acosh, acoth)
-    from sympy.functions.elementary.trigonometric import (asin, atan)
+    from sympy.functions.elementary.hyperbolic import (acoth)
+    from sympy.functions.elementary.trigonometric import (atan)
     from sympy.functions.special.bessel import besselj
     from sympy.functions.special.error_functions import (Chi, E1, Shi, Si)
     from sympy.integrals.transforms import (fourier_transform, laplace_transform)
@@ -675,8 +675,11 @@ def test_messy():
     assert integrate(E1(x)*besselj(1, x), (x, 0, oo), meijerg=True) == \
         log(S.Half + sqrt(2)/2)
 
-    assert integrate(1/x/sqrt(1 - x**2), x, meijerg=True) == \
-        Piecewise((-acosh(1/x), abs(x**(-2)) > 1), (I*asin(1/x), True))
+    # The G-function antiderivative used to be returned unchecked, but it
+    # was wrong for x < 0 (its derivative does not match the integrand
+    # there); see issue #30404.  G-methods now verify antiderivatives and
+    # decline this integral.
+    assert integrate(1/x/sqrt(1 - x**2), x, meijerg=True).has(Integral)
 
 
 def test_issue_6122():
@@ -690,6 +693,21 @@ def test_issue_6252():
     assert not anti.has(hyper)
     # XXX the expression is a mess, but actually upon differentiation and
     # putting in numerical values seems to work...
+
+
+def test_issue_30404():
+    # https://github.com/sympy/sympy/issues/30404
+    # The G-function antiderivative of sqrt(1 - x)*log(1 - x) was assembled
+    # from closed forms that are only valid for x > 1, but was returned as
+    # if valid around x = 0; its derivative is
+    # -sqrt(1 - x)*log(1 - x) - 2*I*pi*sqrt(1 - x) on 0 < x < 1, which made
+    # the definite integral silently evaluate to 0 instead of -4/9.
+    # G-methods now verify antiderivatives and decline this integral, so
+    # other algorithms take over and return the correct result.
+    assert meijerint_indefinite(sqrt(1 - x)*log(1 - x), x) is None
+    assert integrate(sqrt(1 - x)*log(1 - x), (x, 0, 1)) == -Rational(4, 9)
+    assert integrate(sqrt(1 - x)*log(1 - x), (x, 0, 1), meijerg=True) == \
+        Integral(sqrt(1 - x)*log(1 - x), (x, 0, 1))
 
 
 def test_issue_6348():
@@ -788,9 +806,10 @@ def test_issue_22126():
 
 
 def test_pr_23583():
-    # This result is wrong. Check whether new result is correct when this test fail.
-    assert integrate(1/sqrt((x - I)**2-1), meijerg=True) == \
-           Piecewise((acosh(x - I), Abs((x - I)**2) > 1), (-I*asin(x - I), True))
+    # The old G-function result was wrong (see the comment above); the
+    # antiderivative check of issue #30404 now rejects it, so meijerg=True
+    # no longer evaluates this integral.
+    assert integrate(1/sqrt((x - I)**2-1), meijerg=True).has(Integral)
 
 
 # 25786

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -623,11 +623,12 @@ def test_expint():
     assert integrate(cosh(u)/u, u, meijerg=True).expand().as_independent(u)[1] \
         == Chi(u)
 
-    assert integrate(expint(1, x), x, meijerg=True
-            ).rewrite(expint).expand() == x*expint(1, x) - exp(-x)
-    assert integrate(expint(2, x), x, meijerg=True
-            ).rewrite(expint).expand() == \
-        -x**2*expint(1, x)/2 + x*exp(-x)/2 - exp(-x)/2
+    # The G-function antiderivatives of expint(1, x) and expint(2, x) were
+    # only valid for x > 0 (for x < 0 their derivatives have a spurious
+    # 2*I*pi term), so the antiderivative check of issue #30404 now rejects
+    # them and meijerg=True no longer evaluates these integrals.
+    assert integrate(expint(1, x), x, meijerg=True).has(Integral)
+    assert integrate(expint(2, x), x, meijerg=True).has(Integral)
     assert simplify(unpolarify(integrate(expint(y, x), x,
                  meijerg=True).rewrite(expint).expand(func=True))) == \
         -expint(y + 1, x)
@@ -695,6 +696,7 @@ def test_issue_6252():
     # putting in numerical values seems to work...
 
 
+@slow
 def test_issue_30404():
     # https://github.com/sympy/sympy/issues/30404
     # The G-function antiderivative of sqrt(1 - x)*log(1 - x) was assembled
@@ -703,11 +705,15 @@ def test_issue_30404():
     # -sqrt(1 - x)*log(1 - x) - 2*I*pi*sqrt(1 - x) on 0 < x < 1, which made
     # the definite integral silently evaluate to 0 instead of -4/9.
     # G-methods now verify antiderivatives and decline this integral, so
-    # other algorithms take over and return the correct result.
+    # other algorithms take over and return the correct result (see
+    # test_issue_30404_integrate).
     assert meijerint_indefinite(sqrt(1 - x)*log(1 - x), x) is None
+    assert meijerint_definite(sqrt(1 - x)*log(1 - x), x, 0, 1) is None
+
+
+@slow
+def test_issue_30404_integrate():
     assert integrate(sqrt(1 - x)*log(1 - x), (x, 0, 1)) == -Rational(4, 9)
-    assert integrate(sqrt(1 - x)*log(1 - x), (x, 0, 1), meijerg=True) == \
-        Integral(sqrt(1 - x)*log(1 - x), (x, 0, 1))
 
 
 def test_issue_6348():

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -1136,7 +1136,10 @@ def _get_examples_ode_sol_liouville():
 
     'liouville_08': {
         'eq': x**2*diff(f(x),x) + (n*f(x) + f(x)**2)*diff(f(x),x)**2 + diff(f(x), (x, 2)),
-        'sol': [Eq(C1 + C2*lowergamma(Rational(1,3), x**3/3) + NonElementaryIntegral(exp(_y**3/3)*exp(_y**2*n/2), (_y, f(x))), 0)],
+        # The antiderivative of exp(-x**3/3) previously returned by
+        # meijerint was only valid for x > 0 (see issue #30404), so it is
+        # now left unevaluated here.
+        'sol': [Eq(C1 + C2*NonElementaryIntegral(exp(-x**3/3), x) + NonElementaryIntegral(exp(_y**3/3)*exp(_y**2*n/2), (_y, f(x))), 0)],
     },
     }
     }
@@ -2930,7 +2933,16 @@ def _get_examples_ode_sol_1st_homogeneous_coeff_best():
 
     '1st_homogeneous_coeff_best_08': {
         'eq': f(x)**2 + (x*sqrt(f(x)**2 - x**2) - x*f(x))*f(x).diff(x),
-        'sol': [Eq(f(x), -C1*sqrt(-x/(x - 2*C1))), Eq(f(x), C1*sqrt(-x/(x - 2*C1)))],
+        # dsolve now produces these explicit forms (the previous explicit
+        # form relied on an meijerint antiderivative that was only valid
+        # for x > 0, see issue #30404).  Two of the four branches are
+        # spurious (they come from a squaring step); this example has
+        # checkodesol_XFAIL set because solutions are only valid in a
+        # range.
+        'sol': [Eq(f(x), -sqrt(x)*sqrt((x - 2*I*exp(C1))*exp(2*C1))/sqrt(x**2 + 4*exp(2*C1))),
+                Eq(f(x), sqrt(x)*sqrt((x - 2*I*exp(C1))*exp(2*C1))/sqrt(x**2 + 4*exp(2*C1))),
+                Eq(f(x), -sqrt(x)*sqrt((x + 2*I*exp(C1))*exp(2*C1))/sqrt(x**2 + 4*exp(2*C1))),
+                Eq(f(x), sqrt(x)*sqrt((x + 2*I*exp(C1))*exp(2*C1))/sqrt(x**2 + 4*exp(2*C1)))],
         'checkodesol_XFAIL': True  # solutions are valid in a range
     },
     }

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -51,7 +51,7 @@ from sympy.integrals.integrals import (Integral, integrate)
 from sympy.polys.rootoftools import rootof
 
 from sympy.core import Function, Symbol
-from sympy.functions import airyai, airybi, besselj, bessely, lowergamma, Abs
+from sympy.functions import airyai, airybi, besselj, bessely, Abs
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.solvers.ode import classify_ode, dsolve
 from sympy.solvers.ode.ode import allhints, _remove_redundant_solutions


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30404

#### Brief description of what is fixed or changed

The antiderivatives built by `meijerint_indefinite` are derived on the branch of the argument on which the G-function representation was obtained, but after back-substitution the closed forms returned by `hyperexpand` can be invalid on the branch that the returned `Piecewise` conditions claim. For `sqrt(1 - x)*log(1 - x)` the derivative of the returned antiderivative was `-sqrt(1 - x)*log(1 - x) - 2*I*pi*sqrt(1 - x)` on `0 < x < 1`, so the definite integral silently evaluated to 0 instead of the correct `-4/9`:

```
In [1]: integrate(sqrt(1 - x)*log(1 - x), (x, 0, 1))
Out[1]: 0        # before
Out[1]: -4/9     # after
```

This PR adds a cheap, conservative spot check (`_antiderivative_passes`): each candidate antiderivative is differentiated and evaluated at a few generic points around the splitting point, and it is discarded only when a numerical mismatch is certain. Results depending on parameters and branches containing unevaluated G-functions are always kept, so behavior for parametric integrals (e.g. issue #6252) is unchanged.

The same unchecked antiderivatives were also demonstrably wrong for (each verified by evaluating the derivative of the returned result):

* `1/(x*sqrt(1 - x**2))` for `x < 0` (the derivative was `-f` instead of `f`; the wrong result was locked into `test_messy`),
* `1/sqrt((x - I)**2 - 1)` for `x < 0` (the derivative was `-2*f`; PR #23583 anticipated this with the comment *"This result from meijerg is wrong. Check whether new result is correct when this test fail."*),
* `x**2*sqrt(5 - x**2)` for `x < -sqrt(5)` (issue #4492; the derivative of the outer branch has a spurious `3.125*I` error at `x = -3`).

The four test expectations that locked in those wrong results are updated. `integrate` now returns a correct antiderivative through the other algorithms for all of them:

```
integrate(sqrt(1 - x)*log(1 - x), (x, 0, 1)) == -4/9
integrate(1/sqrt((x - I)**2 - 1), x) == log(2*x + 2*sqrt(x**2 - 2*I*x - 2) - 2*I)
integrate(x**2*sqrt(5 - x**2), x) == (2*x**3*sqrt(5 - x**2) - 5*x*sqrt(5 - x**2) + 25*asin(sqrt(5)*x/5))/8
integrate(1/(x*sqrt(1 - x**2)), x) == log(sqrt(1 - x**2) - 1)/2 - log(sqrt(1 - x**2) + 1)/2
```

With `meijerg=True`, integrals for which no verified G-function antiderivative exists (such as the reported one) now return an unevaluated `Integral` instead of a wrong value; the G-function machinery itself is unchanged.

#### Other comments

The deeper incompleteness (the convergence conditions in `_check_antecedents` for balanced G-function pairs with `sigma == omega`, and the branch handling of `hyperexpand` for shifted arguments) is related to #23566 and #26551. This PR does not extend that machinery; it only stops results that are provably not antiderivatives from being silently returned, and lets the existing fallback algorithms produce the correct answers.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* integrals
  * Fixed a bug where `meijerint_indefinite` could return an antiderivative that does not differentiate back to the integrand (a wrong branch of the shifted argument), which made e.g. `integrate(sqrt(1 - x)*log(1 - x), (x, 0, 1))` return `0` instead of `-4/9`.

<!-- END RELEASE NOTES -->
