### PR TITLE
parsing.latex.lark: end control words at the first non-letter

### DIFF
--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -67,9 +67,19 @@ FUNC_ARCCOT: "\\arccot"
 FUNC_SINH: "\\sinh"
 FUNC_COSH: "\\cosh"
 FUNC_TANH: "\\tanh"
-FUNC_ARSINH: "\\arsinh"
-FUNC_ARCOSH: "\\arcosh"
-FUNC_ARTANH: "\\artanh"
+FUNC_COTH: "\\coth"
+FUNC_SECH: "\\sech"
+FUNC_CSCH: "\\csch"
+FUNC_ARSINH: "\\arsinh" | "\\arcsinh"
+FUNC_ARCOSH: "\\arcosh" | "\\arccosh"
+FUNC_ARTANH: "\\artanh" | "\\arctanh"
+
+// Commands sharing a prefix, like \tan and \tanh, are alternatives of a single terminal,
+// so that the lexer matches the longest one: \tanh is never read as \tan followed by h.
+FUNC_TRIG: FUNC_SIN | FUNC_COS | FUNC_TAN | FUNC_CSC | FUNC_SEC | FUNC_COT
+    | FUNC_ARCSIN | FUNC_ARCCOS | FUNC_ARCTAN | FUNC_ARCCSC | FUNC_ARCSEC | FUNC_ARCCOT
+    | FUNC_SINH | FUNC_COSH | FUNC_TANH | FUNC_COTH | FUNC_SECH | FUNC_CSCH
+    | FUNC_ARSINH | FUNC_ARCOSH | FUNC_ARTANH
 
 FUNC_SQRT: "\\sqrt"
 
@@ -353,9 +363,7 @@ inner_product: CMD_LANGLE _expression BAR _expression CMD_RANGLE
 _function: function_applied | _builtin_function
 
 _builtin_function: abs | floor | ceil
-    | _trigonometric_function | _inverse_trigonometric_function
-    | _trigonometric_function_power
-    | _hyperbolic_trigonometric_function | _inverse_hyperbolic_trigonometric_function
+    | trigonometric_function | trigonometric_function_power
     | exponential
     | log
     | square_root
@@ -383,44 +391,9 @@ factorial: _expression_func BANG
 conjugate: CMD_OVERLINE group_curly_parentheses
     | CMD_OVERLINE DIGIT
 
-_trigonometric_function: sin | cos | tan | csc | sec | cot
+trigonometric_function: FUNC_TRIG function_argument
 
-sin: FUNC_SIN function_argument
-cos: FUNC_COS function_argument
-tan: FUNC_TAN function_argument
-csc: FUNC_CSC function_argument
-sec: FUNC_SEC function_argument
-cot: FUNC_COT function_argument
-
-_trigonometric_function_power: sin_power | cos_power | tan_power | csc_power | sec_power | cot_power
-
-sin_power: FUNC_SIN CARET _expression_core function_argument
-cos_power: FUNC_COS CARET _expression_core function_argument
-tan_power: FUNC_TAN CARET _expression_core function_argument
-csc_power: FUNC_CSC CARET _expression_core function_argument
-sec_power: FUNC_SEC CARET _expression_core function_argument
-cot_power: FUNC_COT CARET _expression_core function_argument
-
-_hyperbolic_trigonometric_function: sinh | cosh | tanh
-
-sinh: FUNC_SINH function_argument
-cosh: FUNC_COSH function_argument
-tanh: FUNC_TANH function_argument
-
-_inverse_trigonometric_function: arcsin | arccos | arctan | arccsc | arcsec | arccot
-
-arcsin: FUNC_ARCSIN function_argument
-arccos: FUNC_ARCCOS function_argument
-arctan: FUNC_ARCTAN function_argument
-arccsc: FUNC_ARCCSC function_argument
-arcsec: FUNC_ARCSEC function_argument
-arccot: FUNC_ARCCOT function_argument
-
-_inverse_hyperbolic_trigonometric_function: asinh | acosh | atanh
-
-asinh: FUNC_ARSINH function_argument
-acosh: FUNC_ARCOSH function_argument
-atanh: FUNC_ARTANH function_argument
+trigonometric_function_power: FUNC_TRIG CARET _expression_core function_argument
 
 abs: BAR _expression BAR
 floor: L_FLOOR _expression R_FLOOR

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -220,9 +220,33 @@ div: _expression_mul DIV_SYMBOL (_expression_power | adjacent_expressions)
 
 adjacent_expressions: (_one_letter_symbol | number) _expression_mul
     | (group_round_parentheses | group_square_brackets | group_curly_literal_parentheses) (group_round_parentheses | group_square_brackets | group_curly_parentheses | group_curly_literal_parentheses | _one_letter_symbol)
