### PR TITLE
Fix doctest exception format in __mul__ function docstring example

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1168,6 +1168,7 @@ MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@u
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
 Muhammad Usaid <shkusaid910@gmail.com> shkusaid <shkusaid910@gmail.com>
+Muhammad Talha <shykhtalha33@gmail.com> shkTalha33 <shykhtalha33@gmail.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Musab Kasbati <musab16000@gmail.com> Musab Kasbati <43878981+Musab1Blaser@users.noreply.github.com>
 Musab Kasbati <musab16000@gmail.com> Musab1Blaser <musab16000@gmail.com>

--- a/sympy/combinatorics/permutations.py
+++ b/sympy/combinatorics/permutations.py
@@ -1387,7 +1387,10 @@ class Permutation(Atom):
         since coercion can only handle one argument to the left. To handle
         multiple cycles it is convenient to use Cycle instead of Permutation:
 
-        >>> [[1, 2]]*[[2, 3]]*Permutation([]) # doctest: +SKIP
+        >>> [[1, 2]]*[[2, 3]]*Permutation([])
+        Traceback (most recent call last):
+        ...
+        TypeError: can't multiply sequence by non-int of type 'list'
         >>> from sympy.combinatorics.permutations import Cycle
         >>> Cycle(1, 2)(2, 3)
         (1 3 2)


### PR DESCRIPTION
Fix doctest exception format in Permutations docstring example

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

#6572 

#### Brief description of what is fixed or changed

while exploring the issue #6572 I found the docstring example marked as "doctest: +SKIP"  which cause the TypeError without the Traceback (most recent call last) and elipses header require to parse it as an intensional exception.
>>> [[1, 2]]*[[2, 3]]*Permutation([])
TypeError: can't multiply sequence by non-int of type 'list'

So , I added the "Traceback (most recent call last):" line and "..." ellipsis before the error line to prevent the error and matching the standard doctest exception format. I also removed the doctest: +SKIP comment as the example now passes.

#### Other comments

Ran and confirm by running both
python bin/doctest sympy/combinatorics/permutations.py
python bin/test sympy/combinatorics/tests/test_permutations.py
and both passed

#### AI Generation Disclosure

Used Claude (Anthropic) to help draft the wording of this PR description and to explain the doctest Traceback format requirement. The code change itself was written by me.
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->