### PR TITLE
Fixing _eval_integral/_eval_Integral

### DIFF
--- a/doc/src/modules/functions/elementary.rst
+++ b/doc/src/modules/functions/elementary.rst
@@ -183,7 +183,7 @@ Piecewise
 .. autoclass:: sympy.functions.elementary.piecewise.Piecewise
    :members:
 
-   .. automethod:: sympy.functions.elementary.piecewise.Piecewise._eval_integral
+   .. automethod:: sympy.functions.elementary.piecewise.Piecewise._eval_Integral
 
 .. autofunction:: sympy.functions.elementary.piecewise.piecewise_exclusive
 

--- a/sympy/algebras/quaternion.py
+++ b/sympy/algebras/quaternion.py
@@ -12,7 +12,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (acos, asin, atan2)
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.simplify.trigsimp import trigsimp
-from sympy.integrals.integrals import integrate
+from sympy.integrals.integrals import Integral, integrate
 from sympy.matrices.dense import MutableDenseMatrix as Matrix
 from sympy.core.expr import Expr
 from sympy.core.sympify import sympify, _sympify
@@ -725,8 +725,8 @@ class Quaternion(Expr):
     def __rtruediv__(self, other: SExpr) -> Quaternion:
         return sympify(other) * self**-1
 
-    def _eval_Integral(self, *args) -> Quaternion:
-        return self.integrate(*args)
+    def _eval_Integral(self, x, **hints) -> Quaternion:
+        return Quaternion(*[Integral(arg, x).doit(**hints) for arg in self.args])
 
     def diff(self, *symbols, **kwargs):
         kwargs.setdefault('evaluate', True)

--- a/sympy/algebras/tests/test_quaternion.py
+++ b/sympy/algebras/tests/test_quaternion.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.complexes import (Abs, conjugate, im, re, sign)
 from sympy.functions.elementary.exponential import log
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (acos, asin, cos, sin, atan2, atan)
-from sympy.integrals.integrals import integrate
+from sympy.integrals.integrals import Integral, integrate
 from sympy.matrices.dense import Matrix
 from sympy.simplify import simplify
 from sympy.simplify.trigsimp import trigsimp
@@ -191,6 +191,12 @@ def test_quaternion_functions():
 
     assert integrate(Quaternion(x, x, x, x), x) == \
     Quaternion(x**2 / 2, x**2 / 2, x**2 / 2, x**2 / 2)
+
+    q2 = Quaternion(x, x**2, sin(x), 1)
+    assert isinstance(Integral(q2, x), Integral)
+    assert Integral(q2, x).doit() == Quaternion(x**2/2, x**3/3, -cos(x), x)
+    assert Integral(q2, (x, 0, 1)).doit() == \
+        Quaternion(S.Half, Rational(1, 3), 1 - cos(1), 1)
 
     assert Quaternion(1, x, x**2, x**3).integrate(x) == \
     Quaternion(x, x**2/2, x**3/3, x**4/4)

--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -347,9 +347,22 @@ class ExprWithLimits(Expr):
         return not self.free_symbols
 
     def _eval_interval(self, x, a, b):
+        if x not in self.variables:
+            return super()._eval_interval(x, a, b)
         limits = [(i if i[0] != x else (x, a, b)) for i in self.limits]
         integrand = self.function
         return self.func(integrand, *limits)
+
+    def _avoid_capture(self, *exprs):
+        """Return self with its bound variables renamed if any of them
+        appear free in ``exprs``."""
+        free = set()
+        for e in exprs:
+            if e is not None:
+                free |= e.free_symbols
+        if free & set(self.variables):
+            return self.as_dummy()
+        return self
 
     def _eval_subs(self, old, new):
         """
@@ -559,6 +572,16 @@ class AddWithLimits(ExprWithLimits):
         obj.is_commutative = function.is_commutative  # limits already checked
 
         return obj
+
+    def _eval_interval(self, x, a, b):
+        if x not in self.variables and not any(x in l.free_symbols for l in
+                                                self.limits):
+            expr = self._avoid_capture(a, b)
+            function = expr.function._eval_interval(x, a, b)
+            if function.is_zero:
+                return S.Zero
+            return expr.func(function, *expr.limits)
+        return super()._eval_interval(x, a, b)
 
     def _eval_adjoint(self):
         if all(x.is_real for x in flatten(self.limits)):

--- a/sympy/functions/elementary/piecewise.py
+++ b/sympy/functions/elementary/piecewise.py
@@ -291,7 +291,7 @@ class Piecewise(DefinedFunction):
 
         See Also
         ========
-        Piecewise._eval_integral
+        Piecewise._eval_Integral
         """
         from sympy.integrals import integrate
         return self.func(*[(integrate(e, x, **kwargs), c) for e, c in self.args])
@@ -363,7 +363,7 @@ class Piecewise(DefinedFunction):
             args.append((expr, True))
             return Piecewise(*args)
 
-    def _eval_integral(self, x, _first=True, **kwargs):
+    def _eval_Integral(self, x, _first=True, definite=False, **kwargs):
         """Return the indefinite integral of the
         Piecewise such that subsequent substitution of x with a
         value will give the value of the integral (not including
@@ -388,10 +388,13 @@ class Piecewise(DefinedFunction):
         """
         from sympy.integrals.integrals import integrate
 
+        if definite:
+            return self.piecewise_integrate(x, **kwargs)
+
         if _first:
             def handler(ipw):
                 if isinstance(ipw, self.func):
-                    return ipw._eval_integral(x, _first=False, **kwargs)
+                    return ipw._eval_Integral(x, _first=False, **kwargs)
                 else:
                     return ipw.integrate(x, **kwargs)
             irv = self._handle_irel(x, handler)

--- a/sympy/functions/elementary/tests/test_piecewise.py
+++ b/sympy/functions/elementary/tests/test_piecewise.py
@@ -1007,7 +1007,7 @@ def test_holes():
     assert Piecewise((1, And(x > 0, x < 4))).integrate((x, 1, 3)) == 2
 
     # this also tests that the integrate method is used on non-Piecwise
