### PR TITLE
Fix StateSpace matrices for zero-order transfer functions

### DIFF
--- a/sympy/physics/control/lti.py
+++ b/sympy/physics/control/lti.py
@@ -1460,15 +1460,15 @@ class TransferFunctionBase(SISOLinearTimeInvariant, ABC):
 
         if n == 0:
             return (
-                Matrix([zeros(1)]),
-                Matrix([zeros(1)]),
-                Matrix([zeros(1)]),
+                Matrix(0, 0, []),
+                Matrix(0, 1, []),
+                Matrix(1, 0, []),
                 Matrix([num_coeffs[0] / den_coeffs[0]]),
             )
 
         if self.num == self.den:
             return (
-                Matrix([zeros(1)]), Matrix([zeros(1)]), Matrix([zeros(1)]), Matrix([1])
+                Matrix(0, 0, []), Matrix(0, 1, []), Matrix(1, 0, []), Matrix([1])
             )
 
         diff = n - num_poly.degree()

--- a/sympy/physics/control/tests/test_lti.py
+++ b/sympy/physics/control/tests/test_lti.py
@@ -26,7 +26,7 @@ from sympy.physics.control.lti import (
     TransferFunctionMatrix, MIMOSeries, MIMOParallel, MIMOFeedback, StateSpace,
     DiscreteStateSpace, create_state_space, gbt, bilinear, forward_diff,
     backward_diff, phase_margin, gain_margin)
-from sympy.testing.pytest import raises, XFAIL
+from sympy.testing.pytest import raises
 
 from math import isclose
 
@@ -43,7 +43,6 @@ TF5 = TransferFunction(k, p, s)
 TF6 = TransferFunction(k*s + p, k*s + p, s)
 
 
-@XFAIL
 def test_state_space_rewrite_from_pr_27651():
     c0, c1, c2 = symbols('c0, c1, c2', real=True)
     a0, a1, a2, a3 = symbols('a0, a1, a2, a3', real=True)
@@ -3522,12 +3521,12 @@ def test_conversion():
 
     SS2 = TF5.rewrite(StateSpace)
     assert SS2 == \
-        StateSpace(Matrix([[0]]), Matrix([[0]]), Matrix([[0]]), Matrix([[k/p]]))
+        StateSpace(Matrix(0, 0, []), Matrix(0, 1, []), Matrix(1, 0, []), Matrix([[k/p]]))
     assert SS2.rewrite(TransferFunction)[0][0] == TF5
 
     SS3 = TF6.rewrite(StateSpace)
     assert SS3 == \
-        StateSpace(Matrix([[0]]), Matrix([[0]]), Matrix([[0]]), Matrix([[1]]))
+        StateSpace(Matrix(0, 0, []), Matrix(0, 1, []), Matrix(1, 0, []), Matrix([[1]]))
 
     # TransferFunction cannot be converted to DiscreteStateSpace
     raises(TypeError, lambda: TF1.rewrite(DiscreteStateSpace))


### PR DESCRIPTION
Fixes #27651

This PR fixes the `StateSpace` matrices for zero-order transfer functions (where `n=0`). Previously, `rewrite(StateSpace)` produced incorrect 1x1 zero matrices (`Matrix([zeros(1)])`) for the A, B, C matrices when the transfer function had zero order (numerator degree == denominator degree).

Now uses properly shaped empty matrices:
- A: `Matrix(0, 0, [])` 
- B: `Matrix(0, 1, [])`
- C: `Matrix(1, 0, [])`
- D: unchanged

Also removes the `@XFAIL` marker from `test_state_space_rewrite_from_pr_27651` since the test now passes.

<!-- BEGIN RELEASE NOTES -->
* physics.control
  * Fixed `StateSpace` matrix shapes for zero-order transfer functions in `rewrite(StateSpace)`.
<!-- END RELEASE NOTES -->
