### PR TITLE
ENH/DOC: assumptions: dppl2: introduce new helper methods for readability

### DIFF
--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -97,19 +97,6 @@ class SATSolver:
     Class for representing a SAT solver capable of
      finding a model to a boolean theory in conjunctive
      normal form.
-
-    Parameters
-    ==========
-    clauses : list[set[int]]
-        cnf.data, iterable list of clauses. the CNF formula.
-    variables : range | set[int]
-        EncodedCNF.variables, set of positive numbers that describe the variables in the CNF formula. It does not contain the assignments.
-    var_settings : set[int]
-        The current partial assignment of the variables.
-    symbols : list[Boolean]
-        A way to display an output, purely cosmetic. If nothing is given it is derived by the variables.
-    heuristic : str
-        decision heuristic
     """
 
     def __init__(self, clauses, variables, var_settings, symbols=None,

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -482,8 +482,9 @@ class SATSolver:
         -2
 
         """
+        lit = self._filter_lit(lit)
         self._restart()
-        self._assumptions.append(self._filter_lit(lit))
+        self._assumptions.append(lit)
 
     def add(self, lit):
         """Add *lit* to the clause being built, or add that clause to the

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -116,6 +116,7 @@ class SATSolver:
                 heuristic='vsids', clause_learning='none', INTERVAL=500,
                  lra_theory = None):
 
+        self.levels = []
         self.var_settings = var_settings
         self.heuristic = heuristic
         self.is_unsatisfied = False
@@ -157,7 +158,6 @@ class SATSolver:
         self.lra = lra_theory
 
         # Create the base level
-        self.levels = []
         self._create_level(0)
         self._current_level.var_settings = set(var_settings)
         if self.lra and self._current_level.var_settings:
@@ -688,24 +688,27 @@ class SATSolver:
     def _watch(self, i):
         """
         Watch two literals of the ith clause
-        NOTE: this method only works on the root level
         """
+        # this method works on root level only
+        assert len(self.levels) <= 1
         clause = self.clauses[i]
+
+        # A clause that is true at the root
+        if any(lit in self.var_settings for lit in clause):
+            return
+
         # unassigned lits from the clause
         unassigned = [lit for lit in clause if not self.variable_set[abs(lit)]]
 
-        if len(unassigned) > 1:
+        # every literal is false
+        if not unassigned:
+            self.is_unsatisfied = True
+        # the clause is unit
+        elif len(unassigned) == 1:
+            self._unit_prop_queue.append(unassigned[0])
+        else:
             self.watched_lits[unassigned[0]].add(i)
             self.watched_lits[unassigned[-1]].add(i)
-        # If there's no possible watched literals,
-        # check if clause is true already
-        elif not any(lit in self.var_settings for lit in clause):
-            # check if the clause is unit
-            if unassigned:
-                self._unit_prop_queue.append(unassigned[0])
-            # else the clause is false
-            else:
-                self.is_unsatisfied = True
 
     def _assign_literal(self, lit):
         """Make a literal assignment.

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -179,7 +179,7 @@ class SATSolver:
 
     def _initialize_variables(self, variables):
         """Set up the variable data structures needed."""
-        self.sentinels = defaultdict(set)
+        self.watched_lits = defaultdict(set)
         self.occurrence_count = defaultdict(int)
         self.variable_set = [False] * (len(variables) + 1)
 
@@ -188,7 +188,7 @@ class SATSolver:
 
         For each clause, the following changes are made:
         - Unit clauses are queued for propagation right away.
