### PR TITLE
Fix asech derivative for x < -1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1699,6 +1699,7 @@ Tuan Manh Lai <laituan245@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Unknown <kunda@scribus.net>
+Utsab Dahal <utsabdahal34@gmail.com> Utsab Dahal <134686066+utsab345@users.noreply.github.com>
 Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>
 V1krant <46847915+V1krant@users.noreply.github.com>

--- a/sympy/functions/elementary/hyperbolic.py
+++ b/sympy/functions/elementary/hyperbolic.py
@@ -1937,7 +1937,7 @@ class asech(InverseHyperbolicFunction):
     >>> from sympy import asech, sqrt, S
     >>> from sympy.abc import x
     >>> asech(x).diff(x)
-    -1/(x*sqrt(1 - x**2))
+    -sqrt(1/(x + 1))/(x*sqrt(1 - x))
     >>> asech(1).diff(x)
     0
     >>> asech(1)
@@ -1969,7 +1969,7 @@ class asech(InverseHyperbolicFunction):
     def fdiff(self, argindex=1):
         if argindex == 1:
             z = self.args[0]
-            return -1/(z*sqrt(1 - z**2))
+            return -sqrt(1/(z + 1))/(z*sqrt(1 - z))
         else:
             raise ArgumentIndexError(self, argindex)
 

--- a/sympy/functions/elementary/tests/test_hyperbolic.py
+++ b/sympy/functions/elementary/tests/test_hyperbolic.py
@@ -894,10 +894,10 @@ def test_asech_nseries():
     17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
     assert asech(-I*x + 3)._eval_nseries(x, 4, None) == asech(3) + sqrt(2)*x/12 + \
     17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
-    assert asech(I*x - 3)._eval_nseries(x, 4, None) == -asech(-3) - sqrt(2)*x/12 - \
-    17*sqrt(2)*I*x**2/576 + 443*sqrt(2)*x**3/41472 + O(x**4)
-    assert asech(-I*x - 3)._eval_nseries(x, 4, None) == asech(-3) - sqrt(2)*x/12 + \
-    17*sqrt(2)*I*x**2/576 + 443*sqrt(2)*x**3/41472 + O(x**4)
+    assert asech(I*x - 3)._eval_nseries(x, 4, None) == -asech(-3) + sqrt(2)*x/12 + \
+    17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
+    assert asech(-I*x - 3)._eval_nseries(x, 4, None) == asech(-3) + sqrt(2)*x/12 - \
+    17*sqrt(2)*I*x**2/576 - 443*sqrt(2)*x**3/41472 + O(x**4)
     # Tests concerning im(ndir) == 0
     assert asech(-I*x**2 + x - 2)._eval_nseries(x, 3, None) == 2*I*pi/3 + \
     x*(-sqrt(3) + 3*I)/(6*sqrt(3) + 6*I) + x**2*(36 + sqrt(3)*(7 - 12*I) + 21*I)/(72*sqrt(3) - \
@@ -1471,7 +1471,7 @@ def test_derivs():
     assert acosh(x).diff(x) == 1/(sqrt(x - 1)*sqrt(x + 1))
     assert acosh(x).diff(x) == acosh(x).rewrite(log).diff(x).together()
     assert atanh(x).diff(x) == 1/(-x**2 + 1)
-    assert asech(x).diff(x) == -1/(x*sqrt(1 - x**2))
+    assert asech(x).diff(x) == -sqrt(1/(x + 1))/(x*sqrt(1 - x))
     assert acsch(x).diff(x) == -1/(x**2*sqrt(1 + x**(-2)))
 
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30335

#### Brief description of what is fixed or changed

The derivative of `asech(x)` was `-1/(x*sqrt(1-x**2))`, which is only correct for `0 < x < 1`. For `x < -1` it gives the wrong sign. Changed to the Mathematica formula `-sqrt(1/(x+1))/(x*sqrt(1-x))` which is correct for all real `x` and matches the derivative of `acosh(1/x)`.

For example, `diff(asech(x)).subs(x, -2)` now gives `sqrt(3)*I/6` instead of `-sqrt(3)*I/6`, matching the numerical derivative.

#### Other comments

Also updated the `nseries` test expectations that depended on the old derivative formula, since `_eval_nseries` uses the derivative internally.

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* functions
  * The derivative of ``asech(x)`` is now correct for ``x < -1`` and matches the derivative of ``acosh(1/x)``.
<!-- END RELEASE NOTES -->