### PR TITLE
Fix manualintegrate quadratic denom degenerate case

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2204,6 +2204,11 @@ def quadratic_denom_rule(integral):
                 # If a = 0 and 4*a*c - b**2 = 0 identically, then b = 0 too.
                 substituted = integrand.subs({a: 0, b: 0}, simultaneous=True)
             else:
+                if not _if_zero_implies_zero(b, b*symbol + c):
+                    double_substituted = integrand.subs({a: 0, b: 0}, simultaneous=True)
+                    double_substep = yield IntegralInfo(double_substituted, symbol)
+                    pieces.append((RewriteRule(integrand, symbol, double_substituted, double_substep),
+                        Eq(a, 0) & Eq(b, 0)))
                 substituted = integrand.subs(a, 0)
             substep = yield IntegralInfo(substituted, symbol)
             pieces.append((RewriteRule(integrand, symbol, substituted, substep), Eq(a, 0)))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1153,6 +1153,12 @@ def test_quadratic_denom():
     H = manualintegrate(h, x)
     assert (h.subs({b: 0, c: 3}) - H.subs({b: 0, c: 3}).diff(x)).cancel() == 0
     assert (h.subs({b: 0, c: 0}) - H.subs({b: 0, c: 0}).diff(x)).cancel() == 0
+    q = A*x/(a*x**2 + b*x + c)
+    Q = piecewise_fold(manualintegrate(q, x))
+    assert Q.subs({a: 0, b: 0, c: 3, A: 1}) == x**2/6
+    assert (q.subs({a: 0, b: 0, c: 3, A: 1}) - Q.subs({a: 0, b: 0, c: 3, A: 1}).diff(x)).simplify() == 0
+    assert (q.subs({a: 0, b: 2, c: 3, A: 1}) - Q.subs({a: 0, b: 2, c: 3, A: 1}).diff(x)).simplify() == 0
+    assert (q.subs({a: 1, b: 2, c: 3, A: 1}) - Q.subs({a: 1, b: 2, c: 3, A: 1}).diff(x)).simplify() == 0
 
 
 def test_issue_22757():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30443

#### Brief description of what is fixed or changed

Corrects a wrong result from `manualintegrate` for integrals of the form

```math
\frac{Ax + B}{(ax^2 + bx + c)^n}.
```

The issue occurs in the degenerate case where

```math
a = 0, \qquad b = 0.
```

Previously, the `Eq(a, 0)` branch used `apart`, which divides by `b`. Therefore, substituting both `a = 0` and `b = 0` caused `manualintegrate` to return `0` instead of the correct integral

```math
\int \frac{Ax + B}{c^n}\,dx
=
\frac{Ax^2}{2c^n} + \frac{Bx}{c^n}.
```

The fix adds an explicit `Eq(a, 0)` and `Eq(b, 0)` branch in `_split_sum` that directly integrates

```math
\frac{Ax + B}{c^n}.
```

The general case and the single-degenerate branches remain unchanged.

#### Other comments

Verified the fix using derivative checks for:

* `a = 0` and `b = 0`
* `a = 0` with `b != 0`
* the general case

The existing `test_quadratic_denom` also passes.

I also checked older open issues for linked open PRs and selected this issue because it currently has no open PR addressing it.

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* integrals

  * Fixed an incorrect result from `manualintegrate` for `(A*x + B)/(a*x**2 + b*x + c)**n` when both `a` and `b` are zero. The result now correctly integrates the linear numerator over the constant denominator `c**n`.

<!-- END RELEASE NOTES -->
