### PR TITLE
manualintegrate: sin(x)**n*cos(x)**m

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -43,7 +43,7 @@ from sympy.core.containers import Dict
 from sympy.core.function import Derivative, expand, expand_mul, expand_trig
 from sympy.core.logic import fuzzy_not
 from sympy.core.mul import Mul
-from sympy.core.numbers import Integer, Number, E, Rational
+from sympy.core.numbers import Integer, Number, E, Rational, I, pi
 from sympy.core.power import Pow
 from sympy.core.relational import Eq, Ne
 from sympy.core.singleton import S
@@ -64,6 +64,7 @@ from sympy.functions.special.delta_functions import Heaviside, DiracDelta
 from sympy.functions.special.error_functions import (erf, erfc, erfi, fresnelc,
     fresnels, Ci, Chi, Si, Shi, Ei, li, owens_t)
 from sympy.functions.special.gamma_functions import uppergamma
+from sympy.functions.special.hyper import hyper
 from sympy.functions.special.elliptic_integrals import elliptic_e, elliptic_f
 from sympy.functions.special.polynomials import (chebyshevt, chebyshevu,
     legendre, hermite, laguerre, assoc_laguerre, gegenbauer, jacobi,
@@ -424,6 +425,59 @@ class CosRule(TrigRule):
 
     def eval(self) -> Expr:
         return sin(self.variable)
+
+
+class SinCosHyperRule(AtomicRule):
+    r"""integrate(sin(a*x+b)**n*cos(a*x+b)**m, x) for symbolic n, m
+
+    Used when the exponents cannot be resolved to a parity (odd/even) or a
+    concrete nonnegative integer, so the antiderivative is expressed through
+    the Gauss hypergeometric function:
+
+    .. math::
+
+        \int \sin^n(x)\cos^m(x)\,dx =
+        \frac{\sin^{n+1}(x)\cos^{m-1}(x)\left(\cos^2(x)\right)^{\frac{1-m}{2}}}
+        {n+1}\,_2F_1\!\left(\frac{1-m}{2}, \frac{n+1}{2}; \frac{n+3}{2};
+        \sin^2(x)\right)
+    """
+
+    __slots__ = ("n", "m", "a", "b")
+
+    n: Expr
+    m: Expr
+    a: Expr
+    b: Expr
+
+    def __init__(self, integrand: Expr, variable: Symbol, n: Expr, m: Expr,
+                 a: Expr, b: Expr) -> None:
+        super().__init__(integrand, variable)
+        self.n = n
+        self.m = m
+        self.a = a
+        self.b = b
+
+    def eval(self) -> Expr:
+        n, m, a, b = self.n, self.m, self.a, self.b
+        argument = a*self.variable + b
+        # cos(argument)**(m - 1) * (cos(argument)**2)**((1 - m)/2) is 1 when
+        # cos(argument) > 0. For t = cos(argument) < 0, using the principal
+        # branch (arg(t) = pi) gives t**(m - 1) = |t|**(m - 1)*exp(I*pi*(m - 1))
+        # while (t**2)**((1 - m)/2) = |t|**(1 - m), so the product collapses to
+        # the constant exp(I*pi*(m - 1)) for every such t, with no leftover
+        # |t| dependence. Writing the two cases as an explicit Piecewise
+        # (rather than folding them into a single power expression) avoids an
+        # indeterminate 0**a*0**b form when cos(argument) = 0 is an interval
+        # endpoint, and lets Piecewise._eval_interval split a definite
+        # integral at cos(argument) = 0 instead of evaluating the
+        # antiderivative straight across that discontinuity.
+        branch_factor = Piecewise(
+            (S.One, cos(argument) >= 0),
+            (exp(I*pi*(m - 1)), True))
+        prefactor = sin(argument)**(n + 1) * branch_factor
+        antiderivative = prefactor * hyper(
+            ((1 - m)/2, (n + 1)/2), ((n + 3)/2,), sin(argument)**2) / ((n + 1)*a)
+        return piecewise_fold(antiderivative)
 
 
 class HyperbolicRule(AtomicRule, ABC):
@@ -3298,6 +3352,13 @@ def sincos_cosodd(integral, argument, coefficient, m, n):
         integral, rewritten, coefficient, u_var, sin(argument), substituted)
 
 
+def sincos_hyper(integral, argument, coefficient, n, m):
+    integrand, symbol = integral
+    b = argument - coefficient*symbol
+    rule = SinCosHyperRule(integrand, symbol, n, m, coefficient, b)
+    return _add_trig_degenerate_step(integral, coefficient, rule)
+
+
 def sincos_product_to_sum(integral):
     integrand, symbol = integral
     rewritten = sincos_to_sum(integrand)
@@ -3452,6 +3513,11 @@ def trig_sincos_rule(integral):
             # Symbolic powers may make the delegated rule undecidable.
             if substep is not None:
                 return RewriteRule(integrand, symbol, rewritten, substep)
