### PR TITLE
Fix Euler substitution returning complex results in manualintegrate

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2802,15 +2802,24 @@ def euler_substitution_rule(integral : IntegralInfo):
         numer, denom = rewritten.as_numer_denom()
         if numer.as_poly(x, s) is None or denom.as_poly(x, s) is None:
             return None
-        # Euler's second substitution (u = sqrt(R) + sqrt(c)*x)
         u = Dummy("u")
-        sqrt_c0 = sqrt(c0)
-        x_u = (u**2 - a0)/(b0 + 2*sqrt_c0*u)
-        s_u = u - sqrt_c0*x_u
-        dx_u = 2*(b0*u + sqrt_c0*(u**2 + a0))/(b0 + 2*sqrt_c0*u)**2
+        if c0.is_positive is not False or a0.is_positive is not True:
+            # Euler's first substitution (u = sqrt(R) + sqrt(c)*x)
+            sqrt_c0 = sqrt(c0)
+            x_u = (u**2 - a0)/(b0 + 2*sqrt_c0*u)
+            s_u = u - sqrt_c0*x_u
+            dx_u = 2*(b0*u + sqrt_c0*(u**2 + a0))/(b0 + 2*sqrt_c0*u)**2
+            u_func = sqrt(base0) + sqrt_c0*x
+        else:
+            # Euler's second substitution (u = (sqrt(R) - sqrt(a))/x)
+            sqrt_a0 = sqrt(a0)
+            x_u = (2*sqrt_a0*u - b0)/(c0 - u**2)
+            s_u = u*x_u + sqrt_a0
+            dx_u = 2*(sqrt_a0*u**2 - b0*u + c0*sqrt_a0)/(c0 - u**2)**2
+            u_func = (sqrt(base0) - sqrt_a0)/x
+
         substituted = rewritten.xreplace({x: x_u, s: s_u}) * dx_u
         substep = yield IntegralInfo(substituted, u)
-        u_func = sqrt(base0) + sqrt_c0*x
         return URule(integrand, x, u, u_func, substep)
 
     if delta_zero_cond is S.true:

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2734,6 +2734,13 @@ def sqrt_fractional_linear_rule(integral : IntegralInfo):
 def euler_substitution_rule(integral : IntegralInfo):
     """
     Substitute common sqrt(a + b*x + c*x**2) terms using Euler substitution.
+    
+    This rule implements two of the three Euler substitutions:
+    1. First Euler substitution (when c > 0): u = sqrt(R) + x*sqrt(c)
+    2. Second Euler substitution (when a > 0): u = (sqrt(R) - sqrt(a))/x
+    
+    The second substitution avoids introducing imaginary numbers when c < 0 
+    but a > 0.
     """
     integrand, x = integral
     base0 = None

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1335,6 +1335,15 @@ def test_manualintegrate_euler_substitution():
     F = -sqrt(2)*(2*atan(sqrt(2)*(sqrt(1 - x**2) - 1)/(4*x)) + 2*atan(7*sqrt(2)*(sqrt(1 - x**2) - 1)/(4*x) + sqrt(2)*(sqrt(1 - x**2) - 1)**3/(4*x**3)))/2 + 2*atan((sqrt(1 - x**2) - 1)/x)
     assert manualintegrate(f, x) == F
 
+    # Issue 30443
+    A, a, b = symbols('A a b', real=True)
+    f_443 = A * x / (a * x**2 + b * x + c)
+    assert manualintegrate(f_443, x).has(Integral) is False
+
+    # Issue 30441
+    f_441 = 1/(x*sqrt(a + b*x**2)**3)
+    assert manualintegrate(f_441, x).has(Integral) is False
+
 def test_manualintegrate_sqrt_quadratic():
     assert_is_integral_of(1/sqrt((x - I)**2-1), log(2*x + 2*sqrt(x**2 - 2*I*x - 2) - 2*I))
     assert_is_integral_of(1/sqrt(3*x**2+4*x+5), sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/3)

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1329,6 +1329,12 @@ def test_manualintegrate_euler_substitution():
     assert (F1.diff(x) - f).cancel() == 0
     assert (F2.diff(x) - f.subs(c, 0)).cancel() == 0
 
+    # Negative leading coefficient, positive constant (c < 0, a > 0)
+    # Issue 30447
+    f = sqrt(1 - x**2) / (x**2 + 1)
+    F = -sqrt(2)*(2*atan(sqrt(2)*(sqrt(1 - x**2) - 1)/(4*x)) + 2*atan(7*sqrt(2)*(sqrt(1 - x**2) - 1)/(4*x) + sqrt(2)*(sqrt(1 - x**2) - 1)**3/(4*x**3)))/2 + 2*atan((sqrt(1 - x**2) - 1)/x)
+    assert manualintegrate(f, x) == F
+
 def test_manualintegrate_sqrt_quadratic():
     assert_is_integral_of(1/sqrt((x - I)**2-1), log(2*x + 2*sqrt(x**2 - 2*I*x - 2) - 2*I))
     assert_is_integral_of(1/sqrt(3*x**2+4*x+5), sqrt(3)*asinh(3*sqrt(11)*(x + S(2)/3)/11)/3)


### PR DESCRIPTION
Fixes #30447, #30441, #30443.manualintegrate incorrectly returned imaginary results when integrating real expressions like sqrt(1 - x**2) / (x**2 + 1). This PR updates uler_substitution_rule to dynamically select the correct Euler substitution based on the polynomial coefficients to avoid taking the square root of negative values and introducing unnecessary complex I artifacts.