### PR TITLE
Fix ask(False, False) to raise inconsistent assumptions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1699,6 +1699,7 @@ Tuan Manh Lai <laituan245@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Unknown <kunda@scribus.net>
+Utsab Dahal <utsabdahal34@gmail.com> Utsab Dahal <134686066+utsab345@users.noreply.github.com>
 Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>
 V1krant <46847915+V1krant@users.noreply.github.com>

--- a/sympy/assumptions/ask.py
+++ b/sympy/assumptions/ask.py
@@ -527,10 +527,11 @@ def ask(proposition, assumptions=True, context=global_assumptions):
     known_facts_cnf = get_all_known_facts()
     enc_cnf = EncodedCNF()
     enc_cnf.from_cnf(CNF(known_facts_cnf))
+    enc_cnf.add_from_cnf(assump_cnf)
     enc_cnf.add_from_cnf(local_facts)
 
     # check the satisfiability of given assumptions
-    if local_facts.clauses and satisfiable(enc_cnf) is False:
+    if assump_cnf.clauses and satisfiable(enc_cnf) is False:
         raise ValueError(f"inconsistent assumptions {assumptions}")
 
     # quick computation for single fact

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -2384,6 +2384,12 @@ def test_issue_6732():
     raises(ValueError, lambda: ask(Q.negative(x), Q.positive(x) & Q.negative(x)))
 
 
+def test_issue_27964():
+    raises(ValueError, lambda: ask(False, False))
+    raises(ValueError, lambda: ask(Q.positive(x), False))
+    assert ask(Implies(False, False)) is True
+
+
 def test_issue_7246():
     assert _ask_recursive(Q.positive(atan(p)), Q.positive(p)) is True
     assert _ask_recursive(Q.positive(atan(p)), Q.negative(p)) is False


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #27964

#### Brief description of what is fixed or changed

`ask(False, False)` previously returned `False` instead of raising an inconsistency error. The satisfiability check in `ask()` only ran when there were extracted facts about the proposition's arguments, so a directly unsatisfiable assumption like `False` was never detected.

Now the raw assumption CNF is added to the encoded CNF used for the satisfiability check, so `ask(False, False)` raises `ValueError: inconsistent assumptions False`, consistent with how other inconsistent assumptions are handled (e.g. `Q.even(x) & Q.odd(x)`).

#### Other comments

N/A

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * ``ask(False, False)`` now raises ``ValueError`` for inconsistent assumptions instead of returning ``False``.
<!-- END RELEASE NOTES -->