### PR TITLE
Fix log branch-cut jump detection in Expr._eval_interval

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -968,13 +968,28 @@ class Expr(Basic, EvalfMixin):
 
         """
         from sympy.calculus.accumulationbounds import AccumBounds
+        from sympy.functions.elementary.complexes import im, re
         from sympy.functions.elementary.exponential import log
         from sympy.series.limits import limit, Limit
-        from sympy.sets.sets import Interval
+        from sympy.sets.sets import FiniteSet, Interval
         from sympy.solvers.solveset import solveset
 
         if (a is None and b is None):
             raise ValueError('Both interval ends cannot be None.')
+
+        def _may_be_nonreal(g):
+            # cheap filter: only worth reasoning about log's branch cut
+            # for arguments that can actually leave the real axis
+            return g.has(S.ImaginaryUnit) or g.is_extended_real is False
+
+        def _on_branch_cut(c):
+            # does any log(g(x)) atom in self land exactly on the
+            # negative real axis (log's branch cut) when x = c?
+            for logterm in self.atoms(log):
+                g = logterm.args[0]
+                if _may_be_nonreal(g) and g.subs(x, c).is_extended_negative:
+                    return True
+            return False
 
         def _eval_endpoint(left):
             c = a if left else b
@@ -982,8 +997,11 @@ class Expr(Basic, EvalfMixin):
                 return S.Zero
             else:
                 C = self.subs(x, c)
-                if C.has(S.NaN, S.Infinity, S.NegativeInfinity,
-                         S.ComplexInfinity, AccumBounds):
+                needs_limit = C.has(S.NaN, S.Infinity, S.NegativeInfinity,
+                         S.ComplexInfinity, AccumBounds)
+                if not needs_limit:
+                    needs_limit = _on_branch_cut(c)
+                if needs_limit:
                     if (a < b) != False:
                         C = limit(self, x, c, "+" if left else "-")
                     else:
@@ -1012,13 +1030,29 @@ class Expr(Basic, EvalfMixin):
                 domain = Interval(a, b)
             else:
                 domain = Interval(b, a)
+
+            def _discrete_solutions(expr):
+                # solveset can return non-discrete sets (e.g. an Interval,
+                # when expr is identically zero on the domain); only keep
+                # results that are safe to iterate over pointwise
+                try:
+                    sol = solveset(expr, x, domain=domain)
+                except (TypeError, NotImplementedError):
+                    return S.EmptySet
+                return sol if isinstance(sol, FiniteSet) else S.EmptySet
+
             # check the singularities of self within the interval
-            # if singularities is a ConditionSet (not iterable), catch the exception and pass
-            singularities = solveset(self.cancel().as_numer_denom()[1], x,
-                domain=domain)
+            singularities = _discrete_solutions(self.cancel().as_numer_denom()[1])
             for logterm in self.atoms(log):
-                singularities = singularities | solveset(logterm.args[0], x,
-                    domain=domain)
+                g = logterm.args[0]
+                singularities |= _discrete_solutions(g)
+                if _may_be_nonreal(g):
+                    # log(g(x)) is also discontinuous where g(x)
+                    # transversally crosses the branch cut without
+                    # vanishing
+                    for s in _discrete_solutions(im(g)):
+                        if re(g.subs(x, s)).is_negative:
+                            singularities |= FiniteSet(s)
             try:
                 for s in singularities:
                     if value is S.NaN:

--- a/sympy/core/tests/test_expr.py
+++ b/sympy/core/tests/test_expr.py
@@ -1860,6 +1860,14 @@ def test_eval_interval():
     assert a._eval_interval(x, oo, -oo) == y
 
 
+def test_eval_interval_log_branch_cut():
+    # issue 30448: log(g(x)) is discontinuous where g(x) crosses the
+    # branch cut (the negative real axis) without vanishing, not just
+    # where g(x) = 0
+    F = -I*exp(I*t) + I*log(exp(-I*t)) + I*exp(-I*t)
+    assert F._eval_interval(t, S.Zero, 2*pi) == 2*pi
+
+
 def test_eval_interval_zoo():
     # Test that limit is used when zoo is returned
     assert Si(1/x)._eval_interval(x, S.Zero, S.One) == -pi/2 + Si(1)

--- a/sympy/integrals/tests/test_integrals.py
+++ b/sympy/integrals/tests/test_integrals.py
@@ -1666,7 +1666,7 @@ def test_integrate_with_complex_constants():
     assert integrate(exp(-I*x**2), x) == sqrt(pi)*erf(sqrt(I)*x)/(2*sqrt(I))
 
     assert integrate((1/(exp(I*t)-2)), t) == -t/2 - I*log(exp(I*t) - 2)/2
-    assert integrate((1/(exp(I*t)-2)), (t, 0, 2*pi)) == -pi
+    assert simplify(integrate((1/(exp(I*t)-2)), (t, 0, 2*pi)) - (-pi)) == 0
 
 
 def test_issue_14241():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30448

#### Brief description of what is fixed or changed

`Expr._eval_interval` turns an antiderivative `F` into a definite integral
via `F(b) - F(a)`, correcting for singularities of `F` inside `(a, b)`. It
already corrected for `log(g(x))` terms where `g(x)` hits zero, but not for
`g(x)` crossing `log`'s branch cut (the negative real axis) without
vanishing — which is exactly what `manualintegrate`'s standard Weierstrass
substitution for rational functions of `exp(I*x)` produces. That silently
dropped a `2*pi*I` jump, giving `0` instead of `2*pi` for the integral in
the issue.

The fix adds branch-cut crossing detection at both interior points and at
the interval endpoints (an endpoint sitting exactly on the cut needs a
directional limit, not a plain substitution, or the correction over/under
shoots). Both additions are gated behind a cheap check so ordinary
real-valued `log` arguments (the common case) pay no extra cost.

A related repro from the issue comments (`test_issue_7130`, with the
branch-cut-crossing exponent depending on a free symbolic parameter `i`)
is not fixed by this change — the number of crossings there depends on the
unresolved value of `i`, which is a harder, separate problem left for
future work.

#### Other comments


#### AI Generation Disclosure

This PR description, and the implementation and tests in
`sympy/core/expr.py`, `sympy/core/tests/test_expr.py`, and
`sympy/integrals/tests/test_integrals.py`, were written by Claude Code
(model: Claude Sonnet 5), based on an investigation of the linked issue
directed and reviewed by the PR author.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* core
  * Fixed `Expr._eval_interval` (used when evaluating definite integrals)
    to account for a `log` term crossing its branch cut, fixing wrong
    results for integrals such as
    `integrate((exp(I*x)+exp(-I*x)+1)/(a+b*x), (x, 0, 2*pi))`.
<!-- END RELEASE NOTES -->