### PR TITLE
fix infinite sign negation bug

### DIFF
--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1607,17 +1607,19 @@ class Mul(Expr, AssocOp):
             pos * neg * nonpositive -> pos or zero -> None is returned
             pos * neg * nonnegative -> neg or zero -> False is returned
         """
-        return self._eval_pos_neg(1)
+        return self._eval_pos_neg(1, extended=True)
 
     def _eval_is_positive(self) -> bool | None:
         if self._eval_pos_neg(1, extended=False) is False:
             return False
+        return None
 
     def _eval_is_negative(self) -> bool | None:
         if self._eval_pos_neg(-1, extended=False) is False:
             return False
+        return None
 
-    def _eval_pos_neg(self, sign: int, extended: bool=True) -> bool | None:
+    def _eval_pos_neg(self, sign: int, extended: bool) -> bool | None:
         saw_NON = saw_NOT = False
         for t in self.args:
             if t.is_extended_positive:
@@ -1627,32 +1629,33 @@ class Mul(Expr, AssocOp):
             elif t.is_zero:
                 if all(a.is_finite for a in self.args):
                     return False
-                return
+                return None
             elif t.is_extended_nonpositive:
                 sign = -sign
                 saw_NON = True
             elif t.is_extended_nonnegative:
                 saw_NON = True
             elif extended and t.is_finite is not True:
-                return
+                return None
             elif t.is_positive is False:
                 sign = -sign
                 if saw_NOT:
-                    return
+                    return None
                 saw_NOT = True
             elif t.is_negative is False:
                 if saw_NOT:
-                    return
+                    return None
                 saw_NOT = True
             else:
-                return
+                return None
         if sign == 1 and saw_NON is False and saw_NOT is False:
             return True
         if sign < 0:
             return False
+        return None
 
     def _eval_is_extended_negative(self):
-        return self._eval_pos_neg(-1)
+        return self._eval_pos_neg(-1, extended=True)
 
     def _eval_is_odd(self):
         is_integer = self._eval_is_integer()

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1609,7 +1609,15 @@ class Mul(Expr, AssocOp):
         """
         return self._eval_pos_neg(1)
 
-    def _eval_pos_neg(self, sign):
+    def _eval_is_positive(self) -> bool | None:
+        if self._eval_pos_neg(1, extended=False) is False:
+            return False
+
+    def _eval_is_negative(self) -> bool | None:
+        if self._eval_pos_neg(-1, extended=False) is False:
+            return False
+
+    def _eval_pos_neg(self, sign: int, extended: bool=True) -> bool | None:
         saw_NON = saw_NOT = False
         for t in self.args:
             if t.is_extended_positive:
@@ -1625,9 +1633,8 @@ class Mul(Expr, AssocOp):
                 saw_NON = True
             elif t.is_extended_nonnegative:
                 saw_NON = True
-            # FIXME: is_positive/is_negative is False doesn't take account of
-            # Symbol('x', infinite=True, extended_real=True) which has
-            # e.g. is_positive is False but has uncertain sign.
+            elif extended and t.is_finite is not True:
+                return
             elif t.is_positive is False:
                 sign = -sign
                 if saw_NOT:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1658,6 +1658,8 @@ class Mul(Expr, AssocOp):
             elif t.is_extended_nonnegative:
                 saw_NON = True
             else:
+                pos: bool | None
+                neg: bool | None
                 if extended and t.is_finite is not True:
                     pos, neg = t.is_extended_positive, t.is_extended_negative
                 else:

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -1610,12 +1610,34 @@ class Mul(Expr, AssocOp):
         return self._eval_pos_neg(1, extended=True)
 
     def _eval_is_positive(self) -> bool | None:
-        if self._eval_pos_neg(1, extended=False) is False:
-            return False
-        return None
+        return self._eval_pos_neg(1, extended=False)
 
     def _eval_is_negative(self) -> bool | None:
-        if self._eval_pos_neg(-1, extended=False) is False:
+        return self._eval_pos_neg(-1, extended=False)
+
+    def _eval_is_nonnegative(self) -> bool | None:
+        return self._eval_nonneg_nonpos(1)
+
+    def _eval_is_nonpositive(self) -> bool | None:
+        return self._eval_nonneg_nonpos(-1)
+
+    def _eval_nonneg_nonpos(self, sign: int) -> bool | None:
+        unsigned = None
+        for t in self.args:
+            if t.is_positive:
+                continue
+            if t.is_negative:
+                sign = -sign
+                continue
+            if unsigned is not None:
+                return None
+            unsigned = t
+        if unsigned is None:
+            return None
+        if sign == 1:
+            if unsigned.is_nonnegative is False:
+                return False
+        elif unsigned.is_nonpositive is False:
             return False
         return None
 
@@ -1635,23 +1657,22 @@ class Mul(Expr, AssocOp):
                 saw_NON = True
             elif t.is_extended_nonnegative:
                 saw_NON = True
-            elif extended and t.is_finite is not True:
-                return None
-            elif t.is_positive is False:
-                sign = -sign
-                if saw_NOT:
-                    return None
-                saw_NOT = True
-            elif t.is_negative is False:
-                if saw_NOT:
-                    return None
-                saw_NOT = True
             else:
-                return None
-        if sign == 1 and saw_NON is False and saw_NOT is False:
-            return True
+                if extended and t.is_finite is not True:
+                    pos, neg = t.is_extended_positive, t.is_extended_negative
+                else:
+                    pos, neg = t.is_positive, t.is_negative
+                if pos is not False and neg is not False:
+                    return None
+                if saw_NOT:
+                    return None
+                saw_NOT = True
+                if pos is False:
+                    sign = -sign
         if sign < 0:
             return False
+        if extended and not (saw_NON or saw_NOT):
+            return True
         return None
 
     def _eval_is_extended_negative(self):

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -512,6 +512,12 @@ def test_symbol_falsepositive_unknown_finite_mul():
     assert (-y).is_extended_negative is False
     assert (2*y).is_extended_positive is False
 
+    z = Symbol('z', extended_positive=False)
+    assert z.is_finite is None
+    assert (-z).is_extended_negative is False
+    assert (2*z).is_extended_positive is False
+    assert (2*z).is_positive is False
+
 
 def test_neg_symbol_falsepositive():
     x = -Symbol('x', positive=False)
@@ -565,15 +571,14 @@ def test_symbol_falsenonnegative():
     assert x.is_nonzero is None
 
 
-@XFAIL
 def test_neg_symbol_falsenonnegative():
     x = -Symbol('x', nonnegative=False)
     assert x.is_positive is None
-    assert x.is_nonpositive is False  # this currently returns None
-    assert x.is_negative is False  # this currently returns None
+    assert x.is_nonpositive is False
+    assert x.is_negative is False
     assert x.is_nonnegative is None
-    assert x.is_zero is False  # this currently returns None
-    assert x.is_nonzero is True  # this currently returns None
+    assert x.is_zero is False
+    assert x.is_nonzero is None
 
 
 def test_symbol_falsenonnegative_real():

--- a/sympy/core/tests/test_assumptions.py
+++ b/sympy/core/tests/test_assumptions.py
@@ -479,10 +479,38 @@ def test_symbol_falsepositive_mul():
     assert x.is_nonzero is None
 
 
-@XFAIL
 def test_symbol_infinitereal_mul():
     ix = Symbol('ix', infinite=True, extended_real=True)
+    x = Symbol('x')
+
+    assert ix.is_extended_positive is None
+    assert ix.is_extended_negative is None
+
     assert (-ix).is_extended_positive is None
+    assert (-ix).is_extended_negative is None
+
+    assert (2*ix).is_extended_positive is None
+    assert (2*ix).is_extended_negative is None
+
+    assert (x - ix).is_extended_positive is None
+    assert (x - ix).is_extended_negative is None
+
+
+def test_symbol_falsepositive_unknown_finite_mul():
+    x = Symbol('x', positive=False)
+    assert x.is_finite is None
+
+    assert (-x).is_negative is False
+    assert (-x).is_extended_positive is None
+    assert (-x).is_extended_negative is None
+
+    assert (2*x).is_positive is False
+    assert (2*x).is_extended_positive is None
+    assert (2*x).is_extended_negative is None
+
+    y = Symbol('y', positive=False, finite=True)
+    assert (-y).is_extended_negative is False
+    assert (2*y).is_extended_positive is False
 
 
 def test_neg_symbol_falsepositive():


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

Fixes `FIXME` from https://github.com/sympy/sympy/pull/17535

<!-- If there is an issue related to this PR, include a link to the issue here.
It is important not to waste reviewer's time by skipping this section.

If this pull request fixes an issue, write "Fixes #NNNN" in that exact format,
e.g. "Fixes #1234" (see https://tinyurl.com/auto-closing for more information).

If this does not completely fix the issue, then write "See #NNNN" or "partially
fixes #NNNN", e.g. "See #1234" or "partially fixes #1234". -->

#### Brief description of what is fixed or changed

Before this, the following bug was possible:
```python
ix = Symbol('ix', infinite=True, extended_real=True)
assert (-ix).is_extended_positive is None
```

In this case, `ix` could be negative or positive infinity, so similarly `-ix` could be negative or positive infinity. This means that `(-ix).is_extended_positive` should be `None`. Unfortunately when you run this code it comes out as `True`.

This happens because `_eval_is_extended_positive` uses `_eval_pos_neg` which explicitly checks `t.is_positive is False` and `t.is_negative is False`. `ix.is_positive` is `False` because `ix` is infinite. 

This PR makes an exception for infinite symbols by specifying whether `_eval_pos_neg` is evaluating extended or unextended positivity/negativity.

#### Other comments

Added some static type hints too.

#### AI Generation Disclosure

<!-- If this pull request includes AI-generated code or text, please disclose
the tool used and specify which lines were generated. Disclosure is not
required for minor assistive tasks, such as spell-checking or code reviewing,
in primarily human-authored work. Otherwise, write "NO AI USE" in the text area
below.

DO NOT just delete this AI section of the PR template and do not leave this
blank, or the PR will be closed. If you write "NO AI USE" and the code looks
like it was generated by AI then the PR will be closed. -->

I used Claude Fable 5.1 to research the issue and write test cases. I did the final implementation by hand. All PR info is handwritten.

#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

* core
  * Fixed a bug where unsigned infinite symbols could appear to be positive or negative.

<!-- END RELEASE NOTES -->