-    # arguments in _eval_integral
+    # arguments in _eval_Integral
     A, B = symbols("A B")
     a, b = symbols('a b', real=True)
     assert Piecewise((A, And(x < 0, a < 1)), (B, Or(x < 1, a > 2))

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -517,31 +517,7 @@ class Integral(AddWithLimits):
             return did
 
         # continue with existing assumptions
-        undone_limits = []
-        # ulj = free symbols of any undone limits' upper and lower limits
-        ulj = set()
         for xab in self.limits:
-            # compute uli, the free symbols in the
-            # Upper and Lower limits of limit I
-            if len(xab) == 1:
-                uli = set(xab[:1])
-            elif len(xab) == 2:
-                uli = xab[1].free_symbols
-            elif len(xab) == 3:
-                uli = xab[1].free_symbols.union(xab[2].free_symbols)
-            # this integral can be done as long as there is no blocking
-            # limit that has been undone. An undone limit is blocking if
-            # it contains an integration variable that is in this limit's
-            # upper or lower free symbols or vice versa
-            if xab[0] in ulj or any(v[0] in uli for v in undone_limits):
-                undone_limits.append(xab)
-                ulj.update(uli)
-                function = self.func(*([function] + [xab]))
-                factored_function = function.factor()
-                if not isinstance(factored_function, Integral):
-                    function = factored_function
-                continue
-
             if function.has(Abs, sign) and (
                 (len(xab) < 3 and all(x.is_extended_real for x in xab)) or
                 (len(xab) == 3 and all(x.is_extended_real and not x.is_infinite for
@@ -658,11 +634,7 @@ class Integral(AddWithLimits):
                                 sign(coeff)*pi*floor((a)/pi)))
 
             if antideriv is None:
-                undone_limits.append(xab)
-                function = self.func(*([function] + [xab])).factor()
-                factored_function = function.factor()
-                if not isinstance(factored_function, Integral):
-                    function = factored_function
+                function = self.func(function, xab)
                 continue
             else:
                 if len(xab) == 1:
@@ -726,11 +698,7 @@ class Integral(AddWithLimits):
                         except NotImplementedError:
                             # This can happen if _eval_interval depends in a
                             # complicated way on limits that cannot be computed
-                            undone_limits.append(xab)
-                            function = self.func(*([function] + [xab]))
-                            factored_function = function.factor()
-                            if not isinstance(factored_function, Integral):
-                                function = factored_function
+                            function = self.func(function, xab)
         return function
 
     def _eval_derivative(self, sym):

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -38,6 +38,44 @@ if TYPE_CHECKING:
     SymbolLimits = Expr | tuple[Expr, Expr] | tuple[Expr, Expr, Expr]
 
 
+def _add_atan_floor_terms(antideriv):
+    """
+    Make an antiderivative containing ``atan(c*tan(a))`` or ``atan(c*cot(a))``
+    continuous by adding the appropriate multiple of ``pi*floor(...)``.
+
+    Examples
+    ========
+
+    >>> from sympy import atan, tan, pi, floor
+    >>> from sympy.abc import x
+    >>> from sympy.integrals.integrals import _add_atan_floor_terms
+    >>> _add_atan_floor_terms(2*atan(3*tan(x/2)))
+    2*atan(3*tan(x/2)) + 2*pi*floor((x/2 - pi/2)/pi)
+    """
+    for atan_term in antideriv.atoms(atan):
+        atan_arg = atan_term.args[0]
+        # Checking `atan_arg` to be linear combination of `tan` or `cot`
+        for tan_part in atan_arg.atoms(tan):
+            x1 = Dummy('x1')
+            tan_exp1 = atan_arg.subs(tan_part, x1)
+            # The coefficient of `tan` should be constant
+            coeff = tan_exp1.diff(x1)
+            if x1 not in coeff.free_symbols:
+                a = tan_part.args[0]
+                antideriv = antideriv.subs(atan_term, Add(atan_term,
+                    sign(coeff)*pi*floor((a-pi/2)/pi)))
+        for cot_part in atan_arg.atoms(cot):
+            x1 = Dummy('x1')
+            cot_exp1 = atan_arg.subs(cot_part, x1)
+            # The coefficient of `cot` should be constant
+            coeff = cot_exp1.diff(x1)
+            if x1 not in coeff.free_symbols:
+                a = cot_part.args[0]
+                antideriv = antideriv.subs(atan_term, Add(atan_term,
+                    sign(coeff)*pi*floor((a)/pi)))
+    return antideriv
+
+
 class Integral(AddWithLimits):
     """Represents unevaluated integral."""
 
@@ -594,31 +632,11 @@ class Integral(AddWithLimits):
                         continue
 
             final = hints.get('final', True)
-            # dotit may be iterated but floor terms making atan and acot
+            # doit may be iterated but floor terms making atan and acot
             # continuous should only be added in the final round
             if (final and not isinstance(antideriv, Integral) and
                 antideriv is not None):
-                for atan_term in antideriv.atoms(atan):
-                    atan_arg = atan_term.args[0]
-                    # Checking `atan_arg` to be linear combination of `tan` or `cot`
-                    for tan_part in atan_arg.atoms(tan):
-                        x1 = Dummy('x1')
-                        tan_exp1 = atan_arg.subs(tan_part, x1)
-                        # The coefficient of `tan` should be constant
-                        coeff = tan_exp1.diff(x1)
-                        if x1 not in coeff.free_symbols:
-                            a = tan_part.args[0]
-                            antideriv = antideriv.subs(atan_term, Add(atan_term,
-                                sign(coeff)*pi*floor((a-pi/2)/pi)))
-                    for cot_part in atan_arg.atoms(cot):
-                        x1 = Dummy('x1')
-                        cot_exp1 = atan_arg.subs(cot_part, x1)
-                        # The coefficient of `cot` should be constant
-                        coeff = cot_exp1.diff(x1)
-                        if x1 not in coeff.free_symbols:
-                            a = cot_part.args[0]
-                            antideriv = antideriv.subs(atan_term, Add(atan_term,
-                                sign(coeff)*pi*floor((a)/pi)))
+                antideriv = _add_atan_floor_terms(antideriv)
 
             if antideriv is None:
                 function = self.func(function, xab)

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -536,7 +536,7 @@ class Integral(AddWithLimits):
                     antideriv = function._eval_integral(xab[0],
                         **eval_kwargs)
                 else:
-                    antideriv = self._eval_integral(
+                    antideriv = self._integrate_dispatch(
                         function, xab[0], **eval_kwargs)
             else:
                 # There are a number of tradeoffs in using the
@@ -598,7 +598,7 @@ class Integral(AddWithLimits):
                 if meijerg1 is False and meijerg is True:
                     antideriv = None
                 else:
-                    antideriv = self._eval_integral(
+                    antideriv = self._integrate_dispatch(
                         function, xab[0], **eval_kwargs)
                     if antideriv is None and meijerg is True:
                         ret = try_meijerg(function, xab)
@@ -794,7 +794,7 @@ class Integral(AddWithLimits):
                 rv += self.func(arg, (x, a, b))
         return rv
 
-    def _eval_integral(self, f, x, meijerg=None, risch=None, manual=None,
+    def _integrate_dispatch(self, f, x, meijerg=None, risch=None, manual=None,
                        heurisch=None, conds='piecewise',final=None):
         """
         Calculate the anti-derivative to the function f(x).
@@ -978,10 +978,10 @@ class Integral(AddWithLimits):
             order_term = g.getO()
 
             if order_term is not None:
-                h = self._eval_integral(g.removeO(), x, **eval_kwargs)
+                h = self._integrate_dispatch(g.removeO(), x, **eval_kwargs)
 
                 if h is not None:
-                    h_order_expr = self._eval_integral(order_term.expr, x, **eval_kwargs)
+                    h_order_expr = self._integrate_dispatch(order_term.expr, x, **eval_kwargs)
 
                     if h_order_expr is not None:
                         h_order_term = order_term.func(
@@ -1128,7 +1128,7 @@ class Integral(AddWithLimits):
                     # Note: risch will be identical on the expanded
                     # expression, but maybe it will be able to pick out parts,
                     # like x*(exp(x) + erf(x)).
-                    return self._eval_integral(f, x, **eval_kwargs)
+                    return self._integrate_dispatch(f, x, **eval_kwargs)
 
             if h is not None:
                 parts.append(coeff * h)
@@ -1429,7 +1429,7 @@ def integrate(function, *symbols: SymbolLimits, meijerg=None, conds='piecewise',
     exist.  There is also a (very successful, albeit somewhat slow) general
     implementation of the heuristic Risch algorithm.  This algorithm will
     eventually be phased out as more of the full Risch algorithm is
-    implemented. See the docstring of Integral._eval_integral() for more
+    implemented. See the docstring of Integral._integrate_dispatch() for more
     details on computing the antiderivative using algebraic methods.
 
     The option risch=True can be used to use only the (full) Risch algorithm.

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -1093,7 +1093,7 @@ class Integral(AddWithLimits):
                             # unless we were asked to use manual only.
                             # Keep the rest of eval_kwargs in case another
                             # method was set to False already
-                            new_eval_kwargs = eval_kwargs
+                            new_eval_kwargs = dict(eval_kwargs)
                             new_eval_kwargs["manual"] = False
                             new_eval_kwargs["final"] = False
                             result = result.func(*[

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -85,11 +85,6 @@ class Integral(AddWithLimits):
 
         """
 
-        #This will help other classes define their own definitions
-        #of behaviour with Integral.
-        if hasattr(function, '_eval_Integral'):
-            return function._eval_Integral(*symbols, **assumptions)
-
         if isinstance(function, Poly):
             sympy_deprecation_warning(
                 """
@@ -531,80 +526,72 @@ class Integral(AddWithLimits):
             if (function.has(Piecewise) and
                 not isinstance(function, Piecewise)):
                     function = piecewise_fold(function)
-            if isinstance(function, Piecewise):
-                if len(xab) == 1:
-                    antideriv = function._eval_integral(xab[0],
-                        **eval_kwargs)
-                else:
-                    antideriv = self._integrate_dispatch(
-                        function, xab[0], **eval_kwargs)
-            else:
-                # There are a number of tradeoffs in using the
-                # Meijer G method. It can sometimes be a lot faster
-                # than other methods, and sometimes slower. And
-                # there are certain types of integrals for which it
-                # is more likely to work than others. These
-                # heuristics are incorporated in deciding what
-                # integration methods to try, in what order. See the
-                # integrate() docstring for details.
-                def try_meijerg(function, xab):
-                    ret = None
-                    if len(xab) == 3 and meijerg is not False:
-                        x, a, b = xab
-                        try:
-                            res = meijerint_definite(function, x, a, b)
-                        except NotImplementedError:
-                            _debug('NotImplementedError '
-                                'from meijerint_definite')
-                            res = None
-                        if res is not None:
-                            f, cond = res
-                            if conds == 'piecewise':
-                                u = self.func(function, (x, a, b))
-                                # if Piecewise modifies cond too
-                                # much it may not be recognized by
-                                # _condsimp pattern matching so just
-                                # turn off all evaluation
-                                return Piecewise((f, cond), (u, True),
-                                    evaluate=False)
-                            elif conds == 'separate':
-                                if len(self.limits) != 1:
-                                    raise ValueError(filldedent('''
-                                        conds=separate not supported in
-                                        multiple integrals'''))
-                                ret = f, cond
-                            else:
-                                ret = f
-                    return ret
+            # There are a number of tradeoffs in using the
+            # Meijer G method. It can sometimes be a lot faster
+            # than other methods, and sometimes slower. And
+            # there are certain types of integrals for which it
+            # is more likely to work than others. These
+            # heuristics are incorporated in deciding what
+            # integration methods to try, in what order. See the
+            # integrate() docstring for details.
+            def try_meijerg(function, xab):
+                ret = None
+                if len(xab) == 3 and meijerg is not False:
+                    x, a, b = xab
+                    try:
+                        res = meijerint_definite(function, x, a, b)
+                    except NotImplementedError:
+                        _debug('NotImplementedError '
+                            'from meijerint_definite')
+                        res = None
+                    if res is not None:
+                        f, cond = res
+                        if conds == 'piecewise':
+                            u = self.func(function, (x, a, b))
+                            # if Piecewise modifies cond too
+                            # much it may not be recognized by
+                            # _condsimp pattern matching so just
+                            # turn off all evaluation
+                            return Piecewise((f, cond), (u, True),
+                                evaluate=False)
+                        elif conds == 'separate':
+                            if len(self.limits) != 1:
+                                raise ValueError(filldedent('''
+                                    conds=separate not supported in
+                                    multiple integrals'''))
+                            ret = f, cond
+                        else:
+                            ret = f
+                return ret
 
-                meijerg1 = meijerg
-                if (meijerg is not False and
-                        len(xab) == 3 and xab[1].is_extended_real and xab[2].is_extended_real
-                        and not function.is_Poly and
-                        (xab[1].has(oo, -oo) or xab[2].has(oo, -oo))):
+            meijerg1 = meijerg
+            if (meijerg is not False and
+                    len(xab) == 3 and xab[1].is_extended_real and xab[2].is_extended_real
+                    and not function.is_Poly and
+                    (xab[1].has(oo, -oo) or xab[2].has(oo, -oo))):
+                ret = try_meijerg(function, xab)
+                if ret is not None:
+                    function = ret
+                    continue
+                meijerg1 = False
+            # If the special meijerg code did not succeed in
+            # finding a definite integral, then the code using
+            # meijerint_indefinite will not either (it might
+            # find an antiderivative, but the answer is likely
+            # to be nonsensical). Thus if we are requested to
+            # only use Meijer G-function methods, we give up at
+            # this stage. Otherwise we just disable G-function
+            # methods.
+            if meijerg1 is False and meijerg is True:
+                antideriv = None
+            else:
+                antideriv = self._integrate_dispatch(
+                    function, xab[0], definite=len(xab) > 1, **eval_kwargs)
+                if antideriv is None and meijerg is True:
                     ret = try_meijerg(function, xab)
                     if ret is not None:
                         function = ret
                         continue
-                    meijerg1 = False
-                # If the special meijerg code did not succeed in
-                # finding a definite integral, then the code using
-                # meijerint_indefinite will not either (it might
-                # find an antiderivative, but the answer is likely
-                # to be nonsensical). Thus if we are requested to
-                # only use Meijer G-function methods, we give up at
-                # this stage. Otherwise we just disable G-function
-                # methods.
-                if meijerg1 is False and meijerg is True:
-                    antideriv = None
-                else:
-                    antideriv = self._integrate_dispatch(
-                        function, xab[0], **eval_kwargs)
-                    if antideriv is None and meijerg is True:
-                        ret = try_meijerg(function, xab)
-                        if ret is not None:
-                            function = ret
-                            continue
 
             final = hints.get('final', True)
             # dotit may be iterated but floor terms making atan and acot
@@ -694,7 +681,7 @@ class Integral(AddWithLimits):
                         try:
                             evalued = Add(*others)._eval_interval(x, a, b)
                             evalued_pw = piecewise_fold(Add(*piecewises))._eval_interval(x, a, b)
-                            function = uneval + evalued + evalued_pw
+                            function = Add(uneval, evalued, evalued_pw)
                         except NotImplementedError:
                             # This can happen if _eval_interval depends in a
                             # complicated way on limits that cannot be computed
@@ -795,12 +782,22 @@ class Integral(AddWithLimits):
         return rv
 
     def _integrate_dispatch(self, f, x, meijerg=None, risch=None, manual=None,
-                       heurisch=None, conds='piecewise',final=None):
+                       heurisch=None, conds='piecewise', final=None,
+                       definite=False):
         """
         Calculate the anti-derivative to the function f(x).
 
         Explanation
         ===========
+
+        An object can define a method ``_eval_Integral(x, **hints)`` that
+        returns its antiderivative with respect to ``x``, or ``None`` to fall
+        back to the algorithms below. It can also return an unevaluated
+        Integral when none of those algorithms would do better. Piecewise,
+        Integral (for nested integrals), quaternions and vectors do this. The hint
+        ``definite=True`` means that the antiderivative will be evaluated over
+        an interval with ``_eval_interval``, so it only needs to be correct up
+        to a constant on each interval where it is continuous.
 
         The following algorithms are applied (roughly in this order):
 
@@ -917,9 +914,12 @@ class Integral(AddWithLimits):
             # issued in the Integral constructor.
             return f.integrate(x)
 
-        # Piecewise antiderivatives need to call special integrate.
-        if isinstance(f, Piecewise):
-            return f.piecewise_integrate(x, **eval_kwargs)
+        # f(x) knows how to integrate itself
+        eval_Integral = getattr(f, '_eval_Integral', None)
+        if eval_Integral is not None:
+            h = eval_Integral(x, definite=definite, **eval_kwargs)
+            if h is not None:
+                return h
 
         # let's cut it short if `f` does not depend on `x`; if
         # x is only a dummy, that will be handled below
@@ -973,6 +973,14 @@ class Integral(AddWithLimits):
             if g is S.One and not meijerg:
                 parts.append(coeff*x)
                 continue
+
+            # g(x) knows how to integrate itself
+            eval_Integral = getattr(g, '_eval_Integral', None)
+            if eval_Integral is not None and g is not f:
+                h = eval_Integral(x, definite=definite, **eval_kwargs)
+                if h is not None:
+                    parts.append(coeff*h)
+                    continue
 
             # g(x) = expr + O(x**n)
             order_term = g.getO()

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -564,72 +564,61 @@ class Integral(AddWithLimits):
             if (function.has(Piecewise) and
                 not isinstance(function, Piecewise)):
                     function = piecewise_fold(function)
-            # There are a number of tradeoffs in using the
-            # Meijer G method. It can sometimes be a lot faster
-            # than other methods, and sometimes slower. And
-            # there are certain types of integrals for which it
-            # is more likely to work than others. These
-            # heuristics are incorporated in deciding what
-            # integration methods to try, in what order. See the
-            # integrate() docstring for details.
             def try_meijerg(function, xab):
-                ret = None
-                if len(xab) == 3 and meijerg is not False:
-                    x, a, b = xab
-                    try:
-                        res = meijerint_definite(function, x, a, b)
-                    except NotImplementedError:
-                        _debug('NotImplementedError '
-                            'from meijerint_definite')
-                        res = None
-                    if res is not None:
-                        f, cond = res
-                        if conds == 'piecewise':
-                            u = self.func(function, (x, a, b))
-                            # if Piecewise modifies cond too
-                            # much it may not be recognized by
-                            # _condsimp pattern matching so just
-                            # turn off all evaluation
-                            return Piecewise((f, cond), (u, True),
-                                evaluate=False)
-                        elif conds == 'separate':
-                            if len(self.limits) != 1:
-                                raise ValueError(filldedent('''
-                                    conds=separate not supported in
-                                    multiple integrals'''))
-                            ret = f, cond
-                        else:
-                            ret = f
-                return ret
+                x, a, b = xab
+                try:
+                    res = meijerint_definite(function, x, a, b)
+                except NotImplementedError:
+                    _debug('NotImplementedError '
+                        'from meijerint_definite')
+                    return None
+                if res is None:
+                    return None
+                f, cond = res
+                if conds == 'piecewise':
+                    u = self.func(function, (x, a, b))
+                    # if Piecewise modifies cond too
+                    # much it may not be recognized by
+                    # _condsimp pattern matching so just
+                    # turn off all evaluation
+                    return Piecewise((f, cond), (u, True),
+                        evaluate=False)
+                elif conds == 'separate':
+                    if len(self.limits) != 1:
+                        raise ValueError(filldedent('''
+                            conds=separate not supported in
+                            multiple integrals'''))
+                    return f, cond
+                else:
+                    return f
 
-            meijerg1 = meijerg
-            if (meijerg is not False and
-                    len(xab) == 3 and xab[1].is_extended_real and xab[2].is_extended_real
-                    and not function.is_Poly and
-                    (xab[1].has(oo, -oo) or xab[2].has(oo, -oo))):
+            # The Meijer G-function algorithm for definite integrals is
+            # the method of choice when a limit is infinite. If it does
+            # not succeed, an antiderivative found by the Meijer
+            # G-function algorithm for indefinite integrals is not
+            # trusted either, since evaluating it at the limits gives
+            # wrong answers for divergent integrals. When meijerg=True,
+            # a definite integral is only computed by the definite
+            # algorithm.
+            improper = (len(xab) == 3 and
+                        xab[1].is_extended_real and xab[2].is_extended_real
+                        and not function.is_Poly and
+                        (xab[1].has(oo, -oo) or xab[2].has(oo, -oo)))
+            if len(xab) == 3 and (meijerg is True or
+                                   (meijerg is None and improper)):
                 ret = try_meijerg(function, xab)
                 if ret is not None:
                     function = ret
                     continue
-                meijerg1 = False
-            # If the special meijerg code did not succeed in
-            # finding a definite integral, then the code using
-            # meijerint_indefinite will not either (it might
-            # find an antiderivative, but the answer is likely
-            # to be nonsensical). Thus if we are requested to
-            # only use Meijer G-function methods, we give up at
-            # this stage. Otherwise we just disable G-function
-            # methods.
-            if meijerg1 is False and meijerg is True:
-                antideriv = None
+                if meijerg is True:
+                    antideriv = None
+                else:
+                    antideriv = self._integrate_dispatch(
+                        function, xab[0], definite=True,
+                        **{**eval_kwargs, 'meijerg': False})
             else:
                 antideriv = self._integrate_dispatch(
                     function, xab[0], definite=len(xab) > 1, **eval_kwargs)
-                if antideriv is None and meijerg is True:
-                    ret = try_meijerg(function, xab)
-                    if ret is not None:
-                        function = ret
-                        continue
 
             final = hints.get('final', True)
             # doit may be iterated but floor terms making atan and acot
@@ -1510,20 +1499,19 @@ def integrate(function, *symbols: SymbolLimits, meijerg=None, conds='piecewise',
 
     - If computing a definite integral, and both limits are real,
       and at least one limit is +- oo, try the G-function method of
-      definite integration first.
+      definite integration first. If it fails, the G-function method of
+      indefinite integration is not used for this integral either.
 
     - Try to find an antiderivative, using all available methods, ordered
       by performance (that is try fastest method first, slowest last; in
       particular polynomial integration is tried first, Meijer
       G-functions second to last, and heuristic Risch last).
 
-    - If still not successful, try G-functions irrespective of the
-      limits.
-
     The option meijerg=True, False, None can be used to, respectively:
     always use G-function methods and no others, never use G-function
     methods, or use all available methods (in order as described above).
-    It defaults to None.
+    It defaults to None. With meijerg=True, a definite integral is only
+    computed with the G-function method of definite integration.
 
     Examples
     ========

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -781,6 +781,20 @@ class Integral(AddWithLimits):
                 rv += self.func(arg, (x, a, b))
         return rv
 
+    def _eval_Integral(self, x, **hints):
+        """
+        Integrate this Integral with respect to ``x`` by integrating its
+        integrand, which is valid when ``x`` is not one of the integration
+        variables and does not appear in any of the limits.
+        """
+        if (x not in self.function.free_symbols or x in self.variables or
+                any(x in l.free_symbols for l in self.limits)):
+            return None
+        h = self._integrate_dispatch(self.function, x, **hints)
+        if h is None:
+            return None
+        return self.func(h, *self.limits)
+
     def _integrate_dispatch(self, f, x, meijerg=None, risch=None, manual=None,
                        heurisch=None, conds='piecewise', final=None,
                        definite=False):

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1860,6 +1860,8 @@ def meijerint_definite(f, x, a, b):
 
     elif a is S.Infinity:
         res = meijerint_definite(f, x, b, S.Infinity)
+        if res is None:
+            return None
         return -res[0], res[1]
 
     elif (a, b) == (S.Zero, S.Infinity):

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -39,12 +39,12 @@ from sympy.functions.elementary.integers import floor
 from sympy.integrals.integrals import Integral
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.physics import units
-from sympy.testing.pytest import raises, slow, warns_deprecated_sympy, warns
+from sympy.testing.pytest import XFAIL, raises, slow, warns_deprecated_sympy, warns
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.random import verify_numerically
 
 
-x, y, z, a, b, c, d, e, s, t, x_1, x_2 = symbols('x y z a b c d e s t x_1 x_2')
+w, x, y, z, a, b, c, d, e, s, t, x_1, x_2 = symbols('w x y z a b c d e s t x_1 x_2')
 n = Symbol('n', integer=True)
 f = Function('f')
 
@@ -1068,7 +1068,6 @@ def test_issue_4100():
 
 
 def test_issue_5167():
-    from sympy.abc import w, x, y, z
     f = Function('f')
     assert Integral(Integral(f(x), x), x) == Integral(f(x), x, x)
     assert Integral(f(x)).args == (f(x), Tuple(x))
@@ -1078,16 +1077,22 @@ def test_issue_5167():
     assert Integral(Integral(Integral(f(x), x), y), z).args == \
         (f(x), Tuple(x), Tuple(y), Tuple(z))
     assert integrate(Integral(f(x), x), x) == Integral(f(x), x, x)
-    assert integrate(Integral(f(x), y), x) == y*Integral(f(x), x)
+    assert integrate(Integral(f(x), y), x) == Integral(y*f(x), x)
     assert integrate(Integral(f(x), x), y) in [Integral(y*f(x), x), y*Integral(f(x), x)]
     assert integrate(Integral(2, x), x) == x**2
     assert integrate(Integral(2, x), y) == 2*x*y
     # don't re-order given limits
     assert Integral(1, x, y).args != Integral(1, y, x).args
     # do as many as possible
+    res = Integral(f(x), (x, 1, 2), (w, 1, x), (z, 1, y)).doit()
+    expected = (y - 1)*(x - 1)*Integral(f(x), (x, 1, 2))
+    assert (res - expected).expand() == 0
+
+
+@XFAIL
+def test_issue_5167_nested():
+    f = Function('f')
     assert Integral(f(x), y, x, y, x).doit() == y**2*Integral(f(x), x, x)/2
-    assert Integral(f(x), (x, 1, 2), (w, 1, x), (z, 1, y)).doit() == \
-        y*(x - 1)*Integral(f(x), (x, 1, 2)) - (x - 1)*Integral(f(x), (x, 1, 2))
 
 
 def test_issue_4890():
@@ -1201,7 +1206,7 @@ def test_issue_4892b():
 
 def test_issue_5178():
     assert integrate(sin(x)*f(y, z), (x, 0, pi), (y, 0, pi), (z, 0, pi)) == \
-        2*Integral(f(y, z), (y, 0, pi), (z, 0, pi))
+        Integral(2*f(y, z), (y, 0, pi), (z, 0, pi))
 
 
 def test_integrate_series():
@@ -1376,10 +1381,9 @@ def test_issue_2708():
     assert Integral(f, (z, 2, 3)).doit() == integral_f
     assert integrate(f + exp(z), (z, 2, 3)) == integral_f - exp(2) + exp(3)
     assert integrate(2*f + exp(z), (z, 2, 3)) == \
-        2*integral_f - exp(2) + exp(3)
+        NonElementaryIntegral(2*f, (z, 2, 3)) - exp(2) + exp(3)
     assert integrate(exp(1.2*n*s*z*(-t + z)/t), (z, 0, x)) == \
-        NonElementaryIntegral(exp(-1.2*n*s*z)*exp(1.2*n*s*z**2/t),
-                                  (z, 0, x))
+        NonElementaryIntegral(exp(1.2*n*s*z*(-t + z)/t), (z, 0, x))
 
 
 def test_issue_2884():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -39,7 +39,7 @@ from sympy.functions.elementary.integers import floor
 from sympy.integrals.integrals import Integral
 from sympy.integrals.risch import NonElementaryIntegral
 from sympy.physics import units
-from sympy.testing.pytest import XFAIL, raises, slow, warns_deprecated_sympy, warns
+from sympy.testing.pytest import raises, slow, warns_deprecated_sympy, warns
 from sympy.utilities.exceptions import SymPyDeprecationWarning
 from sympy.core.random import verify_numerically
 
@@ -1099,10 +1099,16 @@ def test_eval_Integral():
     assert integrate(F(x) + x, x) == x**2/2 + 3*x
 
 
-@XFAIL
-def test_issue_5167_nested():
+def test_integrate_nested_integral():
     f = Function('f')
-    assert Integral(f(x), y, x, y, x).doit() == y**2*Integral(f(x), x, x)/2
+    assert Integral(f(x), y, x, y, x).doit() == Integral(y**2*f(x)/2, x, x)
+    assert integrate(Integral(y*f(x), x), (y, 0, 2)) == Integral(2*f(x), x)
+    assert integrate(Integral(f(x, y), (x, 0, y)), y) == \
+        Integral(f(x, y), (x, 0, y), y)
+    # the free x in the limit must not be captured by the bound x
+    res = Integral(Integral(w*f(x), (x, 1, 2)), (w, 1, x)).doit()
+    d = res.variables[0]
+    assert d != x and res == Integral(x**2*f(d)/2 - f(d)/2, (d, 1, 2))
 
 
 def test_issue_4890():

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1089,6 +1089,16 @@ def test_issue_5167():
     assert (res - expected).expand() == 0
 
 
+def test_eval_Integral():
+    class F(Expr):
+        def _eval_Integral(self, x, **hints):
+            return 3*x
+
+    assert integrate(2*F(x), x) == 6*x
+    assert integrate(F(x), (x, 0, 1)) == 3
+    assert integrate(F(x) + x, x) == x**2/2 + 3*x
+
+
 @XFAIL
 def test_issue_5167_nested():
     f = Function('f')

--- a/sympy/integrals/tests/test_meijerint.py
+++ b/sympy/integrals/tests/test_meijerint.py
@@ -5,6 +5,7 @@ from sympy.core.singleton import S
 from sympy.core.sorting import default_sort_key
 from sympy.functions.elementary.complexes import Abs, arg, re, unpolarify
 from sympy.functions.elementary.exponential import (exp, exp_polar, log)
+from sympy.functions.special.bessel import besselj
 from sympy.functions.elementary.hyperbolic import cosh, acosh, sinh
 from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.piecewise import Piecewise, piecewise_fold
@@ -236,7 +237,7 @@ def test_meijerint():
 
 
 def test_bessel():
-    from sympy.functions.special.bessel import (besseli, besselj)
+    from sympy.functions.special.bessel import besseli
     assert simplify(integrate(besselj(a, z)*besselj(b, z)/z, (z, 0, oo),
                      meijerg=True, conds='none')) == \
         2*sin(pi*(a/2 - b/2))/(pi*(a - b)*(a + b))
@@ -467,16 +468,16 @@ def test_probability():
         /(beta - 2)/(beta - 1)**2
 
     # Beta distribution
-    # NOTE: this is evaluated using antiderivatives. It also tests that
-    #       meijerint_indefinite returns the simplest possible answer.
     a, b = symbols('a b', positive=True)
     betadist = x**(a - 1)*(-x + 1)**(b - 1)*gamma(a + b)/(gamma(a)*gamma(b))
-    assert simplify(integrate(betadist, (x, 0, 1), meijerg=True)) == 1
-    assert simplify(integrate(x*betadist, (x, 0, 1), meijerg=True)) == \
-        a/(a + b)
+    assert simplify(integrate(betadist, (x, 0, 1), meijerg=True,
+                              conds='none')) == 1
+    assert simplify(integrate(x*betadist, (x, 0, 1), meijerg=True,
+                              conds='none')) == a/(a + b)
     assert simplify(integrate(x**2*betadist, (x, 0, 1), meijerg=True)) == \
         a*(a + 1)/(a + b)/(a + b + 1)
-    assert simplify(integrate(x**y*betadist, (x, 0, 1), meijerg=True)) == \
+    assert simplify(integrate(x**y*betadist, (x, 0, 1), meijerg=True,
+                              conds='none')) == \
         gamma(a + b)*gamma(a + y)/gamma(a)/gamma(a + b + y)
 
     # Chi distribution
@@ -609,8 +610,8 @@ def test_expint():
     assert integrate(-cos(x)/x, (x, t, oo), meijerg=True).expand() == Ci(t)
     assert integrate(-sin(x)/x, (x, t, oo), meijerg=True).expand() == \
         Si(t) - pi/2
-    assert integrate(sin(x)/x, (x, 0, z), meijerg=True) == Si(z)
-    assert integrate(sinh(x)/x, (x, 0, z), meijerg=True) == Shi(z)
+    assert integrate(sin(x)/x, x, meijerg=True) == Si(x)
+    assert integrate(sinh(x)/x, x, meijerg=True) == Shi(x)
     assert integrate(exp(-x)/x, x, meijerg=True).expand().rewrite(expint) == \
         I*pi - expint(1, x)
     assert integrate(exp(-x)/x**2, x, meijerg=True).rewrite(expint).expand() \
@@ -766,10 +767,25 @@ def test_pr_23583():
 
 # 25786
 def test_integrate_function_of_square_over_negatives():
-    assert integrate(exp(-x**2), (x,-5,0), meijerg=True) == sqrt(pi)/2 * erf(5)
+    assert integrate(exp(-x**2), x, meijerg=True) == sqrt(pi)/2 * erf(x)
+    assert integrate(exp(-x**2), (x, -5, 0)) == sqrt(pi)/2 * erf(5)
 
 
 def test_issue_25949():
     from sympy.core.symbol import symbols
     y = symbols("y", nonzero=True)
-    assert integrate(cosh(y*(x + 1)), (x, -1, -0.25), meijerg=True) == sinh(0.75*y)/y
+    assert integrate(cosh(y*(x + 1)), x, meijerg=True) == sinh(y*(x + 1))/y
+    assert integrate(cosh(y*(x + 1)), (x, -1, -0.25)) == sinh(0.75*y)/y
+
+
+def test_meijerg_definite_only():
+    for f, lim in [(1/sqrt(Abs(x)), (x, -1, 1)), (Abs(x)**Rational(-1, 3),
+                   (x, -1, 1)), (log(Abs(x)), (x, -1, 2)), (1/x, (x, -1, 2))]:
+        assert isinstance(integrate(f, lim, meijerg=True), Integral)
+    assert integrate(1/sqrt(Abs(x)), (x, -1, 1)) == 4
+    assert integrate(Abs(x)**Rational(-1, 3), (x, -1, 1)) == 3
+    assert integrate(exp(-x**2), (x, 0, 1), meijerg=True) == sqrt(pi)*erf(1)/2
+
+
+def test_no_meijerint_indefinite_for_improper_integrals():
+    assert isinstance(integrate(besselj(0, x)**2, (x, 0, oo)), Integral)

--- a/sympy/solvers/ode/single.py
+++ b/sympy/solvers/ode/single.py
@@ -1085,7 +1085,8 @@ class SecondNonlinearAutonomousConserved(SinglePatternODESolver):
         u = Dummy('u')
         g = g.subs(fx, u)
         C1, C2 = self.ode_problem.get_numbered_constants(num=2)
-        inside = -2*Integral(g, u) + C1
+        coeff, g = g.as_independent(u, as_Add=False)
+        inside = -2*coeff*Integral(g, u) + C1
         lhs = Integral(1/sqrt(inside), (u, fx))
         return [Eq(lhs, C2 + x), Eq(lhs, C2 - x)]
 

--- a/sympy/solvers/ode/tests/test_single.py
+++ b/sympy/solvers/ode/tests/test_single.py
@@ -545,7 +545,7 @@ def test_separable():
 
 @slow
 def test_factorable():
-    assert integrate(-asin(f(2*x)+pi), x) == -Integral(asin(pi + f(2*x)), x)
+    assert integrate(-asin(f(2*x)+pi), x) == Integral(-asin(pi + f(2*x)), x)
     _ode_solver_test(_get_examples_ode_sol_factorable)
 
 
@@ -1136,7 +1136,7 @@ def _get_examples_ode_sol_liouville():
 
     'liouville_08': {
         'eq': x**2*diff(f(x),x) + (n*f(x) + f(x)**2)*diff(f(x),x)**2 + diff(f(x), (x, 2)),
-        'sol': [Eq(C1 + C2*lowergamma(Rational(1,3), x**3/3) + NonElementaryIntegral(exp(_y**3/3)*exp(_y**2*n/2), (_y, f(x))), 0)],
+        'sol': [Eq(C1 + C2*lowergamma(Rational(1,3), x**3/3) + NonElementaryIntegral(exp(_y**2*(2*_y + 3*n)/6), (_y, f(x))), 0)],
     },
     }
     }
@@ -2197,8 +2197,8 @@ def _get_examples_ode_sol_2nd_nonlinear_autonomous_conserved():
     '2nd_nonlinear_autonomous_conserved_02': {
         'eq': f(x).diff(x, 2) + cbrt(f(x)) + 1/f(x),
         'sol': [
-            Eq(sqrt(2)*Integral(1/sqrt(2*C1 - 3*_u**Rational(4, 3) - 4*log(_u)), (_u, f(x))), C2 + x),
-            Eq(sqrt(2)*Integral(1/sqrt(2*C1 - 3*_u**Rational(4, 3) - 4*log(_u)), (_u, f(x))), C2 - x)
+            Eq(Integral(1/sqrt(C1 - 3*_u**Rational(4, 3)/2 - 2*log(_u)), (_u, f(x))), C2 + x),
+            Eq(Integral(1/sqrt(C1 - 3*_u**Rational(4, 3)/2 - 2*log(_u)), (_u, f(x))), C2 - x)
         ],
         'simplify_flag': False,
     },
@@ -2420,7 +2420,7 @@ def _get_examples_ode_sol_lie_group():
 
     'lie_group_13': {
         'eq': diff(f(x),x) + f(x)*cos(x) - exp(2*x),
-        'sol': [Eq(f(x), exp(-sin(x))*(C1 + Integral(exp(2*x)*exp(sin(x)), x)))],
+        'sol': [Eq(f(x), exp(-sin(x))*(C1 + Integral(exp(2*x + sin(x)), x)))],
     },
 
     'lie_group_14': {

--- a/sympy/solvers/ode/tests/test_systems.py
+++ b/sympy/solvers/ode/tests/test_systems.py
@@ -1495,13 +1495,13 @@ def test_sysode_linear_neq_order1_type4():
             + h(x))*log(x) + sin(x)), Eq(Derivative(h(x), x), (f(x) + g(x) + h(x))*log(x) + sin(x))]
     sol7 = [Eq(f(x), -C1/3 - C2/3 + 2*C3/3 + (C1/3 + C2/3 +
                 C3/3)*exp(x*(3*log(x) - 3)) + exp(x*(3*log(x) -
-                    3))*Integral(exp(3*x)*exp(-3*x*log(x))*sin(x), x)),
+                    3))*Integral(exp(-3*x*log(x) + 3*x)*sin(x), x)),
             Eq(g(x), 2*C1/3 - C2/3 - C3/3 + (C1/3 + C2/3 +
                 C3/3)*exp(x*(3*log(x) - 3)) + exp(x*(3*log(x) -
-                    3))*Integral(exp(3*x)*exp(-3*x*log(x))*sin(x), x)),
+                    3))*Integral(exp(-3*x*log(x) + 3*x)*sin(x), x)),
             Eq(h(x), -C1/3 + 2*C2/3 - C3/3 + (C1/3 + C2/3 +
                 C3/3)*exp(x*(3*log(x) - 3)) + exp(x*(3*log(x) -
-                    3))*Integral(exp(3*x)*exp(-3*x*log(x))*sin(x), x))]
+                    3))*Integral(exp(-3*x*log(x) + 3*x)*sin(x), x))]
     with dotprodsimp(True):
         assert dsolve(eqs7, simplify=False, doit=False) == sol7
     assert checksysodesol(eqs7, sol7) == (True, [0, 0, 0])