-    | _function _function
+    | _function adjacent_functions
     | fraction _expression_mul
     | superscript _expression_mul
+
+?adjacent_functions: _function
+    | _function adjacent_functions -> adjacent_expressions
+
+// The argument of a function command binds tighter than any operator and cannot start
+// with a product or function application led by a letter: that letter could be the end
+// of a longer command, as in \tan h x for \tanh x.
+?function_argument: _expression_core
+    | group_round_parentheses
+    | fraction
+    | binomial
+    | _builtin_function
+    | _integral
+    | limit
+    | matrix
+    | superscript
+    | matrix_prime
+    | symbol_prime
+    | summation
+    | product
+    | (number | fraction) (_expression_power | adjacent_expressions) -> adjacent_expressions
+    | (group_round_parentheses | group_square_brackets | group_curly_literal_parentheses) (group_round_parentheses | group_square_brackets | group_curly_parentheses | group_curly_literal_parentheses | _one_letter_symbol) -> adjacent_expressions
+    | ADD function_argument -> add
+    | SUB function_argument -> sub
 
 _expression_func: _expression_core
     | group_round_parentheses
@@ -326,8 +350,9 @@ ket: BAR _expression CMD_RANGLE
 
 inner_product: CMD_LANGLE _expression BAR _expression CMD_RANGLE
 
-_function: function_applied
-    | abs | floor | ceil
+_function: function_applied | _builtin_function
+
+_builtin_function: abs | floor | ceil
     | _trigonometric_function | _inverse_trigonometric_function
     | _trigonometric_function_power
     | _hyperbolic_trigonometric_function | _inverse_hyperbolic_trigonometric_function
@@ -342,13 +367,13 @@ _function: function_applied
     | trace
     | adjugate
 
-exponential: FUNC_EXP _expression
+exponential: FUNC_EXP function_argument
 
-log: FUNC_LOG _expression
-    | FUNC_LN _expression
-    | FUNC_LG _expression
-    | FUNC_LOG UNDERSCORE (DIGIT | _one_letter_symbol) _expression
-    | FUNC_LOG UNDERSCORE group_curly_parentheses _expression
+log: FUNC_LOG function_argument
+    | FUNC_LN function_argument
+    | FUNC_LG function_argument
+    | FUNC_LOG UNDERSCORE (DIGIT | _one_letter_symbol) function_argument
+    | FUNC_LOG UNDERSCORE group_curly_parentheses function_argument
 
 square_root: FUNC_SQRT group_curly_parentheses
     | FUNC_SQRT group_square_brackets group_curly_parentheses
@@ -360,42 +385,42 @@ conjugate: CMD_OVERLINE group_curly_parentheses
 
 _trigonometric_function: sin | cos | tan | csc | sec | cot
 
-sin: FUNC_SIN _expression
-cos: FUNC_COS _expression
-tan: FUNC_TAN _expression
-csc: FUNC_CSC _expression
-sec: FUNC_SEC _expression
-cot: FUNC_COT _expression
+sin: FUNC_SIN function_argument
+cos: FUNC_COS function_argument
+tan: FUNC_TAN function_argument
+csc: FUNC_CSC function_argument
+sec: FUNC_SEC function_argument
+cot: FUNC_COT function_argument
 
 _trigonometric_function_power: sin_power | cos_power | tan_power | csc_power | sec_power | cot_power
 
-sin_power: FUNC_SIN CARET _expression_core _expression
-cos_power: FUNC_COS CARET _expression_core _expression
-tan_power: FUNC_TAN CARET _expression_core _expression
-csc_power: FUNC_CSC CARET _expression_core _expression
-sec_power: FUNC_SEC CARET _expression_core _expression
-cot_power: FUNC_COT CARET _expression_core _expression
+sin_power: FUNC_SIN CARET _expression_core function_argument
+cos_power: FUNC_COS CARET _expression_core function_argument
+tan_power: FUNC_TAN CARET _expression_core function_argument
+csc_power: FUNC_CSC CARET _expression_core function_argument
+sec_power: FUNC_SEC CARET _expression_core function_argument
+cot_power: FUNC_COT CARET _expression_core function_argument
 
 _hyperbolic_trigonometric_function: sinh | cosh | tanh
 
