### PR TITLE
Improve arity() and nargs for functions with *args

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1699,6 +1699,7 @@ Tuan Manh Lai <laituan245@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Unknown <kunda@scribus.net>
+Utsab Dahal <utsabdahal34@gmail.com>
 Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>
 V1krant <46847915+V1krant@users.noreply.github.com>

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -134,19 +134,37 @@ def arity(cls):
     Examples
     ========
 
-    >>> from sympy import arity, log
+    >>> from sympy import S, Range, oo, arity, log
     >>> arity(lambda x: x)
     1
     >>> arity(log)
     (1, 2)
     >>> arity(lambda *x: sum(x)) is None
     True
+
+    When the function takes a variable number of arguments, the arity
+    begins at the number of required arguments (``1`` in the example
+    below) and extends without bound:
+
+    >>> arity(lambda x, *args: x) == S.Naturals
+    True
+    >>> arity(lambda x, y, z, *args: x) == Range(3, oo)
+    True
     """
     eval_ = getattr(cls, 'eval', cls)
 
     parameters = inspect.signature(eval_).parameters.items()
-    if [p for _, p in parameters if p.kind == p.VAR_POSITIONAL]:
-        return
+    if any(p.kind == p.VAR_POSITIONAL for _, p in parameters):
+        # the number of arguments is at least the number of required
+        # positional arguments
+        required = [p for _, p in parameters
+            if p.kind == p.POSITIONAL_OR_KEYWORD and p.default == p.empty]
+        if not required:
+            return
+        from sympy.sets.fancysets import Range
+        if len(required) == 1:
+            return S.Naturals
+        return Range(len(required), S.Infinity)
     p_or_k = [p for _, p in parameters if p.kind == p.POSITIONAL_OR_KEYWORD]
     # how many have no default and how many have a default value
     no, yes = map(len, sift(p_or_k,
@@ -175,7 +193,11 @@ class FunctionClass(type):
                     continue
 
         # Canonicalize nargs here; change to set in nargs.
-        if is_sequence(nargs):
+        if getattr(nargs, 'sup', None) is S.Infinity and hasattr(nargs, 'is_FiniteSet'):
+            # an unbounded set of integers, e.g. Naturals or Range(3, oo),
+            # is kept as-is (importing it here would cause a cyclic import)
+            pass
+        elif is_sequence(nargs):
             if not nargs:
                 raise ValueError(filldedent('''
                     Incorrectly specified nargs as %s:
@@ -248,6 +270,15 @@ class FunctionClass(type):
         >>> Function('f', nargs=(2, 1)).nargs
         {1, 2}
 
+        If the function can take a minimum number of arguments, an
+        unbounded set of integers is returned:
+
+        >>> class f(Function):
+        ...     @classmethod
+        ...     def eval(cls, x, *args): pass
+        >>> f.nargs
+        Naturals
+
         The undefined function, after application, also has the nargs
         attribute; the actual number of arguments is always available by
         checking the ``args`` attribute:
@@ -258,9 +289,12 @@ class FunctionClass(type):
         >>> len(f(1).args)
         1
         """
+        from sympy.sets.fancysets import Range, Naturals
         from sympy.sets.sets import FiniteSet
         # XXX it would be nice to handle this in __init__ but there are import
         # problems with trying to import FiniteSet there
+        if isinstance(self._nargs, (Range, Naturals)):
+            return self._nargs
         return FiniteSet(*self._nargs) if self._nargs else S.Naturals0
 
     def _valid_nargs(self, n : int) -> bool:
@@ -333,8 +367,12 @@ class Application(Basic, metaclass=FunctionClass):
             #  - WildFunction('f').nargs
             #  - AppliedUndef with no nargs like Function('f')(1).nargs
             nargs = obj._nargs  # note the underscore here
-        # convert to FiniteSet
-        obj.nargs = FiniteSet(*nargs) if nargs else Naturals0()
+        # convert to a Set
+        from sympy.sets.fancysets import Range, Naturals
+        if isinstance(nargs, (Range, Naturals)):
+            obj.nargs = nargs
+        else:
+            obj.nargs = FiniteSet(*nargs) if nargs else Naturals0()
         return obj
 
     @classmethod
@@ -462,11 +500,19 @@ class Function(Application, Expr):
             # the exception and change NumPy to take advantage of this.
             temp = ('%(name)s takes %(qual)s %(args)s '
                    'argument%(plural)s (%(given)s given)')
+            from sympy.sets.fancysets import Range, Naturals
+            if isinstance(cls.nargs, (Range, Naturals)):
+                qual = 'at least'
+            elif len(cls.nargs) == 1:
+                qual = 'exactly'
+            else:
+                qual = 'at least'
+            minarg = cls.nargs.inf
             raise TypeError(temp % {
                 'name': cls,
-                'qual': 'exactly' if len(cls.nargs) == 1 else 'at least',
-                'args': min(cls.nargs),
-                'plural': 's'*(min(cls.nargs) != 1),
+                'qual': qual,
+                'args': minarg,
+                'plural': 's'*(minarg != 1),
                 'given': n})
 
         evaluate = options.get('evaluate', global_parameters.evaluate)

--- a/sympy/core/tests/test_function.py
+++ b/sympy/core/tests/test_function.py
@@ -31,6 +31,7 @@ from sympy.core.parameters import _exp_is_pow
 from sympy.core.sympify import sympify, SympifyError
 from sympy.matrices import MutableMatrix, ImmutableMatrix
 from sympy.sets.sets import FiniteSet
+from sympy.sets.fancysets import Range
 from sympy.solvers.solveset import solveset
 from sympy.tensor.array import NDimArray
 from sympy.utilities.iterables import subsets, variations
@@ -224,6 +225,38 @@ def test_arity():
     assert arity(f) == (2, 3)
     assert arity(lambda *x: x) is None
     assert arity(log) == (1, 2)
+
+
+def test_nargs_varargs():
+    # issue 23487
+    class f(Function):
+        @classmethod
+        def eval(cls, x, *args):
+            return None
+
+    assert f.nargs == S.Naturals
+    assert f._valid_nargs(1) is True
+    assert f(1).nargs == S.Naturals
+    assert f(1, 2, 3).nargs == S.Naturals
+    raises(TypeError, lambda: f())
+
+    class g(Function):
+        @classmethod
+        def eval(cls, x, y, z, *args):
+            return None
+
+    assert g.nargs == Range(3, oo)
+    assert g(1, 2, 3).nargs == Range(3, oo)
+    raises(TypeError, lambda: g(1))
+    raises(TypeError, lambda: g(1, 2))
+
+    class h(Function):
+        @classmethod
+        def eval(cls, *args):
+            return None
+
+    assert h.nargs == S.Naturals0
+    assert h().nargs == S.Naturals0
 
 
 def test_Lambda():


### PR DESCRIPTION
Fixes #23487

This PR improves how `arity()` and `nargs` handle functions with variable-length positional arguments (`*args`).

Previously, `arity()` returned `None` for functions with `*args`, and `nargs` always returned `Naturals0` regardless of required arguments. Now:

- `arity()` returns the appropriate set (`Naturals`, `Range`) based on the number of required positional arguments
- `nargs` property correctly returns `Naturals` or `Range` for functions with variable arguments

<!-- BEGIN RELEASE NOTES -->
* core
  * `arity()` now returns proper sets (`Naturals`, `Range`) for functions with `*args` instead of `None`.
<!-- END RELEASE NOTES -->
