### PR TITLE
Restructure unbranched_argument to hold its own implementation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1166,6 +1166,7 @@ MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@u
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
+Muhammad Usaid <shkusaid910@gmail.com> shkusaid <shkusaid910@gmail.com>
 Musab Kasbati <musab16000@gmail.com> Musab Kasbati <43878981+Musab1Blaser@users.noreply.github.com>
 Musab Kasbati <musab16000@gmail.com> Musab1Blaser <musab16000@gmail.com>
 Muskan Kumar <31043527+muskanvk@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1165,8 +1165,8 @@ Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
 MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@users.noreply.github.com>
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
-Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Muhammad Usaid <shkusaid910@gmail.com> shkusaid <shkusaid910@gmail.com>
+Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Musab Kasbati <musab16000@gmail.com> Musab Kasbati <43878981+Musab1Blaser@users.noreply.github.com>
 Musab Kasbati <musab16000@gmail.com> Musab1Blaser <musab16000@gmail.com>
 Muskan Kumar <31043527+muskanvk@users.noreply.github.com>

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -1146,7 +1146,7 @@ def unbranched_argument(ar):
     periodic_argument
     '''
     from sympy.functions.elementary.exponential import exp_polar, log
-    if isinstance(ar , principal_branch):
+    if isinstance(ar, principal_branch):
         return periodic_argument(*ar.args)
     if ar.is_Mul:
         args = ar.args
@@ -1160,12 +1160,12 @@ def unbranched_argument(ar):
             unbranched += a.exp.as_real_imag()[1]
         elif a.is_Pow:
             re, im = a.exp.as_real_imag()
-            unbranched += re*unbranched_argument(
-                a.base) + im*log(abs(a.base))
+            base_unbranched = unbranched_argument(a.base)
+            unbranched += re*base_unbranched + im*log(abs(a.base))
         elif isinstance(a, polar_lift):
             unbranched += arg(a.args[0])
         else:
-            return None
+            return periodic_argument(ar, oo , evaluate=False)
     return unbranched
 
 class periodic_argument(DefinedFunction):

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -1126,6 +1126,48 @@ class polar_lift(DefinedFunction):
         return Abs(self.args[0], evaluate=True)
 
 
+def unbranched_argument(ar):
+    '''
+    Returns periodic argument of arg with period as infinity.
+
+    Examples
+    ========
+
+    >>> from sympy import exp_polar, unbranched_argument
+    >>> from sympy import I, pi
+    >>> unbranched_argument(exp_polar(15*I*pi))
+    15*pi
+    >>> unbranched_argument(exp_polar(7*I*pi))
+    7*pi
+
+    See also
+    ========
+
+    periodic_argument
+    '''
+    from sympy.functions.elementary.exponential import exp_polar, log
+    if isinstance(ar , principal_branch):
+        return periodic_argument(*ar.args)
+    if ar.is_Mul:
+        args = ar.args
+    else:
+        args = [ar]
+    unbranched = 0
+    for a in args:
+        if not a.is_polar:
+            unbranched += arg(a)
+        elif isinstance(a, exp_polar):
+            unbranched += a.exp.as_real_imag()[1]
+        elif a.is_Pow:
+            re, im = a.exp.as_real_imag()
+            unbranched += re*unbranched_argument(
+                a.base) + im*log(abs(a.base))
+        elif isinstance(a, polar_lift):
+            unbranched += arg(a.args[0])
+        else:
+            return None
+    return unbranched
+
 class periodic_argument(DefinedFunction):
     r"""
     Return the argument of a complex number modulo a given period.
@@ -1192,28 +1234,6 @@ class periodic_argument(DefinedFunction):
 
     """
 
-    @classmethod
-    def _getunbranched(cls, ar):
-        from sympy.functions.elementary.exponential import exp_polar, log
-        if ar.is_Mul:
-            args = ar.args
-        else:
-            args = [ar]
-        unbranched = 0
-        for a in args:
-            if not a.is_polar:
-                unbranched += arg(a)
-            elif isinstance(a, exp_polar):
-                unbranched += a.exp.as_real_imag()[1]
-            elif a.is_Pow:
-                re, im = a.exp.as_real_imag()
-                unbranched += re*unbranched_argument(
-                    a.base) + im*log(abs(a.base))
-            elif isinstance(a, polar_lift):
-                unbranched += arg(a.args[0])
-            else:
-                return None
-        return unbranched
 
     @classmethod
     def eval(cls, ar, period):
@@ -1231,7 +1251,7 @@ class periodic_argument(DefinedFunction):
             newargs = [x for x in ar.args if not x.is_positive]
             if len(newargs) != len(ar.args):
                 return periodic_argument(Mul(*newargs), period)
-        unbranched = cls._getunbranched(ar)
+        unbranched = unbranched_argument(ar)
         if unbranched is None:
             return None
         from sympy.functions.elementary.trigonometric import atan, atan2
@@ -1248,7 +1268,7 @@ class periodic_argument(DefinedFunction):
     def _eval_evalf(self, prec):
         z, period = self.args
         if period == oo:
-            unbranched = periodic_argument._getunbranched(z)
+            unbranched = unbranched_argument(z)
             if unbranched is None:
                 return self
             return unbranched._eval_evalf(prec)
@@ -1257,26 +1277,7 @@ class periodic_argument(DefinedFunction):
         return (ub - ceiling(ub/period - S.Half)*period)._eval_evalf(prec)
 
 
-def unbranched_argument(arg):
-    '''
-    Returns periodic argument of arg with period as infinity.
 
