### PR TITLE
binary splitting for harmonic(n,m)

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -890,8 +890,61 @@ class harmonic(DefinedFunction):
 
     """
 
-    # This prevents redundant recalculations and speeds up harmonic number computations.
-    harmonic_cache: dict[Integer, Callable[[int], Rational]] = {}
+    class HarmonicTree:
+        def __init__(t, l, m):
+            t.n = 1 << (l - 1)
+            t.tree = [S.One / (2**l + 1 + 2*i)**m for i in range(t.n)]
+            t.done = -1
+
+        def __getitem__(t, i):
+            if i < 0: i += t.n
+
+            while t.done < i:
+                t.done += 1
+                j = t.done | t.done+1
+                if j < t.n:
+                    t.tree[j] += t.tree[t.done]
+
+            return t.tree[i]
+
+
+    @classmethod
+    @cacheit
+    def __eval_tree(cls, l, m): return cls.HarmonicTree(l, m)
+
+    @classmethod
+    @cacheit
+    def __eval_block(cls, l, m): # H_(2**(l+1)-1) - H_(2**l-1)
+        if l == 0: return S.One
+
+        return cls.__eval_tree(l, m)[-1] + cls.__eval_block(l - 1, m) / 2**m
+
+    @classmethod
+    @cacheit
+    def __eval_stem(cls, l, m): # H_(2**(l+1)-1)
+        if l < 0: return S.Zero
+        if l == 0: return S.One
+
+        return cls.__eval_stem(l - 1, m) + cls.__eval_block(l, m)
+
+    @classmethod
+    def __eval_tail(cls, l, r, m): # Sum_{j=0..r} 1/(2**l + j)^m, r in [0..2**l)
+        if l == 0: return S.One
+        odd = S.Zero
+        n = r+1>>1
+        tree = cls.__eval_tree(l, m)
+        while n: # sums over odd j except tree-ified
+            odd += tree[n - 1]
+            n &= n - 1
+        return odd + cls.__eval_tail(l - 1, r>>1, m) / 2**m #even
+
+    @classmethod
+    def _eval(cls, n, m=1):
+        if n == 0: return S.Zero
+
+        l = int(n).bit_length() - 1
+
+        return cls.__eval_stem(l - 1, m) + cls.__eval_tail(l, n - (1<<l), m)
 
     @classmethod
     def eval(cls, n, m=None):
@@ -918,12 +971,7 @@ class harmonic(DefinedFunction):
                 return S.ComplexInfinity if m is S.One else S.NaN
             if n.is_nonnegative:
                 if m.is_Integer:
-                    if m not in cls.harmonic_cache:
-                        @recurrence_memo([0])
-                        def f(n, prev):
-                            return prev[-1] + S.One / n**m
-                        cls.harmonic_cache[m] = f
-                    return cls.harmonic_cache[m](int(n))
+                    return cls._eval(n, m)
                 return Add(*(k**(-m) for k in range(1, int(n) + 1)))
 
     def _eval_rewrite_as_polygamma(self, n, m=S.One, **kwargs):

--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -9,7 +9,6 @@ the separate 'factorials' module.
 from __future__ import annotations
 from math import prod
 from collections import defaultdict
-from typing import Callable
 
 from sympy.core import S, Symbol, Add, Dummy
 from sympy.core.cache import cacheit


### PR DESCRIPTION
#### References to other Issues or PRs
#27853 says
> [`harmonic(100000)`] takes to long to compute .actually i didnt get result i look for almost 20 minutes

which i daresay this fixes!

here are the results of a little test script (inserted after `class harmonic`) on my 2020 M1 MacBook Pro:
```python
if __name__=='__main__':
    import resource
    from time import time
    mem=lambda: resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
    t=time()
    print(m:=mem())
    print(hash(harmonic.eval(Integer(100000),Integer(1)).numerator))
    print(time()-t,mem()-m)
```
the existing version returns
```python
starting mem: 63275008
hash: 973855462977283126
time: 660.965499162674 memory surplus: 326668288
```
(that is, 311.5MiB in 11 minutes), while my change reduces it to
```python
starting mem: 63692800
hash: 973855462977283126
time: 1.5170791149139404 memory surplus: 14692352
```
(14MiB in 1.5 seconds!)

#### Brief description of what is fixed or changed
Peter Luschny has a page about [computing the factorial with binary splitting](https://www.luschny.de/math/factorial/binarysplitfact.html) (which is cited by `math.factorial`'s [current implementation](https://github.com/python/cpython/blob/894af95edf7d5a1b0ebdc3699889743c8f41baf1/Modules/mathintegermodule.c#L496)), which the image at the top explains the idea of pretty well,
<img width="527" height="187" alt="image" src="https://github.com/user-attachments/assets/e58f4d57-f87b-456e-b080-30ea37be2cc8" />
we likewise split the summation for harmonic numbers into blocks of odd terms but instead of taking the `k`th power of each block, we multiply it by `1+1/2+1/4+...+1/2**(k-1)`, and (like Luschny's implementation) we add terms in each block together in a binary tree.

note that this idea is even more suited to computing harmonic numbers than factorials! since
* H_n ~ log(n), so numerators' binary representations are only negligibly longer than denominators
* if we neglect cancellation and pretend `(harmonic(b)-harmonic(a)).denominator = lcm(range(a+1,b+1))`, then
  * (as explained in [A003418](https://oeis.org/A003418)) the prime number theorem tells us that `len(harmonic(n).denominator) ~ n`,
  * `lcm(range(1,b-a+1))` is always a divisor of `lcm(range(a+1,b+1))`, and the other factor is not usually very large
we can deduce that each block's sum's bit-length is approximately commensurate to its number of summands!

so whereas splitting a factorial apart requires choosing splitpoints to balance the multiplicands on either side (see [this comment](https://github.com/more-itertools/more-itertools/pull/1196#issuecomment-5015212862) on my PR in more_itertools), here just using a binary tree approximately does that already!

the existing implementation caches previous outputs, so i made the binary trees store themselves as Fenwick trees; the initialisation (for each `i`, add the `i`th element to the `i|i+1`th) is done lazily (the purpose of the `HarmonicTree` class being to facilitate this), but it creates the initial list of summands all at once (which is why the plot below exhibits jumps at each power of 2).

note also that `harmonic._eval`'s output itself is no longer cached! when the cached trees *have* been generated up to the `n`th term, it now takes `O(log(n))` instead of `O(1)` operations to compute, which i think the memory savings justify.

specifically, according to the above unrigorous heuristic justification, memory usage with the Fenwick trees is only linear instead of quadratic (although for the existing implementation one would have to measure cache writes rather than raw size as i did, since `@cacheit` has limited capacity before overwriting existing entries like `@lru_cache`).

#### Other comments
here is a log-log plot of time (in seconds) wrt input size, without any existing cache, for the first- and second-order harmonic numbers for `n` sampled in `[128,16384]`:
<img width="1540" height="901" alt="harmonic_loglog" src="https://github.com/user-attachments/assets/a26a6cfd-8170-46dc-ba5c-de2ea04bbbb8" />

#### AI Generation Disclosure
NO AI USE in the submitted code, although in making the plot i got (the free version of) ChatGPT to
* wrangle `timeit` for me
  * make the program reinitialise the original SymPy and my altered version each test to clear the cache
* tell me how to use features of matplotlib without going through its documentation for them

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * Optimise `harmonic.eval(n,m)`; it now computes the sum via binary splitting on each of a sequence of Fenwick trees when `n,m` are both positive integers.
<!-- END RELEASE NOTES -->