+
+        if not (sin_power.is_integer and sin_power.is_nonnegative and
+                cos_power.is_integer and cos_power.is_nonnegative):
+            return sincos_hyper(integral, argument, coefficient,
+                                 sin_power, cos_power)
 
     # Linearize products not handled by a direct substitution.
     if all(isinstance(power, Integer) and power >= 0

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -14,10 +14,12 @@ from sympy.functions.special.delta_functions import Heaviside, DiracDelta
 from sympy.functions.special.elliptic_integrals import (elliptic_e, elliptic_f)
 from sympy.functions.special.error_functions import (Chi, Ci, Ei, Shi, Si, erf, erfc, erfi, fresnelc, fresnels, li, owens_t)
 from sympy.functions.special.gamma_functions import uppergamma
+from sympy.functions.special.hyper import hyper
 from sympy.functions.special.polynomials import (assoc_laguerre, chebyshevt, chebyshevu, gegenbauer, hermite, jacobi, laguerre, legendre)
 from sympy.functions.special.zeta_functions import polylog
 from sympy.integrals.integrals import (Integral, integrate)
 from sympy.logic.boolalg import And
+from sympy.simplify.simplify import simplify
 from sympy.integrals.manualintegrate import (manualintegrate, find_substitutions,
     _parts_rule, bioche_substitution, integral_steps, manual_subs, IntegrationSolver)
 from sympy.testing.pytest import raises, slow
@@ -371,6 +373,54 @@ def test_manualintegrate_trigpowers():
     f, F = cot(2*x)**-4, tan(2*x)**3/6 - tan(2*x)/2 + x
     assert manualintegrate(f, x) == F
     assert (F.diff(x) - f).rewrite(exp).cancel() == 0
+
+
+def test_manualintegrate_trigpowers_symbolic():
+    n, m = symbols('n m')
+
+    assert manualintegrate(sin(x)**n, x) == \
+        Piecewise(
+            (sin(x)**(n + 1)*hyper((S.Half, n/2 + S.Half),
+                (n/2 + Rational(3, 2),), sin(x)**2)/(n + 1), cos(x) >= 0),
+            (-sin(x)**(n + 1)*hyper((S.Half, n/2 + S.Half),
+                (n/2 + Rational(3, 2),), sin(x)**2)/(n + 1), True))
+
+    assert manualintegrate(sin(x)**n * cos(x)**m, x) == \
+        Piecewise(
+            (sin(x)**(n + 1)*hyper((S.Half - m/2, n/2 + S.Half),
+                (n/2 + Rational(3, 2),), sin(x)**2)/(n + 1), cos(x) >= 0),
+            (exp(I*pi*(m - 1))*sin(x)**(n + 1)*hyper((S.Half - m/2, n/2 + S.Half),
+                (n/2 + Rational(3, 2),), sin(x)**2)/(n + 1), True))
+
+    assert manualintegrate(sin(x)**2 * cos(x)**m, x) == \
+        Piecewise(
+            (sin(x)**3*hyper((Rational(3, 2), S.Half - m/2),
+                (Rational(5, 2),), sin(x)**2)/3, cos(x) >= 0),
+            (exp(I*pi*(m - 1))*sin(x)**3*hyper((Rational(3, 2), S.Half - m/2),
+                (Rational(5, 2),), sin(x)**2)/3, True))
+
+    argument = a*x + b
+    f = sin(argument)**n * cos(argument)**m
+    generic_pos_F = sin(argument)**(n + 1)*hyper((S.Half - m/2, n/2 + S.Half),
+        (n/2 + Rational(3, 2),), sin(argument)**2)/(a*(n + 1))
+    generic_neg_F = exp(I*pi*(m - 1))*sin(argument)**(n + 1) * \
+        hyper((S.Half - m/2, n/2 + S.Half),
+            (n/2 + Rational(3, 2),), sin(argument)**2)/(a*(n + 1))
+    degenerate_F = x*sin(b)**n*cos(b)**m
+    assert manualintegrate(f, x) == Piecewise(
+        (generic_pos_F, Ne(a, 0) & (cos(argument) >= 0)),
+        (generic_neg_F, Ne(a, 0)),
+        (degenerate_F, True))
+
+
+def test_manualintegrate_trigpowers_symbolic_definite():
+    n, m = symbols('n m')
+
+    assert simplify(integrate(cos(x)**n, (x, 0, pi)).subs(n, 2)) == pi/2
+    assert simplify(integrate(cos(x)**n, (x, 0, 2*pi)).subs(n, 2)) == pi
+
+    assert simplify(integrate(cos(x)**m, (x, 0, pi/2)).subs(m, 2)) == pi/4
+    assert simplify(integrate(sin(x)**m, (x, 0, pi/2)).subs(m, 2)) == pi/4
 
 
 @slow


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #29882.

#### Brief description of what is fixed or changed

Adds a `manualintegrate` rule (`SinCosHyperRule`) for
$\int \sin^n(x)\cos^m(x)\,dx$ when $n$ and $m$ are symbolic (or otherwise
can't be resolved to a nonnegative integer/parity), expressed through the
Gauss hypergeometric function:

$$
\int \sin^n(x)\cos^m(x)\,dx =
\frac{\sin^{n+1}(x)\cos^{m-1}(x)\left(\cos^2(x)\right)^{\frac{1-m}{2}}}{n+1}
{}_2F_1\left(\frac{1-m}{2},\ \frac{n+1}{2};\ \frac{n+3}{2};\ \sin^2(x)\right)
$$

**The bug and the fix.** The prefactor
$\cos^{m-1}(x)\left(\cos^2(x)\right)^{\frac{1-m}{2}}$ is not a fixed constant.
Using the principal branch, for $t = \cos(x)$:

$$
t^{m-1}\left(t^2\right)^{\frac{1-m}{2}} =
\begin{cases}
1 & t > 0 \\
e^{i\pi(m-1)} & t < 0
\end{cases}
$$

(for $t>0$ the two factors are inverse powers of the same positive base and
cancel; for $t<0$, $t^{m-1}=|t|^{m-1}e^{i\pi(m-1)}$ and
$(t^2)^{\frac{1-m}{2}}=|t|^{1-m}$, and the $|t|$ dependence cancels too,
leaving the constant $e^{i\pi(m-1)}$ exactly, not just in the limit).

The rule as originally added folded this into a single power expression,
so the antiderivative jumps at every zero of $\cos(x)$. Since
`Expr._eval_interval` only looks for singularities in denominators and
`log` arguments, a definite integral was evaluated straight across that
jump instead of being split there. Concretely, on master before this PR:

```pycon
>>> integrate(cos(x)**n, (x, 0, pi)).subs(n, 2)
0                    # should be pi/2
>>> integrate(cos(x)**m, (x, 0, pi/2)).subs(m, 2)
nan                  # should be pi/4 -- 0**a*0**b at the endpoint cos(x)=0
```

This commit rewrites the prefactor as an explicit `Piecewise` on the sign
of $\cos(x)$ and `piecewise_fold`s the whole antiderivative so the
`Piecewise` sits at the top level. `Piecewise._eval_interval` then splits a
definite integral at $\cos(x) = 0$ instead of evaluating across it, and the
value at $\cos(x) = 0$ as an endpoint is the well-defined constant $1$ or
$e^{i\pi(m-1)}$ instead of an indeterminate power. Verified by
derivative-checking both branches at random $(n, m, x)$ and by:

```pycon
>>> integrate(cos(x)**n, (x, 0, pi)).subs(n, 2)
pi/2
>>> integrate(cos(x)**n, (x, 0, 2*pi)).subs(n, 2)
pi
>>> integrate(cos(x)**m, (x, 0, pi/2)).subs(m, 2)
pi/4
```

#### Other comments

**Known remaining issue.** This only fixes domains within the single
period that `solve_univariate_inequality` resolves for
$\cos(x) \geq 0$ (that solver is documented as returning a solution
"restricted in its periodic interval" for trigonometric inequalities,
rather than a periodic solution over all of $\mathbb{R}$). A definite
integral whose bounds straddle outside that window is still wrong, e.g.:

```pycon
>>> integrate(cos(x)**m, (x, -pi/2, pi/2)).subs(m, 2)
0     # should be pi/2
```

This is not new: it's the same reason
`integrate(Abs(cos(x)), (x, -pi/2, pi/2))` is *already* wrong (returns `0`
instead of `2`) on current master, unrelated to this rule. Fixing it means
teaching `solve_univariate_inequality`/`Piecewise` interval-splitting to
handle periodic conditions over all reals, which is a separate,
pre-existing issue and out of scope here.

#### AI Generation Disclosure

Claude Code (Sonnet 5) was used to identify and fix a correctness bug in
the `SinCosHyperRule.eval` antiderivative (the `Piecewise` rewrite in
`sympy/integrals/manualintegrate.py`) and to update/add the corresponding
tests in `sympy/integrals/tests/test_manual.py`
(`test_manualintegrate_trigpowers_symbolic` and the new
`test_manualintegrate_trigpowers_symbolic_definite`). This PR description
was also drafted by Claude Code. The original `SinCosHyperRule` addition
this PR builds on is human-authored.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * Added a `manualintegrate` rule for integrating $\sin^n(x)\cos^m(x)$
    with symbolic exponents $n$, $m$ using the Gauss hypergeometric
    function, with correct handling of definite integrals that cross a
    zero of $\cos(x)$.
<!-- END RELEASE NOTES -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P5FwpZoPje8CPAyvCCMd6
