### PR TITLE
Enforce mpmath imports through sympy.external.mpmath

### DIFF
--- a/sympy/__init__.py
+++ b/sympy/__init__.py
@@ -20,13 +20,15 @@ if sys.version_info < (3, 9):
 del sys
 
 
-try:
-    import mpmath
-except ImportError:
+from sympy.external import import_module
+
+mpmath = import_module('mpmath')
+if mpmath is None:
     raise ImportError("SymPy now depends on mpmath as an external library. "
     "See https://docs.sympy.org/latest/install.html#mpmath for more information.")
 
 del mpmath
+del import_module
 
 from sympy.release import __version__
 from sympy.core.cache import lazy_function

--- a/sympy/core/function.py
+++ b/sympy/core/function.py
@@ -60,9 +60,8 @@ from sympy.utilities.iterables import (has_dups, sift, iterable,
 from sympy.utilities.lambdify import MPMATH_TRANSLATIONS
 from sympy.utilities.misc import as_int, filldedent, func_name
 
-import mpmath
-from sympy.external.mpmath import (prec_to_dps, mpf, mpc, mp, workprec, diff as
-                                   mpmath_diff)
+from sympy.external.mpmath import (mpmath, prec_to_dps, mpf, mpc, mp,
+                                   workprec, diff as mpmath_diff)
 
 import inspect
 from collections import Counter

--- a/sympy/external/mpmath.py
+++ b/sympy/external/mpmath.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from functools import update_wrapper as _update_wrapper
 
 
+import mpmath
+
 from mpmath import (
     MPContext,
     MPIntervalContext,
@@ -32,7 +34,13 @@ from mpmath import (
 
 NoConvergence = mp.NoConvergence
 
-from mpmath.ctx_mp_python import mpnumeric
+from mpmath.ctx_mp_python import (
+    PythonMPContext,
+    _constant,
+    _mpc,
+    _mpf,
+    mpnumeric,
+)
 from mpmath.libmp import (
     MPZ,
     MPZ_ONE,
@@ -206,6 +214,11 @@ __all__ = [
     "to_str",
     "workprec",
     "_matrix",
+    "PythonMPContext",
+    "_constant",
+    "_mpc",
+    "_mpf",
+    "mpmath",
 ]
 
 
@@ -215,7 +228,6 @@ def conserve_mpmath_dps(func):
     It is not recommended to use this in new code which should instead use
     the :class:`local_workdps` or :class:`local_workprec` context managers.
     """
-    import mpmath
 
     def func_wrapper(*args, **kwargs):
         dps = mpmath.mp.dps

--- a/sympy/external/tests/test_mpmath.py
+++ b/sympy/external/tests/test_mpmath.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from sympy.external.mpmath import repr_dps
+from sympy.external.mpmath import (PythonMPContext, _constant, _mpc, _mpf,
+    mpmath, mpnumeric, repr_dps)
 
 
 def test_repr_dps_is_stable():
@@ -7,3 +8,15 @@ def test_repr_dps_is_stable():
     assert repr_dps(33) == 12
     assert repr_dps(53) == 17
     assert repr_dps(66) == 22
+
+
+def test_mpmath_module_reexported():
+    assert mpmath is __import__('mpmath')
+
+
+def test_ctx_mp_python_names_reexported():
+    assert PythonMPContext is __import__('mpmath').ctx_mp_python.PythonMPContext
+    assert _mpf is __import__('mpmath').ctx_mp_python._mpf
+    assert _mpc is __import__('mpmath').ctx_mp_python._mpc
+    assert _constant is __import__('mpmath').ctx_mp_python._constant
+    assert mpnumeric is __import__('mpmath').ctx_mp_python.mpnumeric

--- a/sympy/polys/domains/mpelements.py
+++ b/sympy/polys/domains/mpelements.py
@@ -10,10 +10,9 @@ from sympy.external.gmpy import MPQ
 from sympy.polys.domains.domainelement import DomainElement
 from sympy.utilities import public
 
-from mpmath.ctx_mp_python import PythonMPContext, _mpf, _mpc, _constant
-from sympy.external.mpmath import (MPZ_ONE, fzero, fone, finf, fninf, fnan,
-    round_nearest, mpf_mul, repr_dps, int_types,
-    from_int, from_float, from_str, to_rational)
+from sympy.external.mpmath import (MPZ_ONE, PythonMPContext, _constant, _mpc,
+    _mpf, fzero, fone, finf, fninf, fnan, round_nearest, mpf_mul, repr_dps,
+    int_types, from_int, from_float, from_str, to_rational)
 
 
 @public

--- a/sympy/polys/polytools.py
+++ b/sympy/polys/polytools.py
@@ -60,7 +60,7 @@ from sympy.utilities.iterables import iterable, sift
 
 # Required to avoid errors
 import sympy.polys
-from sympy.external.mpmath import local_workdps, NoConvergence
+from sympy.external.mpmath import local_workdps, mpmath, NoConvergence
 
 
 if TYPE_CHECKING:
@@ -3761,7 +3761,7 @@ class Poly(Basic):
         # mpmath 1.4 deprecates calling polyroots without the 'asc' argument
         # and apparently prefers asc=True which reverses the order compared to
         # default behaviour for mpmath < 1.4.
-        from mpmath import __version__ as mpver
+        mpver = mpmath.__version__
         if not any(mpver.startswith(prefix) for prefix in ('0.', '1.0.', '1.1.', '1.2.', '1.3.')):
             # This should be the code when mpmath 1.4.0 is the minimum version:
             opts['asc'] = True

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -54,7 +54,7 @@ from sympy.utilities.lambdify import lambdify
 from sympy.utilities.misc import filldedent, debugf
 from sympy.utilities.iterables import (connected_components,
     generate_bell, uniq, iterable, is_sequence, subsets, flatten, sift)
-from sympy.external.mpmath import conserve_mpmath_dps, findroot
+from sympy.external.mpmath import conserve_mpmath_dps, findroot, mp
 
 from sympy.solvers.polysys import solve_poly_system
 
@@ -3023,8 +3023,7 @@ def nsolve(*args, dict=False, **kwargs):
     if 'prec' in kwargs:
         # XXX: This should use local_workprec instead of changing the global
         # precision.
-        import mpmath
-        mpmath.mp.dps = kwargs.pop('prec')
+        mp.dps = kwargs.pop('prec')
 
     # keyword argument to return result as a dictionary
     as_dict = dict

--- a/sympy/testing/tests/test_code_quality.py
+++ b/sympy/testing/tests/test_code_quality.py
@@ -40,6 +40,8 @@ message_duplicate_test = "This is a duplicate test function: %s, line %s"
 message_self_assignments = "File contains assignments to self/cls: %s, line %s."
 message_func_is = "File contains '.func is': %s, line %s."
 message_bare_expr = "File contains bare expression: %s, line %s."
+message_mpmath_import = ("File imports mpmath directly (mpmath must only be "
+    "imported in sympy/external/mpmath.py): %s, line %s.")
 
 implicit_test_re = re.compile(r'^\s*(>>> )?(\.\.\. )?from .* import .*\*')
 str_raise_re = re.compile(
@@ -51,6 +53,8 @@ test_suite_def_re = re.compile(r'^def\s+(?!(_|test))[^(]*\(\s*\)\s*:$')
 test_ok_def_re = re.compile(r'^def\s+test_.*:$')
 test_file_re = re.compile(r'.*[/\\]test_.*\.py$')
 func_is_re = re.compile(r'\.\s*func\s+is')
+mpmath_import_re = re.compile(r'^\s*(import mpmath\b|from mpmath\b)')
+mpmath_wrapper_path = abspath(join(SYMPY_PATH, 'external', 'mpmath.py'))
 
 
 def tab_in_leading(s):
@@ -249,6 +253,13 @@ def test_files():
                 assert False, message_implicit % (fname, idx + 1)
             if func_is_re.search(line) and not test_file_re.search(fname):
                 assert False, message_func_is % (fname, idx + 1)
+            if (mpmath_import_re.search(line) and
+                    not test_file_re.search(fname) and
+                    fname != mpmath_wrapper_path):
+                # mpmath should only be imported in sympy/external/mpmath.py;
+                # everything else should import it from there. Test files are
+                # exempt for now because several of them exercise mpmath itself:
+                assert False, message_mpmath_import % (fname, idx + 1)
 
             result = old_raise_re.search(line)
 
@@ -417,6 +428,31 @@ def test_implicit_imports_regular_expression():
         assert implicit_test_re.search(_with_space(c)) is None, c
     for c in candidates_fail:
         assert implicit_test_re.search(_with_space(c)) is not None, c
+
+
+def test_mpmath_imports_regular_expression():
+    candidates_ok = [
+        "from sympy.external.mpmath import mpf",
+        "from sympy import external",
+        "import sympy.external.mpmath",
+        "# import mpmath",
+        "some text # from mpmath import mpf",
+        ">>> import mpmath",  # allowed in docstrings
+        ">>> from mpmath import mpf",
+        # test files are exempt
+    ]
+    candidates_fail = [
+        "import mpmath",
+        "import mpmath.libmp",
+        "from mpmath import mpf",
+        "from mpmath import (mpf, mpc)",
+        "from mpmath.libmp import MPZ",
+        "from mpmath.ctx_mp_python import mpnumeric",
+    ]
+    for c in candidates_ok:
+        assert mpmath_import_re.search(_with_space(c)) is None, c
+    for c in candidates_fail:
+        assert mpmath_import_re.search(_with_space(c)) is not None, c
 
 
 def test_test_suite_defs():


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30407

#### Brief description of what is fixed or changed

SymPy centralizes mpmath access through `sympy.external.mpmath`, but nothing
prevented new code from importing mpmath directly again. This PR adds a code
quality check (in the `bin/test quality` suite) that fails on any
`import mpmath` or `from mpmath ...` line outside the wrapper module, and
switches the library files that still imported mpmath directly to use the
wrapper:

* `sympy/external/mpmath.py` now also re-exports the `mpmath` module object and
  the `mpmath.ctx_mp_python` names (`PythonMPContext`, `_mpf`, `_mpc`,
  `_constant`) used by `sympy.polys.domains.mpelements`.
* `sympy/__init__.py` checks the mpmath dependency with
  `sympy.external.import_module`.
* `sympy/core/function.py` gets the `mpmath` module object from the wrapper.
* `sympy/polys/polytools.py` uses `mpmath.__version__` from the wrapper.
* `sympy/solvers/solvers.py` uses the wrapper's `mp` for `nsolve`.

The check exempts test files (several of them deliberately exercise mpmath
itself) and `>>>` docstring examples.

#### Other comments

N/A

#### AI Generation Disclosure

This pull request was written with the assistance of an AI agent (opencode,
model `opencode/big-pickle`). The code changes cover the files
`sympy/__init__.py`, `sympy/core/function.py`, `sympy/external/mpmath.py`,
`sympy/external/tests/test_mpmath.py`, `sympy/polys/domains/mpelements.py`,
`sympy/polys/polytools.py`, `sympy/solvers/solvers.py`, and
`sympy/testing/tests/test_code_quality.py`. The pull request description was
also written by the AI agent.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->

* core
  * mpmath is now only imported in `sympy/external/mpmath.py`; a code quality
    check enforces this, and the wrapper re-exports the mpmath module object
    and the names used by `sympy.polys.domains.mpelements`.

<!-- END RELEASE NOTES -->