### PR TITLE
fix(assumptions): simplify Abs(z)**k under Q.imaginary(z) in refine_Pow (#30473)

### DIFF
--- a/sympy/assumptions/refine.py
+++ b/sympy/assumptions/refine.py
@@ -148,9 +148,12 @@ def refine_Pow(expr, assumptions):
     from sympy.functions import sign
 
     if isinstance(expr.base, Abs):
-        if ask(Q.real(expr.base.args[0]), assumptions) and \
-                ask(Q.even(expr.exp), assumptions):
-            return expr.base.args[0] ** expr.exp
+        arg = expr.base.args[0]
+        if ask(Q.even(expr.exp), assumptions):
+            if ask(Q.real(arg), assumptions):
+                return arg ** expr.exp
+            if ask(Q.imaginary(arg), assumptions):
+                return (-S.One) ** (expr.exp / S(2)) * (arg ** expr.exp)
     if ask(Q.real(expr.base), assumptions):
         if expr.base.is_number:
             if ask(Q.even(expr.exp), assumptions):

--- a/sympy/assumptions/tests/test_refine.py
+++ b/sympy/assumptions/tests/test_refine.py
@@ -29,6 +29,11 @@ def test_Abs():
     assert refine(Abs(x**2)) != x**2
     assert refine(Abs(x**2), Q.real(x)) == x**2
 
+    assert refine(Abs(z)**2, Q.real(z)) == z**2
+    assert refine(Abs(z)**2, Q.imaginary(z)) == -z**2
+    assert refine(Abs(z)**4, Q.imaginary(z)) == z**4
+    assert refine(Abs(z)**6, Q.imaginary(z)) == -z**6
+
 
 def test_pow1():
     assert refine((-1)**x, Q.even(x)) == 1


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

Fixes #30473

#### Brief description of what is fixed or changed

This PR adds support for `Q.imaginary` assumptions when refining powers of absolute values `Abs(z)**k` for even exponents $k$.

For $z \in i\mathbb{R}$, $|z|^k = (-1)^{k/2} z^k$, so `refine(Abs(z)**2, Q.imaginary(z))` simplifies to `-z**2`, `Abs(z)**4` to `z**4`, etc.

#### Other comments


#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

NO AI USE

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* assumptions
  * Fixed `refine` to simplify `Abs(z)**k` to `(-1)**(k/2) * z**k` for even exponent `k` under `Q.imaginary(z)`.
<!-- END RELEASE NOTES -->