### PR TITLE
feat(matrices): support lazy Jordan decomposition and matrix expressions

### DIFF
--- a/sympy/assumptions/handlers/matrices.py
+++ b/sympy/assumptions/handlers/matrices.py
@@ -208,6 +208,10 @@ def _(expr, assumptions):
         return None
     return fuzzy_and([_ask_recursive(Q.invertible(a), assumptions) for a in expr.diag])
 
+@InvertiblePredicate.register(Factorization)
+def _(expr, assumptions):
+    return _Factorization(Q.invertible, expr, assumptions)
+
 
 # OrthogonalPredicate
 

--- a/sympy/matrices/eigen.py
+++ b/sympy/matrices/eigen.py
@@ -1118,18 +1118,21 @@ def _jordan_form(
         calc_transform: Literal[False],
         *,
         chop: bool = False,
+        lazy: bool = False,
     ) -> Tmat: ...
 @overload
 def _jordan_form(M: Tmat,
          calc_transform: bool = True,
          *,
-         chop: bool = False
+         chop: bool = False,
+         lazy: bool = False,
      ) -> tuple[Tmat, Tmat] | Tmat: ...
 
 def _jordan_form(M: Tmat,
          calc_transform: bool = True,
          *,
-         chop: bool = False
+         chop: bool = False,
+         lazy: bool = False,
      ) -> tuple[Tmat, Tmat] | Tmat:
     """Return $(P, J)$ where $J$ is a Jordan block
     matrix and $P$ is a matrix such that $M = P J P^{-1}$
@@ -1145,6 +1148,11 @@ def _jordan_form(M: Tmat,
         eigenvalues and eigenvectors.  As a result, there may be
         approximation errors.  If ``chop==True``, these errors
         will be truncated.
+
+    lazy : bool, optional
+        If ``True``, the returned Jordan form matrix $J$ will be represented
+        lazily as a :class:`~.BlockDiagMatrix` composed of individual Jordan blocks
+        rather than evaluated into an explicit dense matrix. Default is ``False``.
 
     Examples
     ========
@@ -1267,10 +1275,10 @@ def _jordan_form(M: Tmat,
 
     if has_rationals:
         if calc_transform:
-            P, J = _jordan_form_rational_matrix(mat, calc_transform=True)
+            P, J = _jordan_form_rational_matrix(mat, calc_transform=True, lazy=lazy)
             return restore_floats2(P, J)
         else:
-            J = _jordan_form_rational_matrix(mat, calc_transform=False)
+            J = _jordan_form_rational_matrix(mat, calc_transform=False, lazy=lazy)
             return restore_floats1(J)
 
     # first calculate the jordan block structure
@@ -1288,7 +1296,11 @@ def _jordan_form(M: Tmat,
     # do extra work!
     if len(eigs.keys()) == mat.cols:
         blocks     = sorted(eigs.keys(), key=default_sort_key)
-        jordan_mat = mat.diag(*blocks)
+        if lazy:
+            from sympy.matrices.expressions import BlockDiagMatrix
+            jordan_mat = BlockDiagMatrix(*[mat.diag(b) for b in blocks])
+        else:
+            jordan_mat = mat.diag(*blocks)
 
         if not calc_transform:
             return restore_floats1(jordan_mat)
@@ -1325,8 +1337,12 @@ def _jordan_form(M: Tmat,
             "SymPy had encountered an inconsistent result while "
             "computing Jordan block. : {}".format(M))
 
-    blocks2     = (mat.jordan_block(size=size, eigenvalue=eig) for eig, size in block_structure)
-    jordan_mat = mat.diag(*blocks2)
+    blocks2     = [mat.jordan_block(size=size, eigenvalue=eig) for eig, size in block_structure]
+    if lazy:
+        from sympy.matrices.expressions import BlockDiagMatrix
+        jordan_mat = BlockDiagMatrix(*blocks2)
+    else:
+        jordan_mat = mat.diag(*blocks2)
 
     if not calc_transform:
         return restore_floats1(jordan_mat)
@@ -1368,7 +1384,7 @@ def _jordan_form(M: Tmat,
 
     return restore_floats2(basis_mat, jordan_mat)
 
-def _jordan_form_rational_matrix(M, calc_transform):
+def _jordan_form_rational_matrix(M, calc_transform, lazy=False):
     dM = DomainMatrix.from_Matrix(M, field=True)
 
     def char_mat(algebraic_num):
@@ -1471,13 +1487,17 @@ def _jordan_form_rational_matrix(M, calc_transform):
 
     assert jordan_form_size == M.rows
 
-    blocks2 = (
+    blocks2 = [
         M.jordan_block(size=size, eigenvalue=eig)
         for eig, sizes in block_structure.items()
         for size in sizes
-    )
+    ]
 
-    jordan_mat = M.diag(*blocks2)
+    if lazy:
+        from sympy.matrices.expressions import BlockDiagMatrix
+        jordan_mat = BlockDiagMatrix(*blocks2)
+    else:
+        jordan_mat = M.diag(*blocks2)
 
     if not calc_transform:
         return jordan_mat

--- a/sympy/matrices/expressions/__init__.py
+++ b/sympy/matrices/expressions/__init__.py
@@ -22,6 +22,10 @@ from .permutation import PermutationMatrix, MatrixPermute
 from .sets import MatrixSet
 from .special import ZeroMatrix, Identity, OneMatrix, MatrixUnit
 
+from .factorizations import (
+    JordanVectors, JordanBlocks, jordan, JordanForm,
+)
+
 __all__ = [
     'MatrixSlice',
 
@@ -60,5 +64,7 @@ __all__ = [
 
     'PermutationMatrix', 'MatrixPermute',
 
-    'Permanent', 'per'
+    'Permanent', 'per',
+
+    'JordanVectors', 'JordanBlocks', 'jordan', 'JordanForm',
 ]

--- a/sympy/matrices/expressions/factorizations.py
+++ b/sympy/matrices/expressions/factorizations.py
@@ -61,3 +61,34 @@ def eig(expr):
 
 def svd(expr):
     return UofSVD(expr), SofSVD(expr), VofSVD(expr)
+
+
+class JordanVectors(Factorization):
+    @property
+    def predicates(self):
+        return (Q.invertible,)
+
+
+class JordanBlocks(Factorization):
+    @property
+    def predicates(self):
+        return (Q.upper_triangular,)
+
+
+def jordan(expr):
+    """Jordan decomposition of a matrix expression.
+
+    Returns JordanVectors(expr), JordanBlocks(expr).
+    """
+    return JordanVectors(expr), JordanBlocks(expr)
+
+
+def JordanForm(expr):
+    """Construct symbolic similarity transform representing the Jordan normal form.
+
+    Returns P * J * P**(-1) where P = JordanVectors(expr) and J = JordanBlocks(expr).
+    """
+    from sympy.matrices.expressions.inverse import Inverse
+    from sympy.matrices.expressions.matmul import MatMul
+    P, J = jordan(expr)
+    return MatMul(P, J, Inverse(P))

--- a/sympy/matrices/expressions/tests/test_factorizations.py
+++ b/sympy/matrices/expressions/tests/test_factorizations.py
@@ -1,8 +1,10 @@
-from __future__ import annotations
-from sympy.matrices.expressions.factorizations import lu, LofCholesky, qr, svd
+from sympy.matrices.expressions.factorizations import (
+    lu, LofCholesky, qr, svd, jordan, JordanForm, JordanVectors, JordanBlocks,
+)
 from sympy.assumptions.ask import (Q, ask)
 from sympy.core.symbol import Symbol
 from sympy.matrices.expressions.matexpr import MatrixSymbol
+from sympy.matrices.expressions.matmul import MatMul
 
 n = Symbol('n')
 X = MatrixSymbol('X', n, n)
@@ -28,3 +30,15 @@ def test_svd():
     assert ask(Q.orthogonal(U))
     assert ask(Q.orthogonal(V))
     assert ask(Q.diagonal(S))
+
+def test_jordan():
+    P, J = jordan(X)
+    assert P.shape == J.shape == X.shape
+    assert ask(Q.invertible(P))
+    assert ask(Q.upper_triangular(J))
+    jf = JordanForm(X)
+    assert jf.shape == X.shape
+    assert isinstance(jf, MatMul)
+    assert jf.args[0] == P
+    assert jf.args[1] == J
+

--- a/sympy/matrices/matrixbase.py
+++ b/sympy/matrices/matrixbase.py
@@ -3724,7 +3724,8 @@ class MatrixBase(Printable):
             self: Tmat,
             calc_transform: Literal[True] = True,
             *,
-            chop: bool = False
+            chop: bool = False,
+            lazy: bool = False,
         ) -> tuple[Tmat, Tmat]: ...
     @overload
     def jordan_form(
@@ -3732,14 +3733,16 @@ class MatrixBase(Printable):
             calc_transform: Literal[False],
             *,
             chop: bool = False,
+            lazy: bool = False,
         ) -> Tmat: ...
 
     def jordan_form(self: Tmat,
              calc_transform: bool = True,
              *,
-             chop: bool = False
+             chop: bool = False,
+             lazy: bool = False,
          ) -> tuple[Tmat, Tmat] | Tmat:
-        return _jordan_form(self, calc_transform=calc_transform, chop=chop)
+        return _jordan_form(self, calc_transform=calc_transform, chop=chop, lazy=lazy)
 
     def left_eigenvects(self, **flags: Any) -> list[tuple[Expr, int, list[Self]]]:
         return _left_eigenvects(self, **flags)
@@ -4933,8 +4936,17 @@ class MatrixBase(Printable):
         return ans
 
 
-    def exp(self):
+    def exp(self, *, lazy: bool = False):
         """Return the exponential of a square matrix.
