### PR TITLE
fix(interactive): add FunctionClass support to _can_print and printable_types (#28244)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -185,6 +185,7 @@
 #
 # See also: 'git shortlog --help' and 'git check-mailmap --help'.
 #
+
 *Chu-Ching Huang <cchuang@mail.cgu.edu.tw>
 *Dan <coolg49964@gmail.com>
 *Marc-Etienne M.Leveille <protonyc@gmail.com>
@@ -1579,6 +1580,8 @@ Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in> Smit-create <55887635+Smit-cr
 Smit Lunagariya <smitlunagariya.mat18@itbhu.ac.in> Smit-create <smitlunagariya.mat18@itbhu.ac.in>
 Sneha Goddu <s.goddu@wustl.edu>
 Soniya Nayak <soniyanayak51@gmail.com> Soniyanayak51 <39791511+Soniyanayak51@users.noreply.github.com>
+Sonu Sharma <ramprashadkumar11@gmail.com> Sonu Sharma <ramprashadkumar11@gmail.com>
+Sonu Sharma <ramprashadkumar11@gmail.com> sonusharma6-dsa <sonusharma6.dsa@gmail.com>
 Sophia Pustova <tripplezzed@gmail.com>
 Soumendra Ganguly <soumendraganguly@gmail.com>
 Soumi Bardhan <51290447+Soumi7@users.noreply.github.com>

--- a/sympy/interactive/printing.py
+++ b/sympy/interactive/printing.py
@@ -7,8 +7,8 @@ from sympy.printing.latex import latex as default_latex
 from sympy.printing.preview import preview
 from sympy.utilities.misc import debug
 from sympy.printing.defaults import Printable
+from sympy.core.function import FunctionClass
 from sympy.external import import_module
-
 
 def _init_python_printing(stringify_func, **settings):
     """Setup printing in Python interactive session. """
@@ -152,7 +152,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
                 return all(_can_print(i) and _can_print(o[i]) for i in o)
             elif isinstance(o, bool):
                 return False
-            elif isinstance(o, Printable):
+            elif isinstance(o, (Printable, FunctionClass)):
                 # types known to SymPy
                 return True
             elif any(hasattr(o, hook) for hook in printing_hooks):
@@ -222,7 +222,7 @@ def _init_ipython_printing(ip, stringify_func, use_latex, euler, forecolor,
     # the approach required by builtin types. This allows downstream
     # packages to override the methods in their own subclasses of Printable,
     # which avoids the effects of gh-16002.
-    printable_types = [float, tuple, list, set, frozenset, dict, int]
+    printable_types = [float, tuple, list, set, frozenset, dict, int, FunctionClass]
 
     plaintext_formatter = ip.display_formatter.formatters['text/plain']
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #28244

#### Brief description of what is fixed or changed

`_can_print` in `sympy.interactive.printing` doesn't check for unapplied `FunctionClass` objects (like `sp.Function(r'\psi')`), so they don't show up right in interactive mode. Added a check for `FunctionClass` in `_can_print` and `printable_types` so this works.

#### Other comments

Tested locally with a few unapplied function examples, works as expected. Didn't touch anything else in the printing module.

#### AI Generation Disclosure

NO AI USE

#### Release Notes

* interactive
  * Fixed unapplied `FunctionClass` objects not being recognized by `_can_print` in interactive printing.