-sinh: FUNC_SINH _expression
-cosh: FUNC_COSH _expression
-tanh: FUNC_TANH _expression
+sinh: FUNC_SINH function_argument
+cosh: FUNC_COSH function_argument
+tanh: FUNC_TANH function_argument
 
 _inverse_trigonometric_function: arcsin | arccos | arctan | arccsc | arcsec | arccot
 
-arcsin: FUNC_ARCSIN _expression
-arccos: FUNC_ARCCOS _expression
-arctan: FUNC_ARCTAN _expression
-arccsc: FUNC_ARCCSC _expression
-arcsec: FUNC_ARCSEC _expression
-arccot: FUNC_ARCCOT _expression
+arcsin: FUNC_ARCSIN function_argument
+arccos: FUNC_ARCCOS function_argument
+arctan: FUNC_ARCTAN function_argument
+arccsc: FUNC_ARCCSC function_argument
+arcsec: FUNC_ARCSEC function_argument
+arccot: FUNC_ARCCOT function_argument
 
 _inverse_hyperbolic_trigonometric_function: asinh | acosh | atanh
 
-asinh: FUNC_ARSINH _expression
-acosh: FUNC_ARCOSH _expression
-atanh: FUNC_ARTANH _expression
+asinh: FUNC_ARSINH function_argument
+acosh: FUNC_ARCOSH function_argument
+atanh: FUNC_ARTANH function_argument
 
 abs: BAR _expression BAR
 floor: L_FLOOR _expression R_FLOOR
@@ -405,6 +430,6 @@ matrix: CMD_MATRIX_BEGIN matrix_body CMD_MATRIX_END
 matrix_body: matrix_row (MATRIX_ROW_DELIM matrix_row)* (MATRIX_ROW_DELIM)?
 matrix_row: _expression (MATRIX_COL_DELIM _expression)*
 determinant: (CMD_DETERMINANT_BEGIN matrix_body CMD_DETERMINANT_END)
-    | FUNC_DETERMINANT _expression
-trace: FUNC_MATRIX_TRACE _expression
-adjugate: FUNC_MATRIX_ADJUGATE _expression
+    | FUNC_DETERMINANT function_argument
+trace: FUNC_MATRIX_TRACE function_argument
+adjugate: FUNC_MATRIX_ADJUGATE function_argument

--- a/sympy/parsing/latex/lark/grammar/latex.lark
+++ b/sympy/parsing/latex/lark/grammar/latex.lark
@@ -237,14 +237,23 @@ adjacent_expressions: (_one_letter_symbol | number) _expression_mul
 ?adjacent_functions: _function
     | _function adjacent_functions -> adjacent_expressions
 
-// The argument of a function command binds tighter than any operator and cannot start
-// with a product or function application led by a letter: that letter could be the end
-// of a longer command, as in \tan h x for \tanh x.
-?function_argument: _expression_core
+// The argument of a function command binds tighter than any operator, and it contains no
+// function unless it is one: \sin x \cos y is sin(x)*cos(y), \sin \cos x is sin(cos(x)).
+?function_argument: argument_product
+    | _builtin_function
+    | ADD function_argument -> add
+    | SUB function_argument -> sub
+
+?argument_product: _argument_factor
+    | _argument_factor argument_product -> adjacent_expressions
+
+_argument_factor: _expression_core
     | group_round_parentheses
+    | group_square_brackets
+    | group_curly_literal_parentheses
     | fraction
     | binomial
-    | _builtin_function
+    | function_applied
     | _integral
     | limit
     | matrix
@@ -253,10 +262,6 @@ adjacent_expressions: (_one_letter_symbol | number) _expression_mul
     | symbol_prime
     | summation
     | product
-    | (number | fraction) (_expression_power | adjacent_expressions) -> adjacent_expressions
-    | (group_round_parentheses | group_square_brackets | group_curly_literal_parentheses) (group_round_parentheses | group_square_brackets | group_curly_parentheses | group_curly_literal_parentheses | _one_letter_symbol) -> adjacent_expressions
-    | ADD function_argument -> add
-    | SUB function_argument -> sub
 
 _expression_func: _expression_core
     | group_round_parentheses

