### PR TITLE
Add restrictive settings for Claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(gh pr create:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(git push:*)"
+    ]
+  }
+}


### PR DESCRIPTION
Creating restrictions to prevent Claude from using some gh commands and git push.

Not sure this works... but let's try.

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
