### PR TITLE
Improve reduce_rational_inequalities docstring to clarify AND/OR structure

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1167,6 +1167,7 @@ Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
 MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@users.noreply.github.com>
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
+Muhammad Talha <shykhtalha33@gmail.com> Muhammad Talha <128708311+shkTalha33@users.noreply.github.com>
 Muhammad Talha <shykhtalha33@gmail.com> shkTalha33 <shykhtalha33@gmail.com>
 Muhammad Usaid <shkusaid910@gmail.com> shkusaid <shkusaid910@gmail.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1167,6 +1167,7 @@ Moses Paul R <iammosespaulr@gmail.com> Moses PaulR <iammosespaulr@gmail.com>
 MostafaGalal1 <mostafag649.mg@gmail.com> Mostafa Galal <77402549+MostafaGalal1@users.noreply.github.com>
 Mridul Seth <seth.mridul@gmail.com>
 Muhammad Maaz <mmaaz6004@gmail.com> Maaz <76714503+mmaaz-git@users.noreply.github.com>
+Muhammad Talha <shykhtalha33@gmail.com> shkTalha33 <shykhtalha33@gmail.com>
 Muhammad Usaid <shkusaid910@gmail.com> shkusaid <shkusaid910@gmail.com>
 Muhammed Abdul Quadir Owais <quadirowais200@gmail.com> MaqOwais <quadirowais200@gmail.com>
 Musab Kasbati <musab16000@gmail.com> Musab Kasbati <43878981+Musab1Blaser@users.noreply.github.com>

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -196,6 +196,7 @@ def solve_rational_inequalities(eqs):
 
 def reduce_rational_inequalities(exprs, gen, relational=True):
     """Reduce a system of rational inequalities with rational coefficients.
+    expr is a list of lists. The inner list is ANDed together and the outer lists are ORed together.
 
     Examples
     ========
@@ -215,6 +216,14 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
     >>> reduce_rational_inequalities([[x + 2]], x)
     Eq(x, -2)
 
+    condition in which two same inner lists are ANDed together:
+    >>> reduce_rational_inequalities([[x > 0 , x > 1]], x)
+    1 < x
+
+    condition in which two different inner lists are ORed together:
+    >>> reduce_rational_inequalities([[x > 0] , [x > 1]], x)
+    0 < x
+
     This function find the non-infinite solution set so if the unknown symbol
     is declared as extended real rather than real then the result may include
     finiteness conditions:
@@ -224,6 +233,7 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
     (-2 < y) & (y < oo)
     """
     exact = True
+    eqs = []
     solution = S.EmptySet  # add pieces for each group
     for _exprs in exprs:
         if not _exprs:
@@ -269,6 +279,9 @@ def reduce_rational_inequalities(exprs, gen, relational=True):
 
         if _eqs:
             _sol &= solve_rational_inequalities([_eqs])
+            exclude = solve_rational_inequalities([[((d, d.one), '==')
+                for i in eqs for ((n, d), _) in i if d.has(gen)]])
+            _sol -= exclude
 
         solution |= _sol
 


### PR DESCRIPTION
<!-- DO NOT DELETE OR REPLACE THIS TEMPLATE or the PR will be closed.

Read our Policy on AI Generated Code and Communication at
https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html.

As required in the policy do not use AI-generated text to complete the PR
description below or the PR will be closed. Follow the instructions in the
template below and keep all section headings or the PR will be closed.

The PR title above should be a short description of what was changed. Do not
include the issue number in the title. -->

#### References to other Issues or PRs

fixes #24184 

#### Brief description of what is fixed or changed
The issue reporter aditink called the function reduce_rational_inequalities([[x > 0], [x > 1]], x) and was expecting the more restrictive result 1 < x and got the unexpected result of 0 < x. @oscarbenjamin clarified that this wasn't a bug — the function was working as designed, and the confusion was really a documentation gap. The function needed to be called as reduce_rational_inequalities([[x > 0, x > 1]], x) to get the expected behavior.
The root problem was that the docstring never explained that exprs is a list of lists where same inner lists are combined with AND and different inner lists are combined with OR — that ambiguity was exactly the cause of confusion.
I went through the actual function's code to check and confirm the AND/OR structure before writing anything on the basis of my assumptions.
I added the explanation of the structure after the summary of the function.
I also added 2 new examples and a short note on them to clarify and reduce confusion:

>>> reduce_rational_inequalities([[x > 0, x > 1]], x)      # AND case
1 < x
>>> reduce_rational_inequalities([[x > 0], [x > 1]], x)    # OR case
0 < x

My first attempt of adding the explanation between the examples caused a doctest failure.

#### AI Generation Disclosure

AI helped me to understand the the AND/OR logic by walkimg through the exprs nested loop. I wrote the actual docstring examples , text and ran  everything by myself including REPL and test commands


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
NO ENTRY
<!-- END RELEASE NOTES -->