--- a/sympy/parsing/latex/lark/latex_parser.py
+++ b/sympy/parsing/latex/lark/latex_parser.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 
 from sympy.external import import_module
+from sympy.parsing.latex.errors import LaTeXParsingError
 from sympy.parsing.latex.lark.transformer import TransformToSymPyExpr
 
 _lark = import_module("lark")
@@ -60,6 +61,12 @@ class LarkLaTeXParser:
             maybe_placeholders=False,
             keep_all_tokens=True)
 
+        # The control words defined in the grammar, e.g. "frac" for "\\frac", so that
+        # an unknown one is not split into a known command followed by symbols.
+        self.control_words = {word for _, (tree, _) in self.parser.grammar.term_defs
+                              for token in tree.scan_values(lambda v: isinstance(v, _lark.Token))
+                              for word in re.findall(r"\\\\([a-zA-Z]+)", token)}
+
         self.print_debug_output = print_debug_output
         self.transform_expr = transform
 
@@ -71,6 +78,10 @@ class LarkLaTeXParser:
     def doparse(self, s: str):
         if self.print_debug_output:
             _lark.logger.setLevel(logging.DEBUG)
+
+        for match in re.finditer(r"\\(?:\\|([a-zA-Z]+)|.)", s):
+            if match.group(1) and match.group(1) not in self.control_words:
+                raise LaTeXParsingError("Unknown command %s" % match.group(0))
 
         parse_tree = self.parser.parse(s)
 

--- a/sympy/parsing/latex/lark/transformer.py
+++ b/sympy/parsing/latex/lark/transformer.py
@@ -539,101 +539,33 @@ class TransformToSymPyExpr(Transformer):
         from sympy.physics.quantum import Bra, Ket, InnerProduct
         return InnerProduct(Bra(tokens[1]), Ket(tokens[3]))
 
-    def sin(self, tokens):
-        return sympy.sin(tokens[1])
+    _trigonometric_functions = {
+        "\\sin": sympy.sin, "\\cos": sympy.cos, "\\tan": sympy.tan,
+        "\\csc": sympy.csc, "\\sec": sympy.sec, "\\cot": sympy.cot,
+        "\\arcsin": sympy.asin, "\\arccos": sympy.acos, "\\arctan": sympy.atan,
+        "\\arccsc": sympy.acsc, "\\arcsec": sympy.asec, "\\arccot": sympy.acot,
+        "\\sinh": sympy.sinh, "\\cosh": sympy.cosh, "\\tanh": sympy.tanh,
+        "\\coth": sympy.coth, "\\sech": sympy.sech, "\\csch": sympy.csch,
+        "\\arsinh": sympy.asinh, "\\arcosh": sympy.acosh, "\\artanh": sympy.atanh,
+        "\\arcsinh": sympy.asinh, "\\arccosh": sympy.acosh, "\\arctanh": sympy.atanh,
+    }
 
-    def cos(self, tokens):
-        return sympy.cos(tokens[1])
+    _inverse_trigonometric_functions = {
+        sympy.sin: sympy.asin, sympy.cos: sympy.acos, sympy.tan: sympy.atan,
+        sympy.csc: sympy.acsc, sympy.sec: sympy.asec, sympy.cot: sympy.acot,
+        sympy.sinh: sympy.asinh, sympy.cosh: sympy.acosh, sympy.tanh: sympy.atanh,
+        sympy.coth: sympy.acoth, sympy.sech: sympy.asech, sympy.csch: sympy.acsch,
+    }
 
-    def tan(self, tokens):
-        return sympy.tan(tokens[1])
+    def trigonometric_function(self, tokens):
+        return self._trigonometric_functions[tokens[0]](tokens[1])
 
-    def csc(self, tokens):
-        return sympy.csc(tokens[1])
-
-    def sec(self, tokens):
-        return sympy.sec(tokens[1])
-
-    def cot(self, tokens):
-        return sympy.cot(tokens[1])
-
-    def sin_power(self, tokens):
+    def trigonometric_function_power(self, tokens):
+        function = self._trigonometric_functions[tokens[0]]
         exponent = tokens[2]