@@ -1511,16 +1511,16 @@ def test_sysode_linear_neq_order1_type4():
             sin(x)), Eq(Derivative(k(x), x), (f(x) + g(x) + h(x) + k(x))*log(x) + sin(x))]
     sol8 = [Eq(f(x), -C1/4 - C2/4 - C3/4 + 3*C4/4 + (C1/4 + C2/4 + C3/4 +
                 C4/4)*exp(x*(4*log(x) - 4)) + exp(x*(4*log(x) -
-                    4))*Integral(exp(4*x)*exp(-4*x*log(x))*sin(x), x)),
+                    4))*Integral(exp(-4*x*log(x) + 4*x)*sin(x), x)),
             Eq(g(x), 3*C1/4 - C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 +
                 C4/4)*exp(x*(4*log(x) - 4)) + exp(x*(4*log(x) -
-                    4))*Integral(exp(4*x)*exp(-4*x*log(x))*sin(x), x)),
+                    4))*Integral(exp(-4*x*log(x) + 4*x)*sin(x), x)),
             Eq(h(x), -C1/4 + 3*C2/4 - C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 +
                 C4/4)*exp(x*(4*log(x) - 4)) + exp(x*(4*log(x) -
-                    4))*Integral(exp(4*x)*exp(-4*x*log(x))*sin(x), x)),
+                    4))*Integral(exp(-4*x*log(x) + 4*x)*sin(x), x)),
             Eq(k(x), -C1/4 - C2/4 + 3*C3/4 - C4/4 + (C1/4 + C2/4 + C3/4 +
                 C4/4)*exp(x*(4*log(x) - 4)) + exp(x*(4*log(x) -
-                    4))*Integral(exp(4*x)*exp(-4*x*log(x))*sin(x), x))]
+                    4))*Integral(exp(-4*x*log(x) + 4*x)*sin(x), x))]
     with dotprodsimp(True):
         assert dsolve(eqs8) == sol8
     assert checksysodesol(eqs8, sol8) == (True, [0, 0, 0, 0])

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -1899,15 +1899,15 @@ def Gamma(name, k, theta):
     ---------------------
            Gamma(k)
 
