### PR TITLE
Fix Python version mismatch in setup.py and __init__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extra_kwargs = {
 
 # Keep in sync with sympy/__init__.py and python_requires below
 if sys.version_info < (3, 10):
-    print("SymPy requires Python 3.9 or newer. Python %d.%d detected"
+    print("SymPy requires Python 3.10 or newer. Python %d.%d detected"
           % sys.version_info[:2])
     sys.exit(-1)
 
@@ -359,7 +359,7 @@ if __name__ == '__main__':
             'Topic :: Scientific/Engineering :: Mathematics',
             'Topic :: Scientific/Engineering :: Physics',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.9',
+
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',

--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -15,8 +15,8 @@ See the webpage for more information and documentation:
 
 # Keep this in sync with setup.py/pyproject.toml
 import sys
-if sys.version_info < (3, 9):
-    raise ImportError("Python version 3.9 or above is required for SymPy.")
+if sys.version_info < (3, 10):
+    raise ImportError("Python version 3.10 or above is required for SymPy.")
 del sys
 
 


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30257

#### Brief description of what is fixed or changed

The error message in setup.py said SymPy requires Python 3.9, but the check itself and python_requires require Python 3.10. The message in setup.py and the version check in sympy/__init__.py were updated to require Python 3.10, and the outdated Python 3.9 trove classifier was removed.

#### Other comments

N/A

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

NO ENTRY

<!-- END RELEASE NOTES -->