-        if exponent == -1:
-            return sympy.asin(tokens[-1])
-        else:
-            return sympy.Pow(sympy.sin(tokens[-1]), exponent)
-
-    def cos_power(self, tokens):
-        exponent = tokens[2]
-        if exponent == -1:
-            return sympy.acos(tokens[-1])
-        else:
-            return sympy.Pow(sympy.cos(tokens[-1]), exponent)
-
-    def tan_power(self, tokens):
-        exponent = tokens[2]
-        if exponent == -1:
-            return sympy.atan(tokens[-1])
-        else:
-            return sympy.Pow(sympy.tan(tokens[-1]), exponent)
-
-    def csc_power(self, tokens):
-        exponent = tokens[2]
-        if exponent == -1:
-            return sympy.acsc(tokens[-1])
-        else:
-            return sympy.Pow(sympy.csc(tokens[-1]), exponent)
-
-    def sec_power(self, tokens):
-        exponent = tokens[2]
-        if exponent == -1:
-            return sympy.asec(tokens[-1])
-        else:
-            return sympy.Pow(sympy.sec(tokens[-1]), exponent)
-
-    def cot_power(self, tokens):
-        exponent = tokens[2]
-        if exponent == -1:
-            return sympy.acot(tokens[-1])
-        else:
-            return sympy.Pow(sympy.cot(tokens[-1]), exponent)
-
-    def arcsin(self, tokens):
-        return sympy.asin(tokens[1])
-
-    def arccos(self, tokens):
-        return sympy.acos(tokens[1])
-
-    def arctan(self, tokens):
-        return sympy.atan(tokens[1])
-
-    def arccsc(self, tokens):
-        return sympy.acsc(tokens[1])
-
-    def arcsec(self, tokens):
-        return sympy.asec(tokens[1])
-
-    def arccot(self, tokens):
-        return sympy.acot(tokens[1])
-
-    def sinh(self, tokens):
-        return sympy.sinh(tokens[1])
-
-    def cosh(self, tokens):
-        return sympy.cosh(tokens[1])
-
-    def tanh(self, tokens):
-        return sympy.tanh(tokens[1])
-
-    def asinh(self, tokens):
-        return sympy.asinh(tokens[1])
-
-    def acosh(self, tokens):
-        return sympy.acosh(tokens[1])
-
-    def atanh(self, tokens):
-        return sympy.atanh(tokens[1])
+        if exponent == -1 and function in self._inverse_trigonometric_functions:
+            return self._inverse_trigonometric_functions[function](tokens[-1])
+        return sympy.Pow(function(tokens[-1]), exponent)
 
     def abs(self, tokens):
         return sympy.Abs(tokens[1])

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -25,7 +25,7 @@ from sympy import I, pi
 
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum import Bra, Ket, InnerProduct
-from sympy.abc import x, y, z, a, b, c, d, t, k, n
+from sympy.abc import x, y, z, a, b, c, d, h, t, k, n
 
 from .test_latex import theta, f, _Add, _Mul, _Pow, _Sqrt, _Conjugate, _Abs, _factorial, _exp, _binomial
 
@@ -456,9 +456,9 @@ UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\exp(x)", _exp(x)),
     (r"\lg x", _log(x, 10)),
     (r"\ln x", _log(x)),
-    (r"\ln{xy}", _log(x * y)),
+    (r"\ln xy", _log(x * y)),
     (r"\log x", _log(x)),
-    (r"\log{xy}", _log(x * y)),
+    (r"\log xy", _log(x * y)),
     (r"\log_{2} x", _log(x, 2)),
     (r"\log_{a} x", _log(x, a)),
     (r"\log_{11} x", _log(x, 11)),
@@ -490,9 +490,9 @@ EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\exp(x)", exp(x)),
     (r"\lg x", log(x, 10)),
     (r"\ln x", log(x)),
-    (r"\ln{xy}", log(x * y)),
+    (r"\ln xy", log(x * y)),
     (r"\log x", log(x)),
-    (r"\log{xy}", log(x * y)),
+    (r"\log xy", log(x * y)),
     (r"\log_{2} x", log(x, 2)),
     (r"\log_{a} x", log(x, a)),
     (r"\log_{11} x", log(x, 11)),
@@ -926,12 +926,14 @@ def test_function_arguments():
     assert parse_latex_lark(r"\sin x \cos y \tan z") == sin(x)*cos(y)*tan(z)
     assert parse_latex_lark(r"\sin 2x") == sin(2*x)
     assert parse_latex_lark(r"\sin -x") == -sin(x)