+
+        Parameters
+        ==========
+
+        lazy : bool, optional
+            If ``True``, returns the matrix exponential unevaluated as a
+            :class:`~.MatMul` expression $P e^J P^{-1}$ containing the similarity
+            transform and block diagonal exponential $e^J$, avoiding expensive
+            symbolic matrix multiplications and inversions. Default is ``False``.
 
         Examples
         ========
@@ -4959,6 +4971,11 @@ class MatrixBase(Printable):
                 "Exponentiation is implemented only for matrices for which the Jordan normal form can be computed")
 
         blocks = [cell._eval_matrix_exp_jblock() for cell in cells]
+        if lazy:
+            from sympy.matrices.expressions import BlockDiagMatrix, MatMul, Inverse
+            eJ = BlockDiagMatrix(*blocks)
+            return MatMul(P, eJ, Inverse(P))
+
         eJ = self.diag(*blocks)
         # n = self.rows
         ret = P.multiply(eJ, dotprodsimp=None).multiply(P.inv(), dotprodsimp=None)
@@ -5007,7 +5024,7 @@ class MatrixBase(Printable):
         from .sparsetools import banded
         return self._as_type(banded(size, bands))
 
-    def log(self, simplify: Callable[[Self], Self] | Literal[False] = cancel) -> Self:
+    def log(self, simplify: Callable[[Self], Self] | Literal[False] = cancel, *, lazy: bool = False) -> Self | MatMul:
         """Return the logarithm of a square matrix.
 
         Parameters
@@ -5019,6 +5036,12 @@ class MatrixBase(Printable):
             Default is ``cancel``, which is effective to reduce the
             expression growing for taking reciprocals and inverses for
             symbolic matrices.
+
+        lazy : bool, optional
+            If ``True``, returns the matrix logarithm unevaluated as a
+            :class:`~.MatMul` expression $P \\ln(J) P^{-1}$ containing the similarity
+            transform and block diagonal logarithm $\\ln(J)$, avoiding expensive
+            symbolic matrix multiplications and inversions. Default is ``False``.
 
         Examples
         ========
@@ -5076,6 +5099,11 @@ class MatrixBase(Printable):
                 "the Jordan normal form can be computed")
 
         blocks = [cell._eval_matrix_log_jblock() for cell in cells]
+
+        if lazy:
+            from sympy.matrices.expressions import BlockDiagMatrix, MatMul, Inverse
+            eJ = BlockDiagMatrix(*blocks)
+            return MatMul(P, eJ, Inverse(P))
 
         eJ = self.diag(*blocks)
 

--- a/sympy/matrices/tests/test_eigen.py
+++ b/sympy/matrices/tests/test_eigen.py
@@ -807,3 +807,32 @@ def test_issue_28793():
     P, J = A.jordan_form()
     assert P.det() == 16*sqrt(2)
     assert expand(P*J*P.inv()) == expand(A)
+
+
+def test_lazy_jordan_form():
+    from sympy.matrices.expressions import BlockDiagMatrix, MatMul
+    # 1. Non-diagonalizable / defective matrix
+    A = Matrix([[2, 1, 0], [0, 2, 0], [0, 0, 3]])
+    P, J_lazy = A.jordan_form(lazy=True)
+    assert isinstance(J_lazy, BlockDiagMatrix)
+    assert J_lazy.shape == (3, 3)
+    P_orig, J_orig = A.jordan_form(lazy=False)
+    assert J_lazy.as_explicit() == J_orig
+
+    # 2. Rational matrix
+    M = Matrix([[6, 5, -2, -3], [-3, -1, 3, 3], [2, 1, -2, -3], [-1, 1, 5, 5]])
+    P_m, J_m = M.jordan_form(lazy=True)
+    assert isinstance(J_m, BlockDiagMatrix)
+    assert J_m.as_explicit() == M.jordan_form(lazy=False)[1]
+
+    # 3. Lazy exponential
+    exp_lazy = A.exp(lazy=True)
+    assert isinstance(exp_lazy, MatMul)
+    assert (exp_lazy.doit().as_explicit() - A.exp()).is_zero_matrix
+
+    # 4. Lazy logarithm
+    B = Matrix([[2, 0], [0, 4]])
+    log_lazy = B.log(lazy=True)
+    assert isinstance(log_lazy, MatMul)
+    assert (log_lazy.doit().as_explicit() - B.log()).applyfunc(expand).is_zero_matrix
+


### PR DESCRIPTION
### Summary of Changes

Fixes #18867

This PR implements lazy Jordan normal form decomposition and matrix expressions, avoiding expensive symbolic evaluation of matrix products and inverses when analyzing Jordan structures or computing matrix functions.

### Motivation & Background
As discussed in #18867 and suggested by @oscarbenjamin:
Currently, `Matrix.jordan_form`, `Matrix.exp`, and `Matrix.log` eagerly construct dense explicit matrices. For non-trivial matrices (especially containing radical expressions), computing the explicit inverse and multiplying matrices causes symbolic expression ballooning. Furthermore, `sympy.matrices.expressions.factorizations` lacked symbolic representations for Jordan decomposition.

### What this PR adds:
1. **Symbolic Factorizations**:
   - Added `JordanVectors(Factorization)` (predicate: `Q.invertible`) and `JordanBlocks(Factorization)` (predicate: `Q.upper_triangular`) in `sympy.matrices.expressions.factorizations`.
   - Added `jordan(expr)` helper returning `(JordanVectors(expr), JordanBlocks(expr))`.
   - Added `JordanForm(expr)` representing `MatMul(JordanVectors(expr), JordanBlocks(expr), Inverse(JordanVectors(expr)))`.
   - Registered `InvertiblePredicate` for `Factorization` in `sympy.assumptions.handlers.matrices`.
2. **Lazy Jordan Normal Form**:
   - Supported `lazy=True` parameter in `Matrix.jordan_form()`, returning $J$ as a `BlockDiagMatrix` of Jordan cells without expanding into a dense explicit matrix.
3. **Lazy Matrix Functions**:
   - Supported `lazy=True` in `Matrix.exp()` and `Matrix.log()`, returning unevaluated `MatMul(P, eJ, Inverse(P))` similarity transform representations.
4. **Unit Tests**:
   - Added tests in `test_factorizations.py` verifying shapes, predicates, and expression structures.
   - Added `test_lazy_jordan_form` in `test_eigen.py` verifying `BlockDiagMatrix` returns, defective matrices, rational matrices, and analytical equivalence under `.doit().as_explicit()`.

Signed-off-by: Shikhar Kesharwani <ayushgu02@gmail.com>