-        - Non-unit clauses have their first and last literals set as sentinels.
+        - Non-unit clauses have their first and last literals set as watched literals.
         - The number of clauses a literal appears in is computed.
         """
         self.clauses = [list(clause) for clause in clauses]
@@ -200,8 +200,8 @@ class SATSolver:
                 self._unit_prop_queue.append(clause[0])
                 continue
 
-            self.sentinels[clause[0]].add(i)
-            self.sentinels[clause[-1]].add(i)
+            self.watched_lits[clause[0]].add(i)
+            self.watched_lits[clause[-1]].add(i)
 
             for lit in clause:
                 self.occurrence_count[lit] += 1
@@ -546,15 +546,15 @@ class SATSolver:
         for clause_lit in clause_to_add:
             self.occurrence_count[clause_lit] += 1
 
-        # Only a literal that is not already false can be a sentinel. With
+        # Only a literal that is not already false can be a watched literal. With
         # fewer than two of those the clause is satisfied, unit, or false, and
         # none of those needs to be watched.
         unassigned = [clause_lit for clause_lit in clause_to_add
                       if not self.variable_set[abs(clause_lit)]]
 
         if len(unassigned) > 1:
-            self.sentinels[unassigned[0]].add(clause_num)
-            self.sentinels[unassigned[-1]].add(clause_num)
+            self.watched_lits[unassigned[0]].add(clause_num)
+            self.watched_lits[unassigned[-1]].add(clause_num)
         elif not any(clause_lit in self.var_settings
                      for clause_lit in clause_to_add):
             if unassigned:
@@ -681,8 +681,8 @@ class SATSolver:
                 return True
         return False
 
-    def _is_sentinel(self, lit, cls):
-        """Check if a literal is a sentinel of a given clause.
+    def _is_watched_lit(self, lit, cls):
+        """Check if a literal is a watched literal of a given clause.
 
         Examples
         ========
@@ -692,22 +692,22 @@ class SATSolver:
         ... {3, -2}], {1, 2, 3}, set())
         >>> next(l._find_model())
         {1: True, 2: False, 3: False}
-        >>> l._is_sentinel(2, 3)
+        >>> l._is_watched_lit(2, 3)
         True
-        >>> l._is_sentinel(-3, 1)
+        >>> l._is_watched_lit(-3, 1)
         False
 
         """
-        return cls in self.sentinels[lit]
+        return cls in self.watched_lits[lit]
 
     def _assign_literal(self, lit):
         """Make a literal assignment.
 
         The literal assignment must be recorded as part of the current
         decision level. Additionally, if the literal is marked as a
-        sentinel of any clause, then a new sentinel must be chosen. If
-        this is not possible, then unit propagation is triggered and
-        another literal is added to the queue to be set in the future.
+        watched literal of any clause, then a new watched literal must be
+        chosen. If this is not possible, then unit propagation is triggered
+        and another literal is added to the queue to be set in the future.
 
         Examples
         ========
@@ -742,24 +742,24 @@ class SATSolver:
             if res and res[0] is False:
                 conflict = res[1]
 
-        sentinel_list = list(self.sentinels[-lit])
+        watched_list = list(self.watched_lits[-lit])
 
-        for cls in sentinel_list:
+        for cls in watched_list:
             if not self._clause_sat(cls):
-                other_sentinel = None
+                other_watched_lit = None
                 for newlit in self.clauses[cls]:
                     if newlit != -lit:
-                        if self._is_sentinel(newlit, cls):
-                            other_sentinel = newlit
+                        if self._is_watched_lit(newlit, cls):
+                            other_watched_lit = newlit
                         elif not self.variable_set[abs(newlit)]:
-                            self.sentinels[-lit].remove(cls)
-                            self.sentinels[newlit].add(cls)
-                            other_sentinel = None
+                            self.watched_lits[-lit].remove(cls)
+                            self.watched_lits[newlit].add(cls)
+                            other_watched_lit = None
                             break
 
-                # Check if no sentinel update exists
-                if other_sentinel:
-                    self._unit_prop_queue.append(other_sentinel)
+                # Check if no watched literal update exists
+                if other_watched_lit:
+                    self._unit_prop_queue.append(other_watched_lit)
 
         return conflict
 
@@ -830,14 +830,14 @@ class SATSolver:
         ... {3, -2}], {1, 2, 3}, set())
         >>> l.variable_set
         [False, False, False, False]
-        >>> l.sentinels
+        >>> l.watched_lits
         {-3: {0, 2}, -2: {3, 4}, 2: {0, 3}, 3: {2, 4}}
 
         >>> l._simplify()
 
         >>> l.variable_set
         [False, True, False, False]
-        >>> l.sentinels
+        >>> l.watched_lits
         {-3: {0, 2}, -2: {3, 4}, -1: set(), 2: {0, 3},
         ...3: {2, 4}}
 
@@ -1012,14 +1012,14 @@ class SATSolver:
         0
         >>> l.clauses
         [[2, -3], [1], [3, -3], [2, -2], [3, -2]]
-        >>> l.sentinels
+        >>> l.watched_lits
         {-3: {0, 2}, -2: {3, 4}, 2: {0, 3}, 3: {2, 4}}
 
         >>> l._simple_add_learned_clause([3])
 
         >>> l.clauses
         [[2, -3], [1], [3, -3], [2, -2], [3, -2], [3]]
-        >>> l.sentinels
+        >>> l.watched_lits
         {-3: {0, 2}, -2: {3, 4}, 2: {0, 3}, 3: {2, 4, 5}}
 
         """
