### PR TITLE
Fix wrong result from Bioche substitution with a numeric residual phase

### DIFF
--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -2444,45 +2444,54 @@ def bioche_substitution(integral):
 
         else:
             t = Dummy("t")
-            expr_sc = expr_u.xreplace(trig_replacements(u, s, c))
 
-            methods = (
-                # Try t = cos(2*u_func) when both sine and cosine powers are even
-                (-expr_sc/(4*omega*s*c), {s: (1 - t)/2, c: (1 + t)/2}, {}, cos(2*u_func)),
-                # Try t = sin(u_func) when only even powers of cosine remain
-                (expr_sc/(omega*c), {c: 1 - t**2}, {s: t}, sin(u_func)),
-                # Try t = cos(u_func) when only even powers of sine remain
-                (-expr_sc/(omega*s), {s: 1 - t**2}, {c: t}, cos(u_func)),
-                # Try t = tan(u_func) before the higher-degree half-angle substitution
-                ((expr_sc*c**2/omega).xreplace({s: t*c}), {c: (1 + t**2)**-1}, {}, tan(u_func)),
-            )
+            def trig_method(expr_to_integrate):
+                expr_sc = expr_to_integrate.xreplace(trig_replacements(u, s, c))
 
-            generic_step = None
-            for transformed, squares, replacements, substitution in methods:
-                transformed = rewrite_even(transformed, squares, replacements)
-                if transformed is None:
-                    continue
-                substep = yield IntegralInfo(transformed, t)
-                step = URule(integrand, x, t, substitution, substep)
-                if not step.contains_dont_know():
-                    generic_step = step
-                    break
-            else:
+                methods = (
+                    # Try t = cos(2*u_func) when both sine and cosine powers are even
+                    (-expr_sc/(4*omega*s*c), {s: (1 - t)/2, c: (1 + t)/2}, {}, cos(2*u_func)),
+                    # Try t = sin(u_func) when only even powers of cosine remain
+                    (expr_sc/(omega*c), {c: 1 - t**2}, {s: t}, sin(u_func)),
+                    # Try t = cos(u_func) when only even powers of sine remain
+                    (-expr_sc/(omega*s), {s: 1 - t**2}, {c: t}, cos(u_func)),
+                    # Try t = tan(u_func) before the higher-degree half-angle substitution
+                    ((expr_sc*c**2/omega).xreplace({s: t*c}), {c: (1 + t**2)**-1}, {}, tan(u_func)),
+                )
+
+                for transformed, squares, replacements, substitution in methods:
+                    transformed = rewrite_even(transformed, squares, replacements)
+                    if transformed is None:
+                        continue
+                    substep = yield IntegralInfo(transformed, t)
+                    step = URule(integrand, x, t, substitution, substep)
+                    if not step.contains_dont_know():
+                        return step
                 # Fall back to the universal Weierstrass substitution
                 transformed = expr_sc.xreplace({s: 2*t/(1 + t**2), c: (1 - t**2)/(1 + t**2)})
                 transformed = (transformed * 2/(omega*(1 + t**2))).cancel()
                 substep = yield IntegralInfo(transformed, t)
-                generic_step = URule(integrand, x, t, tan(u_func/2), substep)
+                return URule(integrand, x, t, tan(u_func/2), substep)
 
-            if singular_expr_u is not None:
-                singular_substep = yield IntegralInfo((singular_expr_u/omega).cancel(), u)
-                singular_step = URule(integrand, x, u, u_func, singular_substep)
-                generic_step = PiecewiseRule(integrand, x,
-                    [(singular_step, singular_condition), (generic_step, S.true)])
+            generic_step = yield from trig_method(expr_u)
 
             if phase_substitution:
-                generic_step = ReparameterizationRule(
+                if singular_expr_u is not None:
+                    singular_substep = yield IntegralInfo((singular_expr_u/omega).cancel(), u)
+                    singular_step = URule(integrand, x, u, u_func, singular_substep)
+                    generic_step = PiecewiseRule(integrand, x,
+                        [(singular_step, singular_condition), (generic_step, S.true)])
+
+                reparam_step = ReparameterizationRule(
                     integrand, x, phase_substitution, generic_step)
+                phase_value = phase_substitution[next(iter(phase_substitution))]
+                if phase_value.is_number and reparam_step.eval().has(S.ComplexInfinity, S.NaN):
+                    # The parametrized antiderivative (typically a ratint
+                    # RootSum) collapses at the actual phase value, so retry
+                    # with the phase substituted in before integrating.
+                    generic_step = yield from trig_method(expr_u.xreplace(phase_substitution))
+                else:
+                    generic_step = reparam_step
 
         if omega.is_zero is False:
             return generic_step

--- a/sympy/integrals/tests/test_manual.py
+++ b/sympy/integrals/tests/test_manual.py
@@ -309,6 +309,15 @@ def test_manualintegrate_bioche_phase_parametrization():
     assert bioche_substitution((f, x)) is None
     assert not manualintegrate(f, x).has(S.ComplexInfinity, S.NaN)
 
+    # gh-30442: a numeric residual phase must not leave a degenerate
+    # antiderivative (a ratint RootSum collapsing at the phase value).
+    f = -1/(cot(x + pi/4)*cot(2*x + pi/4) - 1)
+    F = manualintegrate(f, x)
+    assert not F.has(S.ComplexInfinity, S.NaN)
+    for value in (S(1)/10, S(3)/10, S(1)/2):
+        assert abs((F.diff(x) - f).subs(x, value).evalf()) < 1e-10
+    assert abs(integrate(f, (x, pi/6, pi/4), manual=True).evalf(8) - 0.24642) < 1e-5
+
 
 @slow
 def test_manualintegrate_trigpowers():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30442

#### Brief description of what is fixed or changed

`manualintegrate(-1/(cot(x + pi/4)*cot(2*x + pi/4) - 1), x)` returned `0`
(and, through the default fallback to `manualintegrate`,
`integrate(...)` as well), so the definite integral

```
integrate(-1/(cot(x + pi/4)*cot(2*x + pi/4) - 1), (x, pi/6, pi/4), manual=True)
```

evaluated to `0` instead of about `0.24642`.

The integrand is handled by the Bioche substitution. When a residual phase
remains (here `-pi/4`), the code parametrizes it with an auxiliary symbol
`z`, integrates the rational function in `z` symbolically, and finally
substitutes the actual phase value back in. When that value is a concrete
number (here `z = tan(-pi/4) = -1`), the parametrized antiderivative
(a `ratint` `RootSum` whose coefficients depend on `z`) can collapse into
`nan`, which `manualintegrate` then turned into `0`. Symbolic phase values
were never affected.

This PR detects the collapsed (`nan`) reparametrized result when the phase
value is a number and retries the Bioche substitution with the phase value
substituted into the rational function *before* integrating it, which is
always well-defined.

#### Other comments

#### AI Generation Disclosure

NO AI USE

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* integrals
  * `manualintegrate` no longer returns `0` when the residual-phase parametrization of the Bioche substitution collapses at a numeric phase value, e.g. `manualintegrate(-1/(cot(x + pi/4)*cot(2*x + pi/4) - 1), x)`.
<!-- END RELEASE NOTES -->