### PR TITLE
BUG: Fix refine(Abs(z)**2, Q.imaginary(z)) to simplify to -z**2

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -148,9 +148,13 @@ def refine_Pow(expr, assumptions):
     from sympy.functions import sign
 
     if isinstance(expr.base, Abs):
-        if ask(Q.real(expr.base.args[0]), assumptions) and \
+        arg = expr.base.args[0]
+        if ask(Q.real(arg), assumptions) and \
                 ask(Q.even(expr.exp), assumptions):
-            return expr.base.args[0] ** expr.exp
+            return arg ** expr.exp
+        if ask(Q.imaginary(arg), assumptions) and \
+                ask(Q.even(expr.exp), assumptions):
+            return (-1) ** (expr.exp / 2) * (arg ** expr.exp)
     if ask(Q.real(expr.base), assumptions):
         if expr.base.is_number:
             if ask(Q.even(expr.exp), assumptions):

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -70,6 +70,12 @@ def test_pow2():
     assert refine(Abs(x)**3, Q.real(x)) == Abs(x)**3
     assert refine(Abs(x)**2) == Abs(x)**2
 
+    # powers of Abs for imaginary arguments
+    assert refine(Abs(x)**2, Q.imaginary(x)) == -x**2
+    assert refine(Abs(x)**4, Q.imaginary(x)) == x**4
+    assert refine(Abs(x)**6, Q.imaginary(x)) == -x**6
+    assert refine(Abs(x)**3, Q.imaginary(x)) == Abs(x)**3
+
 
 def test_exp():
     x = Symbol('x', integer=True)


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30473

#### Brief description of what is fixed or changed

`refine(Abs(z)**2, Q.imaginary(z))` was returning `Abs(z)**2` instead of `-z**2`.

For purely imaginary z = iy where y is real:
- |z|^2 = y^2 = -(iy)^2 = -z^2
- More generally: |z|^k = (-1)^(k/2) * z^k for even integer k

Modified `refine_Pow` in `sympy/assumptions/refine.py` to handle `Abs` raised to even powers when the argument is imaginary. Added test cases in `sympy/assumptions/tests/test_refine.py`.

#### Other comments


#### AI Generation Disclosure

This pull request was prepared with the assistance of opencode (model: opencode/big-pickle). The changes to `sympy/assumptions/refine.py` (the added `Q.imaginary` branch in `refine_Pow`) and the test additions in `sympy/assumptions/tests/test_refine.py` were AI-generated. All code has been reviewed by a human.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* assumptions
  * Fixed `refine(Abs(z)**n, Q.imaginary(z))` to correctly simplify to `(-1)**(n/2) * z**n` for even exponents.

<!-- END RELEASE NOTES -->