-    >>> C = cdf(X, meijerg=True)(z)
+    >>> C = cdf(X)(z)
     >>> pprint(C, use_unicode=False)
-    /            /     z  \
-    |k*lowergamma|k, -----|
-    |            \   theta/
-    <----------------------  for z >= 0
-    |     Gamma(k + 1)
+    /          /     z  \
+    |lowergamma|k, -----|
+    |          \   theta/
+    <--------------------  for z > 0
+    |      Gamma(k)
     |
-    \          0             otherwise
+    \         0            otherwise
 
     >>> E(X)
     k*theta

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -3087,16 +3087,14 @@ def Moyal(name, mu, sigma):
     Examples
     ========
 
-    >>> from sympy.stats import Moyal, density, cdf
-    >>> from sympy import Symbol, simplify
+    >>> from sympy.stats import Moyal, density
+    >>> from sympy import Symbol
     >>> mu = Symbol("mu", real=True)
     >>> sigma = Symbol("sigma", positive=True, real=True)
     >>> z = Symbol("z")
     >>> X = Moyal("x", mu, sigma)
     >>> density(X)(z)
     sqrt(2)*exp(-exp((mu - z)/sigma)/2 - (-mu + z)/(2*sigma))/(2*sqrt(pi)*sigma)
-    >>> simplify(cdf(X)(z))
-    1 - erf(sqrt(2)*exp((mu - z)/(2*sigma))/2)
 
     References
     ==========

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -987,12 +987,19 @@ def test_Moyal():
     M = Moyal('M', mu, sigma)
     assert density(M)(z) == sqrt(2)*exp(-exp((mu - z)/sigma)/2
                         - (-mu + z)/(2*sigma))/(2*sqrt(pi)*sigma)