@@ -1029,8 +1029,8 @@ class SATSolver:
         for lit in cls:
             self.occurrence_count[lit] += 1
 
-        self.sentinels[cls[0]].add(cls_num)
-        self.sentinels[cls[-1]].add(cls_num)
+        self.watched_lits[cls[0]].add(cls_num)
+        self.watched_lits[cls[-1]].add(cls_num)
 
         self.heur_clause_added(cls)
 

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -200,11 +200,10 @@ class SATSolver:
                 self._unit_prop_queue.append(clause[0])
                 continue
 
-            self.watched_lits[clause[0]].add(i)
-            self.watched_lits[clause[-1]].add(i)
-
             for lit in clause:
                 self.occurrence_count[lit] += 1
+            # watched literals for ith clause
+            self._watch(i)
 
     def _find_model(self):
         """
@@ -483,22 +482,13 @@ class SATSolver:
         -2
 
         """
-        if lit == 0 or abs(lit) >= len(self.variable_set):
-            raise ValueError(f"{lit} is not a literal of one of the variables "
-                "the solver was created with.")
-
-        while len(self.levels) > 1:
-            self._undo()
-
-        self._models = None
-        if self._status == IpasirStatus.SATISFIABLE:
-            self._status = IpasirStatus.UNKNOWN
-
-        self._assumptions.append(lit)
+        self._restart()
+        self._assumptions.append(self._filter_lit(lit))
 
     def add(self, lit):
         """Add *lit* to the clause being built, or add that clause to the
-        solver when *lit* is 0.
+        solver when *lit* is 0. ``clause()`` adds a whole clause at once,
+        without the terminator.
 
         The search restarts from the root level, so ``solve()`` may be called
         again, and an unsatisfiable solver stays unsatisfiable.
@@ -521,47 +511,12 @@ class SATSolver:
         -1
 
         """
-        if lit != 0:
-            if abs(lit) >= len(self.variable_set):
-                raise ValueError("%s is not a literal of one of the variables "
-                    "the solver was created with." % lit)
-
-            self._clause_buffer.append(lit)
+        if lit == 0:  # The end of clause marker of IPASIR.
+            self._add_clause(self._clause_buffer)
+            # reset the buffer for future use
+            self._clause_buffer = []
             return
