### PR TITLE
make `_bell_poly` use lists internally for its recurrence instead of expressions

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -33,7 +33,7 @@ from sympy.ntheory.generate import _primepi
 from sympy.ntheory.partitions_ import _partition, _partition_rec
 from sympy.ntheory.primetest import isprime, is_square
 from sympy.polys.appellseqs import bernoulli_poly, euler_poly, genocchi_poly
-from sympy.polys.polytools import cancel
+from sympy.polys.polytools import cancel, Poly
 from sympy.utilities.enumerative import MultisetPartitionTraverser
 from sympy.utilities.exceptions import sympy_deprecation_warning
 from sympy.utilities.iterables import multiset, multiset_derangements, iterable
@@ -681,14 +681,19 @@ class bell(DefinedFunction):
         return s
 
     @staticmethod
-    @recurrence_memo([S.One, _sym])
-    def _bell_poly(n, prev):
-        s = 1
+    @recurrence_memo([[1]])
+    def _bell_poly_coeffs(n, prev):
+        s = [0]*(n-1) + [1,0]
         a = 1
-        for k in range(2, n + 1):
-            a = a * (n - k + 1) // (k - 1)
-            s += a * prev[k - 1]
-        return expand_mul(_sym * s)
+        for k in range(1, n):
+            a = a * (n - k) // k
+            for i in range(k):
+                s[n-k-1+i] += a * prev[k][i]
+        return s
+
+    @classmethod
+    def _bell_poly(cls, n):
+        return Poly(cls._bell_poly_coeffs(n), _sym).as_expr()
 
     @staticmethod
     def _bell_incomplete_poly(n, k, symbols):


### PR DESCRIPTION
#### References to other Issues or PRs
N/A

#### Brief description of what is fixed or changed
`_bell_poly` (which uses a recurrence) returns an `Add` object, but adding together two `Add` objects is apparently quite slow; this commit adds an intermediate function `__bell_poly` which does the recurrence using lists (of polynomial coefficients) instead, so `_bell_poly` can cast it to a `Poly` then use `as_expr`.

#### Other comments
Running `_bell_poly(128)` (with the recurrence cache empty) takes 0.102s vs. 19.98s this way.

(this commit would be superseded by #30372; on the same input, #30372's version takes only 0.0107s, but this is a much smaller change and easier to review)

#### AI Generation Disclosure
NO AI USE

#### Release Notes
<!-- BEGIN RELEASE NOTES -->
* functions
  * `_bell_poly` (univariate Bell/Touchard polynomial) in `functions.combinatorial.numbers.bell` now performs its recurrence on lists instead of expressions. (This is about 100 times faster for `bell(192,x)`.)
<!-- END RELEASE NOTES -->
