### PR TITLE
Return EX for complex coefficients with an infinite part

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -37,8 +37,13 @@ def _construct_simple(coeffs, opt):
         else:
             is_complex = pure_complex(coeff)
             if is_complex:
-                complexes = True
                 x, y = is_complex
+                if not (x.is_finite and y.is_finite):
+                    # e.g. oo*I. There is no simple domain that can hold a
+                    # non-finite value, so fall through to EX like the real
+                    # infinities do.
+                    return None
+                complexes = True
                 if x.is_Rational and y.is_Rational:
                     if not (x.is_Integer and y.is_Integer):
                         rationals = True

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -252,3 +252,12 @@ def test_issue_25337():
 
     x_algebraic = Symbol('x', algebraic=True)
     assert construct_domain(x_algebraic)[0] == ZZ[x_algebraic]
+
+
+def test_issue_30061():
+    assert construct_domain([I*S.Infinity]) == (EX, [EX(I*S.Infinity)])
+    assert construct_domain([I*S.NegativeInfinity]) == (EX, [EX(I*S.NegativeInfinity)])
+    assert construct_domain([1 + I*S.Infinity]) == (EX, [EX(1 + I*S.Infinity)])
+    assert construct_domain([S.Infinity + I]) == (EX, [EX(S.Infinity + I)])
+
+    assert construct_domain(I*S.Infinity) == (EX, EX(I*S.Infinity))


### PR DESCRIPTION
#### References to other Issues or PRs

Fixes #30061

#### Brief description of what is fixed or changed

`construct_domain([oo*I])` raised `TypeError: cannot create mpf from oo`.

In `_construct_simple` a pure complex coefficient is split into its real and imaginary parts. When those parts are not both `Rational` the coefficient is treated as a complex float, so `oo*I` reached `ComplexField.from_sympy`, which hands `oo` to mpmath.

Real infinities never get that far. `pure_complex` returns `None` for them, so they fall through to `EX`. This makes the complex case do the same when either part is not finite:

```
>>> construct_domain([oo*I])
(EX, [EX(oo*I)])
```

Finite complex coefficients are unchanged: `I` and `1 + 2*I` still give `ZZ_I`, `S(1)/2 + I` gives `QQ_I`, and `1.5*I` gives `CC`.

#### Other comments

The new test fails on master with the `TypeError` above.

`sympy/polys` passes (2378 tests), and so do `matrices`, `solvers` and `simplify` (1851 tests), since `construct_domain` is reached from those.

`test_issue_30061` sits next to `test_issue_25337`, which covers the real infinities.

#### AI Generation Disclosure

Claude Code was used to locate the branch in `_construct_simple` that mishandles the coefficient, and to draft the five changed lines in `sympy/polys/constructor.py` and `test_issue_30061`. I reviewed the change, ran the test suites listed above and can explain the behaviour.

#### Release Notes

<!-- BEGIN RELEASE NOTES -->
* polys
  * Fixed a bug where `construct_domain` raised a `TypeError` for complex coefficients with an infinite part such as `oo*I`. The `EX` domain is now used, as it already was for real infinities.
<!-- END RELEASE NOTES -->