-
-        clause_to_add = self._clause_buffer
-        self._clause_buffer = []
-
-        # The decisions were made without this clause, so the search restarts.
-        while len(self.levels) > 1:
-            self._undo()
-
-        self._models = None
-        if self._status == IpasirStatus.SATISFIABLE:
-            self._status = IpasirStatus.UNKNOWN
-
-        clause_num = len(self.clauses)
-        self.clauses.append(clause_to_add)
-
-        for clause_lit in clause_to_add:
-            self.occurrence_count[clause_lit] += 1
-
-        # Only a literal that is not already false can be a watched literal. With
-        # fewer than two of those the clause is satisfied, unit, or false, and
-        # none of those needs to be watched.
-        unassigned = [clause_lit for clause_lit in clause_to_add
-                      if not self.variable_set[abs(clause_lit)]]
-
-        if len(unassigned) > 1:
-            self.watched_lits[unassigned[0]].add(clause_num)
-            self.watched_lits[unassigned[-1]].add(clause_num)
-        elif not any(clause_lit in self.var_settings
-                     for clause_lit in clause_to_add):
-            if unassigned:
-                self._unit_prop_queue.append(unassigned[0])
-            else:
-                self.is_unsatisfied = True
-                self._status = IpasirStatus.UNSATISFIABLE
+        self._clause_buffer.append(self._filter_lit(lit))
 
     def clause(self, *lits):
         """Add the clause made up of *lits*, given one by one or as a single
@@ -572,13 +527,7 @@ class SATSolver:
         """
         if len(lits) == 1 and not isinstance(lits[0], int):
             lits = lits[0]
-
-        for lit in lits:
-            self.add(lit)
-
-        # Zero is never a literal, which is why IPASIR uses it to mark the
-        # end of a clause rather than passing a length around.
-        self.add(0)
+        self._add_clause([self._filter_lit(lit) for lit in lits])
 
     def copy(self):
         """Return an independent solver with the same clauses and state, so
@@ -612,6 +561,42 @@ class SATSolver:
         other.symbols = symbols
 
         return other
+
+    def _filter_lit(self, lit):
+        """
+        Return lit, raise if it is not a literal of a known variable.
+        TODO: In future, this method should be removed and instead handle unknown
+        variables.
+        """
+        if lit == 0 or abs(lit) >= len(self.variable_set):
+            raise ValueError(f"{lit} is not a literal of one of the variables "
+                "the solver was created with.")
+        return lit
+
+    def _restart(self):
+        """Undo the search back to the root level"""
+        # undo all the levels
+        while len(self.levels) > 1:
+            self._undo()
+        # reset the model
+        self._models = None
+        # reset the status
+        if self._status == IpasirStatus.SATISFIABLE:
+            self._status = IpasirStatus.UNKNOWN
+
+    def _add_clause(self, lits):
+        """Register the clause made up of lits with the solver."""
+        # The decisions were made without this clause, so the search restarts.
+        self._restart()
+        # register the new clause on self.clauses
+        self.clauses.append(lits)
+        # count the lits for the heuristic
+        for lit in lits:
+            self.occurrence_count[lit] += 1
+        # register watched literals for the new clause we have added
+        self._watch(len(self.clauses) - 1)
+        if self.is_unsatisfied:
+            self._status = IpasirStatus.UNSATISFIABLE
 
     ########################
     #    Helper Methods    #
@@ -699,6 +684,28 @@ class SATSolver:
 
         """
         return cls in self.watched_lits[lit]
+
+    def _watch(self, i):
+        """
+        Watch two literals of the ith clause
+        NOTE: this method only works on the root level
+        """
+        clause = self.clauses[i]
+        # unassigned lits from the clause
+        unassigned = [lit for lit in clause if not self.variable_set[abs(lit)]]
+
+        if len(unassigned) > 1:
+            self.watched_lits[unassigned[0]].add(i)
+            self.watched_lits[unassigned[-1]].add(i)
+        # If there's no possible watched literals,
+        # check if clause is true already
+        elif not any(lit in self.var_settings for lit in clause):
+            # check if the clause is unit
+            if unassigned:
+                self._unit_prop_queue.append(unassigned[0])
+            # else the clause is false
+            else:
+                self.is_unsatisfied = True
 
     def _assign_literal(self, lit):
         """Make a literal assignment.

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -487,8 +487,8 @@ class SATSolver:
 
     def add(self, lit):
         """Add *lit* to the clause being built, or add that clause to the
