### PR TITLE
Fix ask(Q.imaginary(I*oo)) wrongly returning True

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1699,6 +1699,7 @@ Tuan Manh Lai <laituan245@gmail.com>
 Tuomas Airaksinen <tuomas.airaksinen@gmail.com>
 Tyler Pirtle <teeler@gmail.com>
 Unknown <kunda@scribus.net>
+Utsab Dahal <utsabdahal34@gmail.com> Utsab Dahal <134686066+utsab345@users.noreply.github.com>
 Uttam Bhadauriya <uttamsinghbhadoriya23@gmail.com>
 Uwe L. Korn <uwelk@xhochy.com>
 V1krant <46847915+V1krant@users.noreply.github.com>

--- a/sympy/assumptions/handlers/sets.py
+++ b/sympy/assumptions/handlers/sets.py
@@ -531,6 +531,9 @@ def _(expr, assumptions):
 # ImaginaryPredicate
 
 def _Imaginary_number(expr, assumptions):
+    # imaginary numbers are necessarily finite
+    if expr.is_finite is False:
+        return False
     # let as_real_imag() work first since the expression may
     # be simpler to evaluate
     r = expr.as_real_imag()[0].evalf(2)

--- a/sympy/assumptions/tests/test_query.py
+++ b/sympy/assumptions/tests/test_query.py
@@ -1677,6 +1677,13 @@ def test_imaginary():
     assert _ask_recursive(Q.imaginary(Pow(x, Rational(1, 4))), Q.real(x) & Q.negative(x)) is False
 
 
+def test_issue_27449():
+    z = I*oo
+    assert ask(Q.imaginary(z)) is False
+    assert ask(Q.imaginary(3*I)) is True
+    assert ask(Q.imaginary(oo)) is False
+
+
 def test_integer():
     assert _ask_recursive(Q.integer(x)) is None
     assert _ask_recursive(Q.integer(x), Q.integer(x)) is True


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #27449

#### Brief description of what is fixed or changed

`ask(Q.imaginary(I*oo))` previously returned `True` even though `I*oo` is not a finite complex number and `(I*oo).is_imaginary` is `False` under the old assumptions. Imaginary numbers are by definition finite, so an infinite expression cannot be imaginary.

The `_Imaginary_number` handler in `sympy/assumptions/handlers/sets.py` now returns `False` for expressions that are not finite, instead of relying on the numeric check of the real part alone.

#### Other comments

N/A

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * ``ask(Q.imaginary(I*oo))`` now returns ``False`` instead of ``True``.
<!-- END RELEASE NOTES -->