-    assert cdf(M)(z).simplify() == 1 - erf(sqrt(2)*exp((mu - z)/(2*sigma))/2)
     assert characteristic_function(M)(z) == 2**(-I*sigma*z)*exp(I*mu*z) \
                         *gamma(-I*sigma*z + Rational(1, 2))/sqrt(pi)
     assert E(M) == mu + EulerGamma*sigma + sigma*log(2)
     assert moment_generating_function(M)(z) == 2**(-sigma*z)*exp(mu*z) \
                         *gamma(-sigma*z + Rational(1, 2))/sqrt(pi)
+
+
+@XFAIL
+def test_Moyal_cdf():
+    mu = Symbol('mu', real=True)
+    sigma = Symbol('sigma', positive=True)
+    M = Moyal('M', mu, sigma)
+    assert cdf(M)(z).simplify() == 1 - erf(sqrt(2)*exp((mu - z)/(2*sigma))/2)
 
 
 def test_nakagami():

--- a/sympy/stats/tests/test_continuous_rv.py
+++ b/sympy/stats/tests/test_continuous_rv.py
@@ -755,10 +755,8 @@ def test_gamma():
     assert characteristic_function(X)(x) == ((-I*theta*x + 1)**(-k))
 
     assert density(X)(x) == x**(k - 1)*theta**(-k)*exp(-x/theta)/gamma(k)
