### PR TITLE
Fix wrong a=0 branch in chebyshev substitution rule for manualintegrate

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2602,11 +2602,21 @@ def chebyshev_substitution_rule(integral):
         if _if_zero_implies_zero(bb, denominator_c) or (p.is_negative and _if_zero_implies_zero(bb, reference_base)):
             return general_step
 
-        # The substitution is degenerate when b = 0 (occurs in the denominator above)
+        # The substitution is degenerate when a = 0 (aa appears in the
+        # denominator of the transformed integrand) or when b = 0
+        pieces = []
+        if r - 1 < 0:
+            if not (_if_zero_implies_zero(aa, denominator_c) or (p.is_negative and _if_zero_implies_zero(aa, reference_base))):
+                degenerate_integrand = canonical_integrand.subs(aa, 0)
+                degenerate_substep = yield IntegralInfo(degenerate_integrand, x)
+                degenerate_step = RewriteRule(integrand, x, degenerate_integrand, degenerate_substep)
+                pieces.append((degenerate_step, Eq(aa, 0)))
         degenerate_integrand = canonical_integrand.subs(bb, 0)
         degenerate_substep = yield IntegralInfo(degenerate_integrand, x)
         degenerate_step = RewriteRule(integrand, x, degenerate_integrand, degenerate_substep)
-        return PiecewiseRule(integrand, x, [(degenerate_step, Eq(bb, 0)), (general_step, S.true)])
+        pieces.append((degenerate_step, Eq(bb, 0)))
+        pieces.append((general_step, S.true))
+        return PiecewiseRule(integrand, x, pieces)
 
     s = r + p
 

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1253,6 +1253,16 @@ def test_manualintegrate_chebyshev_substitution():
     assert (generic.diff(x) - integrand).cancel() == 0
     assert degenerate.diff(x) == integrand.subs(b, 0)
 
+    # gh-30441: (m + 1)/n is an integer, check the a = 0 degenerate branch
+    # produced when the transformed integrand has (u**q - a) in the denominator.
+    integrand = 1/(x*sqrt(a + b*x**2)**3)
+    antiderivative = piecewise_fold(manualintegrate(integrand, x))
+    assert (antiderivative.diff(x) - integrand).subs({a: 1, b: 2, x: 3}).simplify() == 0
+    branches = dict((cond, expr) for expr, cond in antiderivative.args)
+    assert branches[Eq(a, 0)].diff(x) == integrand.subs(a, 0)
+    assert (integrand.subs({a: 0, b: 1, x: 4})
+            - antiderivative.diff(x).subs({a: 0, b: 1, x: 4})) == 0
+
     # (m + 1)/n + p is an integer. Check the a = 0 branch separately.
     integrand = sqrt(x)/sqrt(a + x**3)
     antiderivative = piecewise_fold(manualintegrate(integrand, x))

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -1258,7 +1258,7 @@ def test_manualintegrate_chebyshev_substitution():
     integrand = 1/(x*sqrt(a + b*x**2)**3)
     antiderivative = piecewise_fold(manualintegrate(integrand, x))
     assert (antiderivative.diff(x) - integrand).subs({a: 1, b: 2, x: 3}).simplify() == 0
-    branches = dict((cond, expr) for expr, cond in antiderivative.args)
+    branches = {cond: expr for expr, cond in antiderivative.args}
     assert branches[Eq(a, 0)].diff(x) == integrand.subs(a, 0)
     assert (integrand.subs({a: 0, b: 1, x: 4})
             - antiderivative.diff(x).subs({a: 0, b: 1, x: 4})) == 0


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30441

#### Brief description of what is fixed or changed

`manualintegrate(1/(x*sqrt(a + b*x**2)**3), x)` returned a `Piecewise`
whose `Eq(a, 0)` branch evaluated to `0`, which is wrong. The issue is in
`chebyshev_substitution_rule` case 2 (where `r = (m + 1)/n` is an integer
and `r - 1 < 0`). After the substitution `u = (a + b*x**2)**(1/2)`, the
transformed integrand contains `(u**2 - a)` in the denominator, and
`partial_fractions_rule` uses `apart`, which introduces `1/a` coefficients
that cancel incorrectly when `a = 0`. Case 3 already handled the `a = 0`
degenerate branch; this PR adds the analogous branch to case 2, so the
`Eq(a, 0)` branch of the result now evaluates to
`-1/(3*(b*x**2)**(3/2))`, consistent with the general result.

#### Other comments

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * `manualintegrate` now returns a correct result for integrands matching the Chebyshev substitution rule when the `a = 0` branch is degenerate, e.g. `manualintegrate(1/(x*sqrt(a + b*x**2)**3), x)`.
<!-- END RELEASE NOTES -->