+    assert parse_latex_lark(r"\sin xy") == sin(x*y)
+    assert parse_latex_lark(r"\tan hk") == tan(h*k)
     assert parse_latex_lark(r"\tanh^2 x") == tanh(x)**2
     assert parse_latex_lark(r"\sinh^{-1} x") == asinh(x)
     assert parse_latex_lark(r"\arctanh x") == atanh(x)
     assert parse_latex_lark(r"\coth x") == coth(x)
 
-    for latex_str in [r"\tanh", r"\ln xy", r"\sin f(x)", r"\sin hk"]:
+    for latex_str in [r"\tanh", r"\tanh^2"]:
         with raises(lark.exceptions.UnexpectedInput):
             parse_latex_lark(latex_str)
 

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -14,7 +14,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import binomial, factorial
 from sympy.functions.elementary.complexes import Abs, conjugate
 from sympy.functions.elementary.exponential import exp, log
-from sympy.functions.elementary.hyperbolic import cosh, sinh, tanh
+from sympy.functions.elementary.hyperbolic import asinh, atanh, cosh, coth, sinh, tanh
 from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.miscellaneous import root, sqrt, Min, Max
 from sympy.functions.elementary.trigonometric import asin, cos, csc, sec, sin, tan
@@ -926,8 +926,12 @@ def test_function_arguments():
     assert parse_latex_lark(r"\sin x \cos y \tan z") == sin(x)*cos(y)*tan(z)
     assert parse_latex_lark(r"\sin 2x") == sin(2*x)
     assert parse_latex_lark(r"\sin -x") == -sin(x)
+    assert parse_latex_lark(r"\tanh^2 x") == tanh(x)**2
+    assert parse_latex_lark(r"\sinh^{-1} x") == asinh(x)
+    assert parse_latex_lark(r"\arctanh x") == atanh(x)
+    assert parse_latex_lark(r"\coth x") == coth(x)
 
-    for latex_str in [r"\ln xy", r"\sin f(x)", r"\arctanh x"]:
+    for latex_str in [r"\tanh", r"\ln xy", r"\sin f(x)", r"\sin hk"]:
         with raises(lark.exceptions.UnexpectedInput):
             parse_latex_lark(latex_str)
 

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from sympy.testing.pytest import XFAIL, raises
 from sympy.parsing.latex.lark import parse_latex_lark
+from sympy.parsing.latex.errors import LaTeXParsingError
 from sympy.external import import_module
 
 from sympy.concrete.products import Product
@@ -25,7 +26,7 @@ from sympy import I, pi
 
 from sympy.core.relational import Eq, Ne, Lt, Le, Gt, Ge
 from sympy.physics.quantum import Bra, Ket, InnerProduct
-from sympy.abc import x, y, z, a, b, c, d, h, t, k, n
+from sympy.abc import x, y, z, a, b, c, d, h, t, k, n, v
 
 from .test_latex import theta, f, _Add, _Mul, _Pow, _Sqrt, _Conjugate, _Abs, _factorial, _exp, _binomial
 
@@ -936,6 +937,17 @@ def test_function_arguments():
     for latex_str in [r"\tanh", r"\tanh^2"]:
         with raises(lark.exceptions.UnexpectedInput):
             parse_latex_lark(latex_str)
+
+
+def test_unknown_commands():
+    for latex_str in [r"\logv", r"\logv x", r"\lnx", r"\sinx", r"\tanhx", r"\arctanhx", r"\expx", r"\intx dx",
+                      r"\alphabeta", r"\thetax", r"\lefta", r"x \leqx", r"\sin\foo", r"\foo", r"\foo x", r"\foo{x}"]:
+        with raises(LaTeXParsingError):
+            parse_latex_lark(latex_str)
+
+    assert parse_latex_lark(r"\log v") == log(v)
+    assert parse_latex_lark(r"\alpha\beta") == Symbol("alpha")*Symbol("beta")
+    assert parse_latex_lark(r"\begin{pmatrix}a\\b\end{pmatrix}") == Matrix([[a], [b]])
 
 
 def test_binomial_expressions():

--- a/sympy/parsing/tests/test_latex_lark.py
+++ b/sympy/parsing/tests/test_latex_lark.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from sympy.testing.pytest import XFAIL
+from sympy.testing.pytest import XFAIL, raises
 from sympy.parsing.latex.lark import parse_latex_lark
 from sympy.external import import_module
 