-        solver when *lit* is 0. ``clause()`` adds a whole clause at once,
-        without the terminator.
+        solver when *lit* is 0.
+        clause() is a convenience method of add().
 
         The search restarts from the root level, so ``solve()`` may be called
         again, and an unsatisfiable solver stays unsatisfiable.

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -469,14 +469,13 @@ class SATSolver:
         -2
 
         """
-        lit = self._filter_lit(lit)
+        lit = self._check_lit(lit)
         self._restart()
         self._assumptions.append(lit)
 
     def add(self, lit):
         """Add *lit* to the clause being built, or add that clause to the
         solver when *lit* is 0.
-        clause() is a convenience method of add().
 
         The search restarts from the root level, so ``solve()`` may be called
         again, and an unsatisfiable solver stays unsatisfiable.
@@ -504,18 +503,20 @@ class SATSolver:
             # reset the buffer for future use
             self._clause_buffer = []
             return
-        self._clause_buffer.append(self._filter_lit(lit))
+        self._clause_buffer.append(self._check_lit(lit))
 
     def clause(self, *lits):
         """Add the clause made up of *lits*, given one by one or as a single
         iterable, which covers the ``clause`` overloads of CaDiCaL.
 
         Without any literal it adds the empty clause, which is false.
+        clause() is a convenience method of add().
+
 
         """
         if len(lits) == 1 and not isinstance(lits[0], int):
             lits = lits[0]
-        self._add_clause([self._filter_lit(lit) for lit in lits])
+        self._add_clause([self._check_lit(lit) for lit in lits])
 
     def copy(self):
         """Return an independent solver with the same clauses and state, so
@@ -550,7 +551,7 @@ class SATSolver:
 
         return other
 
-    def _filter_lit(self, lit):
+    def _check_lit(self, lit):
         """
         Return lit, raise if it is not a literal of a known variable.
         TODO: In future, this method should be removed and instead handle unknown
@@ -563,12 +564,9 @@ class SATSolver:
 
     def _restart(self):
         """Undo the search back to the root level"""
-        # undo all the levels
         while len(self.levels) > 1:
             self._undo()
-        # reset the model
         self._models = None
-        # reset the status
         if self._status == IpasirStatus.SATISFIABLE:
             self._status = IpasirStatus.UNKNOWN
 
@@ -576,12 +574,9 @@ class SATSolver:
         """Register the clause made up of lits with the solver."""
         # The decisions were made without this clause, so the search restarts.
         self._restart()
-        # register the new clause on self.clauses
         self.clauses.append(lits)
-        # count the lits for the heuristic
         for lit in lits:
             self.occurrence_count[lit] += 1
-        # register watched literals for the new clause we have added
         self._watch(len(self.clauses) - 1)
         if self.is_unsatisfied:
             self._status = IpasirStatus.UNSATISFIABLE

--- a/sympy/logic/algorithms/dpll2.py
+++ b/sympy/logic/algorithms/dpll2.py
@@ -97,6 +97,19 @@ class SATSolver:
     Class for representing a SAT solver capable of
      finding a model to a boolean theory in conjunctive
      normal form.
+
+    Parameters
+    ==========
+    clauses : list[set[int]]
+        cnf.data, iterable list of clauses. the CNF formula.
+    variables : range | set[int]
+        EncodedCNF.variables, set of positive numbers that describe the variables in the CNF formula. It does not contain the assignments.
+    var_settings : set[int]
+        The current partial assignment of the variables.
+    symbols : list[Boolean]
+        A way to display an output, purely cosmetic. If nothing is given it is derived by the variables.
+    heuristic : str
+        decision heuristic
     """
 
     def __init__(self, clauses, variables, var_settings, symbols=None,


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

https://github.com/sympy/sympy/issues/30320

#### Brief description of what is fixed or changed
I changed the `sentinel` naming to `watched_lits` as I believe it is a literature naming standard.
The new methods should be self-explanatory

I think the code is easier to follow this way?

#### Other comments
the reason `self._levels` are initialized a little bit earlier is because of using `_watch` on `_initialize_clauses`. 

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE
#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
