### PR TITLE
[BUG] Fix biomechanics rigid tendon equation with assumption in documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -899,6 +899,7 @@ Jonathan Gutow <gutow@uwosh.edu> gutow <gutow@uwosh.edu>
 Jonathan Miller <jdmiller93@gmail.com>
 Jonathan Warner <warnerjon12@gmail.com>
 Jonty16117 <jonty@DESKTOP-J1O6ANP.localdomain>
+Joraaver Chahal <joraaverchahal@gmail.com>
 Jorge E. Cardona <jorgeecardona@gmail.com>
 Jorn Baayen <jorn.baayen@gmail.com>
 Jose M. Gomez <chemoki@gmail.com> jmgc <chemoki@gmail.com>

--- a/doc/src/explanation/modules/physics/biomechanics/biomechanics.rst
+++ b/doc/src/explanation/modules/physics/biomechanics/biomechanics.rst
@@ -990,7 +990,7 @@ the muscle fibers relative to the direction parallel to the tendon) at which
 
 .. math::
 
-   l^M = \sqrt{\left(l^{MT} - l^T\right)^2 + \left(l^M_{opt}\right)^2}
+   l^M = l^{MT} - l^T
 
 With :math:`\tilde{l}^M = \frac{l^M}{l^M_{opt}}`, the muscle fiber velocity can
 be expressed as


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

N/A

#### Brief description of what is fixed or changed

Rigid tendon equation in msk dynamics incorrectly left coefficient $l_{opt}^M$ in equation when $\sin(\alpha_{opt}) = 0$ when $\alpha_{opt} = 0$

$$l^M = \sqrt{\left(l^{MT} - l^T\right)^2 + \left(l^M_{opt}\right)^2}$$

should be just

$$l^M = l^{MT} - l^T$$

#### Other comments

N/A

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

Used AI, but these were trivial changes. I discovered the documentation error while I was working through the biomechanics primer.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* physics.biomechanics
  * Fixed incorrect rigid tendon dynamics equation when assuming $\alpha_{opt} = 0$ 

<!-- END RELEASE NOTES -->