@@ -14,6 +14,7 @@ from sympy.core.symbol import Symbol
 from sympy.functions.combinatorial.factorials import binomial, factorial
 from sympy.functions.elementary.complexes import Abs, conjugate
 from sympy.functions.elementary.exponential import exp, log
+from sympy.functions.elementary.hyperbolic import cosh, sinh, tanh
 from sympy.functions.elementary.integers import ceiling, floor
 from sympy.functions.elementary.miscellaneous import root, sqrt, Min, Max
 from sympy.functions.elementary.trigonometric import asin, cos, csc, sec, sin, tan
@@ -455,9 +456,9 @@ UNEVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\exp(x)", _exp(x)),
     (r"\lg x", _log(x, 10)),
     (r"\ln x", _log(x)),
-    (r"\ln xy", _log(x * y)),
+    (r"\ln{xy}", _log(x * y)),
     (r"\log x", _log(x)),
-    (r"\log xy", _log(x * y)),
+    (r"\log{xy}", _log(x * y)),
     (r"\log_{2} x", _log(x, 2)),
     (r"\log_{a} x", _log(x, a)),
     (r"\log_{11} x", _log(x, 11)),
@@ -489,9 +490,9 @@ EVALUATED_COMMON_FUNCTION_EXPRESSION_PAIRS = [
     (r"\exp(x)", exp(x)),
     (r"\lg x", log(x, 10)),
     (r"\ln x", log(x)),
-    (r"\ln xy", log(x * y)),
+    (r"\ln{xy}", log(x * y)),
     (r"\log x", log(x)),
-    (r"\log xy", log(x * y)),
+    (r"\log{xy}", log(x * y)),
     (r"\log_{2} x", log(x, 2)),
     (r"\log_{a} x", log(x, a)),
     (r"\log_{11} x", log(x, 11)),
@@ -824,10 +825,7 @@ def test_derivative_expressions():
 
 
 def test_trigonometric_expressions():
-    expected_failures = {3}
-    for i, (latex_str, sympy_expr) in enumerate(TRIGONOMETRIC_EXPRESSION_PAIRS):
-        if i in expected_failures:
-            continue
+    for latex_str, sympy_expr in TRIGONOMETRIC_EXPRESSION_PAIRS:
         with evaluate(False):
             assert parse_latex_lark(latex_str) == sympy_expr, latex_str
 
@@ -914,6 +912,24 @@ def test_negthinspace_not_equal_conflict():
 
     assert parse_latex_lark(r"\negthinspace x \ne y") == Ne(x, y)
     assert parse_latex_lark(r"x \neq \negmedspace y") == Ne(x, y)
+
+
+def test_function_arguments():
+    assert parse_latex_lark(r"\tanh x") == tanh(x)
+    assert parse_latex_lark(r"\tanh(x)") == tanh(x)
+    assert parse_latex_lark(r"\sinh{x}") == sinh(x)
+    assert parse_latex_lark(r"\cosh x + 1") == cosh(x) + 1
+    assert parse_latex_lark(r"\sin x - 1") == sin(x) - 1
+    assert parse_latex_lark(r"\log x + 1") == log(x) + 1
+    assert parse_latex_lark(r"\sin x \cdot y") == sin(x)*y
+    assert parse_latex_lark(r"\sin x / 2") == sin(x)/2
+    assert parse_latex_lark(r"\sin x \cos y \tan z") == sin(x)*cos(y)*tan(z)
+    assert parse_latex_lark(r"\sin 2x") == sin(2*x)
+    assert parse_latex_lark(r"\sin -x") == -sin(x)
+
+    for latex_str in [r"\ln xy", r"\sin f(x)", r"\arctanh x"]:
+        with raises(lark.exceptions.UnexpectedInput):
+            parse_latex_lark(latex_str)
 
 
 def test_binomial_expressions():


### PR DESCRIPTION
I notices a bug parsing $\sinh$ and $\sinh x$ with the Lark LaTeX parser.

<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->


#### Brief description of what is fixed or changed

$\sinh x$ should parse into `sinh(x)`

#### Other comments


#### AI Generation Disclosure

~~Claude Opus 5~~

Claude Fable 5.1

(switched to Fable as Opus was writing low quality code)

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