-    Examples
-    ========
-
-    >>> from sympy import exp_polar, unbranched_argument
-    >>> from sympy import I, pi
-    >>> unbranched_argument(exp_polar(15*I*pi))
-    15*pi
-    >>> unbranched_argument(exp_polar(7*I*pi))
-    7*pi
-
-    See also
-    ========
-
-    periodic_argument
-    '''
-    return periodic_argument(arg, oo)
 
 
 class principal_branch(DefinedFunction):

--- a/sympy/functions/elementary/tests/test_complexes.py
+++ b/sympy/functions/elementary/tests/test_complexes.py
@@ -904,7 +904,7 @@ def test_periodic_argument():
     x = Symbol('x')
     p = Symbol('p', positive=True)
 
-    assert unbranched_argument(2 + I) == periodic_argument(2 + I, oo)
+    assert unbranched_argument(2 + I) == atan(S.Half)
     assert unbranched_argument(1 + x) == periodic_argument(1 + x, oo)
     assert N_equals(unbranched_argument((1 + I)**2), pi/2)
     assert N_equals(unbranched_argument((1 - I)**2), -pi/2)


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

#11166 


#### Brief description of what is fixed or changed

The issue solution expected to clean the periodic_argument specially pointing out that unbranched_argument was just a thin wrapper, even though it is actual public API and widely used in the meijerint.py at the very top level.
The issue's exact wording was "branched_argument" function, but I found via git grep that unbranched_argument is public API used elsewhere so renaming it can cause major breakdown and can break things. I posted this reasoning on the issue and got no objection by the mentor after a week. So, I proceeded by keeping the real name as it is but make it hold the real computation, and have periodic_argument.eval() call it instead of the reverse.
Previously the logic was hold by the function periodic_argument._getunbranched but now it lives in unbranched_argument directly. The reason to do this was the bug I found in periodic_argument._getunbranched's logic that it did NOT have an explicit case for principal_branch inputs. It worked before as the periodic_argument.eval() always called it as it had a special case for principal_branch that was applied automatically. I fixed it by adding principal_branch inside the unbranched_argument.
Also a test case needs to be updated and that was test_periodic_argument asserted unbranched_argument(2 + I) == periodic_argument(2 + I, oo), didn't break before because of the same call. Now they are separate because unbranched_argument(2 + I) correctly evaluates to atan(1/2). I updated the assertion to check the correct direct value.

After opening the PR I found the CI test suite caught something that my local scoped testing had missed: test_issue_8368i failed with TypeError: unsupported operand type(s) for *: 'Integer' and 'NoneType'. Root cause for that failure was the Pow branch's recursive call to unbranched_argument that was returning raw python None in that test case and couldn't resolve. This never happened previously because old code went through periodic_argument's function which silently converts None into symbolic objects that can not be evaluated.
In my first attempt, which was falling back to constructing periodic_argument(ar, oo) directly, I faced a new problem of infinite recursion because constructing that object was retriggering the eval() function, which called unbranched_argument again and hence got stuck in an infinite loop.
The correct fix was calling periodic_argument with arguments (ar, oo, evaluate=False), a sympy built-in keyword argument for constructing an unevaluated symbolic expression without calling eval() again, while fixing the original None leaking bug.
I also found and fixed a second None leaking issue in meijerint.py's _check_antecedents, which had the same root cause and was fixed the same way by the evaluate=False approach inside unbranched_argument, so all the callers are now protected, not just the one site.

#### Other comments

I ran the verification commands to run the test cases and all passed:
python bin/doctest sympy/functions/elementary/complexes.py
python bin/test sympy/functions/elementary/tests/test_complexes.py
python bin/test sympy/integrals/tests/test_meijerint.py
python bin/test sympy/integrals/tests/test_integrals.py -k test_issue_8368i

#### AI Generation Disclosure

AI helped me to identify the parameters before writing the actual code, understand the problem, and identify the root cause. I made all the actual code edits, ran all test cases, and decided how to fix the failing test, all by myself.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * unbranched_argument now returns a fully evaluated result in more
    cases (e.g. unbranched_argument(2 + I) now returns atan(1/2)
    instead of an unevaluated expression), since it no longer shares
    periodic_argument's evaluation guard.
<!-- END RELEASE NOTES -->