-    assert cdf(X, meijerg=True)(z) == Piecewise(
-            (-k*lowergamma(k, 0)/gamma(k + 1) +
-                k*lowergamma(k, z/theta)/gamma(k + 1), z >= 0),
-            (0, True))
+    assert cdf(X)(z) == Piecewise(
+            (lowergamma(k, z/theta)/gamma(k), z > 0), (0, True))
 
     # assert simplify(variance(X)) == k*theta**2  # handled numerically below
     assert E(X) == moment(X, 1)

--- a/sympy/stats/tests/test_joint_rv.py
+++ b/sympy/stats/tests/test_joint_rv.py
@@ -150,12 +150,10 @@ def test_GeneralizedMultivariateLogGammaDistribution():
           "exp((n + 4)*(y_1 + 2*y_2 + 3*y_3 + 4*y_4) - exp(y_1) - exp(2*y_2)/2 - "
           "exp(3*y_3)/3 - exp(4*y_4)/4)/(gamma(n + 1)*gamma(n + 4)**3), (n, 0, oo))/64")
     assert str(density(G)(y_1, y_2, y_3, y_4)) == den
-    marg = ("5*2**(2/3)*5**(1/3)*exp(4*y_1)*exp(-exp(y_1))*Integral(exp(-exp(4*G[3])"
-            "/4)*exp(16*G[3])*Integral(exp(-exp(3*G[2])/3)*exp(12*G[2])*Integral(exp("
-            "-exp(2*G[1])/2)*exp(8*G[1])*Sum((-1/4)**n*(-4 + 2**(2/3)*5**(1/3"
-            "))**n*exp(n*y_1)*exp(2*n*G[1])*exp(3*n*G[2])*exp(4*n*G[3])/(24**n*gamma(n + 1)"
-            "*gamma(n + 4)**3), (n, 0, oo)), (G[1], -oo, oo)), (G[2], -oo, oo)), (G[3]"
-            ", -oo, oo))/5308416")
+    marg = ("Integral(5*2**(2/3)*5**(1/3)*Sum(4*24**(-n - 4)*(-2**(2/3)*5**(1/3)/4 + 1)**n*"
+            "exp((n + 4)*(y_1 + 2*G[1] + 3*G[2] + 4*G[3]) - exp(y_1) - exp(2*G[1])/2 - "
+            "exp(3*G[2])/3 - exp(4*G[3])/4)/(gamma(n + 1)*gamma(n + 4)**3), (n, 0, oo))/64, "
+            "(G[1], -oo, oo), (G[2], -oo, oo), (G[3], -oo, oo))")
     assert str(marginal_distribution(G, G[0])(y_1)) == marg
     omega_f1 = Matrix([[1, h, h]])
     omega_f2 = Matrix([[1, h, h, h],

--- a/sympy/vector/basisdependent.py
+++ b/sympy/vector/basisdependent.py
@@ -118,8 +118,8 @@ class BasisDependent(Expr):
     def _eval_derivative(self, wrt):
         return self.diff(wrt)
 
-    def _eval_Integral(self, *symbols, **assumptions):
-        integral_components = [Integral(v, *symbols, **assumptions) * k
+    def _eval_Integral(self, x, **hints):
+        integral_components = [Integral(v, x).doit(**hints) * k
                                for k, v in self.components.items()]
         return self._add_func(*integral_components)
 

--- a/sympy/vector/integrals.py
+++ b/sympy/vector/integrals.py
@@ -183,8 +183,6 @@ def vector_integrate(field, *region):
     >>> vector_integrate(C.x**2*C.z, C.x)
     C.x**3*C.z/3
     >>> vector_integrate(C.x*C.i - C.y*C.k, C.x)
-    (Integral(C.x, C.x))*C.i + (Integral(-C.y, C.x))*C.k
-    >>> _.doit()
     C.x**2/2*C.i + (-C.x*C.y)*C.k
 
     """

--- a/sympy/vector/tests/test_integrals.py
+++ b/sympy/vector/tests/test_integrals.py
@@ -5,6 +5,7 @@ from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.functions.elementary.trigonometric import (cos, sin)
 from sympy.testing.pytest import raises
 from sympy.vector.coordsysrect import CoordSys3D
+from sympy.integrals.integrals import Integral, integrate
 from sympy.vector.integrals import ParametricIntegral, vector_integrate
 from sympy.vector.parametricregion import ParametricRegion
 from sympy.vector.implicitregion import ImplicitRegion
@@ -105,3 +106,10 @@ def test_vector_integrate():
 
     pl = Plane(Point(1, 1, 1), Point(2, 3, 4), Point(2, 2, 2))
     raises(ValueError, lambda: vector_integrate(C.x*C.z*C.i + C.k, pl))
+
+
+def test_integrate_vector():
+    v = C.x*C.i - C.y*C.k
+    assert isinstance(Integral(v, C.x), Integral)
+    assert Integral(v, C.x).doit() == C.x**2/2*C.i - C.x*C.y*C.k
+    assert integrate(v, (C.x, 0, 1)) == C.i/2 - C.y*C.k

--- a/sympy/vector/tests/test_vector.py
+++ b/sympy/vector/tests/test_vector.py
@@ -316,8 +316,9 @@ def test_vector_diff_integrate():
                                           a**2*C.j + (-1)*C.k, a)
     assert (diff(v, a) == v.diff(a) == Derivative(v, a).doit() ==
             (Derivative(f(a), a))*C.i + 2*a*C.j)
-    assert (Integral(v, a) == (Integral(f(a), a))*C.i +
-            (Integral(a**2, a))*C.j + (Integral(-1, a))*C.k)
+    assert Integral(v, a) == Integral((f(a))*C.i + a**2*C.j + (-1)*C.k, a)
+    assert (Integral(v, a).doit() == (Integral(f(a), a))*C.i +
+            a**3/3*C.j + (-a)*C.k)
 
 
 def test_vector_args():


### PR DESCRIPTION
This is work in progress cleanup of `_eval_integral` and `_eval_Integral`. It also removes the unnecessary `factor` calls from the top-level `integrate()`.

Fixes #30382
Fixes #30444

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->


#### Brief description of what is fixed or changed


#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

All code was generated with Claude Fable 5.1.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
- integrals
  - The `_eval_Integral` method defined on custom objects is now only called when an `Integral` is evaluated. 
<!-- END RELEASE NOTES -->
